### PR TITLE
Exclude getters/setters from one_member_abstracts lint.  Fix #64.

### DIFF
--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -55,7 +55,10 @@ class Visitor extends SimpleAstVisitor {
         node.extendsClause == null &&
         node.members.length == 1) {
       var member = node.members[0];
-      if (member is MethodDeclaration && member.isAbstract) {
+      if (member is MethodDeclaration &&
+          member.isAbstract &&
+          !member.isGetter &&
+          !member.isSetter) {
         rule.reportLint(node.name);
       }
     }

--- a/test/rules/one_member_abstracts.dart
+++ b/test/rules/one_member_abstracts.dart
@@ -21,3 +21,7 @@ abstract class Z extends X {
 }
 
 abstract class ZZ extends Predicate {}
+
+abstract class Config {
+  String get datasetId; //OK -- Issue #64
+}


### PR DESCRIPTION
@bwilkerson 