### PR TITLE
Bump analyzer dep to `0.29.11`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/linter
 environment:
   sdk: '>=1.12.0 <2.0.0'
 dependencies:
-  analyzer: ^0.29.6
+  analyzer: ^0.29.11
   args: '>=0.12.1 <0.14.0'
   cli_util: ^0.0.1
   glob: ^1.0.3


### PR DESCRIPTION
Pulls in _Driver enableAssertInitializer backport_ (https://github.com/dart-lang/sdk/commit/fbafaf05303e224a41cf8c551fa536c46e6dc5af).

Should unblock: https://github.com/dart-lang/linter/pull/630

@bwilkerson 

FYI @a14n 