### PR TITLE
Fix example code

### DIFF
--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -49,7 +49,7 @@ void compute(int foo) {
 
 **BAD:**
 ```
-void compute(boolean foo) {
+void compute(bool foo) {
   if (foo) {
     return;
   }


### PR DESCRIPTION
Sample code uses boolean, most probably as a relic of the original C++ rule.