### PR TITLE
Fix rule: do_not_check_for_null_in_equality_operators

### DIFF
--- a/lib/src/rules/do_not_check_for_null_in_equality_operators.dart
+++ b/lib/src/rules/do_not_check_for_null_in_equality_operators.dart
@@ -99,8 +99,8 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   visitMethodDeclaration(MethodDeclaration node) {
-    final parameters = node.parameters.parameters;
-    if (_isComparingEquality(node.name.token?.type) && parameters.length == 1) {
+    final parameters = node.parameters?.parameters;
+    if (node.name.token?.type == TokenType.EQ_EQ && parameters?.length == 1) {
       final parameter = DartTypeUtilities
           .getCanonicalElementFromIdentifier(parameters.first.identifier);
       bool checkIfParameterIsNull(AstNode node) {

--- a/test/rules/do_not_check_for_null_in_equality_operators.dart
+++ b/test/rules/do_not_check_for_null_in_equality_operators.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// test w/ `pub run test -N do_not_check_for_null_in_double_equals_operator`
+// test w/ `pub run test -N do_not_check_for_null_in_equality_operators`
 
 class BadPerson1 {
   final String name = 'I am a bad person';
+
+  get age => 42;
 
   @override
   operator ==(other) =>


### PR DESCRIPTION
Fixes #530

This was caused by `node.parameters.parameters` on getters.