### PR TITLE
Cleanup linter warnings.

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -16,7 +16,7 @@ linter:
     - await_only_futures
 #    - camel_case_types
     - cancel_subscriptions
-    - cascade_invocations
+#    - cascade_invocations
 #    - close_sinks # https://github.com/dart-lang/linter/issues/268
     - comment_references
 #    - constant_identifier_names
@@ -42,9 +42,9 @@ linter:
     - package_names
     - package_prefixed_library_names
     - parameter_assignments
-    - prefer_const_constructors
+#    - prefer_const_constructors
     - prefer_final_fields
-    - prefer_final_locals
+#    - prefer_final_locals
 #    - prefer_is_empty # not recognized
     - prefer_is_not_empty
 #    - public_member_api_docs

--- a/bin/linter.dart
+++ b/bin/linter.dart
@@ -145,11 +145,11 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
     lintOptions.enableTiming = true;
   }
 
-  lintOptions.packageConfigPath = packageConfigFile;
+  lintOptions
+    ..packageConfigPath = packageConfigFile
+    ..visitTransitiveClosure = options['visit-transitive-closure'];
 
-  lintOptions.visitTransitiveClosure = options['visit-transitive-closure'];
-
-  var linter = new DartLinter(lintOptions);
+  final linter = new DartLinter(lintOptions);
 
   List<File> filesToLint = [];
   for (var path in options.rest) {
@@ -157,8 +157,7 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
   }
 
   try {
-    Stopwatch timer = new Stopwatch();
-    timer.start();
+    final timer = new Stopwatch()..start();
     List<AnalysisErrorInfo> errors = linter.lintFiles(filesToLint);
     timer.stop();
 
@@ -168,15 +167,13 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
 
     var commonRoot = getRoot(options.rest);
 
-    ReportFormatter reporter = new ReportFormatter(
-        errors, lintOptions.filter, outSink,
+    new ReportFormatter(errors, lintOptions.filter, outSink,
         elapsedMs: timer.elapsedMilliseconds,
         fileCount: linter.numSourcesAnalyzed,
         fileRoot: commonRoot,
         showStatistics: stats,
         machineOutput: options['machine'],
-        quiet: options['quiet']);
-    reporter.write();
+        quiet: options['quiet'])..write();
   } catch (err, stack) {
     errorSink.writeln('''An error occurred while linting
   Please report it at: github.com/dart-lang/linter/issues

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -250,10 +250,11 @@ class SimpleFormatter implements ReportFormatter {
     int pad = tableWidth - longestName;
     String line = ''.padLeft(tableWidth, '-');
 
-    out.writeln();
-    out.writeln(line);
-    out.writeln('${'Timings'.padRight(longestName)}${'ms'.padLeft(pad)}');
-    out.writeln(line);
+    out
+      ..writeln()
+      ..writeln(line)
+      ..writeln('${'Timings'.padRight(longestName)}${'ms'.padLeft(pad)}')
+      ..writeln(line);
     int totalTime = 0;
     for (String name in names) {
       Stopwatch stopwatch = timers[name];
@@ -261,10 +262,11 @@ class SimpleFormatter implements ReportFormatter {
       out.writeln(
           '${name.padRight(longestName)}${stopwatch.elapsedMilliseconds.toString().padLeft(pad)}');
     }
-    out.writeln(line);
-    out.writeln(
-        '${'Total'.padRight(longestName)}${totalTime.toString().padLeft(pad)}');
-    out.writeln(line);
+    out
+      ..writeln(line)
+      ..writeln(
+          '${'Total'.padRight(longestName)}${totalTime.toString().padLeft(pad)}')
+      ..writeln(line);
   }
 
   void _recordStats(AnalysisError error) {

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -300,9 +300,10 @@ class _Visitor extends SimpleAstVisitor {
 
     TestedExpressions testedNodes = _findPreviousTestedExpressions(node);
     testedNodes.evaluateInvariant().forEach((ContradictoryComparisons e) {
-      _ContradictionReportRule reportRule = new _ContradictionReportRule(e);
-      reportRule.reporter = rule.reporter;
-      reportRule.reportLint(e.second);
+      final reportRule = new _ContradictionReportRule(e);
+      reportRule
+        ..reporter = rule.reporter
+        ..reportLint(e.second);
     });
 
     // In dart booleanVariable == true is a valid comparison since the variable

--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -50,8 +50,8 @@ class Visitor extends SimpleAstVisitor {
   @override
   visitClassDeclaration(ClassDeclaration decl) {
     // Sort members by offset.
-    List<ClassMember> members = decl.members.toList();
-    members.sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
+    List<ClassMember> members = decl.members.toList()
+      ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
 
     bool seenMethod = false;
     for (ClassMember member in members) {

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -80,8 +80,8 @@ class Visitor extends SimpleAstVisitor {
     }
 
     // Only select getters with setter pairs
-    var candidates = getters.keys.where((id) => setters.keys.contains(id));
-    candidates.forEach((id) => _visitGetterSetter(getters[id], setters[id]));
+    getters.keys.where((id) => setters.keys.contains(id))
+      ..forEach((id) => _visitGetterSetter(getters[id], setters[id]));
   }
 
   _visitGetterSetter(MethodDeclaration getter, MethodDeclaration setter) {
@@ -89,8 +89,7 @@ class Visitor extends SimpleAstVisitor {
         isSimpleGetter(getter) &&
         !isProtected(getter) &&
         !isProtected(setter)) {
-      rule.reportLint(getter.name);
-      rule.reportLint(setter.name);
+      rule..reportLint(getter.name)..reportLint(setter.name);
     }
   }
 }

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -58,8 +58,9 @@ class DartTypeUtilities {
         .where((c) =>
             c is AstNode && (excludeCriteria == null || !excludeCriteria(c)))
         .forEach((c) {
-      nodes.add(c);
-      nodes.addAll(traverseNodesInDFS(c));
+      nodes
+        ..add(c)
+        ..addAll(traverseNodesInDFS(c));
     });
     return nodes;
   }

--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -52,19 +52,19 @@ _VisitVariableDeclaration _buildVariableReporter(
         validators.add(containerNodes.where(f(variable)));
       });
 
-      validators.add(_findVariableAssignments(containerNodes, variable));
-      validators.add(_findNodesInvokingMethodOnVariable(
-          containerNodes, variable, predicates));
       validators
-          .add(_findMethodCallbackNodes(containerNodes, variable, predicates));
-      // If any function is invoked with our variable, we suppress lints. This
-      // is because it is not so uncommon to invoke the target method there. We
-      // might not have access to the body of such function at analysis time, so
-      // trying to infer if the close method is invoked there is not always
-      // possible.
-      // TODO: Should there be another lint more relaxed that omits this step?
-      validators.add(_findMethodInvocationsWithVariableAsArgument(
-          containerNodes, variable));
+        ..add(_findVariableAssignments(containerNodes, variable))
+        ..add(_findNodesInvokingMethodOnVariable(
+            containerNodes, variable, predicates))
+        ..add(_findMethodCallbackNodes(containerNodes, variable, predicates))
+        // If any function is invoked with our variable, we suppress lints. This
+        // is because it is not so uncommon to invoke the target method there. We
+        // might not have access to the body of such function at analysis time, so
+        // trying to infer if the close method is invoked there is not always
+        // possible.
+        // TODO: Should there be another lint more relaxed that omits this step?
+        ..add(_findMethodInvocationsWithVariableAsArgument(
+            containerNodes, variable));
 
       if (validators.every((i) => i.isEmpty)) {
         rule.reportLint(variable);

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -123,8 +123,7 @@ void defineLinterEngineTests() {
       test('error collecting', () {
         var error = new AnalysisError(new StringSource('foo', ''), 0, 0,
             new LintCode('MockLint', 'This is a test...'));
-        var linter = new SourceLinter(new LinterOptions([]));
-        linter.onError(error);
+        var linter = new SourceLinter(new LinterOptions([]))..onError(error);
         expect(linter.errors.contains(error), isTrue);
       });
       test('pubspec visitor error handling', () {
@@ -135,9 +134,8 @@ void defineLinterEngineTests() {
         when(rule.getPubspecVisitor()).thenReturn(visitor);
 
         var reporter = new MockReporter();
-        var linter =
-            new SourceLinter(new LinterOptions([rule]), reporter: reporter);
-        linter.lintPubspecSource(contents: 'author: foo');
+        new SourceLinter(new LinterOptions([rule]), reporter: reporter)
+          ..lintPubspecSource(contents: 'author: foo');
         verify(reporter.exception(any)).called(1);
       });
     });

--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -53,9 +53,8 @@ defineTests() {
       when(info.errors).thenReturn([error]);
       var out = new CollectingSink();
 
-      var reporter =
-          new SimpleFormatter([info], null, out, fileCount: 1, elapsedMs: 13);
-      reporter.write();
+      var reporter = new SimpleFormatter([info], null, out,
+          fileCount: 1, elapsedMs: 13)..write();
 
       test('count', () {
         expect(reporter.errorCount, 1);
@@ -71,9 +70,8 @@ defineTests() {
 
       test('stats', () {
         out.buffer.clear();
-        var reporter = new SimpleFormatter([info], null, out,
-            fileCount: 1, showStatistics: true, elapsedMs: 13);
-        reporter.write();
+        new SimpleFormatter([info], null, out,
+            fileCount: 1, showStatistics: true, elapsedMs: 13)..write();
         expect(out.buffer.toString(),
             startsWith('''/foo/bar/baz.dart 3:3 [test] MSG
 
@@ -115,8 +113,7 @@ mock_code                               1
 
       group('filtered', () {
         var reporter = new SimpleFormatter([info], new _RejectingFilter(), out,
-            fileCount: 1, elapsedMs: 13);
-        reporter.write();
+            fileCount: 1, elapsedMs: 13)..write();
 
         test('error count', () {
           expect(reporter.errorCount, 0);
@@ -135,9 +132,8 @@ mock_code                               1
       group('machine-ouptut', () {
         test('write', () {
           out.buffer.clear();
-          var reporter = new SimpleFormatter([info], null, out,
-              fileCount: 1, machineOutput: true, elapsedMs: 13);
-          reporter.write();
+          new SimpleFormatter([info], null, out,
+              fileCount: 1, machineOutput: true, elapsedMs: 13)..write();
 
           expect(
               out.buffer.toString().trim(),

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -60,25 +60,25 @@ defineRuleTests() {
 defineRuleUnitTests() {
   group('uris', () {
     group('isPackage', () {
-      var uris = [
+      [
         Uri.parse('package:foo/src/bar.dart'),
         Uri.parse('package:foo/src/baz/bar.dart')
-      ];
-      uris.forEach((uri) {
-        test(uri.toString(), () {
-          expect(isPackage(uri), isTrue);
+      ]
+        ..forEach((uri) {
+          test(uri.toString(), () {
+            expect(isPackage(uri), isTrue);
+          });
         });
-      });
-      var uris2 = [
+      [
         Uri.parse('foo/bar.dart'),
         Uri.parse('src/bar.dart'),
         Uri.parse('dart:async')
-      ];
-      uris2.forEach((uri) {
-        test(uri.toString(), () {
-          expect(isPackage(uri), isFalse);
+      ]
+        ..forEach((uri) {
+          test(uri.toString(), () {
+            expect(isPackage(uri), isFalse);
+          });
         });
-      });
     });
 
     group('samePackage', () {
@@ -97,24 +97,21 @@ defineRuleUnitTests() {
     });
 
     group('implementation', () {
-      var uris = [
+      [
         Uri.parse('package:foo/src/bar.dart'),
         Uri.parse('package:foo/src/baz/bar.dart')
-      ];
-      uris.forEach((uri) {
-        test(uri.toString(), () {
-          expect(isImplementation(uri), isTrue);
+      ]
+        ..forEach((uri) {
+          test(uri.toString(), () {
+            expect(isImplementation(uri), isTrue);
+          });
         });
-      });
-      var uris2 = [
-        Uri.parse('package:foo/bar.dart'),
-        Uri.parse('src/bar.dart')
-      ];
-      uris2.forEach((uri) {
-        test(uri.toString(), () {
-          expect(isImplementation(uri), isFalse);
+      [Uri.parse('package:foo/bar.dart'), Uri.parse('src/bar.dart')]
+        ..forEach((uri) {
+          test(uri.toString(), () {
+            expect(isImplementation(uri), isFalse);
+          });
         });
-      });
     });
   });
 
@@ -443,8 +440,7 @@ testRule(String ruleName, File file, {bool debug: false}) {
         new Spelunker(file.absolute.path).spelunk();
         print('');
         // Lints.
-        var reporter = new ResultReporter(lints);
-        reporter.write();
+        new ResultReporter(lints)..write();
       }
 
       // Rethrow and fail.

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -12,9 +12,8 @@ import 'package:markdown/markdown.dart';
 
 /// Generates lint rule docs for publishing to http://dart-lang.github.io/
 void main([List<String> args]) {
-  var parser = new ArgParser(allowTrailingOptions: true);
-
-  parser.addOption('out', abbr: 'o', help: 'Specifies output directory.');
+  var parser = new ArgParser(allowTrailingOptions: true)
+    ..addOption('out', abbr: 'o', help: 'Specifies output directory.');
 
   var options;
   try {


### PR DESCRIPTION
Disabled `prefer_final_locals` because it has too many occurrences and `cascade_invocations` because it was linting the tests.

Also, my team disabled the rule because the way is implemented is not really useful for us so I might rewrite it to be aligned with usages that look like builder/fluent api.

Some changes are just dartfmt being run.

FIXES https://github.com/dart-lang/linter/issues/407