### PR TITLE
Rule prefer_is_empty.

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -42,6 +42,7 @@ import 'package:linter/src/rules/package_prefixed_library_names.dart';
 import 'package:linter/src/rules/parameter_assignments.dart';
 import 'package:linter/src/rules/prefer_final_fields.dart';
 import 'package:linter/src/rules/prefer_final_locals.dart';
+import 'package:linter/src/rules/prefer_is_empty.dart';
 import 'package:linter/src/rules/prefer_is_not_empty.dart';
 import 'package:linter/src/rules/pub/package_names.dart';
 import 'package:linter/src/rules/public_member_api_docs.dart';
@@ -99,6 +100,7 @@ void registerLintRules() {
     ..register(new ParameterAssignments())
     ..register(new PreferFinalFields())
     ..register(new PreferFinalLocals())
+    ..register(new PreferIsEmpty())
     ..register(new PreferIsNotEmpty())
     ..register(new PublicMemberApiDocs())
     ..register(new PubPackageNames())

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -1,0 +1,226 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.prefer_is_empty;
+
+import 'package:analyzer/context/declared_variables.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/src/dart/constant/evaluation.dart';
+import 'package:analyzer/src/dart/constant/value.dart';
+import 'package:analyzer/src/error/codes.dart';
+import 'package:analyzer/src/generated/engine.dart';
+import 'package:analyzer/src/generated/resolver.dart';
+import 'package:analyzer/src/lint/linter.dart';
+
+const desc = 'Use isNotEmpty for Iterables and Maps.';
+
+const useIsNotEmpty = 'Use isNotEmpty instead of length';
+const useIsEmpty = 'Use isEmpty instead of length';
+const alwaysFalse = 'Always false because length is always greater or equal 0.';
+const alwaysTrue = 'Always true because length is always greater or equal 0.';
+
+const details = '''
+**DO NOT** use `.length` to see if a collection is empty.
+
+The `Iterable` contract does not require that a collection know its length or be
+able to provide it in constant time. Calling `.length` just to see if the
+collection contains anything can be painfully slow.
+
+Instead, there are faster and more readable getters: `.isEmpty` and
+`.isNotEmpty`. Use the one that doesn’t require you to negate the result.
+
+**GOOD:**
+```
+if (lunchBox.isEmpty) return 'so hungry...';
+if (words.isNotEmpty) return words.join(' ');
+```
+
+**BAD:**
+```
+if (lunchBox.length == 0) return 'so hungry...';
+if (words.length != 0) return words.join(' ');
+```
+''';
+
+class _LintCode extends LintCode {
+  static final registry = <String, LintCode>{};
+
+  factory _LintCode(String name, String message) => registry.putIfAbsent(
+      name + message, () => new _LintCode._(name, message));
+
+  _LintCode._(String name, String message) : super(name, message);
+}
+
+class PreferIsEmpty extends LintRule {
+  PreferIsEmpty()
+      : super(
+            name: 'prefer_is_empty',
+            description: desc,
+            details: details,
+            group: Group.style);
+
+  @override
+  AstVisitor getVisitor() => new Visitor(this);
+
+  void reportLintWithDescription(AstNode node, String description) {
+    if (node != null) {
+      reporter.reportErrorForNode(new _LintCode(name, description), node, []);
+    }
+  }
+}
+
+class Visitor extends SimpleAstVisitor {
+  final PreferIsEmpty rule;
+  Visitor(this.rule);
+
+  @override
+  visitSimpleIdentifier(SimpleIdentifier identifier) {
+    // Should be "length".
+    Element propertyElement = identifier.bestElement;
+    if (propertyElement?.name != 'length') {
+      return;
+    }
+
+    AstNode lengthAccess;
+    InterfaceType type;
+
+    AstNode parent = identifier.parent;
+    if (parent is PropertyAccess && identifier == parent.propertyName) {
+      lengthAccess = parent;
+      if (parent.target?.bestType is! InterfaceType) {
+        return;
+      }
+      type = parent.target?.bestType;
+    } else if (parent is PrefixedIdentifier &&
+        identifier == parent.identifier) {
+      lengthAccess = parent;
+      if (parent.prefix.bestType is! InterfaceType) {
+        return;
+      }
+      type = parent.prefix.bestType;
+    } else {
+      return;
+    }
+
+    // Should be subtype of Iterable, Map or String.
+    AnalysisContext context = propertyElement.context;
+    TypeProvider typeProvider = context.typeProvider;
+    TypeSystem typeSystem = context.typeSystem;
+
+    if (typeSystem.mostSpecificTypeArgument(type, typeProvider.iterableType) ==
+            null &&
+        typeSystem.mostSpecificTypeArgument(type, typeProvider.mapType) ==
+            null &&
+        !type.element.type.isSubtypeOf(typeProvider.stringType)) {
+      return;
+    }
+
+    AstNode search = lengthAccess;
+    while (
+        search != null && search is Expression && search is! BinaryExpression) {
+      search = search.parent;
+    }
+
+    if (search is! BinaryExpression) {
+      return;
+    }
+    BinaryExpression binaryExpression = search;
+
+    Token operator = binaryExpression.operator;
+    DeclaredVariables declaredVariables = context.declaredVariables;
+
+    // Comparing constants with length.
+
+    ConstantVisitor visitor = new ConstantVisitor(
+        new ConstantEvaluationEngine(typeProvider, declaredVariables,
+            typeSystem: typeSystem),
+        new ErrorReporter(
+            AnalysisErrorListener.NULL_LISTENER, rule.reporter.source));
+
+    DartObjectImpl rightValue = binaryExpression.rightOperand.accept(visitor);
+
+    if (rightValue?.type?.name == "int") {
+      // Constants is on right side of comparison operator
+      int value = rightValue.toIntValue();
+      if (value == 0) {
+        if (operator.type == TokenType.EQ_EQ ||
+            operator.type == TokenType.LT_EQ) {
+          rule.reportLintWithDescription(binaryExpression, useIsEmpty);
+        } else if (operator.type == TokenType.GT ||
+            operator.type == TokenType.BANG_EQ) {
+          rule.reportLintWithDescription(binaryExpression, useIsNotEmpty);
+        } else if (operator.type == TokenType.LT) {
+          rule.reportLintWithDescription(binaryExpression, alwaysFalse);
+        } else if (operator.type == TokenType.GT_EQ) {
+          rule.reportLintWithDescription(binaryExpression, alwaysTrue);
+        }
+      } else if (value == 1) {
+        // 'length >= 1' is same as 'isNotEmpty',
+        // and 'length < 1' is same as 'isEmpty'
+        if (operator.type == TokenType.GT_EQ) {
+          rule.reportLintWithDescription(binaryExpression, useIsNotEmpty);
+        } else if (operator.type == TokenType.LT) {
+          rule.reportLintWithDescription(binaryExpression, useIsEmpty);
+        }
+      } else if (value < 0) {
+        // 'length' is always >= 0, so comparing with negative makes no sense.
+        if (operator.type == TokenType.EQ_EQ ||
+            operator.type == TokenType.LT_EQ ||
+            operator.type == TokenType.LT) {
+          rule.reportLintWithDescription(binaryExpression, alwaysFalse);
+        } else if (operator.type == TokenType.BANG_EQ ||
+            operator.type == TokenType.GT_EQ ||
+            operator.type == TokenType.GT) {
+          rule.reportLintWithDescription(binaryExpression, alwaysTrue);
+        }
+      }
+      return;
+    }
+
+    DartObjectImpl leftValue = binaryExpression.leftOperand.accept(visitor);
+
+    if (leftValue?.type?.name == "int") {
+      // Constants is on left side of comparison operator
+      int value = leftValue.toIntValue();
+
+      if (value == 0) {
+        if (operator.type == TokenType.EQ_EQ ||
+            operator.type == TokenType.GT_EQ) {
+          rule.reportLintWithDescription(binaryExpression, useIsEmpty);
+        } else if (operator.type == TokenType.LT ||
+            operator.type == TokenType.BANG_EQ) {
+          rule.reportLintWithDescription(binaryExpression, useIsNotEmpty);
+        } else if (operator.type == TokenType.GT) {
+          rule.reportLintWithDescription(binaryExpression, alwaysFalse);
+        } else if (operator.type == TokenType.LT_EQ) {
+          rule.reportLintWithDescription(binaryExpression, alwaysTrue);
+        }
+      } else if (value == 1) {
+        // '1 <= length' is same as 'isNotEmpty',
+        // and '1 > length' is same as 'isEmpty'
+        if (operator.type == TokenType.LT_EQ) {
+          rule.reportLintWithDescription(binaryExpression, useIsNotEmpty);
+        } else if (operator.type == TokenType.GT) {
+          rule.reportLintWithDescription(binaryExpression, useIsEmpty);
+        }
+      } else if (value < 0) {
+        // 'length' is always >= 0, so comparing with negative makes no sense.
+        if (operator.type == TokenType.EQ_EQ ||
+            operator.type == TokenType.GT_EQ ||
+            operator.type == TokenType.GT) {
+          rule.reportLintWithDescription(binaryExpression, alwaysFalse);
+        } else if (operator.type == TokenType.BANG_EQ ||
+            operator.type == TokenType.LT_EQ ||
+            operator.type == TokenType.LT) {
+          rule.reportLintWithDescription(binaryExpression, alwaysTrue);
+        }
+      }
+    }
+  }
+}

--- a/test/mock_sdk.dart
+++ b/test/mock_sdk.dart
@@ -41,7 +41,7 @@ abstract class Comparable<T> {
   int compareTo(T other);
 }
 
-abstract class String implements Comparable<String> {
+abstract class String extends Object implements Comparable<String> {
   external factory String.fromCharCodes(Iterable<int> charCodes,
                                         [int start = 0, int end]);
   bool get isEmpty => false;
@@ -52,7 +52,7 @@ abstract class String implements Comparable<String> {
 }
 
 class bool extends Object {}
-abstract class num implements Comparable<num> {
+abstract class num extends Object implements Comparable<num> {
   bool operator <(num other);
   bool operator <=(num other);
   bool operator >(num other);
@@ -94,6 +94,9 @@ abstract class Iterable<E> {
   Iterator<E> get iterator;
   bool get isEmpty;
   bool get isNotEmpty;
+  E get first;
+  E get last;
+  int get length;
 }
 
 abstract class List<E> implements Iterable<E> {
@@ -110,6 +113,7 @@ abstract class Map<K, V> extends Object {
   Iterable<K> get keys;
   bool get isEmpty;
   bool get isNotEmpty;
+  int get length;
 }
 
 external bool identical(Object a, Object b);
@@ -125,6 +129,7 @@ const Object override = const _Override();
 abstract class RegExp {
   external factory RegExp(String source, {bool multiLine: false,
                                           bool caseSensitive: true});
+}
 ''');
 
   static const _MockSdkLibrary LIB_ASYNC = const _MockSdkLibrary(

--- a/test/rules/prefer_is_empty.dart
+++ b/test/rules/prefer_is_empty.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_is_empty`
+
+const int ZERO = 0;
+Iterable<int> list = [];
+Map map = {};
+
+Iterable get iterable => [];
+
+typedef Iterable F();
+
+F a() {
+  return () => [];
+}
+
+bool le = list.length > 0; //LINT
+bool le2 = [].length > 0; //LINT
+bool le3 = ([].length as int) > 0; //LINT
+bool le4 = 0 < list.length; //LINT
+bool le5 = [].length < ZERO; //LINT
+bool le6 = ZERO < [].length; //LINT
+bool me = (map.length) == 0; //LINT
+bool ie = iterable.length != 0; //LINT
+bool ce = a()().length == 0; //LINT
+bool mixed = list.length + map.length > 0; //OK
+
+Iterable length = [];
+bool ok = length.first > 0; // OK
+
+condition() {
+  final int a = list.length > 0 ? list.first : 0; //LINT
+  list..length;
+}
+
+bool le7 = [].length > 1; //OK
+
+testOperators() {
+  [].length == 0; // LINT
+  [].length != 0; // LINT
+  [].length > 0; // LINT
+  [].length >= 0; // LINT
+  [].length < 0; // LINT
+  [].length <= 0; // LINT
+
+  [].length == -1; // LINT
+  [].length != -1; // LINT
+  [].length > -1; // LINT
+  [].length >= -1; // LINT
+  [].length < -1; // LINT
+  [].length <= -1; // LINT
+
+  [].length == 1; // OK
+  [].length != 1; // OK
+  [].length > 1; // OK
+  [].length >= 1; // LINT
+  [].length < 1; // LINT
+  [].length <= 1; // OK
+
+  0 == [].length; // LINT
+  0 != [].length; // LINT
+  0 < [].length; // LINT
+  0 <= [].length; // LINT
+  0 > [].length; // LINT
+  0 >= [].length; // LINT
+
+  -1 == [].length; // LINT
+  -1 != [].length; // LINT
+  -1 < [].length; // LINT
+  -1 <= [].length; // LINT
+  -1 > [].length; // LINT
+  -1 >= [].length; // LINT
+
+  1 == [].length; // OK
+  1 != [].length; // OK
+  1 < [].length; // OK
+  1 <= [].length; // LINT
+  1 > [].length; // LINT
+  1 >= [].length; // OK
+}


### PR DESCRIPTION
Prefer using `isEmpty` or `isNotEmpty` over comparison of length with 0.

Description from [Effective Dart](https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty).

There are 11 lints in SDK and 1 in Flutter.