### PR TITLE
cascade_invocations: Include assignment expressions when looking for cascade candidates.

### DIFF
--- a/test/rules/cascade_invocations.dart
+++ b/test/rules/cascade_invocations.dart
@@ -62,3 +62,22 @@ void withDifferentTypes() {
   foo.foo();
   if (foo.bar > 5) {}
 }
+
+class FieldInScope {
+  Foo foo;
+
+  void someMethod() {
+    foo = new Foo();
+    foo.bar; // LINT
+    foo.baz(); // LINT
+  }
+}
+
+class VariableInScope {
+  void someMethod() {
+    Foo foo;
+    foo = new Foo();
+    foo.bar; // LINT
+    foo.baz(); // LINT
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/340