### PR TITLE
Linter 0.1.30-alpha.1.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.29
+version: 0.1.30-alpha.1
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
* alpha to pickup `invariant_booleans` fix.

@bwilkerson @scheglov 