### PR TITLE
Third party package imports before own

### DIFF
--- a/test/_data/directives_ordering/lint_one_node_no_more_than_once/bad.dart
+++ b/test/_data/directives_ordering/lint_one_node_no_more_than_once/bad.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+
+import 'package:linter/src/formatter.dart'; // OK
+import 'dummy.dart';
+import 'package:async/async.dart';  // LINT

--- a/test/_data/directives_ordering/third_party_package_imports_before_own/bad.dart
+++ b/test/_data/directives_ordering/third_party_package_imports_before_own/bad.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:ansicolor/ansicolor.dart';  // OK
+
+import 'package:linter/src/formatter.dart'; // OK
+
+import 'package:async/async.dart';  // LINT
+import 'package:yaml/yaml.dart';  // LINT
+
+import 'package:linter/src/analyzer.dart'; // OK

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -276,6 +276,44 @@ defineTests() {
               '3 files analyzed, 2 issues found, in'
             ]));
       });
+
+      test('third_party_package_imports_before_own', () {
+        var packagesFilePath = new File('.packages').absolute.path;
+        dartlint.main([
+          '--packages',
+          packagesFilePath,
+          'test/_data/directives_ordering/third_party_package_imports_before_own',
+          '--rules=directives_ordering'
+        ]);
+        expect(exitCode, 1);
+        expect(
+            collectingOut.trim(),
+            stringContainsInOrder([
+              "Place 'third-party' 'package:' imports before other imports.",
+              "import 'package:async/async.dart';  // LINT",
+              "Place 'third-party' 'package:' imports before other imports.",
+              "import 'package:yaml/yaml.dart';  // LINT",
+              '1 file analyzed, 2 issues found, in'
+            ]));
+      });
+
+      test('lint_one_node_no_more_than_once', () {
+        var packagesFilePath = new File('.packages').absolute.path;
+        dartlint.main([
+          '--packages',
+          packagesFilePath,
+          'test/_data/directives_ordering/lint_one_node_no_more_than_once',
+          '--rules=directives_ordering'
+        ]);
+        expect(exitCode, 1);
+        expect(
+            collectingOut.trim(),
+            stringContainsInOrder([
+              "Place 'package:' imports before relative imports.",
+              "import 'package:async/async.dart';  // LINT",
+              '2 files analyzed, 1 issue found, in'
+            ]));
+      });
     });
 
     group('only_throw_errors', () {


### PR DESCRIPTION
Extend rule: directives_ordering

In this third commit we verify that all third-party package: imports go before own. From https://www.dartlang.org/guides/language/effective-dart/style#prefer-placing-third-party-package-imports-before-other-imports

Also take care of linting each node at most once.