### PR TITLE
New rule: package_imports_before_relative

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -39,6 +39,7 @@ import 'package:linter/src/rules/one_member_abstracts.dart';
 import 'package:linter/src/rules/only_throw_errors.dart';
 import 'package:linter/src/rules/overridden_fields.dart';
 import 'package:linter/src/rules/package_api_docs.dart';
+import 'package:linter/src/rules/package_imports_before_relative.dart';
 import 'package:linter/src/rules/package_prefixed_library_names.dart';
 import 'package:linter/src/rules/parameter_assignments.dart';
 import 'package:linter/src/rules/prefer_const_constructors.dart';
@@ -102,6 +103,7 @@ void registerLintRules() {
     ..register(new OnlyThrowErrors())
     ..register(new OverriddenFields())
     ..register(new PackageApiDocs())
+    ..register(new PackageImportsBeforeRelative())
     ..register(new PackagePrefixedLibraryNames())
     ..register(new ParameterAssignments())
     ..register(new PreferConstConstructors())

--- a/lib/src/rules/package_imports_before_relative.dart
+++ b/lib/src/rules/package_imports_before_relative.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.package_imports_before_relative;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r"Place '*package:*' imports before relative imports.";
+const _details = r'''**DO** place “*package:*” imports before relative imports.
+
+**BAD:**
+```
+import 'a.dart';
+import 'b.dart';
+
+import 'package:bar/bar.dart';  // LINT
+import 'package:foo/foo.dart';  // LINT
+```
+**BAD:**
+```
+import 'package:bar/bar.dart';  // OK
+import 'a.dart';
+
+import 'package:foo/foo.dart';  // LINT
+import 'b.dart';
+```
+
+**GOOD:**
+```
+import 'package:bar/bar.dart';  // OK
+import 'package:foo/foo.dart';  // OK
+
+import 'a.dart';
+import 'b.dart';
+```
+
+''';
+
+bool _isImportDirective(Directive node) => node is ImportDirective;
+
+bool _isNotDartImport(Directive node) =>
+    !(node as ImportDirective).uriContent.startsWith("dart:");
+
+bool _isPackageImport(Directive node) =>
+    (node as ImportDirective).uriContent.startsWith("package:");
+
+class PackageImportsBeforeRelative extends LintRule {
+  _Visitor _visitor;
+
+  PackageImportsBeforeRelative()
+      : super(
+            name: 'package_imports_before_relative',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    node.directives
+        .where(_isImportDirective)
+        .where(_isNotDartImport)
+        .skipWhile(_isPackageImport)
+        .where(_isPackageImport)
+        .forEach(rule.reportLint);
+  }
+}

--- a/test/_data/package_imports_before_relative/bad.dart
+++ b/test/_data/package_imports_before_relative/bad.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math';
+import 'package:ansicolor/ansicolor.dart';  // OK
+import 'dummy.dart';
+import 'package:async/async.dart';  // LINT
+import 'package:yaml/yaml.dart';  // LINT

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -224,6 +224,38 @@ defineTests() {
       });
     });
 
+    group('package_imports_before_relative', () {
+      IOSink currentOut = outSink;
+      CollectingSink collectingOut = new CollectingSink();
+      setUp(() {
+        exitCode = 0;
+        outSink = collectingOut;
+      });
+      tearDown(() {
+        collectingOut.buffer.clear();
+        outSink = currentOut;
+        exitCode = 0;
+      });
+
+      test('package_imports_before_relative', () {
+        var packagesFilePath = new File('.packages').absolute.path;
+        dartlint.main([
+          '--packages',
+          packagesFilePath,
+          'test/_data/package_imports_before_relative',
+          '--rules=package_imports_before_relative'
+        ]);
+        expect(exitCode, 1);
+        expect(
+            collectingOut.trim(),
+            stringContainsInOrder([
+              "import 'package:async/async.dart';  // LINT",
+              "import 'package:yaml/yaml.dart';  // LINT",
+              '2 files analyzed, 2 issues found, in'
+            ]));
+      });
+    });
+
     group('only_throw_errors', () {
       IOSink currentOut = outSink;
       CollectingSink collectingOut = new CollectingSink();


### PR DESCRIPTION
Verify that all "package:" imports go before relative. From https://www.dartlang.org/guides/language/effective-dart/style#do-place-package-imports-before-relative-imports

Fixes: https://github.com/dart-lang/linter/issues/423