### PR TITLE
Bring all non-API accesses into analyzer facade (#394).

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -22,7 +22,7 @@ linter:
     - empty_constructor_bodies
     - empty_statements
     - hash_and_equals
-    # - implementation_imports
+    - implementation_imports
     - iterable_contains_unrelated_type
     - library_names
     - library_prefixes

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -4,12 +4,25 @@
 
 import 'package:analyzer/src/lint/linter.dart'; // ignore: implementation_imports
 import 'package:analyzer/src/lint/registry.dart'; // ignore: implementation_imports
-import 'package:analyzer/src/lint/util.dart'
-    as util; // ignore: implementation_imports
+import 'package:analyzer/src/lint/util.dart' // ignore: implementation_imports
+    as util;
 
+export 'package:analyzer/src/dart/ast/token.dart';
+export 'package:analyzer/src/dart/constant/evaluation.dart'
+    show ConstantEvaluationEngine, ConstantVisitor;
+export 'package:analyzer/src/dart/constant/value.dart' show DartObjectImpl;
+export 'package:analyzer/src/generated/engine.dart'
+    show AnalysisContext, AnalysisErrorInfo;
+export 'package:analyzer/src/generated/resolver.dart'
+    show InheritanceManager, TypeProvider, TypeSystem;
+export 'package:analyzer/src/generated/source.dart' show LineInfo, Source;
 export 'package:analyzer/src/lint/linter.dart'
     show LintRule, Group, Maturity, LintFilter;
+export 'package:analyzer/src/lint/project.dart'
+    show DartProject, ProjectVisitor;
+export 'package:analyzer/src/lint/pub.dart' show PubspecVisitor, PSEntry;
 export 'package:analyzer/src/lint/util.dart' show Spelunker;
+export 'package:analyzer/src/services/lint.dart' show lintRegistry;
 
 /// Facade for managing access to `analyzer` package APIs.
 class Analyzer {

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -5,40 +5,11 @@
 /// Common AST helpers.
 library linter.src.ast;
 
-import 'package:analyzer/dart/ast/ast.dart'
-    show
-        Annotation,
-        AssignmentExpression,
-        AstNode,
-        Block,
-        BlockFunctionBody,
-        ClassDeclaration,
-        ClassMember,
-        ClassTypeAlias,
-        ConstructorDeclaration,
-        Declaration,
-        EnumConstantDeclaration,
-        EnumDeclaration,
-        Expression,
-        ExpressionFunctionBody,
-        ExpressionStatement,
-        FieldDeclaration,
-        FunctionDeclaration,
-        FunctionTypeAlias,
-        Identifier,
-        MethodDeclaration,
-        NamedCompilationUnitMember,
-        ReturnStatement,
-        SimpleIdentifier,
-        TopLevelVariableDeclaration,
-        TypeParameter,
-        VariableDeclaration;
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
-import 'package:analyzer/dart/element/element.dart'
-    show Element, ParameterElement, PropertyAccessorElement;
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor.dart';
-import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:linter/src/analyzer.dart';
 
 /// Returns direct children of [parent].

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -8,10 +8,8 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/src/generated/engine.dart';
-import 'package:analyzer/src/generated/source.dart';
+
 import 'package:linter/src/analyzer.dart';
-import 'package:analyzer/src/services/lint.dart';
 
 final int _pipeCodeUnit = '|'.codeUnitAt(0);
 final int _slashCodeUnit = '\\'.codeUnitAt(0);

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/generated/resolver.dart';
 import 'package:linter/src/analyzer.dart';
 
 const desc = r'Annotate overridden members';

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -6,7 +6,6 @@ library linter.src.rules.empty_catches;
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:linter/src/analyzer.dart';
 
 const desc = r'Avoid empty catch blocks.';

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -6,7 +6,6 @@ library linter.src.rules.empty_constructor_bodies;
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:linter/src/analyzer.dart';
 
 const desc = 'Use `;` instead of `{}` for empty constructor bodies.';

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -5,16 +5,12 @@
 library linter.src.rules.no_duplicate_case_values;
 
 import 'dart:collection';
+import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/context/declared_variables.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/listener.dart';
-import 'package:analyzer/src/dart/constant/evaluation.dart';
-import 'package:analyzer/src/dart/constant/value.dart';
-import 'package:analyzer/src/error/codes.dart';
-import 'package:analyzer/src/generated/engine.dart';
-import 'package:analyzer/src/generated/resolver.dart';
 import 'package:linter/src/analyzer.dart';
 
 const desc = 'Do not use more the one case with same value';

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -7,7 +7,6 @@ library linter.src.rules.package_api_docs;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
-import 'package:analyzer/src/lint/project.dart';
 import 'package:linter/src/ast.dart';
 
 const desc = r'Provide doc comments for all public APIs';

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -7,9 +7,7 @@ library linter.src.rules.package_prefixed_library_names;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/src/generated/source.dart';
 import 'package:linter/src/analyzer.dart';
-import 'package:analyzer/src/lint/project.dart';
 
 const desc =
     r'Prefix library names with the package name and a dot-separated path.';

--- a/lib/src/rules/pub/package_names.dart
+++ b/lib/src/rules/pub/package_names.dart
@@ -5,7 +5,6 @@
 library linter.src.rules.pub.package_names;
 
 import 'package:linter/src/analyzer.dart';
-import 'package:analyzer/src/lint/pub.dart';
 import 'package:linter/src/ast.dart';
 
 const desc = 'Use `lowercase_with_underscores` for package names.';

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/generated/resolver.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 

--- a/lib/src/rules/unnecessary_brace_in_string_interp.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interp.dart
@@ -7,7 +7,6 @@ library linter.src.rules.unnecessary_brace_in_string_interp;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/src/dart/ast/token.dart';
 import 'package:linter/src/analyzer.dart';
 
 const desc = 'Avoid using braces in interpolation when not needed.';


### PR DESCRIPTION
* roundup all non-API calls
* enable `implementation_imports` lint

Fixes: #394 

@bwilkerson 