### PR TITLE
cascade_invocations: Method invocations should be linted only if target is simple identifier.

### DIFF
--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -196,9 +196,12 @@ class _CascadableExpression {
     final executableElement = _getExecutableElementFromMethodInvocation(node);
     bool isNonStatic = executableElement?.isStatic == false;
     if (isNonStatic) {
+      final isSimpleIdentifier = node.target is SimpleIdentifier;
       return new _CascadableExpression._internal(
           _getTargetElementFromMethodInvocation(node), [node.argumentList],
-          canJoin: true, canReceive: true, canBeCascaded: true);
+          canJoin: isSimpleIdentifier,
+          canReceive: isSimpleIdentifier,
+          canBeCascaded: true);
     }
     return NULL_CASCADABLE_EXPRESSION;
   }

--- a/test/rules/cascade_invocations.dart
+++ b/test/rules/cascade_invocations.dart
@@ -161,3 +161,14 @@ void otherDependencies3() {
   resource = (entry.resource as Practitioner339);
   resource.bar(resource); // OK
 }
+
+class Bug661 {
+  Bug661 parent;
+  Practitioner339 practicioner;
+
+  void bar() {
+    practicioner.bar(1);
+    practicioner.bar(2); // LINT
+    parent.practicioner.bar(3);
+  }
+}


### PR DESCRIPTION
For other invocations it may hurt readability anyways.

Fixes https://github.com/dart-lang/linter/issues/661