### PR TITLE
Un-orphan `prefer_adjacent_string_concatenation` test.

### DIFF
--- a/test/rules/prefer_adjacent_string_concatenation.dart
+++ b/test/rules/prefer_adjacent_string_concatenation.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// test w/ `pub run test -N use_adjacent_strings_to_concatenate_literals`
+// test w/ `pub run test -N prefer_adjacent_string_concatenation`
 
 main() {
   String string1 = 'hola means' + // LINT


### PR DESCRIPTION
This test got missed in a rename and so was orphaned. 😢 

@bwilkerson @alexeieleusis 