### PR TITLE
Add no_duplicate_cases rule (#354)

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -33,6 +33,7 @@ import 'package:linter/src/rules/library_prefixes.dart';
 import 'package:linter/src/rules/list_remove_unrelated_type.dart';
 import 'package:linter/src/rules/literal_only_boolean_expressions.dart';
 import 'package:linter/src/rules/no_adjacent_strings_in_list.dart';
+import 'package:linter/src/rules/no_duplicate_case_values.dart';
 import 'package:linter/src/rules/non_constant_identifier_names.dart';
 import 'package:linter/src/rules/one_member_abstracts.dart';
 import 'package:linter/src/rules/only_throw_errors.dart';
@@ -90,6 +91,7 @@ void registerLintRules() {
     ..register(new ListRemoveUnrelatedType())
     ..register(new LiteralOnlyBooleanExpressions())
     ..register(new NoAdjacentStringsInList())
+    ..register(new NoDuplicateCaseValues())
     ..register(new NonConstantIdentifierNames())
     ..register(new OneMemberAbstracts())
     ..register(new OnlyThrowErrors())

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.no_duplicate_case_values;
+
+import 'dart:collection';
+import 'package:analyzer/context/declared_variables.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/src/dart/constant/evaluation.dart';
+import 'package:analyzer/src/dart/constant/value.dart';
+import 'package:analyzer/src/error/codes.dart';
+import 'package:analyzer/src/generated/engine.dart';
+import 'package:analyzer/src/generated/resolver.dart';
+import 'package:analyzer/src/lint/linter.dart';
+
+const desc = 'Do not use more the one case with same value';
+
+String message(String value1, String value2) =>
+    'Do not use more the one case with same value ($value1 and $value2)';
+
+const details = r'''
+**DO NOT** use more the one case with same value. This can be
+of typo or changed value of constant.
+
+**GOOD:**
+
+```
+const int A = 1;
+switch (v) {
+  case A:
+  case 2:
+}
+```
+
+**BAD:**
+
+```
+const int A = 1;
+switch (v) {
+  case 1:
+  case 2:
+  case A:
+  case 2:
+}
+```
+''';
+
+class NoDuplicateCaseValues extends LintRule {
+  NoDuplicateCaseValues()
+      : super(
+            name: 'no_duplicate_case_values',
+            description: desc,
+            details: details,
+            group: Group.errors);
+
+  @override
+  AstVisitor getVisitor() => new Visitor(this);
+
+  void reportLintWithDescription(AstNode node, String description) {
+    if (node != null) {
+      reporter.reportErrorForNode(new _LintCode(name, description), node, []);
+    }
+  }
+}
+
+class _LintCode extends LintCode {
+  static final registry = <String, LintCode>{};
+
+  factory _LintCode(String name, String message) => registry.putIfAbsent(
+      name + message, () => new _LintCode._(name, message));
+
+  _LintCode._(String name, String message) : super(name, message);
+}
+
+class Visitor extends SimpleAstVisitor {
+  NoDuplicateCaseValues rule;
+
+  Visitor(this.rule);
+
+  @override
+  void visitSwitchStatement(SwitchStatement node) {
+    AnalysisContext context = node?.expression?.bestType?.element?.context;
+    if (context == null) {
+      return;
+    }
+    TypeProvider typeProvider = context.typeProvider;
+    TypeSystem typeSystem = context.typeSystem;
+    DeclaredVariables declaredVariables = context.declaredVariables;
+
+    Map<DartObjectImpl, Expression> values =
+        new HashMap<DartObjectImpl, Expression>(
+            equals: (DartObjectImpl key1, DartObjectImpl key2) {
+      DartObjectImpl equals = key1.isIdentical(typeProvider, key2);
+      return equals.isBool && equals.toBoolValue();
+    });
+
+    final ConstantVisitor constantVisitor = new ConstantVisitor(
+        new ConstantEvaluationEngine(
+            typeProvider, declaredVariables, typeSystem: typeSystem),
+        new ErrorReporter(
+            AnalysisErrorListener.NULL_LISTENER, rule.reporter.source));
+
+    for (SwitchMember member in node.members) {
+      if (member is SwitchCase) {
+        Expression expression = member.expression;
+
+        DartObjectImpl result = expression.accept(constantVisitor);
+
+        if (result == null) {
+          continue;
+        }
+
+        Expression duplicateValue = values[result];
+        if (duplicateValue != null) {
+          rule.reportLintWithDescription(member,
+              message(duplicateValue.toString(), expression.toString()));
+        } else {
+          values[result] = expression;
+        }
+      }
+    }
+  }
+}

--- a/test/rules/no_duplicate_case_values.dart
+++ b/test/rules/no_duplicate_case_values.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N no_adjacent_strings_in_list`
+
+void switchInt() {
+  const int A = 1;
+  int v = 5;
+
+  switch (v) {
+    case 1: // OK
+    case 2: // OK
+    case A: // LINT
+    case 2: // LINT
+    case 3: // OK
+    default:
+  }
+}
+
+void switchString() {
+  const String A = 'a';
+  String v = 'aa';
+
+  switch (v) {
+    case 'aa':  // OK
+    case 'bb':  // OK
+    case A + A: // LINT
+    case 'bb':  // LINT
+    case A + 'b': // OK
+    default:
+  }
+}
+
+enum E {
+  one,
+  two,
+  three
+}
+
+void switchEnum() {
+  E v = E.one;
+
+  switch (v) {
+    case E.one:  // OK
+    case E.two:  // OK
+    case E.three: // OK
+    case E.two:  // LINT
+    default:
+  }
+}
+
+class ConstClass {
+  final int v;
+  const ConstClass(this.v);
+}
+
+void switchConstClass() {
+  ConstClass v = new ConstClass(1);
+
+  switch (v) {
+    case const ConstClass(1): // OK
+    case const ConstClass(2): // OK
+    case const ConstClass(3): // OK
+    case const ConstClass(2): // LINT
+    default:
+  }
+}
+


### PR DESCRIPTION
This rule has found 4 lints (2 x 2 duplicated cases) in SDK and 0 in Flutter.

Here's the thing with SDK:

KeyCode.WIN_KEY_LEFT and KeyCode.META have same value, so _convertKeyCodeToKeyName will return _KeyName.META instead of _KeyName.WIN for first constant as may be expected.

Check html_dart2js.dart lines 41086 and 41100, and html_dartium.dart line 45611 and 45625.
