### PR TITLE
LeakDetectorVisitor: When analyzing places where a node is referenced, include the whole library.

### DIFF
--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -59,8 +59,7 @@ _VisitVariableDeclaration _buildVariableReporter(
       validators.add(_findMethodInvocationsWithVariableAsArgument(
           containerNodes, variable));
 
-      // Read this as: validators.forAll((i) => i.isEmpty).
-      if (!validators.any((i) => i.isNotEmpty)) {
+      if (validators.every((i) => i.isEmpty)) {
         rule.reportLint(variable);
       }
     };
@@ -147,9 +146,9 @@ abstract class LeakDetectorVisitor extends SimpleAstVisitor {
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
-    ClassDeclaration classDecl = node.getAncestor((a) => a is ClassDeclaration);
+    CompilationUnit unit = node.getAncestor((a) => a is CompilationUnit);
     node.fields.variables.forEach(_buildVariableReporter(
-        classDecl, _fieldPredicateBuilders, rule, predicates));
+        unit, _fieldPredicateBuilders, rule, predicates));
   }
 
   @override

--- a/test/_data/cancel_subscriptions/cancel_subscriptions.dart
+++ b/test/_data/cancel_subscriptions/cancel_subscriptions.dart
@@ -30,3 +30,18 @@ void someFunctionOK() {
   StreamSubscription _subscriptionB; // OK
   _subscriptionB.cancel();
 }
+
+class C {
+  StreamSubscription _subscriptionC; // OK
+  void init(Stream stream) {
+    _subscriptionC = stream.listen((_) {});
+  }
+}
+
+class C_What {
+  C c = new C();
+
+  C_What() {
+    c._subscriptionC.cancel();
+  }
+}

--- a/test/_data/close_sinks/src/a.dart
+++ b/test/_data/close_sinks/src/a.dart
@@ -79,7 +79,7 @@ class D {
 }
 
 void someFunction() {
-  IOSink _sinkF; // LINT
+  IOSink _sinkSomeFunction; // LINT
 }
 
 void someFunctionOK() {

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -189,7 +189,7 @@ defineTests() {
             collectingOut.trim(),
             stringContainsInOrder([
               'IOSink _sinkA; // LINT',
-              'IOSink _sinkF; // LINT',
+              'IOSink _sinkSomeFunction; // LINT',
               '1 file analyzed, 2 issues found, in'
             ]));
       });
@@ -219,7 +219,7 @@ defineTests() {
             stringContainsInOrder([
               'StreamSubscription _subscriptionA; // LINT',
               'StreamSubscription _subscriptionF; // LINT',
-              '1 file analyzed, 2 issues found, in'
+              '1 file analyzed, 3 issues found, in'
             ]));
       });
     });


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/317