### PR TITLE
False positive fix for overriden_field rule.

### DIFF
--- a/test/rules/overriden_field.dart
+++ b/test/rules/overriden_field.dart
@@ -20,10 +20,97 @@ class Bad2 extends Base {
   Object something = 'done'; // LINT
 }
 
+class Bad3 extends Object with Base {
+  @override
+  Object something = 'done'; // LINT
+}
+
 class Ok extends Base {
   Object newField; // OK
 
   final Object newFinal = 'ignore'; // OK
+}
+
+class OK2 implements Base {
+  @override
+  Object something = 'done'; // OK
+
+  @override
+  Object field;
+}
+
+abstract class OK3 implements Base {
+  @override
+  Object something = 'done'; // OK
+}
+
+class GC11 extends Bad1 {
+  @override
+  Object something = 'done'; // LINT
+
+  Object gc33 = 'gc33';
+}
+
+abstract class GC12 implements Bad1 {
+  @override
+  Object something = 'done'; // OK
+}
+
+class GC13 extends Object with Bad1 {
+  @override
+  Object something = 'done'; // OK
+
+  @override
+  Object field = 'lint'; // LINT
+}
+
+abstract class GC21 extends GC11 {
+  @override
+  Object something = 'done'; // LINT
+}
+
+abstract class GC22 implements GC11 {
+  @override
+  Object something = 'done'; // OK
+}
+
+class GC23 extends Object with GC13 {
+  @override
+  Object something = 'done'; // LINT
+
+  @override
+  Object field = 'lint'; // LINT
+}
+
+class GC23_2 extends GC13 {
+  @override
+  var x = 7; // LINT
+}
+
+abstract class GC31 extends GC13 {
+  @override
+  Object something = 'done'; // LINT
+}
+
+abstract class GC32 implements GC13 {
+  @override
+  Object something = 'done'; // OK
+}
+
+class GC33 extends GC21 with GC13 {
+  @override
+  Object something = 'done'; // LINT
+
+  @override
+  Object gc33 = 'yada'; // LINT
+}
+
+class GC33_2 extends GC33 {
+  @override
+  var x = 3; // LINT
+
+  @override
+  Object gc33 = 'yada'; // LINT
 }
 
 class Super1 {}
@@ -48,4 +135,22 @@ class Super3 {
 
 class Sub3 extends Super3 {
   int x; // LINT
+}
+
+class A1 {
+  int f;
+}
+
+class B1 extends A1 {}
+
+abstract class C1 implements A1 {}
+
+class D1 extends B1 implements C1 {
+  @override
+  int f; // LINT
+}
+
+class A extends B {}
+class B extends A {
+  int field;
 }


### PR DESCRIPTION
When overriding a field, don't lint if the overriden field is inherited through an interface (implements keyword).

dart-lang/linter#230