### PR TITLE
add always_put_control_body_on_new_line

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -6,6 +6,7 @@ library linter.src.rules;
 
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules/always_declare_return_types.dart';
+import 'package:linter/src/rules/always_put_control_body_on_new_line.dart';
 import 'package:linter/src/rules/always_specify_types.dart';
 import 'package:linter/src/rules/annotate_overrides.dart';
 import 'package:linter/src/rules/avoid_annotating_with_dynamic.dart';
@@ -90,6 +91,7 @@ import 'package:linter/src/rules/valid_regexps.dart';
 void registerLintRules() {
   Analyzer.facade
     ..register(new AlwaysDeclareReturnTypes())
+    ..register(new AlwaysPutControlBodyOnNewLine())
     ..register(new AlwaysSpecifyTypes())
     ..register(new AnnotateOverrides())
     ..register(new AvoidAnnotatingWithDynamic())

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -91,8 +91,12 @@ class Visitor extends SimpleAstVisitor {
     // if (node is Block) return;
 
     final unit = node.root as CompilationUnit;
-    if (unit.lineInfo.getLocation(controlEnd).lineNumber ==
-        unit.lineInfo.getLocation(node.end).lineNumber) {
+    if (node is Block &&
+            unit.lineInfo.getLocation(controlEnd).lineNumber ==
+                unit.lineInfo.getLocation(node.end).lineNumber ||
+        node is! Block &&
+            unit.lineInfo.getLocation(controlEnd).lineNumber ==
+                unit.lineInfo.getLocation(node.offset).lineNumber) {
       rule.reportLintForToken(node.beginToken);
     }
   }

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -13,9 +13,9 @@ From the [flutter style guide](https://flutter.io/style-guide/):
 
 **DO** Separate the control structre expression from its statement.
 
-Don't put the statement part of an `if`, `for`, `while` on the same line as the
-expression, even if it is short. (Doing so makes it unobvious that there is
-relevant code there. This is especially important for early returns.)
+Don't put the statement part of an `if`, `for`, `while`, `do` on the same line
+as the expression, even if it is short. (Doing so makes it unobvious that there
+is relevant code there. This is especially important for early returns.)
 
 **GOOD:**
 ```
@@ -82,29 +82,18 @@ class Visitor extends SimpleAstVisitor {
     _checkNodeOnNextLine(node.body, node.rightParenthesis.end);
   }
 
+  @override
+  visitDoStatement(DoStatement node) {
+    _checkNodeOnNextLine(node.body, node.doKeyword.end);
+  }
+
   void _checkNodeOnNextLine(AstNode node, int controlEnd) {
     // if (node is Block) return;
 
     final unit = node.root as CompilationUnit;
-    final content = unit.element.context.getContents(unit.element.source).data;
-
-    if (_getLine(content, controlEnd) == _getLine(content, node.end)) {
+    if (unit.lineInfo.getLocation(controlEnd).lineNumber ==
+        unit.lineInfo.getLocation(node.end).lineNumber) {
       rule.reportLintForToken(node.beginToken);
     }
   }
-}
-
-const int _LF = 10;
-const int _CR = 13;
-
-int _getLine(String content, int offset) {
-  int line = 1;
-  int char = 0;
-  for (int i = 0; i < offset; i++) {
-    int previousChar = char;
-    char = content.codeUnitAt(i);
-    if (char == _CR) line++;
-    if (char == _LF && previousChar != _CR) line++;
-  }
-  return line;
 }

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -91,12 +91,10 @@ class Visitor extends SimpleAstVisitor {
     if (node is Block && node.statements.isEmpty) return;
 
     final unit = node.root as CompilationUnit;
-    if (node is Block &&
-            unit.lineInfo.getLocation(controlEnd).lineNumber ==
-                unit.lineInfo.getLocation(node.end).lineNumber ||
-        node is! Block &&
-            unit.lineInfo.getLocation(controlEnd).lineNumber ==
-                unit.lineInfo.getLocation(node.offset).lineNumber) {
+    final offsetFirstStatement =
+        node is Block ? node.statements.first.offset : node.offset;
+    if (unit.lineInfo.getLocation(controlEnd).lineNumber ==
+        unit.lineInfo.getLocation(offsetFirstStatement).lineNumber) {
       rule.reportLintForToken(node.beginToken);
     }
   }

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -88,7 +88,7 @@ class Visitor extends SimpleAstVisitor {
   }
 
   void _checkNodeOnNextLine(AstNode node, int controlEnd) {
-    // if (node is Block) return;
+    if (node is Block && node.statements.isEmpty) return;
 
     final unit = node.root as CompilationUnit;
     if (node is Block &&

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const desc = 'Separate the control structure expression from its statement.';
+
+const details = '''
+From the [flutter style guide](https://flutter.io/style-guide/):
+
+**DO** Separate the control structre expression from its statement.
+
+Don't put the statement part of an `if`, `for`, `while` on the same line as the
+expression, even if it is short. (Doing so makes it unobvious that there is
+relevant code there. This is especially important for early returns.)
+
+**GOOD:**
+```
+if (notReady)
+  return;
+
+if (notReady)
+  return;
+else
+  print('ok')
+
+while (condition)
+  i += 1;
+```
+
+**BAD:**
+```
+if (notReady) return;
+
+if (notReady)
+  return;
+else print('ok')
+
+while (condition) i += 1;
+```
+''';
+
+class AlwaysPutControlBodyOnNewLine extends LintRule {
+  AlwaysPutControlBodyOnNewLine()
+      : super(
+            name: 'always_put_control_body_on_new_line',
+            description: desc,
+            details: details,
+            group: Group.style);
+
+  @override
+  AstVisitor getVisitor() => new Visitor(this);
+}
+
+class Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  Visitor(this.rule);
+
+  @override
+  visitIfStatement(IfStatement node) {
+    _checkNodeOnNextLine(node.thenStatement, node.rightParenthesis.end);
+    if (node.elseKeyword != null)
+      _checkNodeOnNextLine(node.elseStatement, node.elseKeyword.end);
+  }
+
+  @override
+  visitForEachStatement(ForEachStatement node) {
+    _checkNodeOnNextLine(node.body, node.rightParenthesis.end);
+  }
+
+  @override
+  visitForStatement(ForStatement node) {
+    _checkNodeOnNextLine(node.body, node.rightParenthesis.end);
+  }
+
+  @override
+  visitWhileStatement(WhileStatement node) {
+    _checkNodeOnNextLine(node.body, node.rightParenthesis.end);
+  }
+
+  void _checkNodeOnNextLine(AstNode node, int controlEnd) {
+    // if (node is Block) return;
+
+    final unit = node.root as CompilationUnit;
+    final content = unit.element.context.getContents(unit.element.source).data;
+
+    if (_getLine(content, controlEnd) == _getLine(content, node.end)) {
+      rule.reportLintForToken(node.beginToken);
+    }
+  }
+}
+
+const int _LF = 10;
+const int _CR = 13;
+
+int _getLine(String content, int offset) {
+  int line = 1;
+  int char = 0;
+  for (int i = 0; i < offset; i++) {
+    int previousChar = char;
+    char = content.codeUnitAt(i);
+    if (char == _CR) line++;
+    if (char == _LF && previousChar != _CR) line++;
+  }
+  return line;
+}

--- a/test/rules/always_put_control_body_on_new_line.dart
+++ b/test/rules/always_put_control_body_on_new_line.dart
@@ -7,7 +7,7 @@
 testIfElse() {
   if (false) return; // LINT
 
-  if (false) {} // LINT
+  if (false) {} // OK
 
   if (false)
     return; // OK
@@ -19,7 +19,7 @@ testIfElse() {
     return; // OK
   else return; // LINT
 
-  if (false) { } // LINT
+  if (false) { } // OK
   else return; // LINT
 
   if (false)
@@ -27,8 +27,8 @@ testIfElse() {
   else
     return; // OK
 
-  if (false){ }// LINT
-  else {} // LINT
+  if (false){ }// OK
+  else {} // OK
 
   if (false) print( // LINT
     'First argument'
@@ -38,7 +38,7 @@ testIfElse() {
 testWhile() {
   while (true) return; // LINT
 
-  while (true) {} // LINT
+  while (true) {} // OK
 
   while (true)
     return; // OK
@@ -47,7 +47,7 @@ testWhile() {
 testForEach(List l) {
   for (var i in l) return; // LINT
 
-  for (var i in l) {} // LINT
+  for (var i in l) {} // OK
 
   for (var i in l)
     return; // OK
@@ -56,7 +56,7 @@ testForEach(List l) {
 testFor() {
   for (;;) return; // LINT
 
-  for (;;) {} // LINT
+  for (;;) {} // OK
 
   for (;;)
     return; // OK

--- a/test/rules/always_put_control_body_on_new_line.dart
+++ b/test/rules/always_put_control_body_on_new_line.dart
@@ -57,3 +57,12 @@ testFor() {
   for (;;)
     return; // OK
 }
+
+testDo() {
+  do print(''); // LINT
+  while (true);
+
+  do
+    print(''); // OK
+  while (true);
+}

--- a/test/rules/always_put_control_body_on_new_line.dart
+++ b/test/rules/always_put_control_body_on_new_line.dart
@@ -33,6 +33,9 @@ testIfElse() {
   if (false) print( // LINT
     'First argument'
     'Second argument');
+
+  if (false) { print('should be on next line'); // LINT
+  }
 }
 
 testWhile() {

--- a/test/rules/always_put_control_body_on_new_line.dart
+++ b/test/rules/always_put_control_body_on_new_line.dart
@@ -29,6 +29,10 @@ testIfElse() {
 
   if (false){ }// LINT
   else {} // LINT
+
+  if (false) print( // LINT
+    'First argument'
+    'Second argument');
 }
 
 testWhile() {

--- a/test/rules/always_put_control_body_on_new_line.dart
+++ b/test/rules/always_put_control_body_on_new_line.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N always_put_control_body_on_new_line`
+
+testIfElse() {
+  if (false) return; // LINT
+
+  if (false) {} // LINT
+
+  if (false)
+    return; // OK
+
+  if (false) { // OK
+  }
+
+  if (false)
+    return; // OK
+  else return; // LINT
+
+  if (false) { } // LINT
+  else return; // LINT
+
+  if (false)
+    return; // OK
+  else
+    return; // OK
+
+  if (false){ }// LINT
+  else {} // LINT
+}
+
+testWhile() {
+  while (true) return; // LINT
+
+  while (true) {} // LINT
+
+  while (true)
+    return; // OK
+}
+
+testForEach(List l) {
+  for (var i in l) return; // LINT
+
+  for (var i in l) {} // LINT
+
+  for (var i in l)
+    return; // OK
+}
+
+testFor() {
+  for (;;) return; // LINT
+
+  for (;;) {} // LINT
+
+  for (;;)
+    return; // OK
+}


### PR DESCRIPTION
This addresses [Flutter style: Separate the 'if' expression from its statement](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#separate-the-if-expression-from-its-statement) that is present in #142