### PR TITLE
Add a lint rule for preferring single quote strings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -49,6 +49,7 @@ linter:
 #    - prefer_final_locals
 #    - prefer_is_empty # not recognized
     - prefer_is_not_empty
+    - prefer_single_quotes
 #    - public_member_api_docs
 #    - recursive_getter # not recognized
     - slash_for_doc_comments

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -70,6 +70,7 @@ linter:
     - prefer_interpolation_to_compose_strings
     - prefer_is_empty
     - prefer_is_not_empty
+    - prefer_single_quotes
     - public_member_api_docs
     - recursive_getters
     - slash_for_doc_comments

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -70,6 +70,7 @@ import 'package:linter/src/rules/prefer_initializing_formals.dart';
 import 'package:linter/src/rules/prefer_interpolation_to_compose_strings.dart';
 import 'package:linter/src/rules/prefer_is_empty.dart';
 import 'package:linter/src/rules/prefer_is_not_empty.dart';
+import 'package:linter/src/rules/prefer_single_quotes.dart';
 import 'package:linter/src/rules/pub/package_names.dart';
 import 'package:linter/src/rules/public_member_api_docs.dart';
 import 'package:linter/src/rules/recursive_getters.dart';
@@ -166,6 +167,7 @@ void registerLintRules() {
     ..register(new PreferIsEmpty())
     ..register(new PreferIsNotEmpty())
     ..register(new PublicMemberApiDocs())
+    ..register(new PreferSingleQuotes())
     ..register(new PubPackageNames())
     ..register(new RecursiveGetters())
     ..registerDefault(new SlashForDocComments())

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -17,11 +17,9 @@ apostrophe isn't escaped (note: we don't lint the other way around, ie, a single
 quoted string with an escaped apostrophe is not flagged).
 
 Its also rare, but possible, to have strings within string interpolations. In
-this case, its more or less necessary to use a double quote somewhere (unless
-you want to do single quotes within triple single quotes, which most people
-don't, and then you still have an isue with strings within strings within
-strings). So double quotes are allowed either within, or containing, an
-interpolated string literal.
+this case, its much more readable to use a double quote somewhere. So double
+quotes are allowed either within, or containing, an interpolated string literal.
+Arguably strings within string interpolations should be its own type of lint.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = "Prefer single quotes where it won't require escape sequences";
+
+const _details = '''
+
+**DO** use single quotes where it wouldn't require additional escapes
+
+**BAD:**
+```
+useStrings(
+    "should be single",
+    r"should be single",
+    r"""should be single""",
+    "here's ok");
+```
+
+**GOOD:**
+```
+useStrings(
+    'should be single',
+    r'should be single",
+    r\'''should be single\''',
+    "here's ok");
+```
+
+''';
+
+class PreferSingleQuotes extends LintRule {
+  _Visitor _visitor;
+  PreferSingleQuotes()
+      : super(
+            name: 'prefer_single_quotes',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  visitSimpleStringLiteral(SimpleStringLiteral string) {
+    if (string.isSingleQuoted || string.value.contains("'")) {
+      return;
+    }
+
+    // Bail out on "strings ${x ? 'containing' : 'other'} strings"
+    if (!isNestedString(string)) {
+      rule.reportLintForToken(string.literal);
+    }
+  }
+
+  @override
+  visitStringInterpolation(StringInterpolation string) {
+    if (string.isSingleQuoted) {
+      return;
+    }
+
+    // slightly more complicated check there are no single quotes
+    if (string.elements
+        .any((e) => e is InterpolationString && e.value.contains("'"))) {
+      return;
+    }
+
+    // Bail out on "strings ${x ? 'containing' : 'other'} strings"
+    if (!containsString(string) && !isNestedString(string)) {
+      rule.reportLint(string);
+    }
+  }
+
+  /// Strings can be within interpolations (ie, nested). Check like this.
+  bool isNestedString(AstNode node) {
+    final checkWithinString = new _WithinStringVisitor();
+    node.parent?.accept(checkWithinString);
+
+    return checkWithinString.withinString;
+  }
+
+  /// Strings interpolations can contain other string nodes. Check like this.
+  bool containsString(StringInterpolation string) {
+    final checkHasString = new _HasStringVisitor();
+    for (final child in string.elements) {
+      child.accept(checkHasString);
+    }
+
+    return checkHasString.hasString;
+  }
+}
+
+/// Do a depth analysis to search for string nodes. Note, do not pass in string
+/// nodes directly to this visitor, or you will always get true. Pass in its
+/// children.
+class _HasStringVisitor extends RecursiveAstVisitor {
+  bool hasString = false;
+
+  @override
+  visitSimpleStringLiteral(SimpleStringLiteral string) {
+    hasString = true;
+  }
+
+  @override
+  visitStringInterpolation(StringInterpolation string) {
+    hasString = true;
+  }
+}
+
+/// Do a bottom-up analysis to search for string nodes. Note, do not pass in
+/// string nodes directly to this visitor, or you will always get true. Pass in
+/// its parent.
+class _WithinStringVisitor extends UnifyingAstVisitor {
+  bool withinString = false;
+
+  @override
+  visitNode(AstNode n) {
+    n.parent?.accept(this);
+  }
+
+  @override
+  visitSimpleStringLiteral(SimpleStringLiteral string) {
+    withinString = true;
+  }
+
+  @override
+  visitStringInterpolation(StringInterpolation string) {
+    withinString = true;
+  }
+}

--- a/test/rules/prefer_single_quotes.dart
+++ b/test/rules/prefer_single_quotes.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_single_quotes`
+
+main() {
+  String string1 = "no quote"; // LINT
+  String string2 = 'uses single'; // OK
+  String string3 = "has quote '"; // OK
+
+  String rawString1 = r"no quote"; // LINT
+  String rawString2 = r'uses single'; // OK
+  String rawString3 = r"has quote '"; // OK
+
+  String multilineString1 = r"""no quote"""; // LINT
+  String multilineString2 = r'''uses single'''; // OK
+  String multilineString3 = r"""has quote '"""; // OK
+
+  String x = 'x';
+
+  String interpString1 = "no quote $x"; // LINT
+  String interpString2 = 'uses single $x'; // OK
+  String interpString3 = "has quote ' $x"; // OK
+
+  String interpString4 = "no quote $x has quote ' $x no quote"; // OK
+  String interpString5 = "no quote $x no quote $x no quote"; // LINT
+
+  String stringWithinStringDoubleFirst = "foo ${x == 'x'} bar"; // OK
+  String stringWithinStringSingleFirst = 'foo ${x == "x"} bar'; // OK
+}

--- a/test/rules/prefer_single_quotes.dart
+++ b/test/rules/prefer_single_quotes.dart
@@ -4,6 +4,9 @@
 
 // test w/ `pub run test -N prefer_single_quotes`
 
+import "dart:collection"; // LINT
+import 'dart:async'; // OK
+
 main() {
   String string1 = "no quote"; // LINT
   String string2 = 'uses single'; // OK


### PR DESCRIPTION
Do not suggest double quotes for
- strings with ' in them naturally
- strings containing other strings ie "foo ${'bar'}"
- strings within other strings (we check 'bar' in the case above!)

Also be careful for the difference between interpolated and non
interpolated strings.

cc @mk13