### PR TITLE
New rule: prefer_interpolation_to_compose_strings

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -46,6 +46,7 @@ import 'package:linter/src/rules/prefer_const_constructors.dart';
 import 'package:linter/src/rules/prefer_contains.dart';
 import 'package:linter/src/rules/prefer_final_fields.dart';
 import 'package:linter/src/rules/prefer_final_locals.dart';
+import 'package:linter/src/rules/prefer_interpolation_to_compose_strings.dart';
 import 'package:linter/src/rules/prefer_is_empty.dart';
 import 'package:linter/src/rules/prefer_is_not_empty.dart';
 import 'package:linter/src/rules/pub/package_names.dart';
@@ -111,6 +112,7 @@ void registerLintRules() {
     ..register(new PreferContainsOverIndexOf())
     ..register(new PreferFinalFields())
     ..register(new PreferFinalLocals())
+    ..register(new PreferInterpolationToComposeStrings())
     ..register(new PreferIsEmpty())
     ..register(new PreferIsNotEmpty())
     ..register(new PublicMemberApiDocs())

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.prefer_interpolation_to_compose_strings;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+
+const _desc = r'Use interpolation to compose strings and values.';
+
+const _details = r'''
+
+**PREFER** using interpolation to compose strings and values.
+
+**BAD:**
+```
+'Hello, ' + name + '! You are ' + (year - birth) + ' years old.';
+```
+
+**GOOD:**
+```
+'Hello, $name! You are ${year - birth} years old.';
+```
+
+''';
+
+class PreferInterpolationToComposeStrings extends LintRule {
+  _Visitor _visitor;
+  PreferInterpolationToComposeStrings()
+      : super(
+            name: 'prefer_interpolation_to_compose_strings',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  visitCompilationUnit(CompilationUnit node) {
+    final skippedNodes = new Set<AstNode>();
+    void checkRule(AstNode node) {
+      if (skippedNodes.contains(node)) {
+        return;
+      }
+      if (node is BinaryExpression) {
+        _checkBinaryExpression(node, skippedNodes);
+      }
+      if (node is AssignmentExpression) {
+        _checkAssignmentExpression(node, skippedNodes);
+      }
+    }
+    DartTypeUtilities.traverseNodesInDFS(node).forEach(checkRule);
+  }
+
+  _checkAssignmentExpression(AssignmentExpression node, Set<AstNode> skippedNodes) {
+    if (node.operator.type == TokenType.PLUS_EQ &&
+        (DartTypeUtilities.isClass(node.leftHandSide.bestType, 'String', 'dart.core') ||
+            DartTypeUtilities.isClass(node.rightHandSide.bestType, 'String', 'dart.core'))) {
+      DartTypeUtilities.traverseNodesInDFS(node).forEach(skippedNodes.add);
+      rule.reportLint(node);
+    }
+  }
+
+
+  _checkBinaryExpression(BinaryExpression node, Set<AstNode> skippedNodes) {
+    if (node.operator.type == TokenType.PLUS) {
+      if (node.leftOperand is StringLiteral &&
+          node.rightOperand is StringLiteral) {
+        return;
+      }
+      if (DartTypeUtilities.isClass(node.leftOperand.bestType, 'String', 'dart.core') ||
+          DartTypeUtilities.isClass(node.rightOperand.bestType, 'String', 'dart.core')) {
+        DartTypeUtilities.traverseNodesInDFS(node).forEach(skippedNodes.add);
+        rule.reportLint(node);
+      }
+    }
+  }
+}

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -14,9 +14,7 @@ typedef bool AstNodePredicate(AstNode node);
 
 class DartTypeUtilities {
   static bool extendsClass(DartType type, String className, String library) =>
-      type != null &&
-          type.name == className &&
-          type.element.library.name == library ||
+      isClass(type, className, library) ||
       (type is InterfaceType &&
           extendsClass(type.superclass, className, library));
 
@@ -47,6 +45,11 @@ class DartTypeUtilities {
             type is InterfaceType &&
             element.allSupertypes.any(predicate);
   }
+
+  static bool isClass(DartType type, String className, String library) =>
+      type != null &&
+      type.name == className &&
+      type.element.library.name == library;
 
   /// Builds the list resulting from traversing the node in DFS and does not
   /// include the node itself, it excludes the nodes for which the exclusion

--- a/test/rules/prefer_interpolation_to_compose_strings.dart
+++ b/test/rules/prefer_interpolation_to_compose_strings.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_interpolation_to_compose_strings`
+
+void main() {
+  String name = 'Juan'+'Pablo'; // OK // It is not the business of this rule
+  int year = 2017;
+  int birth = 1993;
+  'Hello, $name! You are ${year - birth} years old.';
+  'Hello, ' + // LINT
+      name +
+      '! You are ' +
+      (year - birth).toString() +
+      ' years old.';
+  name += 'casanueva'; // LINT
+
+  int width = 10;
+  String pad = '';
+  for (int i = 0; i < width; i++) {
+    pad = pad + ' '; // LINT
+  }
+
+}

--- a/test/rules/use_adjacent_strings_to_concatenate_literals.dart
+++ b/test/rules/use_adjacent_strings_to_concatenate_literals.dart
@@ -22,5 +22,4 @@ main() {
   String string4 = prefix + 'really' + string3; // OK
 
   String string5 = 'but this' + ' not'; // LINT
-
 }


### PR DESCRIPTION
In this commit we implement this rule from: https://www.dartlang.org/guides/language/effective-dart/usage#prefer-using-interpolation-to-compose-strings-and-values

Fixes https://github.com/dart-lang/linter/issues/448