### PR TITLE
Cover more use cases where '$' may be used

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -15,9 +15,10 @@ import 'package:analyzer/src/generated/parser.dart' show Parser;
 import 'package:analyzer/src/string_source.dart' show StringSource;
 import 'package:path/path.dart' as p;
 
-final _identifier = new RegExp(r'^([_a-zA-Z]+([_a-zA-Z0-9])*)$');
+final _identifier = new RegExp(r'^([(_|$)a-zA-Z]+([_a-zA-Z0-9])*)$');
 
-final _lowerCamelCase = new RegExp(r'^[_]*[a-z][a-z0-9?$]*([A-Z][a-z0-9?$]*)*$');
+final _lowerCamelCase =
+    new RegExp(r'^(_)*[?$a-z][a-z0-9?$]*([A-Z][a-z0-9?$]*)*$');
 
 final _lowerCaseUnderScore = new RegExp(r'^([a-z]+([_]?[a-z0-9]+)*)+$');
 

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -123,7 +123,17 @@ defineRuleUnitTests() {
       testEach(bad, isKeyWord, isFalse);
     });
     group('identifiers', () {
-      var good = ['foo', '_if', '_', 'f2', 'fooBar', 'foo_bar'];
+      var good = [
+        'foo',
+        '_if',
+        '_',
+        'f2',
+        'fooBar',
+        'foo_bar',
+        '\$foo',
+        'foo\$Bar',
+        'foo\$'
+      ];
       testEach(good, isValidDartIdentifier, isTrue);
       var bad = ['if', '42', '3', '2f'];
       testEach(bad, isValidDartIdentifier, isFalse);
@@ -144,6 +154,8 @@ defineRuleUnitTests() {
           'FB',
           'F1',
           'FooBar1',
+          '\$Foo',
+          'Bar\$',
           'Foo\$Generated',
           'Foo\$Generated\$Bar'
         ];
@@ -203,6 +215,8 @@ defineRuleUnitTests() {
         'F',
         '__x',
         '___x',
+        '\$foo',
+        'bar\$',
         'foo\$Generated',
         'foo\$Generated\$Bar'
       ];


### PR DESCRIPTION
I missed a couple of use cases with https://github.com/dart-lang/linter/pull/290.

This covers any rule that uses `identifier` or `lowerCamelCase` RegExp checks, including:

- constant_identifier_names
- non_constant_identifier_names

This solves generated code issues in Angular (@ferhatb)