### PR TITLE
cascade_invocations: Exclude top level function invocations in aliased imported library.

### DIFF
--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -7,6 +7,7 @@ library linter.src.rules.cascade_invocations;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/lint/linter.dart';
 
 const _desc = r'Cascade consecutive method invocations on the same reference.';
@@ -115,7 +116,8 @@ class _Visitor extends SimpleAstVisitor {
     final previousNode = previousNodes.last;
     final SimpleIdentifier previousIdentifier = _findTarget(previousNode);
     if (previousIdentifier != null &&
-        previousIdentifier.staticElement == prefixIdentifier.staticElement) {
+        previousIdentifier.staticElement == prefixIdentifier.staticElement &&
+        previousIdentifier.staticElement is! PrefixElement) {
       rule.reportLint(node);
     }
 

--- a/test/rules/cascade_invocations.dart
+++ b/test/rules/cascade_invocations.dart
@@ -4,6 +4,8 @@
 
 // test w/ `pub run test -N cascade_invocations`
 
+import 'dart:math' as math;
+
 void noCascade() {
   List<int> list = [];
   list.removeWhere((i) => i % 5 == 0); // LINT
@@ -66,4 +68,9 @@ void withDifferentTypes() {
 void cascade() {
   final foo = new Foo();
   foo?.baz();
+}
+
+void prefixLibrary() {
+  math.sin(0);
+  math.cos(0);
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/350