### PR TITLE
New rule: Prefer spaces before EOL in string literals on the left

### DIFF
--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -74,6 +74,7 @@ import 'package:linter/src/rules/prefer_interpolation_to_compose_strings.dart';
 import 'package:linter/src/rules/prefer_is_empty.dart';
 import 'package:linter/src/rules/prefer_is_not_empty.dart';
 import 'package:linter/src/rules/prefer_single_quotes.dart';
+import 'package:linter/src/rules/prefer_string_spaces_at_beginning.dart';
 import 'package:linter/src/rules/pub/package_names.dart';
 import 'package:linter/src/rules/public_member_api_docs.dart';
 import 'package:linter/src/rules/recursive_getters.dart';
@@ -174,6 +175,7 @@ void registerLintRules() {
     ..register(new PreferIsNotEmpty())
     ..register(new PublicMemberApiDocs())
     ..register(new PreferSingleQuotes())
+    ..register(new PreferStringSpacesAtBeginning())
     ..register(new PubPackageNames())
     ..register(new RecursiveGetters())
     ..registerDefault(new SlashForDocComments())

--- a/lib/src/rules/prefer_string_spaces_at_beginning.dart
+++ b/lib/src/rules/prefer_string_spaces_at_beginning.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = "Put spaces in wrapped strings on the beginning of new lines.";
+
+const _details = '''
+
+**DO** put your spaces between words in wrapped strings at the beginning of new
+lines.
+
+That means you should prefer '... foo' \\n ' bar' over '... foo ' \\n 'bar'.
+This provides a few advantages:
+
+- with this lint on, you can't accidentally do *both*.
+- with this lint on, your project will at least be consistent in either way
+- by preferring spaces at the beginning, it is easier for code reviewers to
+  catch when they are missing entirely
+
+Pretty much every exception to this is in raw strings, which is a solid
+indicator of something that is not human text and does not conform to any
+predictable spacing pattern.
+
+**BAD:**
+```
+ 'some amount of words that wrap around where the space is very '
+ 'easily missed'
+```
+
+**GOOD:**
+```
+ 'some amount of words that wrap around where the space is very'
+ ' easily recognized'
+```
+
+''';
+
+class PreferStringSpacesAtBeginning extends LintRule {
+  _Visitor _visitor;
+
+  PreferStringSpacesAtBeginning()
+      : super(
+            name: 'prefer_string_spaces_at_beginning',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor<bool> {
+  final LintRule rule;
+  final Set<AstNode> visited = new HashSet<AstNode>();
+  _Visitor(this.rule);
+
+  bool isPlusOp(AstNode node) =>
+      node is BinaryExpression && node.operator.lexeme == '+';
+
+  @override
+  bool visitAdjacentStrings(AdjacentStrings strings) {
+    if (visited.contains(strings)) {
+      return false;
+    }
+
+    visited.add(strings);
+
+    strings.strings.getRange(0, strings.strings.length - 1).forEach((string) {
+      string.accept(new _ReportIfEndsInSpace(this));
+    });
+
+    return true;
+  }
+
+  @override
+  bool visitBinaryExpression(BinaryExpression expr) {
+    if (!isPlusOp(expr)) {
+      return false;
+    }
+
+    if (visited.contains(expr)) {
+      return false;
+    }
+
+    visited.add(expr);
+
+    // anything + notAString(), not concatted strings
+    if (expr.rightOperand is! StringLiteral &&
+        expr.rightOperand is! AdjacentStrings) {
+      return false;
+    }
+
+    var leftOperand = expr.leftOperand;
+
+    // 'a' + 'b', we've hit the depth of the concatenation, on the left side
+    if (leftOperand is StringLiteral || leftOperand is AdjacentStrings) {
+      // check A for trailing spaces
+      leftOperand.accept(new _ReportIfEndsInSpace(this));
+      // B is allowed to have them
+      return true;
+    }
+
+    // use `== true`, because may be null, as in, not a concatenation
+    if (leftOperand.accept(this) == true) {
+      leftOperand.accept(new _ReportIfEndsInSpace(this));
+      return true;
+    }
+
+    return false;
+  }
+}
+
+class _ReportIfEndsInSpace extends SimpleAstVisitor {
+  final _Visitor owningVisitor;
+  _ReportIfEndsInSpace(this.owningVisitor);
+
+  @override
+  visitBinaryExpression(BinaryExpression expr) {
+    expr.rightOperand.accept(this);
+  }
+
+  @override
+  visitAdjacentStrings(AdjacentStrings strings) {
+    strings.strings.last.accept(this);
+  }
+
+  @override
+  visitSimpleStringLiteral(SimpleStringLiteral string) {
+    if (!string.isRaw && string.value.endsWith(' ')) {
+      owningVisitor.rule.reportLint(string);
+    }
+  }
+
+  @override
+  visitStringInterpolation(StringInterpolation string) {
+    if (string.isRaw) {
+      return;
+    }
+
+    final lastElem = string.elements.last;
+
+    if (lastElem is InterpolationString && lastElem.value.endsWith(' ')) {
+      owningVisitor.rule.reportLint(string);
+    }
+  }
+}

--- a/test/rules/prefer_string_spaces_at_beginning.dart
+++ b/test/rules/prefer_string_spaces_at_beginning.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_string_spaces_at_beginning`
+
+main() {
+  // No sane lint rule could catch this. :(
+  String standalone1 = 'nospaces'; // OK
+  String standalone2 = 'space on the right '; // OK
+
+  // No sane lint rule could catch this. :(
+  String trailing1 = 'adjacent strings' 'trailing space on the right '; // OK
+  String trailing2 = 'catted strings' + 'trailing space on the right '; // OK
+
+  // test for adjacent strings (preferred)
+  String adj1 = 'adjacent strings ' 'with space at the end'; // LINT
+  String adj2 = 'adjacent strings' ' with space at the beginning'; // OK
+  String adj3 = 'multiple adjacent strings ' // LINT
+      'all of which have the wrong style ' // LINT
+      'of spaces being on the right'; // OK
+  String adj4 = 'multiple adjacent strings' // OK
+      ' all of which have the right style' // OK
+      ' of spaces being on the left'; // OK
+
+  // test for concatenated strings (for those not linting this)
+  String cat1 = 'concatenated strings ' + 'with space at the end'; // LINT
+  String cat2 = 'concatenated strings' + ' with space at the beginning'; // OK
+  String cat3 = 'multiple concatenated strings ' + // LINT
+      'all of which have the wrong style ' + // LINT
+      'of spaces being on the right'; // OK
+  String cat4 = 'multiple adjacent strings' + // OK
+      ' all of which have the right style' + // OK
+      ' of spaces being on the left'; // OK
+
+  // test a mixture of the two, for those who really hate doing things right
+  String mixedWrong = 'mixture of adjacent strings ' // LINT
+      'and concatenated strings too ' + // LINT
+      'all of which use the wrong style ' // LINT
+      'of spaces being on the right'; // OK
+  String mixedRight = 'mixture of adjacent strings' //  OK
+      ' and concatenated strings too' + //  OK
+      ' all of which use the wrong style' // OK
+      ' of spaces being on the right'; // OK
+
+  // Usually regexes, html, or special formats. Ignore.
+  String rawStrings1 = r'can do ' r' any strategy with ' r' adjacents '; // OK
+  String rawStrings2 = r'can do ' + r' any strategy with ' + r' catting '; // OK
+
+  String aStringVar = '';
+
+  String varConcatenation = 'trailing space allowed here ' + aStringVar; // OK
+}


### PR DESCRIPTION
Ie, bad:

```
'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do '
'eiusmod tempor incididunt ut labore et dolore magna aliqua.'
```

good:

```
'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do'
' eiusmod tempor incididunt ut labore et dolore magna aliqua.'
```

Now, this *could do the opposite if that's preferred*. In our example
codebase, I found a 2:1 preference for the former and not the latter.
Why did I then make the former bad? Because what I ultimately want to
catch is missing or doubled spaces. And to catch that, only human
review has a decent chance at it.

My hope is that by turning this on, humans become better at seeing when
the spaces between words in wrapped strings are correct, because the
tool enforces one, which is more obvious, and humans come to expect the
obvious.