### PR TITLE
Tweak help text

### DIFF
--- a/bin/linter.dart
+++ b/bin/linter.dart
@@ -47,7 +47,7 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
 
   parser
     ..addFlag("help",
-        abbr: "h", negatable: false, help: "Shows usage information.")
+        abbr: "h", negatable: false, help: "Show usage information.")
     ..addFlag("stats",
         abbr: "s", negatable: false, help: "Show lint statistics.")
     ..addFlag('visit-transitive-closure',
@@ -59,12 +59,15 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
         negatable: false)
     ..addOption('config', abbr: 'c', help: 'Use configuration from this file.')
     ..addOption('dart-sdk', help: 'Custom path to a Dart SDK.')
-    ..addOption('lints', help: 'A list of lints to run.', allowMultiple: true)
-    ..addOption('packages',
+    ..addOption('lints',
         help:
-            'Path to the package resolution configuration file, which supplies '
-            'a mapping of package names to paths.  This option cannot be used '
-            'with --package-root.')
+            'A list of lint rules to run. For example: '
+            'avoid_as,annotate_overrides',
+        allowMultiple: true)
+    ..addOption('packages',
+        help: 'Path to the package resolution configuration file, which\n'
+            'supplies a mapping of package names to paths.  This option\n'
+            'cannot be used with --package-root.')
     ..addOption('package-root',
         abbr: 'p', help: 'Custom package root. (Discouraged.)');
 


### PR DESCRIPTION
I didn't know how to specify the `--lints` option, and had to attempt it a few times before it worked. So here's some more help text. Prints as:

```
$ dart bin/linter.dart --help
Lints Dart source files and pubspecs.
Usage: linter <file>
-h, --help                             Show usage information.
-s, --stats                            Show lint statistics.
    --[no-]visit-transitive-closure    Visit the transitive closure of imported/exported libraries.
-q, --[no-]quiet                       Don't show individual lint errors.
    --machine                          Print results in a format suitable for parsing.
-c, --config                           Use configuration from this file.
    --dart-sdk                         Custom path to a Dart SDK.
    --lints                            A list of lints to run. For example: avoid_as,annotate_overrides
    --packages                         Path to the package resolution configuration file, which
                                       supplies a mapping of package names to paths.  This option
                                       cannot be used with --package-root.

-p, --package-root                     Custom package root. (Discouraged.)

For more information, see https://github.com/dart-lang/linter
```