### PR TITLE
cascade_invocations: Don't lint cases where assignment expression is conditional

### DIFF
--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -173,7 +173,7 @@ class _CascadableExpression {
           DartTypeUtilities.getCanonicalElement(leftExpression.bestElement),
           [node.rightHandSide],
           canJoin: false,
-          canReceive: true,
+          canReceive: node.operator.type != TokenType.QUESTION_QUESTION_EQ,
           canBeCascaded: false,
           isCritical: true);
     }

--- a/test/rules/cascade_invocations.dart
+++ b/test/rules/cascade_invocations.dart
@@ -172,3 +172,14 @@ class Bug661 {
     parent.practicioner.bar(3);
   }
 }
+
+class Bug701 {
+  int foo;
+  int bar;
+}
+
+void function701({Bug701 something}) {
+  something ??= new Bug701();
+  something.foo = 1; // OK
+  something.bar = 2; // LINT
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/701