### PR TITLE
LeakDetectorVisitor: Include cascade operators when searching for invocations on variable.

### DIFF
--- a/test/_data/close_sinks/src/a.dart
+++ b/test/_data/close_sinks/src/a.dart
@@ -116,6 +116,7 @@ void onListen(Stream<int> stream) {
 }
 
 void someFunctionClosing(StreamController controller) {}
+
 void controllerPassedAsArgument() {
   StreamController controllerArgument = new StreamController();
   someFunctionClosing(controllerArgument);
@@ -125,4 +126,14 @@ void fluentInvocation() {
   StreamController cascadeController = new StreamController()
     ..add(null)
     ..close();
+}
+
+class CascadeSink {
+  StreamController cascadeController = new StreamController(); // OK
+
+  void closeSink() {
+    cascadeController
+      ..add(null)
+      ..close();
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/341

This goes on top of https://github.com/dart-lang/linter/pull/343, so this needs that to be merged before merging, and only consider the last commit when reviewing.