### PR TITLE
update prefer_asserts_in_initializer_list to lint individual asserts

### DIFF
--- a/lib/src/rules/prefer_asserts_in_initializer_list.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_list.dart
@@ -13,6 +13,9 @@ import 'package:linter/src/analyzer.dart';
 const desc = 'Prefer put asserts in initializer list.';
 
 const details = '''
+**WARNING** Putting asserts in initializer lists is only possible using an
+experimental language feature that might be removed.
+
 **DO** put asserts in initializer list for constructors with only asserts in
 their body.
 

--- a/test/_data/prefer_asserts_in_initializer_list/lib.dart
+++ b/test/_data/prefer_asserts_in_initializer_list/lib.dart
@@ -1,11 +1,10 @@
 class A {
   A.c1(a) : assert(a != null); // OK
-  A.c2(a) { // LINT
-    assert(a != null);
-  }
-  A.c3(a) {} // OK
-  A.c4(a) { // OK
+  A.c2(a)
+    : assert(a != null) // OK
+  {
+    assert(a != null); // LINT
     print('');
-    assert(a != null);
+    assert(a != null); // OK
   }
 }

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -441,7 +441,7 @@ defineTests() {
         expect(
             collectingOut.trim(),
             stringContainsInOrder(
-                ['A.c2(a) { // LINT', '1 file analyzed, 1 issue found, in']));
+                ['lib.dart 6:5', '1 file analyzed, 1 issue found, in']));
       });
     });
 

--- a/test/rules/prefer_asserts_in_initializer_list.dart
+++ b/test/rules/prefer_asserts_in_initializer_list.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_asserts_in_initializer_list`
+
+class A {
+  final f;
+  get g => null;
+  m() => null;
+  A.c1(a) {
+    assert(a != null); // LINT
+    assert(a != null); // LINT
+  }
+  // no more lint after non assert statement
+  A.c2(a) {
+    assert(a != null); // LINT
+    assert(a != null); // LINT
+    print('');
+    assert(a != null); // OK
+  }
+  A.c3(a) {} // OK
+  // still lint after unmovable assert
+  A.c4(a) {
+    assert(a != null); // LINT
+    assert(this != null); // OK
+    assert(a != null); // LINT
+  }
+  // no lint if this is used
+  A.c5(a) {
+    assert(this != null); // OK
+  }
+  // no lint if field is used
+  A.c6(a) {
+    assert(this.f != null); // OK
+    assert(f != null); // OK
+  }
+  // no lint if method is used
+  A.c7(a) {
+    assert(this.m() != null); // OK
+    assert(m() != null); // OK
+  }
+  // no lint if property access is used
+  A.c_(a) {
+    assert(this.g != null); // OK
+    assert(g != null); // OK
+  }
+}

--- a/test/rules/prefer_asserts_in_initializer_list.dart
+++ b/test/rules/prefer_asserts_in_initializer_list.dart
@@ -5,7 +5,7 @@
 // test w/ `pub run test -N prefer_asserts_in_initializer_list`
 
 class A {
-  final f;
+  var f;
   get g => null;
   m() => null;
   A.c1(a) {
@@ -41,8 +41,20 @@ class A {
     assert(m() != null); // OK
   }
   // no lint if property access is used
-  A.c_(a) {
+  A.c8(a) {
     assert(this.g != null); // OK
     assert(g != null); // OK
+  }
+  // no lint if method is call on other objet
+  A.c9({f}) : f = f ?? 'f' {
+    assert(f != null); // LINT
+    assert(f.toString() != null); // LINT
+    assert(f.toString().toString() != null); // LINT
+  }
+  A.c10({this.f}) {
+    assert(f != null); // LINT
+  }
+  factory A.c11({f}) {
+    assert(f != null); // OK
   }
 }


### PR DESCRIPTION
With this change the lint is on individual `assert` and it checks that the `assert` can be moved into initializer list (no access to field, method, this)