### PR TITLE
Remove experimental flag from a few rules.

### DIFF
--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -65,8 +65,7 @@ class CancelSubscriptions extends LintRule {
             name: 'cancel_subscriptions',
             description: _desc,
             details: _details,
-            group: Group.errors,
-            maturity: Maturity.experimental) {
+            group: Group.errors) {
     _visitor = new _Visitor(this);
   }
 

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -65,8 +65,7 @@ class CloseSinks extends LintRule {
             name: 'close_sinks',
             description: _desc,
             details: _details,
-            group: Group.errors,
-            maturity: Maturity.experimental) {
+            group: Group.errors) {
     _visitor = new _Visitor(this);
   }
 

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -131,8 +131,7 @@ class IterableContainsUnrelatedType extends LintRule {
       name: 'iterable_contains_unrelated_type',
       description: _desc,
       details: _details,
-      group: Group.errors,
-      maturity: Maturity.experimental) {
+      group: Group.errors) {
     _visitor = new _Visitor(this);
   }
 

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -131,8 +131,7 @@ class ListRemoveUnrelatedType extends LintRule {
       name: 'list_remove_unrelated_type',
       description: _desc,
       details: _details,
-      group: Group.errors,
-      maturity: Maturity.experimental) {
+      group: Group.errors) {
     _visitor = new _Visitor(this);
   }
 

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -60,8 +60,7 @@ class OnlyThrowErrors extends LintRule {
             name: 'only_throw_errors',
             description: _desc,
             details: _details,
-            group: Group.style,
-            maturity: Maturity.experimental) {
+            group: Group.style) {
     _visitor = new _Visitor(this);
   }
 

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -87,8 +87,7 @@ class OverriddenFields extends LintRule {
             name: 'overridden_fields',
             description: desc,
             details: details,
-            group: Group.style,
-            maturity: Maturity.experimental) {
+            group: Group.style) {
     _visitor = new _Visitor(this);
   }
 

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -133,8 +133,7 @@ class UnrelatedTypeEqualityChecks extends LintRule {
             name: 'unrelated_type_equality_checks',
             description: _desc,
             details: _details,
-            group: Group.errors,
-            maturity: Maturity.experimental) {
+            group: Group.errors) {
     _visitor = new _Visitor(this);
   }
 


### PR DESCRIPTION
These have been in use for a while and some tools require not being experimental to loudly report instances.