### PR TITLE
prefer_final_fields: Don't report fields that are used in the same library.

### DIFF
--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -90,9 +90,9 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    ClassDeclaration classDeclaration =
-        node.getAncestor((a) => a is ClassDeclaration);
-    if (classDeclaration == null) {
+    CompilationUnit compilationUnit =
+        node.getAncestor((a) => a is CompilationUnit);
+    if (compilationUnit == null) {
       return;
     }
 
@@ -102,7 +102,7 @@ class _Visitor extends SimpleAstVisitor {
       }
 
       final isMutated = DartTypeUtilities
-          .traverseNodesInDFS(classDeclaration)
+          .traverseNodesInDFS(compilationUnit)
           .where((n) =>
               n is SimpleIdentifier && n.bestElement is PropertyAccessorElement)
           .any((n) {

--- a/test/rules/prefer_final_fields.dart
+++ b/test/rules/prefer_final_fields.dart
@@ -46,3 +46,12 @@ class C {
     _f = '';
   }
 }
+
+class D {
+  int _f = 0; // OK
+}
+
+void accessD_f() {
+  D d = new D();
+  d._f  = 42;
+}


### PR DESCRIPTION
fixes https://github.com/dart-lang/linter/issues/325