### PR TITLE
cascade_invocations: Exclude static method invocations.

### DIFF
--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -117,7 +117,8 @@ class _Visitor extends SimpleAstVisitor {
     final SimpleIdentifier previousIdentifier = _findTarget(previousNode);
     if (previousIdentifier != null &&
         previousIdentifier.staticElement == prefixIdentifier.staticElement &&
-        previousIdentifier.staticElement is! PrefixElement) {
+        previousIdentifier.staticElement is! PrefixElement &&
+        previousIdentifier.bestElement is! ClassElement) {
       rule.reportLint(node);
     }
 

--- a/test/rules/cascade_invocations.dart
+++ b/test/rules/cascade_invocations.dart
@@ -74,3 +74,14 @@ void prefixLibrary() {
   math.sin(0);
   math.cos(0);
 }
+
+class StaticFoo {
+  static int increment() => 0;
+  static int decrement() => 0;
+}
+
+  void cascadeStatic() {
+    StaticFoo.increment();
+    StaticFoo.decrement();
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/356