### PR TITLE
Bugfix: iterable_contains_unrelated_type

### DIFF
--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -134,7 +134,8 @@ List<InterfaceType> _findImplementedInterfaces(InterfaceType type,
 
 DartType _findIterableTypeArgument(InterfaceType type,
     {List<InterfaceType> accumulator: const []}) {
-  if (type == null || type.isObject || accumulator.contains(type)) {
+  if (type == null || type.isObject || type.isDynamic ||
+      accumulator.contains(type)) {
     return null;
   }
 


### PR DESCRIPTION
Dynamic types should return null when finding the iterable type argument. In particular superclass and allSupertypes properties are not defined for those types and NPE will be thrown during analysis.