### PR TITLE
New rule: adjacent_strings_to_concatenate_literals

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -66,6 +66,7 @@ import 'package:linter/src/rules/unnecessary_null_aware_assignments.dart';
 import 'package:linter/src/rules/unnecessary_null_in_if_null_operators.dart';
 import 'package:linter/src/rules/unrelated_type_equality_checks.dart';
 import 'package:linter/src/rules/valid_regexps.dart';
+import 'package:linter/src/rules/use_adjacent_strings_to_concatenate_literals.dart';
 
 void registerLintRules() {
   Analyzer.facade
@@ -131,5 +132,6 @@ void registerLintRules() {
     //..register(new UnnecessaryGetters())
     ..register(new UnnecessaryGettersSetters())
     ..register(new UnrelatedTypeEqualityChecks())
-    ..register(new ValidRegExps());
+    ..register(new ValidRegExps())
+    ..register(new UseAdjacentStringsToConcatenateLiterals());
 }

--- a/lib/src/rules/use_adjacent_strings_to_concatenate_literals.dart
+++ b/lib/src/rules/use_adjacent_strings_to_concatenate_literals.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.adjacent_strings_to_concatenate_literals;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = 'Use adjacent strings to concatenate string literals.';
+
+const _details = r'''
+
+**DO** use adjacent strings to concatenate string literals.
+
+**BAD:**
+```
+raiseAlarm(
+    'ERROR: Parts of the spaceship are on fire. Other ' +
+    'parts are overrun by martians. Unclear which are which.');
+```
+
+**GOOD:**
+```
+raiseAlarm(
+    'ERROR: Parts of the spaceship are on fire. Other '
+    'parts are overrun by martians. Unclear which are which.');
+```
+
+''';
+
+class UseAdjacentStringsToConcatenateLiterals extends LintRule {
+  _Visitor _visitor;
+  UseAdjacentStringsToConcatenateLiterals()
+      : super(
+            name: 'use_adjacent_strings_to_concatenate_literals',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  visitBinaryExpression(BinaryExpression node) {
+    if (node.operator.type.lexeme == '+' &&
+        node.leftOperand is StringLiteral &&
+        node.rightOperand is StringLiteral) {
+      rule.reportLintForToken(node.operator);
+    }
+  }
+}

--- a/test/rules/use_adjacent_strings_to_concatenate_literals.dart
+++ b/test/rules/use_adjacent_strings_to_concatenate_literals.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N adjacent_strings_to_concatenate_literals`
+
+main() {
+  String string1 = 'hola means' + // LINT
+      ' hello in spanish';
+
+  String string2 = 'hola means' // OK
+      ' hello in spanish';
+
+  List<String> list = ['this is' + // LINT
+      ' not allowed'
+  ];
+
+  String prefix = 'this is';
+
+  String string3 = prefix + ' perfectly fine'; // OK
+
+  String string4 = prefix + 'really' + string3; // OK
+
+  String string5 = 'but this' + ' not'; // LINT
+
+}


### PR DESCRIPTION
In this commit we implement this rule from: https://www.dartlang.org/guides/language/effective-dart/usage#do-use-adjacent-strings-to-concatenate-string-literals