### PR TITLE
New rule: avoid_function_literal_in_foreach_method

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/rules/always_specify_types.dart';
 import 'package:linter/src/rules/annotate_overrides.dart';
 import 'package:linter/src/rules/avoid_as.dart';
 import 'package:linter/src/rules/avoid_empty_else.dart';
+import 'package:linter/src/rules/avoid_function_literal_in_foreach_method.dart';
 import 'package:linter/src/rules/avoid_init_to_null.dart';
 import 'package:linter/src/rules/avoid_return_types_on_setters.dart';
 import 'package:linter/src/rules/avoid_slow_async_io.dart';
@@ -77,6 +78,7 @@ void registerLintRules() {
     ..register(new AnnotateOverrides())
     ..register(new AvoidAs())
     ..register(new AvoidEmptyElse())
+    ..register(new AvoidFunctionLiteralInForeachMethod())
     ..register(new AvoidInitToNull())
     ..register(new AvoidReturnTypesOnSetters())
     ..register(new AvoidSlowAsyncIo())

--- a/lib/src/rules/avoid_function_literal_in_foreach_method.dart
+++ b/lib/src/rules/avoid_function_literal_in_foreach_method.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.avoid_function_literal_in_foreach_method;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+
+const _desc = r'Avoid using Iterable.forEach() with a function literal.';
+
+const _details = r'''
+
+**AVOID** using Iterable.forEach() with a function literal.
+
+**BAD:**
+```
+people.forEach((person) {
+  ...
+});
+```
+
+**GOOD:**
+```
+for (var person in people) {
+  ...
+}
+```
+
+**GOOD:**
+```
+for (var person in people) {
+  ...
+}
+```
+people.forEach(print);
+''';
+
+class AvoidFunctionLiteralInForeachMethod extends LintRule {
+  _Visitor _visitor;
+  AvoidFunctionLiteralInForeachMethod()
+      : super(
+            name: 'avoid_function_literal_in_foreach_method',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  visitMethodInvocation(MethodInvocation node) {
+    if (node.target != null &&
+        node.methodName.token.value() == 'forEach' &&
+        node.argumentList.arguments.isNotEmpty &&
+        node.argumentList.arguments[0] is FunctionExpression &&
+        DartTypeUtilities.implementsInterface(
+            node.target.bestType, 'Iterable', 'dart.core')) {
+      rule.reportLint(node);
+    }
+  }
+}

--- a/test/rules/avoid_function_literal_in_foreach_method.dart
+++ b/test/rules/avoid_function_literal_in_foreach_method.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_function_literal_in_foreach_method`
+
+void main() {
+  Iterable<String> people;
+
+  for (var person in people) { // OK
+    print(person);
+  }
+  people.forEach((person) { // LINT
+    print(person);
+  });
+
+  people.forEach((person) => print(person)); // LINT
+
+  people.forEach(print); // OK
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/457