### PR TITLE
Expect unawaited futures in test.expect (attempt to fix #419)

### DIFF
--- a/test/rules/unawaited_futures.dart
+++ b/test/rules/unawaited_futures.dart
@@ -21,3 +21,14 @@ foo6() async {
   var map = <String, Future>{};
   map.putIfAbsent('foo', fut());
 }
+foo7() async {
+  expect(fut(), throws);
+}
+
+// Note: we cheat a bit here: this function's library source URI will actually
+// be 'package:test/rules/unawaited_futures.dart', so the rule is happy that
+// it starts with 'package:test/' (which "sounds" like the actual function we
+// are targetting). It seems non-trivial to have the linter resolve the actual
+// package:test here, so living with this workaround for now.
+Future expect(dynamic a, dynamic b) async {}
+final throws = null;


### PR DESCRIPTION
Note: I couldn't find an easy way to test the package origin from the tests themselves, suggestions welcome! Also, not sure if that will work with summaries (do we still have sourcefiles then?), etc... Pointers as to how to test would be welcome!