### PR TITLE
Run lint benchmarks w/ all the lints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.32
+
+* Lint stats (`-s`) output now sorted.
+
 # 0.1.31
 
 * New `prefer_foreach` lint.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -20,7 +20,8 @@ if [ "$LINTER_BOT" = "benchmark" ]; then
   # The actual lints can have errors - we don't want to fail the benchmark bot.
   set +e
 
-  dart bin/linter.dart -s -q .
+  # Run linter with all lints enabled.
+  dart bin/linter.dart -s -q -c example/all.yaml .
 
   echo ""
 else


### PR DESCRIPTION
* enables all the lints for benchmarking
* (note that `all.yaml` is guaranteed to be complete by the 'all.yaml' test in `integration_test.dart`)

Follow-up from https://github.com/dart-lang/linter/pull/670.

@devoncarew 