### PR TITLE
Widen analyzer constraint to include analyzer version 0.26.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/linter
 environment:
   sdk: '>=1.8.0 <2.0.0'
 dependencies:
-  analyzer: ^0.25.1-alpha.2
+  analyzer: '>=0.25.1-alpha.2 <0.27.0'
   args: '>=0.12.1 <0.14.0'
   cli_util: ^0.0.1
   glob: ^1.0.3


### PR DESCRIPTION
The only breaking change in analyzer 0.26 is to
UriResolver.resolveUri(), which linter doesn't use.

@pq 