### PR TITLE
invariant_booleans: Extend rule to analyze simple identifiers.

### DIFF
--- a/test/rules/invariant_booleans.dart
+++ b/test/rules/invariant_booleans.dart
@@ -226,3 +226,14 @@ void bug373(int foo) {
     // ...
   }
 }
+
+void bug372(bool foo) {
+  if (foo) {
+    return;
+  }
+  // doSomething();
+
+  if (foo) { // LINT
+    // doSomethingElse();
+  }
+}


### PR DESCRIPTION
FIXES #372

N.B. Only the last commit fixes the bug, the other two are the commits in https://github.com/dart-lang/linter/pull/402 and https://github.com/dart-lang/linter/pull/401