### PR TITLE
Linter should catch cases of passing a non-T value to List.remove().

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -28,6 +28,7 @@ import 'package:linter/src/rules/empty_statements.dart';
 import 'package:linter/src/rules/hash_and_equals.dart';
 import 'package:linter/src/rules/implementation_imports.dart';
 import 'package:linter/src/rules/iterable_contains_unrelated_type.dart';
+import 'package:linter/src/rules/list_remove_unrelated_type.dart';
 import 'package:linter/src/rules/library_names.dart';
 import 'package:linter/src/rules/library_prefixes.dart';
 import 'package:linter/src/rules/non_constant_identifier_names.dart';
@@ -75,6 +76,7 @@ final Registry ruleRegistry = new Registry()
   ..register(new HashAndEquals())
   ..register(new ImplementationImports())
   ..register(new IterableContainsUnrelatedType())
+  ..register(new ListRemoveUnrelatedType())
   ..register(new LibraryNames())
   ..register(new LibraryPrefixes())
   ..register(new NonConstantIdentifierNames())

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library linter.src.rules.iterable_contains_unrelated_type;
+library linter.src.rules.list_remove_unrelated_type;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
@@ -10,15 +10,15 @@ import 'package:linter/src/linter.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 import 'package:linter/src/util/unrelated_types_visitor.dart';
 
-const _desc = r'Invocation of Iterable<E>.contains with references of unrelated'
+const _desc = r'Invocation of List<E>.remove with references of unrelated'
     r' types.';
 
 const _details = r'''
 
-**DON'T** Invoke `contains` on `Iterable` with an instance of different type than
+**DON'T** Invoke `remove` on `List` with an instance of different type than
 the parameter type since it will invoke `==` on its elements and most likely will
 return `false`. Strictly speaking it could evaluate to true since in Dart it
-is possible for an Iterable to contain elements of type unrelated to its
+is possible for an List to contain elements of type unrelated to its
 parameter type, but this practice also should be avoided.
 
 **BAD:**
@@ -48,9 +48,9 @@ void someFunction8() {
 
 **BAD:**
 ```
-abstract class SomeIterable<E> implements Iterable<E> {}
+abstract class SomeList<E> implements List<E> {}
 
-abstract class MyClass implements SomeIterable<int> {
+abstract class MyClass implements SomeList<int> {
   bool badMethod(String thing) => this.contains(thing); // LINT
 }
 ```
@@ -123,12 +123,12 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 ```
 ''';
 
-class IterableContainsUnrelatedType extends LintRule {
+class ListRemoveUnrelatedType extends LintRule {
   _Visitor _visitor;
 
-  IterableContainsUnrelatedType()
+  ListRemoveUnrelatedType()
       : super(
-      name: 'iterable_contains_unrelated_type',
+      name: 'list_remove_unrelated_type',
       description: _desc,
       details: _details,
       group: Group.errors,
@@ -141,7 +141,7 @@ class IterableContainsUnrelatedType extends LintRule {
 }
 
 class _Visitor extends UnrelatedTypesVisitor {
-  static final _DEFINITION = new InterfaceTypeDefinition('Iterable', 'dart.core');
+  static final _DEFINITION = new InterfaceTypeDefinition('List', 'dart.core');
 
   _Visitor(LintRule rule) : super(rule);
 
@@ -149,5 +149,5 @@ class _Visitor extends UnrelatedTypesVisitor {
   InterfaceTypeDefinition get definition => _DEFINITION;
 
   @override
-  String get methodName => 'contains';
+  String get methodName => 'remove';
 }

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.util.unrelated_types_visitor;
+
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:linter/src/linter.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+
+typedef bool _InterfaceTypePredicate(InterfaceType type);
+
+/// Base class for visitors used in rules where we want to lint about invoking
+/// methods on generic classes where the parameter is unrelated to the parameter
+/// type of the class. Extending this visitor is as simple as knowing the method,
+/// class and library that uniquely define the target, i.e. implement only
+/// [definition] and [methodName].
+abstract class UnrelatedTypesVisitor extends SimpleAstVisitor {
+  final LintRule rule;
+  UnrelatedTypesVisitor(this.rule);
+
+  InterfaceTypeDefinition get definition;
+  String get methodName;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_isParameterizedMethodInvocation(methodName, node)) {
+      return;
+    }
+
+    DartType type = node.target != null
+        ? node.target.bestType
+        : (node.getAncestor((a) => a is ClassDeclaration) as ClassDeclaration)
+            ?.element?.type;
+    Expression argument = node.argumentList.arguments.first;
+    if (type is InterfaceType &&
+        DartTypeUtilities.unrelatedTypes(
+            argument.bestType, _findIterableTypeArgument(definition, type))) {
+      rule.reportLint(node);
+    }
+  }
+}
+
+_InterfaceTypePredicate _buildImplementsDefinitionPredicate(
+    InterfaceTypeDefinition definition) =>
+        (InterfaceType interface) =>
+    interface.name == definition.name &&
+        interface.element.library.name == definition.library;
+
+List<InterfaceType> _findImplementedInterfaces(InterfaceType type,
+    {List<InterfaceType> acc: const []}) =>
+    acc.contains(type)
+        ? acc
+        : type.interfaces.fold(
+        <InterfaceType>[type],
+        (List<InterfaceType> acc, InterfaceType e) => new List.from(acc)
+      ..addAll(_findImplementedInterfaces(e, acc: acc)));
+
+DartType _findIterableTypeArgument(
+    InterfaceTypeDefinition definition, InterfaceType type,
+    {List<InterfaceType> accumulator: const []}) {
+  if (type == null || type.isObject || type.isDynamic || accumulator.contains(type)) {
+    return null;
+  }
+
+  _InterfaceTypePredicate predicate =
+  _buildImplementsDefinitionPredicate(definition);
+  if (predicate(type)) {
+    return type.typeArguments.first;
+  }
+
+  List<InterfaceType> implementedInterfaces = _findImplementedInterfaces(type);
+  InterfaceType interface =
+  implementedInterfaces.firstWhere(predicate, orElse: () => null);
+  if (interface != null && interface.typeArguments.isNotEmpty) {
+    return interface.typeArguments.first;
+  }
+
+  return _findIterableTypeArgument(definition, type.superclass,
+      accumulator: [type]..addAll(accumulator)..addAll(implementedInterfaces));
+}
+
+bool _isParameterizedMethodInvocation(
+    String methodName, MethodInvocation node) =>
+    node.methodName.name == methodName &&
+        node.argumentList.arguments.length == 1;

--- a/test/rules/list_remove_unrelated_type.dart
+++ b/test/rules/list_remove_unrelated_type.dart
@@ -1,0 +1,175 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test/util/solo_test.dart list_remove_unrelated_type`
+
+void someFunction() {
+  var list = <int>[];
+  if (list.remove('1')) print('someFunction'); // LINT
+}
+
+void someFunction1() {
+  var list = <int>[];
+  if (list.remove(1)) print('someFunction1'); // OK
+}
+
+void someFunction3() {
+  List<int> list = <int>[];
+  if (list.remove('1')) print('someFunction3'); // LINT
+}
+
+void someFunction4() {
+  List<int> list = <int>[];
+  if (list.remove(1)) print('someFunction4'); // OK
+}
+
+void someFunction4_1() {
+  List list;
+  if(list.remove(null)) print('someFucntion4_1');
+}
+
+void someFunction5_1() {
+  List<ClassBase> list = <ClassBase>[];
+  Object instance;
+  if (list.remove(instance)) print('someFunction5_1'); // OK
+}
+
+void someFunction5() {
+  List<ClassBase> list = <ClassBase>[];
+  DerivedClass1 instance;
+  if (list.remove(instance)) print('someFunction5'); // OK
+}
+
+void someFunction6() {
+  List<Mixin> list = <Mixin>[];
+  DerivedClass2 instance;
+  if (list.remove(instance)) print('someFunction6'); // OK
+}
+
+void someFunction6_1() {
+  List<DerivedClass2> list = <DerivedClass2>[];
+  Mixin instance;
+  if (list.remove(instance)) print('someFunction6_1'); // OK
+}
+
+void someFunction7() {
+  List<Mixin> list = <Mixin>[];
+  DerivedClass3 instance;
+  if (list.remove(instance)) print('someFunction7'); // OK
+}
+
+void someFunction7_1() {
+  List<DerivedClass3> list = <DerivedClass3>[];
+  Mixin instance;
+  if (list.remove(instance)) print('someFunction7_1'); // OK
+}
+
+void someFunction8() {
+  List<DerivedClass2> list = <DerivedClass2>[];
+  DerivedClass3 instance;
+  if (list.remove(instance)) print('someFunction8'); // OK
+}
+
+void someFunction9() {
+  List<Implementation> list = <Implementation>[];
+  Abstract instance = new Abstract();
+  if (list.remove(instance)) print('someFunction9'); // OK
+}
+
+void someFunction10() {
+  var list = [];
+  if (list.remove(1)) print('someFunction10'); // OK
+}
+
+void someFunction11(unknown) {
+  var what = unknown - 1;
+  List<int> list = <int>[];
+  list.forEach((int i) {
+    if (what == i) print('someFunction11'); // OK
+  });
+}
+
+void someFunction12() {
+  List<DerivedClass4> list = <DerivedClass4>[];
+  DerivedClass5 instance;
+  if (list.remove(instance)) print('someFunction12'); // LINT
+}
+
+void bug_267(list) {
+  if (list.remove('1')) print('someFunction'); // https://github.com/dart-lang/linter/issues/267
+}
+
+abstract class ClassBase {}
+
+class DerivedClass1 extends ClassBase {}
+
+abstract class Mixin {}
+
+class DerivedClass2 extends ClassBase with Mixin {}
+
+class DerivedClass3 extends ClassBase implements Mixin {}
+
+abstract class Abstract {
+  factory Abstract() {
+    return new Implementation();
+  }
+
+  Abstract._internal();
+}
+
+class Implementation extends Abstract {
+  Implementation() : super._internal();
+}
+
+class DerivedClass4 extends DerivedClass2 {}
+
+class DerivedClass5 extends DerivedClass3 {}
+
+bool takesList(List<int> list) => list.remove('a'); // LINT
+
+bool takesList2(List<String> list) => list.remove('a'); // OK
+
+bool takesList3(List list) => list.remove('a'); // OK
+
+abstract class A implements List<int> {}
+abstract class B extends A {}
+bool takesB(B b) => b.remove('a'); // LINT
+
+abstract class A1 implements List<String> {}
+abstract class B1 extends A1 {}
+bool takesB1(B1 b) => b.remove('a'); // OK
+
+abstract class A3 implements List {}
+abstract class B3 extends A3 {}
+bool takesB3(B3 b) => b.remove('a'); // OK
+
+abstract class A2 implements List<String> {}
+abstract class B2 extends A2 {}
+abstract class A2 extends B2 {}
+bool takesB2(B2 b) => b.remove('a'); // OK
+
+abstract class SomeList<E> implements List<E> {}
+
+abstract class MyClass implements SomeList<int> {
+  bool badMethod(String thing) => this.remove(thing); // LINT
+  bool badMethod1(String thing) => remove(thing); // LINT
+}
+
+abstract class MyDerivedClass extends MyClass {
+  bool myConcreteBadMethod(String thing) => this.remove(thing); // LINT
+  bool myConcreteBadMethod1(String thing) => remove(thing); // LINT
+}
+
+abstract class MyMixedClass extends Object with MyClass {
+  // No lint since is not List.
+  bool myConcreteBadMethod(String thing) => this.remove(thing); // OK
+  bool myConcreteBadMethod1(String thing) => remove(thing); // OK
+}
+
+abstract class MyListMixedClass extends Object
+    with MyClass
+    implements List<int> {
+  bool myConcreteBadMethod(String thing) => this.remove(thing); // LINT
+  bool myConcreteBadMethod1(String thing) => remove(thing); // LINT
+}


### PR DESCRIPTION
fixes #271