### PR TITLE
New rule: avoid_annotating_types_on_function_expressions

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -8,6 +8,7 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules/always_declare_return_types.dart';
 import 'package:linter/src/rules/always_specify_types.dart';
 import 'package:linter/src/rules/annotate_overrides.dart';
+import 'package:linter/src/rules/avoid_annotating_types_on_function_expressions.dart';
 import 'package:linter/src/rules/avoid_as.dart';
 import 'package:linter/src/rules/avoid_catches_without_on_clauses.dart';
 import 'package:linter/src/rules/avoid_classes_with_only_static_members.dart';
@@ -89,6 +90,7 @@ void registerLintRules() {
     ..register(new AlwaysDeclareReturnTypes())
     ..register(new AlwaysSpecifyTypes())
     ..register(new AnnotateOverrides())
+    ..register(new AvoidAnnotatingTypesOnFunctionExpressions())
     ..register(new AvoidAs())
     ..register(new AvoidCatchesWithoutOnClauses())
     ..register(new AvoidClassesWithOnlyStaticMembers())

--- a/lib/src/rules/avoid_annotating_types_on_function_expressions.dart
+++ b/lib/src/rules/avoid_annotating_types_on_function_expressions.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library linter.src.rules.avoid_annotating_types_on_function_expressions;
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Avoid annotating types on function expressions.';
+
+const _details = r'''
+
+**AVOID** annotating types on function expressions.
+
+**BAD:**
+```
+var names = people.map((Person person) => person.name);
+```
+
+**GOOD:**
+```
+var names = people.map((person) => person.name);
+```
+
+''';
+
+bool _isNotDynamic(FormalParameter parameter) {
+  return !parameter.element.type.isDynamic;
+}
+
+class AvoidAnnotatingTypesOnFunctionExpressions extends LintRule {
+  _Visitor _visitor;
+  AvoidAnnotatingTypesOnFunctionExpressions()
+      : super(
+            name: 'avoid_annotating_types_on_function_expressions',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  visitFunctionExpression(FunctionExpression node) {
+    if (node.parent is FunctionDeclaration) {
+      return;
+    }
+    node.parameters.parameters.where(_isNotDynamic).forEach(rule.reportLint);
+  }
+}

--- a/test/rules/avoid_annotating_types_on_function_expressions.dart
+++ b/test/rules/avoid_annotating_types_on_function_expressions.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_annotating_types_on_function_expressions`
+
+class Person {
+  String name;
+}
+
+List<Person> people;
+
+var names = people.map((person) => person.name);
+var names2 = people.map((Person person) => person.name); // LINT


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/543