### PR TITLE
Don't use "yield" in AnalysisDriver._getAllUnitSources().

### DIFF
--- a/lib/src/analysis.dart
+++ b/lib/src/analysis.dart
@@ -120,10 +120,11 @@ class AnalysisDriver {
   /// Yield the sources for all the compilation units constituting
   /// [librarySource] (including the defining compilation unit).
   Iterable<Source> _getAllUnitSources(
-      AnalysisContext context, Source librarySource) sync* {
-    yield librarySource;
-    yield* context.getLibraryElement(librarySource).parts
-        .map((CompilationUnitElement e) => e.source);
+      AnalysisContext context, Source librarySource) {
+    List<Source> result = <Source>[librarySource];
+    result.addAll(context.getLibraryElement(librarySource).parts
+        .map((CompilationUnitElement e) => e.source));
+    return result;
   }
 }
 


### PR DESCRIPTION
This syntax won't be available until Dart 1.9.