### PR TITLE
cascade_invocations: Don't lint static properties.

### DIFF
--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -178,12 +178,12 @@ class _CascadableExpression {
           isCritical: true);
     }
     // setters
-    return new _CascadableExpression._internal(
-        _getPrefixElementFromExpression(node.leftHandSide),
-        [node.rightHandSide],
-        canJoin: true,
-        canReceive: true,
-        canBeCascaded: true);
+    final VariableElement variable =
+        _getPrefixElementFromExpression(node.leftHandSide);
+    final canReceive = node.operator.type != TokenType.QUESTION_QUESTION_EQ &&
+        !variable.isStatic;
+    return new _CascadableExpression._internal(variable, [node.rightHandSide],
+        canJoin: true, canReceive: canReceive, canBeCascaded: true);
   }
 
   factory _CascadableExpression._fromCascadeExpression(

--- a/test/rules/cascade_invocations.dart
+++ b/test/rules/cascade_invocations.dart
@@ -183,3 +183,14 @@ void function701({Bug701 something}) {
   something.foo = 1; // OK
   something.bar = 2; // LINT
 }
+
+// https://github.com/dart-lang/linter/issues/694
+class Bug694 {
+  static int foo = 0;
+  static int bar = 1;
+}
+
+void function694() {
+  Bug694.bar = 2;
+  Bug694.foo = 3; // OK
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/694