### PR TITLE
Fix rule: unnecessary_lambda

### DIFF
--- a/test/rules/unnecessary_lambdas.dart
+++ b/test/rules/unnecessary_lambdas.dart
@@ -4,8 +4,36 @@
 
 // test w/ `pub run test -N unnecessary_lambdas`
 
+
+
+/* TODO: Uncomment this test when parser accepts generics
+Function stateList<T>(int finder) {
+  return (int element) => _stateOf<T>(element, finder); // OK
+}
+
+_stateOf<T>(int a, int b) {
+
+}
+*/
+
+class MyClass {
+  int m1() {
+    return 0;
+  }
+
+  int m2(int p) {
+    return p;
+  }
+}
+
 void main() {
   List<String> names = [];
+
+  final array = <MyClass>[];
+  final x = new MyClass();
+
+  // ignore: unused_local_variable
+  final notRelevantQuestionPeriod = (p) => array[x?.m1()].m2(p); // LINT
 
   names.forEach((name) { // LINT
     print(name);
@@ -14,8 +42,11 @@ void main() {
   names.forEach(print); // OK
 
   names.where((e) => names.contains(e)); // LINT
+  names.where((e) => names?.contains(e)); // OK
   // ignore: unused_local_variable
   var a = (() => names.removeLast()); // LINT
+  // ignore: unused_local_variable
+  var b = (() => names?.removeLast()); // OK
 
   names.where((e) => e.contains(e)); // OK
 
@@ -24,6 +55,9 @@ void main() {
 
   names.where((e) => // OK
       ((a) => e.contains(a))(e)); // LINT
+
+  names.where((e) => // OK
+      ((a) => e?.contains(a))(e)); // OK
 
   var noStatementLambda = () { // OK
     // Empty lambda
@@ -40,19 +74,23 @@ void main() {
   };
 }
 
-foo(a) {
-
-}
+foo(a) {}
 
 void method() {
   List<List> names = [];
   names.add(names);
+
+  // ignore: unused_local_variable
   var a = names.where((e) => ((e) => e.contains(e))(e)); // LINT
-  var b = names.where((e) { // LINT
+  // ignore: unused_local_variable
+  var b = names.where((e) => // LINT
+      ((e) => e?.contains(e))(e));
+  // Can be replaced by names.where((e) => e?.contains(e));
+
+  // ignore: unused_local_variable
+  var c = names.where((e) { // LINT
     return ((e) {
       return e.contains(e);
     })(e);
   });
-  print(a.length);
-  print(b.length);
 }


### PR DESCRIPTION
Fixes:

1.- Check that arguments and parameters lengths are equal
2.- Check if there is a ? operator in the target of a method invocation