### PR TITLE
New Rule: Prefer interpolation to compose strings

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -47,6 +47,7 @@ import 'package:linter/src/rules/prefer_const_constructors.dart';
 import 'package:linter/src/rules/prefer_contains.dart';
 import 'package:linter/src/rules/prefer_final_fields.dart';
 import 'package:linter/src/rules/prefer_final_locals.dart';
+import 'package:linter/src/rules/prefer_interpolation_to_compose_strings.dart';
 import 'package:linter/src/rules/prefer_is_empty.dart';
 import 'package:linter/src/rules/prefer_is_not_empty.dart';
 import 'package:linter/src/rules/pub/package_names.dart';
@@ -112,6 +113,7 @@ void registerLintRules() {
     ..register(new PreferContainsOverIndexOf())
     ..register(new PreferFinalFields())
     ..register(new PreferFinalLocals())
+    ..register(new PreferInterpolationToComposeStrings())
     ..register(new PreferIsEmpty())
     ..register(new PreferIsNotEmpty())
     ..register(new PublicMemberApiDocs())

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -5,6 +5,7 @@
 library linter.src.rules;
 
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/rules/adjacent_strings_to_concatenate_literals.dart';
 import 'package:linter/src/rules/always_declare_return_types.dart';
 import 'package:linter/src/rules/always_specify_types.dart';
 import 'package:linter/src/rules/annotate_overrides.dart';
@@ -69,6 +70,7 @@ import 'package:linter/src/rules/valid_regexps.dart';
 
 void registerLintRules() {
   Analyzer.facade
+    ..register(new AdjacentStringsToConcatenateLiterals())
     ..register(new AlwaysDeclareReturnTypes())
     ..register(new AlwaysSpecifyTypes())
     ..register(new AnnotateOverrides())

--- a/lib/src/rules/adjacent_strings_to_concatenate_literals.dart
+++ b/lib/src/rules/adjacent_strings_to_concatenate_literals.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.adjacent_strings_to_concatenate_literals;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = 'Use adjacent strings to concatenate string literals.';
+
+const _details = r'''
+
+**DO** use adjacent strings to concatenate string literals.
+
+**BAD:**
+```
+raiseAlarm(
+    'ERROR: Parts of the spaceship are on fire. Other ' +
+    'parts are overrun by martians. Unclear which are which.');
+```
+
+**GOOD:**
+```
+raiseAlarm(
+    'ERROR: Parts of the spaceship are on fire. Other '
+    'parts are overrun by martians. Unclear which are which.');
+```
+
+''';
+
+class AdjacentStringsToConcatenateLiterals extends LintRule {
+  _Visitor _visitor;
+  AdjacentStringsToConcatenateLiterals()
+      : super(
+            name: 'adjacent_strings_to_concatenate_literals',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  visitBinaryExpression(BinaryExpression node) {
+    if (node.operator.type.lexeme == '+' &&
+        node.leftOperand is StringLiteral &&
+        node.rightOperand is StringLiteral) {
+      rule.reportLint(node);
+    }
+  }
+}

--- a/test/rules/adjacent_strings_to_concatenate_literals.dart
+++ b/test/rules/adjacent_strings_to_concatenate_literals.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N adjacent_strings_to_concatenate_literals`
+
+main() {
+  String string1 = 'hola means' + // LINT
+      ' hello in spanish';
+
+  String string2 = 'hola means' // OK
+      ' hello in spanish';
+
+  List<String> list = ['this is' + // LINT
+    ' not allowed'];
+}


### PR DESCRIPTION
From: https://www.dartlang.org/guides/language/effective-dart/usage#prefer-using-interpolation-to-compose-strings-and-values