### PR TITLE
No adjacent strings in list. Fixes #225.

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -34,6 +34,7 @@ import 'package:linter/src/rules/library_names.dart';
 import 'package:linter/src/rules/library_prefixes.dart';
 import 'package:linter/src/rules/list_remove_unrelated_type.dart';
 import 'package:linter/src/rules/literal_only_boolean_expressions.dart';
+import 'package:linter/src/rules/no_adjacent_strings_in_list.dart';
 import 'package:linter/src/rules/non_constant_identifier_names.dart';
 import 'package:linter/src/rules/one_member_abstracts.dart';
 import 'package:linter/src/rules/only_throw_errors.dart';
@@ -87,6 +88,7 @@ final Registry ruleRegistry = new Registry()
   ..register(new LibraryPrefixes())
   ..register(new ListRemoveUnrelatedType())
   ..register(new LiteralOnlyBooleanExpressions())
+  ..register(new NoAdjacentStringsInList())
   ..register(new NonConstantIdentifierNames())
   ..register(new OneMemberAbstracts())
   ..register(new OnlyThrowErrors())

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.no_adjacent_strings_in_list;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/linter.dart';
+
+const desc = 'Do not use adjacent strings in list';
+
+const details = r'''
+**DO NOT** use adjacent strings in list. This can be
+sign of forgotten comma.
+
+**GOOD:**
+
+```
+List<String> list = <String>[
+  'a' +
+  'b',
+  'c',
+];
+```
+
+**BAD:**
+
+```
+List<String> list = <String>[
+  'a'
+  'b',
+  'c',
+];
+```
+''';
+
+class NoAdjacentStringsInList extends LintRule {
+  NoAdjacentStringsInList()
+      : super(
+            name: 'no_adjacent_strings_in_list',
+            description: desc,
+            details: details,
+            group: Group.errors);
+
+  @override
+  AstVisitor getVisitor() => new Visitor(this);
+}
+
+class Visitor extends SimpleAstVisitor {
+  LintRule rule;
+
+  Visitor(this.rule);
+
+  @override
+  void visitListLiteral(ListLiteral node) {
+    node.elements.forEach((Expression e) {
+      if (e is AdjacentStrings) {
+        rule.reportLint(e);
+      }
+    });
+  }
+}

--- a/test/rules/no_adjacent_strings_in_list.dart
+++ b/test/rules/no_adjacent_strings_in_list.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N no_adjacent_strings_in_list`
+
+void bad() {
+  List<String> list = <String>[
+    'a' // LINT
+    'b',
+    'c',
+  ];
+
+  List<String> list2 = <String>[
+    'a' // LINT
+    'b'
+    'c'
+  ];
+}
+
+void good() {
+  List<String> list = <String>[
+    'a' + // OK
+    'b',
+    'c',
+  ];
+}


### PR DESCRIPTION
Simple rule, but can be useful in some cases.

There're no such lints in SDK and Flutter.