### PR TITLE
New rule: recursive_getter.

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -46,6 +46,7 @@ import 'package:linter/src/rules/prefer_final_locals.dart';
 import 'package:linter/src/rules/prefer_is_not_empty.dart';
 import 'package:linter/src/rules/pub/package_names.dart';
 import 'package:linter/src/rules/public_member_api_docs.dart';
+import 'package:linter/src/rules/recursive_getter.dart';
 import 'package:linter/src/rules/slash_for_doc_comments.dart';
 import 'package:linter/src/rules/sort_constructors_first.dart';
 import 'package:linter/src/rules/sort_unnamed_constructors_first.dart';
@@ -99,6 +100,7 @@ final Registry ruleRegistry = new Registry()
   ..register(new PreferIsNotEmpty())
   ..register(new PublicMemberApiDocs())
   ..register(new PubPackageNames())
+  ..register(new RecursiveGetter())
   ..register(new SlashForDocComments())
   ..register(new SortConstructorsFirst())
   ..register(new SortUnnamedConstructorsFirst())

--- a/lib/src/rules/recursive_getter.dart
+++ b/lib/src/rules/recursive_getter.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.recursive_getter;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:linter/src/linter.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+
+const _desc = r'Property getter recursivlely returns itself.';
+
+const _details = r'''
+
+**DON'T** Return the property itself in a getter body, this can be due to a typo.
+
+**BAD:**
+```
+  int get field => field; // LINT
+```
+
+**BAD:**
+```
+  int get otherField {
+    return otherField; // LINT
+  }
+```
+
+**GOOD:**
+```
+  int get field => _field;
+```
+
+''';
+
+class RecursiveGetter extends LintRule {
+  _Visitor _visitor;
+
+  RecursiveGetter()
+      : super(
+            name: 'recursive_getter',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    // getters have null arguments, methods have parameters, could be empty.
+    if (node.functionExpression.parameters != null) {
+      return;
+    }
+
+    final element = node.element;
+    _verifyElement(node.functionExpression, element);
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    // getters have null arguments, methods have parameters, could be empty.
+    if (node.parameters != null) {
+      return;
+    }
+
+    final element = node.element;
+    _verifyElement(node.body, element);
+  }
+
+  void _verifyElement(AstNode node, ExecutableElement element) {
+    final nodes = DartTypeUtilities.traverseNodesInDFS(node);
+
+    nodes.where((n) => n is SimpleIdentifier).forEach((n) {
+      if (element == (n as SimpleIdentifier).staticElement) {
+        rule.reportLint(n);
+      }
+    });
+  }
+}

--- a/test/rules/recursive_getter.dart
+++ b/test/rules/recursive_getter.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N recursive_getter`
+
+class C {
+  int _field = 0;
+
+  int get field => field; // LINT
+
+  int get otherField {
+    return otherField; // LINT
+  }
+
+  int get correct => _field;
+
+  int get correctBody {
+    return _field;
+  }
+
+  int someMethod() => someMethod();
+
+  int get value => plusOne(value); // LINT
+}
+
+int _field = 0;
+
+int get field => field; // LINT
+
+int get otherField {
+  return otherField; // LINT
+}
+
+int get correct => _field;
+
+int get correctBody {
+  return _field;
+}
+
+int get value => _field == null ? 0 : value; // LINT
+
+int plusOne(int arg) => 0;


### PR DESCRIPTION
Flag getters recursively returning themselves.

Ran the rule with no problems on SDK and Flutter codebases.

Fixes https://github.com/dart-lang/sdk/issues/27704