### PR TITLE
Add BUILD.gn to linter package

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+import("//build/dart/dart_package.gni")
+
+dart_package("linter") {
+  package_name = "linter"
+
+  source_dir = "lib"
+
+  disable_analysis = true
+
+  deps = [
+    "//dart/pkg/analyzer",
+    "//third_party/dart-pkg/pub/yaml",
+    "//third_party/dart-pkg/pub/plugin",
+    "//third_party/dart-pkg/pub/source_span",
+    "//third_party/dart-pkg/pub/cli_util",
+    "//third_party/dart-pkg/pub/glob",
+    "//third_party/dart-pkg/pub/args",
+  ]
+}


### PR DESCRIPTION
This is necessary for correctly running the dart analyzer cli for fuchsia.