### PR TITLE
literal_only_boolean_expressions: Only check literals on left side for ??.ˆ

### DIFF
--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:linter/src/analyzer.dart';
 
 const _desc =
-    r'Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"';
+    r'Boolean expression composed only with literals';
 
 const _details = r'''
 
@@ -90,8 +90,7 @@ bool _onlyLiterals(Expression rawExpression) {
   }
   if (expression is BinaryExpression) {
     if (expression.operator.type == TokenType.QUESTION_QUESTION) {
-      return _onlyLiterals(expression.leftOperand) ||
-          _onlyLiterals(expression.rightOperand);
+      return _onlyLiterals(expression.leftOperand);
     }
     return _onlyLiterals(expression.leftOperand) &&
         _onlyLiterals(expression.rightOperand);

--- a/test/rules/invariant_booleans.dart
+++ b/test/rules/invariant_booleans.dart
@@ -452,3 +452,7 @@ void test337_5() {
   }
 }
 
+void bug658() {
+  String text;
+  if ((text?.length ?? 0) != 0) {}
+}

--- a/test/rules/literal_only_boolean_expressions.dart
+++ b/test/rules/literal_only_boolean_expressions.dart
@@ -20,3 +20,8 @@ void bad() {
 }
 
 bool m() => true;
+
+void bug658() {
+  String text;
+  if ((text?.length ?? 0) != 0) {}
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/658