### PR TITLE
Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -27,10 +27,12 @@ import 'package:linter/src/rules/empty_constructor_bodies.dart';
 import 'package:linter/src/rules/empty_statements.dart';
 import 'package:linter/src/rules/hash_and_equals.dart';
 import 'package:linter/src/rules/implementation_imports.dart';
+import 'package:linter/src/rules/invariant_booleans.dart';
 import 'package:linter/src/rules/iterable_contains_unrelated_type.dart';
 import 'package:linter/src/rules/library_names.dart';
 import 'package:linter/src/rules/library_prefixes.dart';
 import 'package:linter/src/rules/list_remove_unrelated_type.dart';
+import 'package:linter/src/rules/literal_only_boolean_expressions.dart';
 import 'package:linter/src/rules/non_constant_identifier_names.dart';
 import 'package:linter/src/rules/one_member_abstracts.dart';
 import 'package:linter/src/rules/only_throw_errors.dart';
@@ -74,10 +76,12 @@ final Registry ruleRegistry = new Registry()
   ..register(new EmptyStatements())
   ..register(new HashAndEquals())
   ..register(new ImplementationImports())
+  ..register(new InvariantBooleans())
   ..register(new IterableContainsUnrelatedType())
   ..register(new LibraryNames())
   ..register(new LibraryPrefixes())
   ..register(new ListRemoveUnrelatedType())
+  ..register(new LiteralOnlyBooleanExpressions())
   ..register(new NonConstantIdentifierNames())
   ..register(new OneMemberAbstracts())
   ..register(new OnlyThrowErrors())

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -1,0 +1,275 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.invariant_booleans;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/linter.dart';
+import 'package:linter/src/util/boolean_expression_utilities.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+import 'package:linter/src/util/tested_expressions.dart';
+
+const _desc = r'Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"';
+
+const _details = r'''
+
+**DON'T** test for conditions that can be inferred at compile time or test the
+same condition twice.
+Conditional statements using a condition which cannot be anything but FALSE have
+the effect of making blocks of code non-functional. If the condition cannot
+evaluate to anything but TRUE, the conditional statement is completely
+redundant, and makes the code less readable.
+It is quite likely that the code does not match the programmer's intent.
+Either the condition should be removed or it should be updated so that it does
+not always evaluate to TRUE or FALSE and does not perform redundant tests.
+This rule will hint to the test conflicting with the linted one.
+
+**BAD:**
+```
+//foo can't be both equal and not equal to bar in the same expression
+if(foo == bar && something && foo != bar) {...}
+```
+
+**BAD:**
+```
+void compute(int foo) {
+  if (foo == 4) {
+    doSomething();
+    // We know foo is equal to 4 at this point, so the next condition is always false
+    if (foo > 4) {...}
+    ...
+  }
+  ...
+}
+```
+
+**BAD:**
+```
+void compute(boolean foo) {
+  if (foo) {
+    return;
+  }
+  doSomething();
+  // foo is always false here
+  if (foo){...}
+  ...
+}
+```
+
+**GOOD:**
+```
+void nestedOK() {
+  if (foo == bar) {
+    foo = baz;
+    if (foo != bar) {...}
+  }
+}
+```
+
+**GOOD:**
+```
+void nestedOk2() {
+  if (foo == bar) {
+    return;
+  }
+
+  foo = baz;
+  if (foo == bar) {...} // OK
+}
+```
+
+**GOOD:**
+```
+void nestedOk5() {
+  if (foo != null) {
+    if (bar != null) {
+      return;
+    }
+  }
+
+  if (bar != null) {...} // OK
+}
+```
+''';
+
+
+class InvariantBooleans extends LintRule {
+  _Visitor _visitor;
+
+  InvariantBooleans() : super(
+      name: 'invariant_booleans',
+      description: _desc,
+      details: _details,
+      group: Group.errors,
+      maturity: Maturity.experimental) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  _reportBinaryExpressionIfConstantValue(BinaryExpression node) {
+    // Right part discards reporting a subexpression already reported.
+    if (node.bestType.name != 'bool' || node.parent is! IfStatement) {
+      return;
+    }
+
+    TestedExpressions testedNodes = _findPreviousTestedExpressions(node);
+    testedNodes.evaluateInvariant().forEach((ContradictoryComparisons e) {
+      _ContradictionReportRule reportRule = new _ContradictionReportRule(e);
+      reportRule.reporter = rule.reporter;
+      reportRule.reportLint(e.second);
+    });
+
+    // In dart booleanVariable == true is a valid comparison since the variable
+    // can be null.
+    if (!BooleanExpressionUtilities.EQUALITY_OPERATIONS
+        .contains(node.operator.type) &&
+        (node.leftOperand is BooleanLiteral ||
+            node.rightOperand is BooleanLiteral)) {
+      rule.reportLint(node);
+    }
+  }
+
+  @override
+  visitForStatement(ForStatement node) {
+    if (node.condition is BinaryExpression) {
+      _reportBinaryExpressionIfConstantValue(node.condition);
+    }
+  }
+
+  @override
+  visitDoStatement(DoStatement node) {
+    if (node.condition is BinaryExpression) {
+      _reportBinaryExpressionIfConstantValue(node.condition);
+    }
+  }
+
+  @override
+  visitIfStatement(IfStatement node) {
+    if (node.condition is BinaryExpression) {
+      _reportBinaryExpressionIfConstantValue(node.condition);
+    }
+  }
+
+  @override
+  visitWhileStatement(WhileStatement node) {
+    if (node.condition is BinaryExpression) {
+      _reportBinaryExpressionIfConstantValue(node.condition);
+    }
+  }
+
+
+}
+
+/// The only purpose of this rule is to report the second node on a cotradictory
+/// comparison indicating the first node as the cause of the inconsistency.
+class _ContradictionReportRule extends LintRule {
+  _ContradictionReportRule(ContradictoryComparisons comparisons) : super(
+      name: 'invariant_boolean',
+      description: _desc + ' verify: ${comparisons.first}.',
+      details: _details,
+      group: Group.errors,
+      maturity: Maturity.experimental);
+}
+
+TestedExpressions _findPreviousTestedExpressions(BinaryExpression node) {
+  Block block = node
+      .getAncestor((a) => a is Block && a.parent is BlockFunctionBody);
+  Iterable<AstNode> nodesInDFS = DartTypeUtilities.traverseNodesInDFS(block);
+  Iterable<Expression> conjunctions =
+  _findConditionsOfIfStatementAncestor(node.parent, nodesInDFS).toSet();
+  Iterable<Expression> negations =
+  (_findConditionsCausingReturns(node, nodesInDFS)
+    ..addAll(_findConditionsOfElseStatementAncestor(node.parent, nodesInDFS)))
+      .toSet();
+  return new TestedExpressions(node, conjunctions, negations);
+}
+
+Set<Expression> _findConditionsOfIfStatementAncestor(IfStatement statement,
+    Iterable<AstNode> nodesInDFS) {
+  return _findConditionsUnderIfStatementBranch(statement,
+      (n) =>
+  n is IfStatement &&
+      statement.getAncestor((a) => a == n.thenStatement) != null, nodesInDFS);
+}
+
+Set<Expression> _findConditionsOfElseStatementAncestor(IfStatement statement,
+    Iterable<AstNode> nodesInDFS) {
+  return _findConditionsUnderIfStatementBranch(statement,
+      (n) =>
+  n is IfStatement &&
+      statement.getAncestor((a) => a == n.elseStatement) != null, nodesInDFS);
+}
+
+Set<Expression> _findConditionsUnderIfStatementBranch(IfStatement statement,
+    AstNodePredicate predicate, Iterable<AstNode> nodesInDFS) {
+  AstNodePredicate noFurtherAssignmentInvalidatingCondition =
+  _noFurtherAssignmentInvalidatingCondition(statement.condition, nodesInDFS);
+  return nodesInDFS
+      .where((n) => n == statement.getAncestor((a) => a == n && a != statement))
+      .where((n) => n is IfStatement)
+      .where(predicate)
+      .where(noFurtherAssignmentInvalidatingCondition)
+      .fold(<Expression>[],
+      (List<Expression> previous, AstNode statement) {
+    if (statement is IfStatement) {
+      previous.add(statement.condition);
+    }
+    return previous;
+  }).toSet();
+}
+
+Set<Identifier> _findStatementIdentifiers(IfStatement statement) =>
+    DartTypeUtilities.traverseNodesInDFS(statement)
+        .where((n) => n is Identifier).toSet();
+
+Set<Expression> _findConditionsCausingReturns(BinaryExpression node,
+    Iterable<AstNode> nodesInDFS) =>
+    nodesInDFS
+        .takeWhile((n) => n != node.parent)
+        .where(_isIfStatementWithReturn(nodesInDFS))
+        .where((_noFurtherAssignmentInvalidatingCondition(node, nodesInDFS)))
+        .fold(<Expression>[],
+        (List<Expression> previous, AstNode statement) {
+      if (statement is IfStatement) {
+        previous.add(statement.condition);
+      }
+      return previous;
+    }).toSet();
+
+AstNodePredicate _isIfStatementWithReturn(Iterable<AstNode> blockNodes) =>
+        (AstNode node) {
+      Block block = node
+          .getAncestor((a) => a is Block && a.parent is BlockFunctionBody);
+      Iterable<AstNode> nodesInDFS = DartTypeUtilities.traverseNodesInDFS(node);
+      return node is IfStatement
+          && nodesInDFS.any((n) => n is ReturnStatement)
+          // Ignore nested if statements.
+          && !nodesInDFS.any((n) => n is IfStatement)
+          && node.getAncestor((n) =>
+          n != node && n is IfStatement &&
+              n.getAncestor((a) => a == block) == block) == null;
+    };
+
+AstNodePredicate _noFurtherAssignmentInvalidatingCondition(
+    BinaryExpression node,
+    Iterable<AstNode> nodesInDFS) {
+  Set<Identifier> identifiers = _findStatementIdentifiers(node.parent);
+  return (AstNode statement) =>
+  nodesInDFS
+      .skipWhile((n) => n != statement)
+      .takeWhile((n) => n != node)
+      .where((n) =>
+  n is AssignmentExpression &&
+      !identifiers.contains(n.leftHandSide))
+      .length == 0;
+}

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.literal_only_boolean_expressions;
+
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:linter/src/linter.dart';
+import 'package:analyzer/analyzer.dart';
+
+const _desc = r'Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"';
+
+const _details = r'''
+
+**DON'T** test for conditions composed only by literals, since the value can be
+inferred at compile time.
+Conditional statements using a condition which cannot be anything but FALSE have
+the effect of making blocks of code non-functional. If the condition cannot
+evaluate to anything but TRUE, the conditional statement is completely
+redundant, and makes the code less readable.
+It is quite likely that the code does not match the programmer's intent.
+Either the condition should be removed or it should be updated so that it does
+not always evaluate to TRUE or FALSE.
+
+**BAD:**
+```
+void bad() {
+  if (true) {} // LINT
+}
+```
+
+**BAD:**
+```
+void bad() {
+  if (true && 1 != 0) {} // LINT
+}
+```
+
+**BAD:**
+```
+void bad() {
+  if (1 != 0 && true) {} // LINT
+}
+```
+
+**BAD:**
+```
+void bad() {
+  if (1 < 0 && true) {} // LINT
+}
+```
+
+**BAD:**
+```
+void bad() {
+  if (true && false) {} // LINT
+}
+```
+
+**BAD:**
+```
+void bad() {
+  if (1 != 0) {} // LINT
+}
+```
+
+**BAD:**
+```
+void bad() {
+  if (true && 1 != 0 || 3 < 4) {} // LINT
+}
+```
+
+**BAD:**
+```
+void bad() {
+  if (1 != 0 || 3 < 4 && true) {} // LINT
+}
+```
+
+''';
+
+class LiteralOnlyBooleanExpressions extends LintRule {
+  _Visitor _visitor;
+
+  LiteralOnlyBooleanExpressions() : super(
+      name: 'literal_only_boolean_expressions',
+      description: _desc,
+      details: _details,
+      group: Group.errors,
+      maturity: Maturity.experimental) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  visitWhileStatement(WhileStatement node) {
+    if (_onlyLiterals(node.condition)) {
+      rule.reportLint(node);
+    }
+  }
+
+  @override
+  visitDoStatement(DoStatement node) {
+    if (_onlyLiterals(node.condition)) {
+      rule.reportLint(node);
+    }
+  }
+
+  @override
+  visitIfStatement(IfStatement node) {
+    if (_onlyLiterals(node.condition)) {
+      rule.reportLint(node);
+    }
+  }
+
+  @override
+  visitForStatement(ForStatement node) {
+    if (_onlyLiterals(node.condition)) {
+      rule.reportLint(node);
+    }
+  }
+}
+
+bool _onlyLiterals(Expression expression) {
+  final literalsOnBothSides = expression is BinaryExpression &&
+      (_onlyLiterals(expression.leftOperand) &&
+          _onlyLiterals(expression.rightOperand));
+  final ifNullOperatorWithLiteral = expression is BinaryExpression &&
+      (_onlyLiterals(expression.leftOperand) ||
+          _onlyLiterals(expression.rightOperand)) &&
+      expression.operator.type == TokenType.QUESTION_QUESTION;
+  final literalNegation = expression is PrefixExpression &&
+      _onlyLiterals(expression.operand);
+  final parenthesizedLiteral = expression is ParenthesizedExpression &&
+      _onlyLiterals(expression.expression);
+  return expression is Literal || literalsOnBothSides ||
+      ifNullOperatorWithLiteral || literalNegation || parenthesizedLiteral;
+}

--- a/lib/src/util/boolean_expression_utilities.dart
+++ b/lib/src/util/boolean_expression_utilities.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.util.boolean_expression_utilities;
+
+import 'dart:collection';
+import 'package:analyzer/dart/ast/token.dart';
+
+class BooleanExpressionUtilities {
+  static HashSet<TokenType> BOOLEAN_OPERATIONS = new HashSet.from(const [
+    TokenType.AMPERSAND_AMPERSAND, TokenType.BAR_BAR
+  ]);
+
+  static HashSet<TokenType> EQUALITY_OPERATIONS = new HashSet.from(const [
+    TokenType.EQ_EQ, TokenType.BANG_EQ
+  ]);
+
+  static HashMap<TokenType, TokenType> IMPLICATIONS = new HashMap.from(const {
+    TokenType.GT: TokenType.GT_EQ,
+    TokenType.LT: TokenType.LT_EQ,
+  });
+
+  static HashMap<TokenType, TokenType> NEGATIONS = new HashMap.from(const {
+    TokenType.EQ_EQ: TokenType.BANG_EQ,
+    TokenType.BANG_EQ: TokenType.EQ_EQ,
+    TokenType.GT: TokenType.LT_EQ,
+    TokenType.GT_EQ: TokenType.LT,
+    TokenType.LT: TokenType.GT_EQ,
+    TokenType.LT_EQ: TokenType.GT,
+  });
+
+  static HashSet<TokenType> TRICHOTOMY_OPERATORS = new HashSet.from(const [
+    TokenType.EQ_EQ, TokenType.LT, TokenType.GT
+  ]);
+
+  static final HashSet<TokenType> COMPARISONS = new HashSet.from(NEGATIONS.keys);
+}

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -1,10 +1,10 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
-
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
 library linter.src.util.dart_type_utilities;
 
+import 'dart:collection';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/ast/ast.dart';
@@ -66,8 +66,8 @@ class DartTypeUtilities {
 
   /// Builds the list resulting from traversing the node in DFS and does not
   /// include the node itself.
-  static List<AstNode> traverseNodesInDFS(AstNode node) {
-    List<AstNode> nodes = [];
+  static Iterable<AstNode> traverseNodesInDFS(AstNode node) {
+    LinkedHashSet<AstNode> nodes = new LinkedHashSet();
     node.childEntities.where((c) => c is AstNode).forEach((c) {
       nodes.add(c);
       nodes.addAll(traverseNodesInDFS(c));

--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -37,7 +37,7 @@ _VisitVariableDeclaration _buildVariableReporter(
         return;
       }
 
-      List<AstNode> containerNodes =
+      Iterable<AstNode> containerNodes =
           DartTypeUtilities.traverseNodesInDFS(container);
 
       List<Iterable<AstNode>> validators = <Iterable<AstNode>>[];

--- a/lib/src/util/tested_expressions.dart
+++ b/lib/src/util/tested_expressions.dart
@@ -1,0 +1,160 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.util.tested_expressions;
+
+import 'dart:collection';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:linter/src/util/boolean_expression_utilities.dart';
+
+typedef void _recurseCallback(Expression expression);
+
+class TestedExpressions {
+  final BinaryExpression testingExpression;
+  final LinkedHashSet<Expression> truths;
+  final LinkedHashSet<Expression> negations;
+  LinkedHashSet<ContradictoryComparisons> _contradictions;
+
+  TestedExpressions(this.testingExpression, this.truths, this.negations);
+
+  LinkedHashSet<ContradictoryComparisons> evaluateInvariant() {
+    if (_contradictions != null) {
+      return _contradictions;
+    }
+
+    _contradictions = _findContradictoryComparisons(
+        new LinkedHashSet.from(
+            [testingExpression.leftOperand, testingExpression.rightOperand]),
+        testingExpression.operator.type);
+
+    if (_contradictions.isEmpty) {
+      HashSet<Expression> set = _extractComparisons(testingExpression)
+        ..addAll(truths)..addAll(negations);
+      // Here and in several places we proceed only for
+      // TokenType.AMPERSAND_AMPERSAND because we then know that all comparisons
+      // must be true.
+      _contradictions.addAll(
+          _findContradictoryComparisons(set, TokenType.AMPERSAND_AMPERSAND));
+    }
+
+    return _contradictions;
+  }
+
+  /// TODO: A truly smart implementation would detect
+  /// (ref.prop && other.otherProp) && (!ref.prop || !other.otherProp)
+  /// assuming properties are pure computations. i.e. dealing with De Morgan's
+  /// laws https://en.wikipedia.org/wiki/De_Morgan%27s_laws
+  LinkedHashSet<ContradictoryComparisons> _findContradictoryComparisons
+      (HashSet<Expression> comparisons,
+      TokenType tokenType) {
+    final Iterable<Expression> binaryExpressions = comparisons
+        .where((e) => e is BinaryExpression).toSet();
+
+    LinkedHashSet<ContradictoryComparisons> contradictions =
+        new LinkedHashSet.identity();
+    binaryExpressions.forEach((Expression ex) {
+      if (contradictions.isNotEmpty) {
+        return;
+      }
+
+      BinaryExpression e = ex as BinaryExpression;
+      final String eLeftOperand = e.leftOperand.toString();
+      final String eRightOperand = e.rightOperand.toString();
+      TokenType eOperatorType = e.operator.type;
+      comparisons
+          .where((c) => c.offset < e.offset && c is BinaryExpression)
+          .forEach((Expression c) {
+        if (contradictions.isNotEmpty) {
+          return;
+        }
+
+        BinaryExpression bc = c;
+        TokenType cOperatorType = negations.contains(c)
+            ? BooleanExpressionUtilities.NEGATIONS[bc.operator.type]
+            : bc.operator.type;
+        final String bcLeftOperand = bc.leftOperand.toString();
+        final String bcRightOperand = bc.rightOperand.toString();
+        final bool sameOperands =
+            eLeftOperand == bcLeftOperand && eRightOperand == bcRightOperand;
+        final bool sameOperandsInverted =
+            eRightOperand == bcLeftOperand && eLeftOperand == bcRightOperand;
+        final bool isNegationOperation =
+            cOperatorType ==
+                BooleanExpressionUtilities.NEGATIONS[eOperatorType] ||
+                BooleanExpressionUtilities.IMPLICATIONS[cOperatorType] ==
+                    BooleanExpressionUtilities.NEGATIONS[eOperatorType];
+        final bool isTrichotomyConjunction =
+            BooleanExpressionUtilities.
+            TRICHOTOMY_OPERATORS.contains(eOperatorType) &&
+                BooleanExpressionUtilities.
+                TRICHOTOMY_OPERATORS.contains(cOperatorType) &&
+                tokenType == TokenType.AMPERSAND_AMPERSAND;
+        if ((isNegationOperation || isTrichotomyConjunction) &&
+            (sameOperands || sameOperandsInverted)) {
+          contradictions.add(new ContradictoryComparisons(c, ex));
+        }
+      });
+    });
+
+    if (contradictions.isEmpty) {
+      binaryExpressions.forEach(_recurseOnChildNodes(contradictions));
+    }
+
+    return contradictions;
+  }
+
+  _recurseCallback _recurseOnChildNodes(
+      LinkedHashSet<ContradictoryComparisons> expressions) =>
+          (Expression e) {
+            BinaryExpression ex = e as BinaryExpression;
+            if (ex.operator.type != TokenType.AMPERSAND_AMPERSAND) {
+              return;
+            }
+
+            LinkedHashSet<ContradictoryComparisons> set =
+            _findContradictoryComparisons(
+                new HashSet.from([ex.leftOperand, ex.rightOperand]),
+                ex.operator.type);
+            expressions.addAll(set);
+          };
+}
+
+class ContradictoryComparisons {
+  final BinaryExpression first;
+  final BinaryExpression second;
+
+  ContradictoryComparisons(this.first, this.second);
+}
+
+HashSet<Expression> _extractComparisons(BinaryExpression node) {
+  final HashSet<Expression> comparisons = new HashSet<Expression>.identity();
+  if (_isComparison(node)) {
+    comparisons.add(node);
+  }
+  if (node.operator.type != TokenType.AMPERSAND_AMPERSAND) {
+    return comparisons;
+  }
+
+  _addNodeComparisons(node.leftOperand, comparisons);
+  _addNodeComparisons(node.rightOperand, comparisons);
+
+  return comparisons;
+}
+
+void _addNodeComparisons(Expression node, HashSet<Expression> comparisons) {
+  if (_isComparison(node)) {
+    comparisons.add(node);
+  } else if (_isBooleanOperation(node)) {
+    comparisons.addAll(_extractComparisons(node));
+  }
+}
+
+bool _isComparison(Expression expression) => expression is BinaryExpression &&
+    BooleanExpressionUtilities.COMPARISONS.contains(expression.operator.type);
+
+bool _isBooleanOperation(Expression expression) =>
+    expression is BinaryExpression &&
+        BooleanExpressionUtilities.BOOLEAN_OPERATIONS.
+        contains(expression.operator.type);

--- a/test/rules/invariant_booleans.dart
+++ b/test/rules/invariant_booleans.dart
@@ -1,0 +1,166 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test/util/solo_test.dart invariant_booleans`
+
+int bar = 1;
+
+int baz = 2;
+
+int foo = 0;
+bool setting = null;
+
+A a = new A();
+B b = new B();
+
+void bad() {
+  if ((foo == bar && someComputation()) || (foo != bar && otherComputation())) {} // OK
+  if (foo > bar || foo == bar) {} // OK
+  if (a.fooNumber > b.barNumber || a.fooNumber == b.barNumber) {} // OK
+  if (foo > bar && someComputation() || foo == bar) {} // OK
+  if (foo > bar || foo == bar && someComputation()) {} // OK
+  if (foo < bar - baz || foo > bar) {} // OK
+  if (setting == true) {} // OK
+  if (setting != true) {} // OK
+  if (a.foo == b.bar || a.foo != b.bar) {} // LINT
+  if (foo == bar || foo != bar) {} // LINT
+  if (foo == bar || bar != foo) {} // LINT
+  if (foo == bar && foo != bar) {} // LINT
+  if (foo == bar && someComputation() && foo != bar) {} // LINT
+  if (foo > bar && someComputation() && foo <= bar) {} // LINT
+  if (foo > bar && someComputation() && foo < bar) {} // LINT
+  if (foo < bar && someComputation() && foo > bar) {} // LINT
+  if (foo < bar && foo > bar) {} // LINT
+  if (true || foo == bar) {} // LINT
+  if (false || foo == bar) {} // LINT
+  if (false && foo == bar) {} // LINT
+  if (true && foo == bar) {} // LINT
+  if (foo > bar && foo == bar) {} // LINT
+  if (foo < bar && foo == bar) {} // LINT
+  if (foo > bar && someComputation() && foo == bar) {} // LINT
+  if (foo > bar && someComputation() || foo == bar && foo != bar) {} // LINT
+  if (foo > bar && foo > bar) {} // LINT
+  if (foo > bar && bar < foo) {} // LINT
+  if (foo == bar && bar == foo) {} // LINT
+}
+void nestedBad1() {
+  if (foo == bar) {
+    if (foo != bar) {} // LINT
+  }
+}
+
+void nestedBad2() {
+  if (foo == bar) {
+    return;
+  }
+
+  if (foo == bar) {} // LINT
+}
+
+void nestedBad7() {
+  if (foo < bar) {
+  } else {
+   if (foo < bar) {} // LINT
+  }
+}
+
+void nestedOK1() {
+  if (foo == bar) {
+    foo = baz;
+    if (foo != bar) {} // OK
+  }
+}
+
+void nestedOk2() {
+  if (foo == bar) {
+    return;
+  }
+
+  foo = baz;
+  if (foo == bar) {} // OK
+}
+
+void nestedOk3() {
+  if (foo < bar) {
+    return;
+  }
+
+  if (foo == bar) {} // OK
+}
+
+void nestedOk4() {
+  if (foo <= bar) {
+    return;
+  }
+
+  if (foo == bar) {} // LINT
+}
+
+void nestedOk5() {
+  if (foo != null) {
+    if (bar != null) {
+      return;
+    }
+  }
+
+  if (bar != null) {} // OK
+}
+
+void nestedOk5_1() {
+  if (foo != null) {
+    if (bar != null) {
+      return;
+    }
+  }
+
+  if (foo != null) {} // OK
+}
+
+void nestedOk6() {
+  if (foo < bar) {
+  } else if (foo > bar) {} // OK
+}
+
+void nestedOk7() {
+  if (foo < bar) {
+  } else {
+   if (foo > bar) {} // OK
+  }
+}
+
+void nestedOk8() {
+  if (foo == bar) {
+    foo = baz;
+    if (foo == bar) {} // OK
+  }
+}
+
+bool otherComputation() {
+  // Ignore return value, assume more complex logic.
+  return false;
+}
+
+bool someComputation() {
+  // Ignore return value, assume more complex logic.
+  return false;
+}
+
+String sixDigits(int n) {
+  if (n >= 100000) return "$n";
+  if (n >= 10000) return "0$n";
+  if (n >= 1000) return "00$n";
+  if (n >= 100) return "000$n";
+  if (n >= 10) return "0000$n";
+  return "00000$n";
+}
+
+class A {
+  bool foo;
+  int fooNumber;
+}
+
+class B {
+  bool bar;
+  int barNumber;
+}

--- a/test/rules/literal_only_boolean_expressions.dart
+++ b/test/rules/literal_only_boolean_expressions.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test/util/solo_test.dart literal_only_boolean_expressions`
+
+bool variable = true;
+
+void bad() {
+  if (!true) {} // LINT
+  if (true) {} // LINT
+  if (true && 1 != 0) {} // LINT
+  if (1 != 0 && true) {} // LINT
+  if (1 < 0 && true) {} // LINT
+  if (true && false) {} // LINT
+  if (1 != 0) {} // LINT
+  if (true && 1 != 0 || 3 < 4) {} // LINT
+  if (1 != 0 || 3 < 4 && true) {} // LINT
+  if (null ?? m()) {} // LINT
+}
+
+bool m() => true;


### PR DESCRIPTION
I would like to think of this as the first pass implementation (or even first draft) since is quite complex to figure out false things and I am not an expert in either parsing, deducting, logic programming or whatsoever. I am open to discuss the feature and approach and I am aware that might be too complex to be included in the linter. Still I think adds a lot of value since it is very common to break this rule as you can see in the metrics here https://nemo.sonarqube.org/

Ran this rule in the following projects dart-lang/sdk, dart-lang/markdown and dart-lang/reflectable and these were the only occurrences reported, there are some debatable false positives that rely on side effects. SDK at commit 8caa5a6dcb9f35a101516460d6b0abf12affeaf5

```
/Users/.../development/dart/sdk/sdk/lib/_internal/js_runtime/lib/js_mirrors.dart 1967:11 [lint] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
/Users/.../development/dart/sdk/sdk/lib/_internal/js_runtime/lib/js_number.dart 249:9 [lint] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
/Users/.../development/dart/sdk/sdk/lib/_internal/js_runtime/lib/js_number.dart 288:9 [lint] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
/Users/.../development/dart/sdk/sdk/lib/core/duration.dart 247:11 [lint] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
/Users/.../development/dart/sdk/sdk/lib/core/uri.dart 2322:15 [lint] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
/Users/.../development/dart/sdk/sdk/lib/html/dartium/html_dartium.dart 3108:9 [lint] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
/Users/.../development/dart/sdk/sdk/lib/io/secure_socket.dart 868:17 [lint] Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
```