### PR TITLE
Modify rule: prefer_final_fields to not lint if field never initializes.

### DIFF
--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -105,6 +105,10 @@ class _Visitor extends SimpleAstVisitor {
         return;
       }
 
+      if (variable.initializer == null){
+        return;
+      }
+
       final isMutated = DartTypeUtilities
           .traverseNodesInDFS(compilationUnit)
           .where((n) =>

--- a/test/rules/prefer_final_fields.dart
+++ b/test/rules/prefer_final_fields.dart
@@ -28,7 +28,7 @@ class GoodMutable {
 
 class MultipleMutable {
   var _label = 'hola mundo! GoodMutable', _offender = 'mumble mumble!'; // LINT
-  var _someOther; // LINT
+  var _never_initialized_field; // OK
 
   MultipleMutable() : _someOther = 5;
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/441