### PR TITLE
Add `--benchmark` support.

### DIFF
--- a/bin/linter.dart
+++ b/bin/linter.dart
@@ -12,6 +12,7 @@ import 'package:analyzer/src/lint/io.dart';
 import 'package:analyzer/src/lint/linter.dart';
 import 'package:analyzer/src/lint/registry.dart';
 import 'package:args/args.dart';
+import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/formatter.dart';
 import 'package:linter/src/rules.dart';
 
@@ -54,6 +55,8 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
         abbr: "h", negatable: false, help: "Show usage information.")
     ..addFlag("stats",
         abbr: "s", negatable: false, help: "Show lint statistics.")
+    ..addFlag("benchmark",
+        abbr: "b", negatable: false, help: "Show lint benchmarks.")
     ..addFlag('visit-transitive-closure',
         help: 'Visit the transitive closure of imported/exported libraries.')
     ..addFlag('quiet', abbr: 'q', help: "Don't show individual lint errors.")
@@ -141,7 +144,8 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
   }
 
   var stats = options['stats'];
-  if (stats == true) {
+  var benchmark = options['benchmark'];
+  if (stats == true || benchmark == true) {
     lintOptions.enableTiming = true;
   }
 
@@ -149,12 +153,17 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
     ..packageConfigPath = packageConfigFile
     ..visitTransitiveClosure = options['visit-transitive-closure'];
 
-  final linter = new DartLinter(lintOptions);
-
   List<File> filesToLint = [];
   for (var path in options.rest) {
     filesToLint.addAll(collectFiles(path));
   }
+
+  if (benchmark) {
+    writeBenchmarks(outSink, filesToLint, lintOptions);
+    return;
+  }
+
+  final linter = new DartLinter(lintOptions);
 
   try {
     final timer = new Stopwatch()..start();
@@ -173,7 +182,8 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
         fileRoot: commonRoot,
         showStatistics: stats,
         machineOutput: options['machine'],
-        quiet: options['quiet'])..write();
+        quiet: options['quiet'])
+      ..write();
   } catch (err, stack) {
     errorSink.writeln('''An error occurred while linting
   Please report it at: github.com/dart-lang/linter/issues

--- a/bin/linter.dart
+++ b/bin/linter.dart
@@ -55,8 +55,7 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
         abbr: "h", negatable: false, help: "Show usage information.")
     ..addFlag("stats",
         abbr: "s", negatable: false, help: "Show lint statistics.")
-    ..addFlag("benchmark",
-        abbr: "b", negatable: false, help: "Show lint benchmarks.")
+    ..addFlag("benchmark", negatable: false, help: "Show lint benchmarks.")
     ..addFlag('visit-transitive-closure',
         help: 'Visit the transitive closure of imported/exported libraries.')
     ..addFlag('quiet', abbr: 'q', help: "Don't show individual lint errors.")
@@ -145,7 +144,7 @@ void runLinter(List<String> args, LinterOptions initialLintOptions) {
 
   var stats = options['stats'];
   var benchmark = options['benchmark'];
-  if (stats == true || benchmark == true) {
+  if (stats || benchmark) {
     lintOptions.enableTiming = true;
   }
 

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -17,7 +17,7 @@ export 'package:analyzer/src/generated/resolver.dart'
     show InheritanceManager, TypeProvider, TypeSystem;
 export 'package:analyzer/src/generated/source.dart' show LineInfo, Source;
 export 'package:analyzer/src/lint/linter.dart'
-    show LintRule, Group, Maturity, LintFilter;
+    show DartLinter, LintRule, Group, Maturity, LinterOptions, LintFilter;
 export 'package:analyzer/src/lint/project.dart'
     show DartProject, ProjectVisitor;
 export 'package:analyzer/src/lint/pub.dart' show PubspecVisitor, PSEntry;

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -21,7 +21,7 @@ if [ "$LINTER_BOT" = "benchmark" ]; then
   set +e
 
   # Benchmark linter with all lints enabled.
-  dart bin/linter.dart -b -q -c example/all.yaml .
+  dart bin/linter.dart --benchmark -q -c example/all.yaml .
 
   echo ""
 else

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -20,8 +20,8 @@ if [ "$LINTER_BOT" = "benchmark" ]; then
   # The actual lints can have errors - we don't want to fail the benchmark bot.
   set +e
 
-  # Run linter with all lints enabled.
-  dart bin/linter.dart -s -q -c example/all.yaml .
+  # Benchmark linter with all lints enabled.
+  dart bin/linter.dart -b -q -c example/all.yaml .
 
   echo ""
 else


### PR DESCRIPTION
New benchmark mode that prints lint stats based on the best of 10 runs.

Follow-up from: https://github.com/dart-lang/linter/issues/669

@devoncarew @bwilkerson 