### PR TITLE
New rule: dart_imports_go_first

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -21,6 +21,7 @@ import 'package:linter/src/rules/close_sinks.dart';
 import 'package:linter/src/rules/comment_references.dart';
 import 'package:linter/src/rules/constant_identifier_names.dart';
 import 'package:linter/src/rules/control_flow_in_finally.dart';
+import 'package:linter/src/rules/directives_ordering.dart';
 import 'package:linter/src/rules/empty_catches.dart';
 import 'package:linter/src/rules/empty_constructor_bodies.dart';
 import 'package:linter/src/rules/empty_statements.dart';
@@ -84,6 +85,7 @@ void registerLintRules() {
     ..register(new CommentReferences())
     ..register(new ControlFlowInFinally())
     ..registerDefault(new ConstantIdentifierNames())
+    ..register(new DirectivesOrdering())
     ..register(new EmptyCatches())
     ..registerDefault(new EmptyConstructorBodies())
     ..register(new EmptyStatements())

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.directives_ordering;
+
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _dartImportGoFirst = r"Place 'dart:' imports before other imports.";
+
+const _desc = r'Adhere to Effective Dart Guide directives sorting conventions.';
+
+const _details = r'''**DO** follow the conventions in the [Effective Dart Guide]
+(https://www.dartlang.org/guides/language/effective-dart/style#ordering)
+
+**BAD:**
+```
+import 'package:bar/bar.dart';
+import 'package:foo/foo.dart';
+
+import 'dart:async';  // LINT
+import 'dart:html';  // LINT
+```
+
+**BAD:**
+```
+import 'dart:html';  // OK
+import 'package:bar/bar.dart';
+
+import 'dart:async';  // LINT
+import 'package:foo/foo.dart';
+```
+
+**GOOD:**
+```
+import 'dart:async';  // OK
+import 'dart:html';  // OK
+
+import 'package:bar/bar.dart';
+import 'package:foo/foo.dart';
+```
+
+''';
+
+bool _isDartImport(Directive node) =>
+    (node as ImportDirective).uriContent.startsWith("dart:");
+
+bool _isImportDirective(Directive node) => node is ImportDirective;
+
+class DirectivesOrdering extends LintRule {
+  _Visitor _visitor;
+
+  DirectivesOrdering()
+      : super(
+            name: 'directives_ordering',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+
+  void _reportLintWithDartImportGoFirstMessage(AstNode node) {
+    _reportLintWithDescription(node, _dartImportGoFirst);
+  }
+
+  void _reportLintWithDescription(AstNode node, String description) {
+    if (node == null) {
+      return;
+    }
+    reporter.reportErrorForNode(new LintCode(name, description), node, []);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final DirectivesOrdering rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    node.directives
+        .where(_isImportDirective)
+        .skipWhile(_isDartImport)
+        .where(_isDartImport)
+        .forEach(rule._reportLintWithDartImportGoFirstMessage);
+  }
+}

--- a/test/_data/directives_ordering/dart_imports_go_first/bad.dart
+++ b/test/_data/directives_ordering/dart_imports_go_first/bad.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math';  // OK
+import 'dummy.dart';
+import 'dart:async';  // LINT
+import 'dart:html';  // LINT

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -224,6 +224,40 @@ defineTests() {
       });
     });
 
+    group('directives_ordering', () {
+      IOSink currentOut = outSink;
+      CollectingSink collectingOut = new CollectingSink();
+      setUp(() {
+        exitCode = 0;
+        outSink = collectingOut;
+      });
+      tearDown(() {
+        collectingOut.buffer.clear();
+        outSink = currentOut;
+        exitCode = 0;
+      });
+
+      test('dart_imports_go_first', () {
+        var packagesFilePath = new File('.packages').absolute.path;
+        dartlint.main([
+          '--packages',
+          packagesFilePath,
+          'test/_data/directives_ordering/dart_imports_go_first',
+          '--rules=directives_ordering'
+        ]);
+        expect(exitCode, 1);
+        expect(
+            collectingOut.trim(),
+            stringContainsInOrder([
+              "Place 'dart:' imports before other imports.",
+              "import 'dart:async';  // LINT",
+              "Place 'dart:' imports before other imports.",
+              "import 'dart:html';  // LINT",
+              '2 files analyzed, 2 issues found, in'
+            ]));
+      });
+    });
+
     group('only_throw_errors', () {
       IOSink currentOut = outSink;
       CollectingSink collectingOut = new CollectingSink();


### PR DESCRIPTION
Verify that all package:dart imports go first. From https://www.dartlang.org/guides/language/effective-dart/style#do-place-dart-imports-before-other-imports