### PR TITLE
Rule prefer_contains.

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -42,6 +42,7 @@ import 'package:linter/src/rules/package_api_docs.dart';
 import 'package:linter/src/rules/package_prefixed_library_names.dart';
 import 'package:linter/src/rules/parameter_assignments.dart';
 import 'package:linter/src/rules/prefer_const_constructors.dart';
+import 'package:linter/src/rules/prefer_contains.dart';
 import 'package:linter/src/rules/prefer_final_fields.dart';
 import 'package:linter/src/rules/prefer_final_locals.dart';
 import 'package:linter/src/rules/prefer_is_empty.dart';
@@ -102,6 +103,7 @@ void registerLintRules() {
     ..register(new PackagePrefixedLibraryNames())
     ..register(new ParameterAssignments())
     ..register(new PreferConstConstructors())
+    ..register(new PreferContainsOverIndexOf())
     ..register(new PreferFinalFields())
     ..register(new PreferFinalLocals())
     ..register(new PreferIsEmpty())

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.prefer_contains;
+
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/context/declared_variables.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+
+const alwaysFalse =
+    'Always false because indexOf is always greater or equal -1.';
+const alwaysTrue = 'Always true because indexOf is always greater or equal -1.';
+
+const desc = 'Use contains for Lists and Strings.';
+const details = '''
+**DO NOT** use `.indexOf` to see if a collection contains an element.
+
+The `Iterable` contract does not require that a collection know its length or be
+able to provide it in constant time. Calling `.length` just to see if the
+collection contains anything can be painfully slow.
+
+Instead, there are faster and more readable getters: `.isEmpty` and
+`.isNotEmpty`. Use the one that doesn’t require you to negate the result.
+
+**GOOD:**
+```
+if (lunchBox.isEmpty) return 'so hungry...';
+if (words.isNotEmpty) return words.join(' ');
+```
+
+**BAD:**
+```
+if (lunchBox.length == 0) return 'so hungry...';
+if (words.length != 0) return words.join(' ');
+```
+''';
+
+const useContains = 'Use contains instead of indexOf';
+
+class PreferContainsOverIndexOf extends LintRule {
+  PreferContainsOverIndexOf()
+      : super(
+            name: 'prefer_contains',
+            description: desc,
+            details: details,
+            group: Group.style);
+
+  @override
+  AstVisitor getVisitor() => new _Visitor(this);
+
+  void reportLintWithDescription(AstNode node, String description) {
+    if (node != null) {
+      reporter.reportErrorForNode(new _LintCode(name, description), node, []);
+    }
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final PreferContainsOverIndexOf rule;
+
+  _Visitor(this.rule);
+
+  @override
+  visitSimpleIdentifier(SimpleIdentifier identifier) {
+    // Should be "indexOf".
+    final Element propertyElement = identifier.bestElement;
+    if (propertyElement?.name != 'indexOf') {
+      return;
+    }
+
+    AstNode indexOfAccess;
+    InterfaceType type;
+
+    final AstNode parent = identifier.parent;
+    if (parent is MethodInvocation && identifier == parent.methodName) {
+      indexOfAccess = parent;
+      if (parent.target?.bestType is! InterfaceType) {
+        return;
+      }
+      type = parent.target?.bestType;
+    } else {
+      return;
+    }
+
+    if (!DartTypeUtilities
+        .implementsAnyInterface(type, <InterfaceTypeDefinition>[
+      new InterfaceTypeDefinition('Iterable', 'dart.core'),
+      new InterfaceTypeDefinition('String', 'dart.core'),
+    ])) {
+      return;
+    }
+
+    // Going up in AST structure to find binary comparison operator for this
+    // `indexOf` access. Most of the time it will be a parent, but sometimes
+    // it can be wrapped in parentheses or `as` operator.
+    AstNode search = indexOfAccess;
+    while (
+        search != null && search is Expression && search is! BinaryExpression) {
+      search = search.parent;
+    }
+
+    if (search is! BinaryExpression) {
+      return;
+    }
+
+    final BinaryExpression binaryExpression = search;
+    final Token operator = binaryExpression.operator;
+
+    final AnalysisContext context = propertyElement.context;
+    final TypeProvider typeProvider = context.typeProvider;
+    final TypeSystem typeSystem = context.typeSystem;
+
+    final DeclaredVariables declaredVariables = context.declaredVariables;
+
+    // Comparing constants with result of indexOf.
+
+    final ConstantVisitor visitor = new ConstantVisitor(
+        new ConstantEvaluationEngine(typeProvider, declaredVariables,
+            typeSystem: typeSystem),
+        new ErrorReporter(
+            AnalysisErrorListener.NULL_LISTENER, rule.reporter.source));
+
+    final DartObjectImpl rightValue = binaryExpression.rightOperand.accept(visitor);
+    if (rightValue?.type?.name == "int") {
+      // Constant is on right side of comparison operator
+      _checkConstant(binaryExpression, rightValue.toIntValue(), operator.type);
+      return;
+    }
+
+    final DartObjectImpl leftValue = binaryExpression.leftOperand.accept(visitor);
+    if (leftValue?.type?.name == "int") {
+      // Constants is on left side of comparison operator
+      _checkConstant(binaryExpression, leftValue.toIntValue(),
+          _invertedTokenType(operator.type));
+    }
+  }
+
+  void _checkConstant(Expression expression, int value, TokenType type) {
+    if (value == -1) {
+      if (type == TokenType.EQ_EQ ||
+          type == TokenType.BANG_EQ ||
+          type == TokenType.LT_EQ ||
+          type == TokenType.GT) {
+        rule.reportLintWithDescription(expression, useContains);
+      } else if (type == TokenType.LT) {
+        // indexOf < -1 is always false
+        rule.reportLintWithDescription(expression, alwaysFalse);
+      } else if (type == TokenType.GT_EQ) {
+        // indexOf >= -1 is always true
+        rule.reportLintWithDescription(expression, alwaysTrue);
+      }
+    } else if (value == 0) {
+      // 'indexOf >= 0' is same as 'contains',
+      // and 'indexOf < 0' is same as '!contains'
+      if (type == TokenType.GT_EQ || type == TokenType.LT) {
+        rule.reportLintWithDescription(expression, useContains);
+      }
+    } else if (value < -1) {
+      // 'indexOf' is always >= -1, so comparing with lesser values makes
+      // no sense.
+      if (type == TokenType.EQ_EQ ||
+          type == TokenType.LT_EQ ||
+          type == TokenType.LT) {
+        rule.reportLintWithDescription(expression, alwaysFalse);
+      } else if (type == TokenType.BANG_EQ ||
+          type == TokenType.GT_EQ ||
+          type == TokenType.GT) {
+        rule.reportLintWithDescription(expression, alwaysTrue);
+      }
+    }
+  }
+
+  TokenType _invertedTokenType(TokenType type) {
+    switch (type) {
+      case TokenType.LT_EQ:
+        return TokenType.GT_EQ;
+
+      case TokenType.LT:
+        return TokenType.GT;
+
+      case TokenType.GT:
+        return TokenType.LT;
+
+      case TokenType.GT_EQ:
+        return TokenType.LT_EQ;
+
+      default:
+        return type;
+    }
+  }
+}
+
+// TODO create common MultiMessageLintCode class
+class _LintCode extends LintCode {
+  static final registry = <String, LintCode>{};
+
+  factory _LintCode(String name, String message) => registry.putIfAbsent(
+      name + message, () => new _LintCode._(name, message));
+
+  _LintCode._(String name, String message) : super(name, message);
+}

--- a/test/mock_sdk.dart
+++ b/test/mock_sdk.dart
@@ -49,6 +49,8 @@ abstract class String extends Object implements Comparable<String> {
   bool get isEmpty => false;
   bool get isNotEmpty => false;
   int get length => 0;
+  bool contains(String other, [int startIndex = 0]);
+  int indexOf(String other, [int start]);
   String toUpperCase();
   List<int> get codeUnits;
 }
@@ -94,6 +96,7 @@ class Iterator<E> {
 
 abstract class Iterable<E> {
   Iterator<E> get iterator;
+  bool contains(Object element);
   bool get isEmpty;
   bool get isNotEmpty;
   E get first;
@@ -107,6 +110,7 @@ abstract class List<E> implements Iterable<E> {
   void operator []=(int index, E value);
   Iterator<E> get iterator => null;
   void clear();
+  int indexOf(Object element);
   bool get isEmpty;
   bool get isNotEmpty;
 }

--- a/test/rules/prefer_contains.dart
+++ b/test/rules/prefer_contains.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_contains`
+
+const int MINUS_ONE = -1;
+
+List<int> list = [];
+
+List get getter => [];
+
+typedef List F();
+
+F a() {
+  return () => [];
+}
+
+bool le = list.indexOf(1) > -1; //LINT
+
+bool le2 = [].indexOf(1) > -1; //LINT
+
+bool le3 = ([].indexOf(1) as int) > -1; //LINT
+
+bool le4 = -1 < list.indexOf(1); //LINT
+
+bool le5 = [].indexOf(1) < MINUS_ONE; //LINT
+
+bool le6 = MINUS_ONE < [].indexOf(1); //LINT
+
+bool ge = getter.indexOf(1) != -1; //LINT
+
+bool ce = a()().indexOf(1) == -1; //LINT
+
+bool se = "aaa".indexOf('a') == -1; //LINT
+
+int ser = "aaa".indexOf('a', 2); //OK
+
+bool mixed = list.indexOf(1) + "a".indexOf("ab") > 0; //OK
+
+condition() {
+  final int a = list.indexOf(1) > -1 ? 2 : 3; //LINT
+  list..indexOf(1);
+}
+
+bool le7 = [].indexOf(1) > 1; //OK
+
+testOperators() {
+  [].indexOf(1) == -1; // LINT
+  [].indexOf(1) != -1; // LINT
+  [].indexOf(1) > -1; // LINT
+  [].indexOf(1) >= -1; // LINT
+  [].indexOf(1) < -1; // LINT
+  [].indexOf(1) <= -1; // LINT
+
+  [].indexOf(1) == -2; // LINT
+  [].indexOf(1) != -2; // LINT
+  [].indexOf(1) > -2; // LINT
+  [].indexOf(1) >= -2; // LINT
+  [].indexOf(1) < -2; // LINT
+  [].indexOf(1) <= -2; // LINT
+
+  [].indexOf(1) == 0; // OK
+  [].indexOf(1) != 0; // OK
+  [].indexOf(1) > 0; // OK
+  [].indexOf(1) >= 0; // LINT
+  [].indexOf(1) < 0; // LINT
+  [].indexOf(1) <= 0; // OK
+
+  -1 == [].indexOf(1); // LINT
+  -1 != [].indexOf(1); // LINT
+  -1 < [].indexOf(1); // LINT
+  -1 <= [].indexOf(1); // LINT
+  -1 > [].indexOf(1); // LINT
+  -1 >= [].indexOf(1); // LINT
+
+  -2 == [].indexOf(1); // LINT
+  -2 != [].indexOf(1); // LINT
+  -2 < [].indexOf(1); // LINT
+  -2 <= [].indexOf(1); // LINT
+  -2 > [].indexOf(1); // LINT
+  -2 >= [].indexOf(1); // LINT
+
+  0 == [].indexOf(1); // OK
+  0 != [].indexOf(1); // OK
+  0 < [].indexOf(1); // OK
+  0 <= [].indexOf(1); // LINT
+  0 > [].indexOf(1); // LINT
+  0 >= [].indexOf(1); // OK
+}


### PR DESCRIPTION
Prefer `contains` over `indexOf() != -1` in Lists and Strings.
Closes #364.
Very similar to PR #353.

There's 6 such lints in SDK (2 on lists and 4 on strings) and 0 in Flutter.