### PR TITLE
Modify linter to make use of analyzer's new "resolution map" interface.

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -34,6 +34,7 @@ import 'package:analyzer/dart/ast/ast.dart'
         TypeParameter,
         VariableDeclaration;
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart'
     show Element, ParameterElement, PropertyAccessorElement;
 import 'package:analyzer/dart/element/visitor.dart';
@@ -104,7 +105,8 @@ bool isProtected(Declaration declaration) =>
     declaration.metadata.any((Annotation a) => a.name.name == 'protected');
 
 /// Returns `true` if the given [ClassMember] is a public method.
-bool isPublicMethod(ClassMember m) => isMethod(m) && m.element.isPublic;
+bool isPublicMethod(ClassMember m) =>
+    isMethod(m) && resolutionMap.elementDeclaredByDeclaration(m).isPublic;
 
 /// Returns `true` if the given method [declaration] is a "simple getter".
 ///
@@ -204,7 +206,7 @@ bool _checkForSimpleSetter(MethodDeclaration setter, Expression expression) {
   var leftHandSide = assignment.leftHandSide;
   var rightHandSide = assignment.rightHandSide;
   if (leftHandSide is SimpleIdentifier && rightHandSide is SimpleIdentifier) {
-    var leftElement = leftHandSide.staticElement;
+    var leftElement = resolutionMap.staticElementForIdentifier(leftHandSide);
     if (leftElement is! PropertyAccessorElement || !leftElement.isSynthetic) {
       return false;
     }

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -5,6 +5,7 @@
 library linter.src.rules.implementation_imports;
 
 import 'package:analyzer/dart/ast/ast.dart' show AstVisitor, ImportDirective;
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/lint/linter.dart';
 
@@ -76,7 +77,9 @@ class Visitor extends SimpleAstVisitor {
   @override
   visitImportDirective(ImportDirective node) {
     Uri importUri = node?.uriSource?.uri;
-    Uri sourceUri = node?.element?.source?.uri;
+    Uri sourceUri = node == null
+        ? null
+        : resolutionMap.elementDeclaredByDirective(node)?.source?.uri;
 
     // Test for 'package:*/src/'.
     if (!isImplementation(importUri)) {

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -5,6 +5,7 @@
 library linter.src.rules.invariant_booleans;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/lint/linter.dart';
@@ -262,7 +263,8 @@ class _Visitor extends SimpleAstVisitor {
 
   _reportBinaryExpressionIfConstantValue(BinaryExpression node) {
     // Right part discards reporting a subexpression already reported.
-    if (node.bestType.name != 'bool' || node.parent is! IfStatement) {
+    if (resolutionMap.bestTypeForExpression(node).name != 'bool' ||
+        node.parent is! IfStatement) {
       return;
     }
 

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -7,6 +7,7 @@ library linter.src.rules.no_duplicate_case_values;
 import 'dart:collection';
 import 'package:analyzer/context/declared_variables.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/src/dart/constant/evaluation.dart';
@@ -82,7 +83,12 @@ class Visitor extends SimpleAstVisitor {
 
   @override
   void visitSwitchStatement(SwitchStatement node) {
-    AnalysisContext context = node?.expression?.bestType?.element?.context;
+    AnalysisContext context = node?.expression == null
+        ? null
+        : resolutionMap
+            .bestTypeForExpression(node.expression)
+            ?.element
+            ?.context;
     if (context == null) {
       return;
     }

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -5,6 +5,7 @@
 library linter.src.rules.package_prefixed_library_names;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/lint/linter.dart';
@@ -86,13 +87,13 @@ class Visitor extends SimpleAstVisitor {
     if (project == null) {
       return;
     }
-    Source source = node.element.source;
+    Source source = resolutionMap.elementDeclaredByDirective(node).source;
     var prefix = createLibraryNamePrefix(
         libraryPath: source.fullName,
         projectRoot: project.root.absolute.path,
         packageName: project.name);
 
-    var libraryName = node.element.name;
+    var libraryName = resolutionMap.elementDeclaredByDirective(node).name;
     if (!matchesOrIsPrefixedBy(libraryName, prefix)) {
       rule.reportLint(node.name);
     }

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -5,6 +5,7 @@
 library linter.src.rules.prefer_final_fields;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/lint/linter.dart';
@@ -97,7 +98,10 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     fields.variables.forEach((VariableDeclaration variable) {
-      if (variable == null || !variable.element.isPrivate) {
+      if (variable == null ||
+          !resolutionMap
+              .elementDeclaredByVariableDeclaration(variable)
+              .isPrivate) {
         return;
       }
 

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -5,6 +5,7 @@
 library linter.src.rules.public_member_api_docs;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/generated/resolver.dart';
@@ -171,7 +172,9 @@ class Visitor extends GeneralizingAstVisitor {
 
   @override
   visitCompilationUnit(CompilationUnit node) {
-    LibraryElement library = node?.element?.library;
+    LibraryElement library = node == null
+        ? null
+        : resolutionMap.elementDeclaredByCompilationUnit(node)?.library;
     manager = library == null ? null : new InheritanceManager(library);
 
     Map<String, FunctionDeclaration> getters = <String, FunctionDeclaration>{};

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -6,6 +6,7 @@
 library linter.src.rules.test_types_in_equals;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/lint/linter.dart';
 
@@ -94,8 +95,13 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     SimpleIdentifier identifier = node.expression;
-    String parameterName =
-        declaration.parameters?.parameterElements?.first?.name;
+    var parameters = declaration.parameters;
+    String parameterName = parameters == null
+        ? null
+        : resolutionMap
+            .parameterElementsForFormalParameterList(parameters)
+            ?.first
+            ?.name;
     if (identifier.name == parameterName) {
       rule.reportLint(node);
     }

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/lint/linter.dart';
 
@@ -56,7 +57,8 @@ class Visitor extends SimpleAstVisitor {
     var expr = node?.expression;
     if (expr is AssignmentExpression) return;
 
-    var type = expr?.staticType;
+    var type =
+        expr == null ? null : resolutionMap.staticTypeForExpression(expr);
     if (type?.isDartAsyncFuture == true) {
       // Ignore a couple of special known cases.
       if (_isFutureDelayedInstanceCreationWithComputation(expr) ||
@@ -79,7 +81,12 @@ class Visitor extends SimpleAstVisitor {
   /// computation.
   bool _isFutureDelayedInstanceCreationWithComputation(Expression expr) =>
       expr is InstanceCreationExpression &&
-      expr.staticElement?.enclosingElement?.type?.isDartAsyncFuture == true &&
+      resolutionMap
+              .staticElementForConstructorReference(expr)
+              ?.enclosingElement
+              ?.type
+              ?.isDartAsyncFuture ==
+          true &&
       expr.constructorName?.name?.name == 'delayed' &&
       expr.argumentList.arguments.length == 2;
 
@@ -90,5 +97,7 @@ class Visitor extends SimpleAstVisitor {
   bool _isMapPutIfAbsentInvocation(Expression expr) =>
       expr is MethodInvocation &&
       expr.methodName.name == 'putIfAbsent' &&
-      _isMapClass(expr.methodName.staticElement?.enclosingElement);
+      _isMapClass(resolutionMap
+          .staticElementForIdentifier(expr.methodName)
+          ?.enclosingElement);
 }

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -5,6 +5,7 @@
 library linter.src.rules.unrelated_type_equality_checks;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/src/lint/linter.dart';
@@ -157,8 +158,10 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
-    bool isDartCoreBoolean = node.bestType.name == _boolClassName &&
-        node.bestType.element?.library?.name == _dartCoreLibraryName;
+    bool isDartCoreBoolean =
+        resolutionMap.bestTypeForExpression(node).name == _boolClassName &&
+            resolutionMap.bestTypeForExpression(node).element?.library?.name ==
+                _dartCoreLibraryName;
     if (!isDartCoreBoolean ||
         (node.operator.type != TokenType.EQ_EQ &&
             node.operator.type != TokenType.BANG_EQ)) {

--- a/lib/src/rules/valid_regexps.dart
+++ b/lib/src/rules/valid_regexps.dart
@@ -5,6 +5,7 @@
 library linter.src.rules.valid_regexps;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/lint/linter.dart';
@@ -47,7 +48,9 @@ class Visitor extends SimpleAstVisitor {
 
   @override
   visitInstanceCreationExpression(InstanceCreationExpression node) {
-    ClassElement element = node.staticElement?.enclosingElement;
+    ClassElement element = resolutionMap
+        .staticElementForConstructorReference(node)
+        ?.enclosingElement;
     if (element?.name == 'RegExp' && element?.library?.name == 'dart.core') {
       NodeList<Expression> args = node.argumentList.arguments;
       if (args.isEmpty) {

--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -5,6 +5,7 @@
 library linter.src.util.leak_detector_visitor;
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -38,8 +39,8 @@ _VisitVariableDeclaration _buildVariableReporter(
         LintRule rule,
         Map<DartTypePredicate, String> predicates) =>
     (VariableDeclaration variable) {
-      if (!predicates.keys
-          .any((DartTypePredicate p) => p(variable.element.type))) {
+      if (!predicates.keys.any((DartTypePredicate p) => p(
+          resolutionMap.elementDeclaredByVariableDeclaration(variable).type))) {
         return;
       }
 
@@ -76,7 +77,10 @@ Iterable<AstNode> _findMethodCallbackNodes(Iterable<AstNode> containerNodes,
       containerNodes.where((n) => n is PrefixedIdentifier);
   return prefixedIdentifiers.where((n) =>
       n.prefix.bestElement == variable.name.bestElement &&
-      _hasMatch(predicates, variable.element.type, n.identifier.token.lexeme));
+      _hasMatch(
+          predicates,
+          resolutionMap.elementDeclaredByVariableDeclaration(variable).type,
+          n.identifier.token.lexeme));
 }
 
 Iterable<AstNode> _findMethodInvocationsWithVariableAsArgument(
@@ -95,7 +99,12 @@ Iterable<AstNode> _findNodesInvokingMethodOnVariable(
         Map<DartTypePredicate, String> predicates) =>
     classNodes.where((AstNode n) =>
         n is MethodInvocation &&
-        ((_hasMatch(predicates, variable.element.type, n.methodName.name) &&
+        ((_hasMatch(
+                    predicates,
+                    resolutionMap
+                        .elementDeclaredByVariableDeclaration(variable)
+                        .type,
+                    n.methodName.name) &&
                 (_isSimpleIdentifierElementEqualToVariable(
                         n.realTarget, variable) ||
                     (n.getAncestor((a) => a == variable) != null))) ||


### PR DESCRIPTION
This will allow analyzer's AST to be decoupled from its element model.