### PR TITLE
New rule for AngularDart2 : Specify template or templateUrl but not both when annotating with @Component.

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/config.dart';
 import 'package:linter/src/linter.dart';
 import 'package:linter/src/rules/always_declare_return_types.dart';
 import 'package:linter/src/rules/always_specify_types.dart';
+import 'package:linter/src/rules/angular_template_metadata.dart';
 import 'package:linter/src/rules/annotate_overrides.dart';
 import 'package:linter/src/rules/avoid_as.dart';
 import 'package:linter/src/rules/avoid_empty_else.dart';
@@ -62,6 +63,7 @@ import 'package:linter/src/rules/valid_regexps.dart';
 final Registry ruleRegistry = new Registry()
   ..register(new AlwaysDeclareReturnTypes())
   ..register(new AlwaysSpecifyTypes())
+  ..register(new AngularTemplateMetadata())
   ..register(new AnnotateOverrides())
   ..register(new AvoidAs())
   ..register(new AvoidEmptyElse())

--- a/lib/src/rules/angular_template_metadata.dart
+++ b/lib/src/rules/angular_template_metadata.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.angular_template_metadata;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:linter/src/linter.dart';
+
+const _desc =
+    r'In `@Component` annotations specify one and only one of `template` and `templateUrl`.';
+
+const _details = r'''
+
+**DO NOT** Annontate an angular component without specifying any of `template` or `templateUrl` also do not specify both.
+
+**BAD:**
+```
+@Component(templateUrl: 'someUrl', template: '<some-node></some-node>') // LINT
+class TemplateAndTemplateUrlComponent { ... }
+```
+
+**BAD:**
+```
+@Component() // LINT
+class Component { ... }
+```
+
+**GOOD:**
+```
+@Component(templateUrl: 'someUrl')
+class TemplateUrlComponent { ... }
+```
+
+**GOOD:**
+```
+@Component(template: '<some-node> ... </some-node>')
+class TemplateComponent { ... }
+```
+''';
+
+class AngularTemplateMetadata extends LintRule {
+  _Visitor _visitor;
+
+  AngularTemplateMetadata()
+      : super(
+            name: 'angular_template_metadata',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitAnnotation(Annotation node) {
+    if (node.element is! ConstructorElement) {
+      return;
+    }
+
+    ConstructorElement constructorElement = node.element;
+    if (node == null ||
+        node.name.name != 'Component' ||
+        node.parent is! ClassDeclaration ||
+        node.atSign == null ||
+        node.element is! ConstructorElement ||
+        !constructorElement.isConst ||
+        !constructorElement.location.components
+            .contains('package:angular2/src/core/metadata.dart') ||
+        node.arguments.arguments.any((a) =>
+                a is NamedExpression && a.name.label.name == 'templateUrl') !=
+            node.arguments.arguments.any((a) =>
+                a is NamedExpression && a.name.label.name == 'template')) {
+      return;
+    }
+
+    rule.reportLint(node);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   source_span: ^1.0.2
   yaml: ^2.1.2
 dev_dependencies:
+  angular2: ^2.0.0-beta.6
   grinder: ^0.8.0
   markdown: ^0.11.0
   matcher: ^0.12.0

--- a/test/_data/angular_template_metadata/src/angular_template_metadata.dart
+++ b/test/_data/angular_template_metadata/src/angular_template_metadata.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:angular2/di.dart';
+
+@Component(templateUrl: 'someUrl')
+class TemplateUrlComponent {}
+
+@Component(template: '<some-node></some-node>')
+class TemplateComponent {}
+
+@Component(templateUrl: 'someUrl', template: '<some-node></some-node>') // LINT
+class TemplateAndTemplateUrlComponent {}
+
+@Component() // LINT
+class NoTemplateComponent {}

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -237,6 +237,36 @@ defineTests() {
         exitCode = 0;
       });
 
+      group('angular_template_metadata', () {
+        IOSink currentOut = outSink;
+        CollectingSink collectingOut = new CollectingSink();
+        setUp(() {
+          exitCode = 0;
+          outSink = collectingOut;
+        });
+        tearDown(() {
+          collectingOut.buffer.clear();
+          outSink = currentOut;
+          exitCode = 0;
+        });
+
+        test('angular_template_metadata', () {
+          dartlint.main([
+            'test/_data/angular_template_metadata',
+            '--packages=.packages',
+            '--rules=angular_template_metadata'
+          ]);
+          expect(exitCode, 1);
+          expect(
+              collectingOut.trim(),
+              stringContainsInOrder([
+                "@Component(templateUrl: 'someUrl', template: '<some-node></some-node>') // LINT",
+                "@Component() // LINT",
+                '1 file analyzed, 2 issues found, in'
+              ]));
+        });
+      });
+
       test('only throw errors', () {
         dartlint.main(
             ['test/_data/only_throw_errors', '--rules=only_throw_errors']);


### PR DESCRIPTION
Sending PR since `git cl upload` stopped working.
@pq @bwilkerson 

previous patches were reviewed at https://codereview.chromium.org/2402943002
