### PR TITLE
Ignore '$' in identifiers; we use in generated code.

### DIFF
--- a/lib/src/linter.dart
+++ b/lib/src/linter.dart
@@ -28,7 +28,7 @@ typedef Printer(String msg);
 /// Describes a String in valid camel case format.
 class CamelCaseString {
   static final _camelCaseMatcher = new RegExp(r'[A-Z][a-z]*');
-  static final _camelCaseTester = new RegExp(r'^([_$]*)([A-Z]+[a-z0-9]*)+$');
+  static final _camelCaseTester = new RegExp(r'^([_$]*)([A-Z?$]+[a-z0-9]*)+$');
 
   final String value;
   CamelCaseString(this.value) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -17,7 +17,7 @@ import 'package:path/path.dart' as p;
 
 final _identifier = new RegExp(r'^([_a-zA-Z]+([_a-zA-Z0-9])*)$');
 
-final _lowerCamelCase = new RegExp(r'^[_]*[a-z][a-z0-9]*([A-Z][a-z0-9]*)*$');
+final _lowerCamelCase = new RegExp(r'^[_]*[a-z][a-z0-9?$]*([A-Z][a-z0-9?$]*)*$');
 
 final _lowerCaseUnderScore = new RegExp(r'^([a-z]+([_]?[a-z0-9]+)*)+$');
 

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -145,7 +145,9 @@ defineRuleUnitTests() {
           'F',
           'FB',
           'F1',
-          'FooBar1'
+          'FooBar1',
+          'Foo\$Generated',
+          'Foo\$Generated\$Bar'
         ];
         testEach(good, isUpperCamelCase, isTrue);
         var bad = ['fooBar', 'foo', 'f', '_f', 'F_B'];
@@ -166,7 +168,7 @@ defineRuleUnitTests() {
         'JS',
         'JSON',
         '1',
-        '1b'
+        '1b',
       ];
       testEach(bad, isLowerCaseUnderScore, isFalse);
     });
@@ -202,7 +204,9 @@ defineRuleUnitTests() {
         '_',
         'F',
         '__x',
-        '___x'
+        '___x',
+        'foo\$Generated',
+        'foo\$Generated\$Bar'
       ];
       testEach(good, isLowerCamelCase, isTrue);
 

--- a/test/rules/camel_case_types.dart
+++ b/test/rules/camel_case_types.dart
@@ -17,7 +17,7 @@ typedef bool predicate(); //LINT [14:9]
 class fooBar // LINT
 {}
 
-class Foo$Bar //LINT
+class Foo$Bar //OK
 {}
 
 class Foo_Bar //LINT


### PR DESCRIPTION
Closes: https://github.com/dart-lang/linter/issues/287

I am not yet _terribly_ familiar with all of the lints, but I think I modified the two lints (and added simple test cases) that we would run into. Both `camel_case_types, `constant_identifier_names`, and `non_constant_identifier_names` should allow the `$` character in between case changes.

i.e., now valid:
- `camel_case_types`: `Foo$Bar`
- `constant_identifier_names` and `non_constant_identifier_names`: `foo$Bar`