### PR TITLE
Update linter to use new driver-based engine (#743).

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/linter
 environment:
   sdk: '>=1.12.0 <2.0.0-dev.infinity'
 dependencies:
-  analyzer: 0.31.0-alpha.0
+  analyzer: ^0.31.0-alpha.0
   args: '>=0.12.1 <0.14.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/linter
 environment:
   sdk: '>=1.12.0 <2.0.0-dev.infinity'
 dependencies:
-  analyzer: ^0.30.0
+  analyzer: 0.31.0-alpha.0
   args: '>=0.12.1 <0.14.0'
   glob: ^1.0.3
   meta: ^1.0.2
@@ -20,5 +20,5 @@ dev_dependencies:
   matcher: ^0.12.0
   mockito: ^1.0.0
   path: '>=0.9.0 <2.0.0'
-  test: ^0.12.0
+  test: ^0.12.24+1
   unscripted: ^0.6.2

--- a/test/_data/directives_ordering/export_directives_after_import_directives/bad.dart
+++ b/test/_data/directives_ordering/export_directives_after_import_directives/bad.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+library dummy_lib;
 
 import 'dummy.dart';
 

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:analyzer/dart/ast/ast.dart' show AstNode, AstVisitor;
@@ -26,7 +27,7 @@ main() {
 }
 
 /// Linter engine tests
-void defineLinterEngineTests() {
+Future defineLinterEngineTests() {
   group('engine', () {
     group('reporter', () {
       _test(String label, String expected, report(PrintingReporter r)) {
@@ -147,39 +148,39 @@ void defineLinterEngineTests() {
         exitCode = 0;
         errorSink = stderr;
       });
-      test('smoke', () {
+      test('smoke', () async {
         FileSystemEntity firstRuleTest =
             new Directory(ruleDir).listSync().firstWhere((f) => isDartFile(f));
-        dartlint.main([firstRuleTest.path]);
+        await dartlint.main([firstRuleTest.path]);
         expect(dartlint.isLinterErrorCode(exitCode), isFalse);
       });
-      test('no args', () {
-        dartlint.main([]);
+      test('no args', () async {
+        await dartlint.main([]);
         expect(exitCode, equals(dartlint.unableToProcessExitCode));
       });
-      test('help', () {
-        dartlint.main(['-h']);
+      test('help', () async {
+        await dartlint.main(['-h']);
         // Help shouldn't generate an error code
         expect(dartlint.isLinterErrorCode(exitCode), isFalse);
       });
-      test('unknown arg', () {
-        dartlint.main(['-XXXXX']);
+      test('unknown arg', () async {
+        await dartlint.main(['-XXXXX']);
         expect(exitCode, equals(dartlint.unableToProcessExitCode));
       });
-      test('custom sdk path', () {
+      test('custom sdk path', () async {
         // Smoke test to ensure a custom sdk path doesn't sink the ship
         FileSystemEntity firstRuleTest =
             new Directory(ruleDir).listSync().firstWhere((f) => isDartFile(f));
         var sdk = getSdkPath();
-        dartlint.main(['--dart-sdk', sdk, firstRuleTest.path]);
+        await dartlint.main(['--dart-sdk', sdk, firstRuleTest.path]);
         expect(dartlint.isLinterErrorCode(exitCode), isFalse);
       });
-      test('custom package root', () {
+      test('custom package root', () async {
         // Smoke test to ensure a custom package root doesn't sink the ship
         FileSystemEntity firstRuleTest =
             new Directory(ruleDir).listSync().firstWhere((f) => isDartFile(f));
         var packageDir = new Directory('.').path;
-        dartlint.main(['--package-root', packageDir, firstRuleTest.path]);
+        await dartlint.main(['--package-root', packageDir, firstRuleTest.path]);
         expect(dartlint.isLinterErrorCode(exitCode), isFalse);
       });
     });

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -13,7 +13,7 @@ import 'package:analyzer/src/lint/io.dart';
 import 'package:analyzer/src/lint/linter.dart';
 import 'package:analyzer/src/lint/pub.dart';
 import 'package:analyzer/src/string_source.dart' show StringSource;
-import 'package:cli_util/cli_util.dart' show getSdkDir;
+import 'package:cli_util/cli_util.dart' show getSdkPath;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -170,8 +170,8 @@ void defineLinterEngineTests() {
         // Smoke test to ensure a custom sdk path doesn't sink the ship
         FileSystemEntity firstRuleTest =
             new Directory(ruleDir).listSync().firstWhere((f) => isDartFile(f));
-        var sdk = getSdkDir();
-        dartlint.main(['--dart-sdk', sdk.path, firstRuleTest.path]);
+        var sdk = getSdkPath();
+        dartlint.main(['--dart-sdk', sdk, firstRuleTest.path]);
         expect(dartlint.isLinterErrorCode(exitCode), isFalse);
       });
       test('custom package root', () {

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -13,7 +13,7 @@ import 'package:analyzer/src/lint/io.dart';
 import 'package:analyzer/src/lint/linter.dart';
 import 'package:analyzer/src/lint/pub.dart';
 import 'package:analyzer/src/string_source.dart' show StringSource;
-import 'package:cli_util/cli_util.dart' show getSdkPath;
+import 'package:cli_util/cli_util.dart' show getSdkDir;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -170,8 +170,8 @@ void defineLinterEngineTests() {
         // Smoke test to ensure a custom sdk path doesn't sink the ship
         FileSystemEntity firstRuleTest =
             new Directory(ruleDir).listSync().firstWhere((f) => isDartFile(f));
-        var sdk = getSdkPath();
-        dartlint.main(['--dart-sdk', sdk, firstRuleTest.path]);
+        var sdk = getSdkDir();
+        dartlint.main(['--dart-sdk', sdk.path, firstRuleTest.path]);
         expect(dartlint.isLinterErrorCode(exitCode), isFalse);
       });
       test('custom package root', () {

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -34,8 +34,8 @@ defineTests() {
         exitCode = 0;
       });
       group('config', () {
-        test('excludes', () {
-          dartlint
+        test('excludes', () async {
+          await dartlint
               .main(['test/_data/p2', '-c', 'test/_data/p2/lintconfig.yaml']);
           expect(exitCode, 1);
           expect(
@@ -43,15 +43,15 @@ defineTests() {
               stringContainsInOrder(
                   ['4 files analyzed, 1 issue found (2 filtered), in']));
         });
-        test('overrrides', () {
-          dartlint
+        test('overrrides', () async {
+          await dartlint
               .main(['test/_data/p2', '-c', 'test/_data/p2/lintconfig2.yaml']);
           expect(exitCode, 0);
           expect(collectingOut.trim(),
               stringContainsInOrder(['4 files analyzed, 0 issues found, in']));
         });
-        test('default', () {
-          dartlint.main(['test/_data/p2']);
+        test('default', () async {
+          await dartlint.main(['test/_data/p2']);
           expect(exitCode, 1);
           expect(collectingOut.trim(),
               stringContainsInOrder(['4 files analyzed, 3 issues found, in']));
@@ -66,8 +66,8 @@ defineTests() {
         collectingOut.buffer.clear();
         outSink = currentOut;
       });
-      test('bad pubspec', () {
-        dartlint.main(['test/_data/p3', 'test/_data/p3/_pubpspec.yaml']);
+      test('bad pubspec', () async {
+        await dartlint.main(['test/_data/p3', 'test/_data/p3/_pubpspec.yaml']);
         expect(collectingOut.trim(),
             startsWith('1 file analyzed, 0 issues found, in'));
       });
@@ -80,10 +80,10 @@ defineTests() {
         collectingOut.buffer.clear();
         outSink = currentOut;
       });
-      test('no warnings due to bad canonicalization', () {
+      test('no warnings due to bad canonicalization', () async {
         var packagesFilePath =
             new File('test/_data/p4/_packages').absolute.path;
-        dartlint.runLinter(['--packages', packagesFilePath, 'test/_data/p4'],
+        await dartlint.runLinter(['--packages', packagesFilePath, 'test/_data/p4'],
             new LinterOptions([]));
         expect(collectingOut.trim(),
             startsWith('3 files analyzed, 0 issues found, in'));
@@ -103,9 +103,9 @@ defineTests() {
         exitCode = 0;
       });
       group('.packages', () {
-        test('basic', () {
+        test('basic', () async {
           // Requires .packages to analyze cleanly.
-          dartlint
+          await dartlint
               .main(['test/_data/p5', '--packages', 'test/_data/p5/_packages']);
           // Should have 0 issues.
           expect(exitCode, 0);
@@ -127,8 +127,8 @@ defineTests() {
       });
 
       // https://github.com/dart-lang/linter/issues/246
-      test('overrides across libraries', () {
-        dartlint.main(
+      test('overrides across libraries', () async {
+        await dartlint.main(
             ['test/_data/overridden_fields', '--rules', 'overridden_fields']);
         expect(exitCode, 1);
         expect(
@@ -151,9 +151,9 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('close sinks', () {
+      test('close sinks', () async {
         var packagesFilePath = new File('.packages').absolute.path;
-        dartlint.main([
+        await dartlint.main([
           '--packages',
           packagesFilePath,
           'test/_data/close_sinks',
@@ -183,8 +183,8 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('cancel subscriptions', () {
-        dartlint.main([
+      test('cancel subscriptions', () async {
+        await dartlint.main([
           'test/_data/cancel_subscriptions',
           '--rules=cancel_subscriptions'
         ]);
@@ -212,9 +212,9 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('dart_directives_go_first', () {
+      test('dart_directives_go_first', () async {
         var packagesFilePath = new File('.packages').absolute.path;
-        dartlint.main([
+        await dartlint.main([
           '--packages',
           packagesFilePath,
           'test/_data/directives_ordering/dart_directives_go_first',
@@ -236,9 +236,9 @@ defineTests() {
             ]));
       });
 
-      test('package_directives_before_relative', () {
+      test('package_directives_before_relative', () async {
         var packagesFilePath = new File('.packages').absolute.path;
-        dartlint.main([
+        await dartlint.main([
           '--packages',
           packagesFilePath,
           'test/_data/directives_ordering/package_directives_before_relative',
@@ -260,9 +260,9 @@ defineTests() {
             ]));
       });
 
-      test('third_party_package_directives_before_own', () {
+      test('third_party_package_directives_before_own', () async {
         var packagesFilePath = new File('.packages').absolute.path;
-        dartlint.main([
+        await dartlint.main([
           '--packages',
           packagesFilePath,
           'test/_data/directives_ordering/third_party_package_directives_before_own',
@@ -284,15 +284,14 @@ defineTests() {
             ]));
       });
 
-      test('export_directives_after_import_directives', () {
+      test('export_directives_after_import_directives', () async {
         var packagesFilePath = new File('.packages').absolute.path;
-        dartlint.main([
+        await dartlint.main([
           '--packages',
           packagesFilePath,
           'test/_data/directives_ordering/export_directives_after_import_directives',
           '--rules=directives_ordering'
         ]);
-        expect(exitCode, 1);
         expect(
             collectingOut.trim(),
             stringContainsInOrder([
@@ -302,11 +301,12 @@ defineTests() {
               "export 'dummy2.dart';  // LINT",
               '5 files analyzed, 2 issues found, in'
             ]));
+        expect(exitCode, 1);
       });
 
-      test('sort_directive_sections_alphabetically', () {
+      test('sort_directive_sections_alphabetically', () async {
         var packagesFilePath = new File('.packages').absolute.path;
-        dartlint.main([
+        await dartlint.main([
           '--packages',
           packagesFilePath,
           'test/_data/directives_ordering/sort_directive_sections_alphabetically',
@@ -344,9 +344,9 @@ defineTests() {
             ]));
       });
 
-      test('lint_one_node_no_more_than_once', () {
+      test('lint_one_node_no_more_than_once', () async {
         var packagesFilePath = new File('.packages').absolute.path;
-        dartlint.main([
+        await dartlint.main([
           '--packages',
           packagesFilePath,
           'test/_data/directives_ordering/lint_one_node_no_more_than_once',
@@ -376,8 +376,8 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('only throw errors', () {
-        dartlint.main(
+      test('only throw errors', () async {
+        await dartlint.main(
             ['test/_data/only_throw_errors', '--rules=only_throw_errors']);
         expect(exitCode, 1);
         expect(
@@ -406,8 +406,8 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('only throw errors', () {
-        dartlint.runLinter([
+      test('only throw errors', () async {
+        await dartlint.runLinter([
           'test/_data/always_require_non_null_named_parameters',
           '--rules=always_require_non_null_named_parameters'
         ], new LinterOptions()..enableAssertInitializer = true);
@@ -432,8 +432,8 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('only throw errors', () {
-        dartlint.runLinter([
+      test('only throw errors', () async {
+        await dartlint.runLinter([
           'test/_data/prefer_asserts_in_initializer_lists',
           '--rules=prefer_asserts_in_initializer_lists'
         ], new LinterOptions()..enableAssertInitializer = true);
@@ -458,8 +458,8 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('only throw errors', () {
-        dartlint.runLinter([
+      test('only throw errors', () async {
+        await dartlint.runLinter([
           'test/_data/prefer_const_constructors_in_immutables',
           '--rules=prefer_const_constructors_in_immutables'
         ], new LinterOptions()..enableAssertInitializer = true);


### PR DESCRIPTION
See: #743

**NOTE:** build greenness depends on a new version of analyzer w/ the corresponding engine changes to be published (https://github.com/dart-lang/sdk/issues/30239). I'll update the pubspec once that's published. 👍 

@scheglov @bwilkerson 