### PR TITLE
Add an unawaited_futures lint (#164)

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -42,6 +42,7 @@ import 'package:linter/src/rules/test_types_in_equals.dart';
 import 'package:linter/src/rules/throw_in_finally.dart';
 import 'package:linter/src/rules/type_annotate_public_apis.dart';
 import 'package:linter/src/rules/type_init_formals.dart';
+import 'package:linter/src/rules/unawaited_futures.dart';
 import 'package:linter/src/rules/unnecessary_brace_in_string_interp.dart';
 import 'package:linter/src/rules/unnecessary_getters_setters.dart';
 import 'package:linter/src/rules/unrelated_type_equality_checks.dart';
@@ -82,6 +83,7 @@ final Registry ruleRegistry = new Registry()
   ..register(new SuperGoesLast())
   ..register(new TypeInitFormals())
   ..register(new TypeAnnotatePublicApis())
+  ..register(new UnawaitedFutures())
   ..register(new UnnecessaryBraceInStringInterp())
   // Disabled pending fix: https://github.com/dart-lang/linter/issues/35
   //..register(new UnnecessaryGetters())

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:linter/src/linter.dart';
+
+const desc =
+    'Await for future expression statements inside async function bodies.';
+
+const details = r'''
+**DO** Await for Future return value of expression statements, or explicitly ignore those cases.
+
+It's easy to forget await in async methods as naming conventions usually don't
+tell us if a method is sync or async (except for some in dart:io).
+
+**GOOD:**
+```dart
+Future doSomething() => ...;
+
+void main() async {
+  await doSomething();
+
+  // ignore: unawaited_futures
+  doSomething(); // Explicitly-ignored fire-and-forget.
+}
+```
+
+**BAD:**
+```dart
+void main() async {
+  doSomething(); // Likely a bug.
+}
+```
+''';
+
+class UnawaitedFutures extends LintRule {
+  UnawaitedFutures()
+      : super(
+            name: 'unawaited_futures',
+            description: desc,
+            details: details,
+            group: Group.style);
+
+  @override
+  AstVisitor getVisitor() => new Visitor(this);
+}
+
+class Visitor extends SimpleAstVisitor {
+  LintRule rule;
+  Visitor(this.rule);
+
+  @override
+  void visitExpressionStatement(ExpressionStatement node) {
+    var expr = node?.expression;
+    if (expr is AssignmentExpression) return;
+
+    var type = expr?.staticType;
+    if (type?.isDartAsyncFuture == true) {
+      // Ignore a couple of special known cases.
+      if (_isFutureDelayedInstanceCreationWithComputation(expr) ||
+          _isMapPutIfAbsentInvocation(expr)) {
+        return;
+      }
+
+      // Not in an async function body: assume fire-and-forget.
+      var enclosingFunctionBody =
+          node.getAncestor((node) => node is FunctionBody) as FunctionBody;
+      if (enclosingFunctionBody?.isAsynchronous != true) return;
+
+      // Future expression statement that isn't awaited in an async function:
+      // while this is legal, it's a very frequent sign of an error.
+      rule.reportLint(node);
+    }
+  }
+
+  /// Detects `new Future.delayed(duration, [computation])` creations with a
+  /// computation.
+  bool _isFutureDelayedInstanceCreationWithComputation(Expression expr) =>
+      expr is InstanceCreationExpression &&
+      expr.staticElement?.enclosingElement?.type?.isDartAsyncFuture == true &&
+      expr.constructorName?.name?.name == 'delayed' &&
+      expr.argumentList.arguments.length == 2;
+
+  /// Detects Map.putIfAbsent invocations.
+  bool _isMapPutIfAbsentInvocation(Expression expr) =>
+      expr is MethodInvocation &&
+      expr.methodName.name == 'putIfAbsent' &&
+      _isMapClass(expr.methodName.staticElement?.enclosingElement);
+
+  bool _isMapClass(Element e) =>
+      e is ClassElement && e.name == 'Map' && e.library?.name == 'dart.core';
+}

--- a/test/rules/unawaited_futures.dart
+++ b/test/rules/unawaited_futures.dart
@@ -1,0 +1,23 @@
+import 'dart:async';
+
+Future fut() => null;
+
+foo1() {
+  fut();
+}
+foo2() async {
+  fut(); //LINT
+
+  // ignore: unawaited_futures
+  fut();
+}
+foo3() async { await fut(); }
+foo4() async { var x = fut(); }
+foo5() async {
+  new Future.delayed(d); //LINT
+  new Future.delayed(d, bar);
+}
+foo6() async {
+  var map = <String, Future>{};
+  map.putIfAbsent('foo', fut());
+}


### PR DESCRIPTION
Triggers on Future non-assignment expression statements inside async
bodies, with small, reasonable exceptions found in real codebases.

Ported from scissors:
https://github.com/google/dart-scissors/blob/7d7b1ab384fbd3b86e1f66181b54884c5967fe19/lib/src/checker/transformer.dart