### PR TITLE
New rule to detect (usually) unnecessary statements (no clear effects)

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -91,6 +91,7 @@ linter:
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
     - unnecessary_overrides
+    - unnecessary_statements
     - unnecessary_this
     - unrelated_type_equality_checks
     - use_rethrow_when_possible

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -92,6 +92,7 @@ import 'package:linter/src/rules/unnecessary_lambdas.dart';
 import 'package:linter/src/rules/unnecessary_null_aware_assignments.dart';
 import 'package:linter/src/rules/unnecessary_null_in_if_null_operators.dart';
 import 'package:linter/src/rules/unnecessary_overrides.dart';
+import 'package:linter/src/rules/unnecessary_statements.dart';
 import 'package:linter/src/rules/unnecessary_this.dart';
 import 'package:linter/src/rules/unrelated_type_equality_checks.dart';
 import 'package:linter/src/rules/use_rethrow_when_possible.dart';
@@ -193,6 +194,7 @@ void registerLintRules() {
     ..register(new UnnecessaryGettersSetters())
     ..register(new UnnecessaryLambdas())
     ..register(new UnnecessaryOverrides())
+    ..register(new UnnecessaryStatements())
     ..register(new UnnecessaryThis())
     ..register(new UnrelatedTypeEqualityChecks())
     ..register(new UseRethrowWhenPossible())

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -1,0 +1,151 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const desc = r'Statements should have a clear effect.';
+
+const details = r'''
+**AVOID** unnecessary statments.
+
+Statements which have no clear effect are usually unnecessary, or should be
+broken up.
+
+For example.
+
+**BAD:**
+```
+myvar;
+1 + 2;
+some.getter;
+methodOne() + methodTwo();
+foo ? bar : baz;
+```
+
+While the getter may trigger a side-effect, it is not usually obvious. And while
+the added methods have a clear effect, the addition itself does not unless there
+is some magical overload of the + operator.
+
+Usually code like this indicates an incomplete thought, and is a bug. For
+instance, the getter was likely supposed to be a function call.
+
+**GOOD:**
+```
+some.method();
+methodOne();
+methodTwo();
+foo ? bar() : baz();
+return myvar;
+```
+''';
+
+class UnnecessaryStatements extends LintRule {
+  UnnecessaryStatements()
+      : super(
+            name: 'unnecessary_statements',
+            description: desc,
+            details: details,
+            group: Group.errors);
+
+  @override
+  AstVisitor getVisitor() =>
+      new _Visitor(new _ReportNoClearEffectVisitor(this));
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final _ReportNoClearEffectVisitor reportNoClearEffect;
+  _Visitor(this.reportNoClearEffect);
+
+  @override
+  visitExpressionStatement(ExpressionStatement node) {
+    if (node.parent is FunctionBody) {
+      return;
+    }
+    node.accept(reportNoClearEffect);
+  }
+
+  @override
+  visitForStatement(ForStatement node) {
+    node.initialization?.accept(reportNoClearEffect);
+    node.updaters?.forEach((u) {
+      u.accept(reportNoClearEffect);
+    });
+  }
+}
+
+class _ReportNoClearEffectVisitor extends GeneralizingAstVisitor {
+  final LintRule rule;
+  _ReportNoClearEffectVisitor(this.rule);
+
+  @override
+  visitInvocationExpression(InvocationExpression node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitAssignmentExpression(AssignmentExpression node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitAwaitExpression(AwaitExpression node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitCascadeExpression(CascadeExpression node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitPostfixExpression(PostfixExpression node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitPrefixExpression(PrefixExpression node) {
+    if (node.operator.lexeme == '--' || node.operator.lexeme == '++') {
+      // Has a clear effect
+      return;
+    }
+    super.visitPrefixExpression(node);
+  }
+
+  @override
+  visitRethrowExpression(RethrowExpression node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitThrowExpression(ThrowExpression node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitConditionalExpression(ConditionalExpression node) {
+    node.thenExpression.accept(this);
+    node.elseExpression.accept(this);
+  }
+
+  @override
+  visitBinaryExpression(BinaryExpression node) {
+    switch (node.operator.lexeme) {
+      case '??':
+      case '||':
+      case '&&':
+        // these are OK when used for control flow
+        node.rightOperand.accept(this);
+        return;
+    }
+
+    super.visitBinaryExpression(node);
+  }
+
+  @override
+  visitExpression(Expression expression) {
+    rule.reportLint(expression);
+  }
+}

--- a/test/rules/unnecessary_statements.dart
+++ b/test/rules/unnecessary_statements.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N unnecessary_statements`
+
+notReturned() {
+  1; // LINT
+  1 + 1; // LINT
+  foo; // LINT
+  new MyClass(); // LINT
+  new MyClass().foo; // LINT
+  []; // LINT
+  <dynamic, dynamic>{}; // LINT
+  "blah"; // LINT
+  ~1; // LINT
+
+  foo(); // OK
+  new MyClass().foo(); // OK
+  var x = 2; // OK
+  x++; // OK
+  x--; // OK
+  ++x; // OK
+  --x; // OK
+  try {
+    throw new Exception(); // OK
+  } catch (x) {
+    rethrow; // OK
+  }
+}
+
+asConditionAndReturnOk() {
+  if (true == someBool) {
+    // OK
+    return 1 + 1; // OK
+  } else if (false == someBool) {
+    return foo; // OK
+  }
+  while (new MyClass() != null) {
+    // OK
+    return new MyClass().foo; // OK
+  }
+  for (; someBool ?? someBool;) {
+    // OK
+    return <dynamic, dynamic>{}; // OK
+  }
+  do {} while ("blah".isEmpty); // OK
+  for (var i in []) {} // OK
+  switch (~1) // OK
+      {
+  }
+
+  () => new MyClass().foo; // LINT
+  myfun() => new MyClass().foo; // OK
+}
+
+myfun() => new MyClass().foo; // OK
+
+expressionBranching() {
+  null ?? 1 + 1; // LINT
+  null ?? foo; // LINT
+  null ?? new MyClass(); // LINT
+  null ?? new MyClass().foo; // LINT
+  false || 1 + 1 == 2; // LINT
+  false || foo == true; // LINT
+  false || new MyClass() as bool; // LINT
+  false || new MyClass().foo == true; // LINT
+  true && 1 + 1 == 2; // LINT
+  true && foo == true; // LINT
+  true && new MyClass() as bool; // LINT
+  true && new MyClass().foo == true; // LINT
+
+  // ternaries can detect either/both sides
+  someBool // OK
+      ? 1 + 1 // LINT
+      : foo(); // OK
+  someBool // OK
+      ? foo() // OK
+      : foo; // LINT
+  someBool // OK
+      ? new MyClass() // LINT
+      : foo(); // OK
+  someBool // OK
+      ? foo() // OK
+      : new MyClass().foo; // LINT
+  someBool // OK
+      ? [] //LINT
+      : {}; // LINT
+
+  // not unnecessary condition, but unnecessary branching
+  foo() ?? 1 + 1; // LINT
+  foo() || new MyClass() as bool; // LINT
+  foo() && foo == true; // LINT
+  foo() ? 1 + 1 : foo(); // LINT
+  foo() ? foo() : foo; // LINT
+  foo() ? new MyClass() : foo(); // LINT
+  foo() ? foo() : new MyClass().foo; // LINT
+
+  null ?? foo(); // OK
+  null ?? new MyClass().foo(); // OK
+  false || foo(); // OK
+  false || new MyClass().foo(); // OK
+  true && foo(); // OK
+  true && new MyClass().foo(); // OK
+  someBool ? foo() : new MyClass().foo(); // OK
+  foo() ? foo() : new MyClass().foo(); // OK
+}
+
+inOtherStatements() {
+  if (foo()) {
+    1; // LINT
+  }
+  while (someBool) {
+    1 + 1; // LINT
+  }
+  for (foo; foo();) {} // LINT
+  for (; foo(); new MyClass()) {} // LINT
+  for (;
+      foo();
+      foo(), // OK
+      new MyClass(), // LINT
+      new MyClass().foo) {} // LINT
+  do {
+    new MyClass().foo; // LINT
+  } while (foo());
+
+  switch (foo()) {
+    case true:
+      []; // LINT
+      break; // OK
+    case false:
+      <dynamic, dynamic>{}; // LINT
+      break; // OK
+    default:
+      "blah"; // LINT
+  }
+
+  for (var i in [1, 2, 3]) {
+    ~1; // LINT
+  }
+}
+
+bool someBool = true;
+bool foo() => true;
+
+class MyClass {
+  bool foo() => true;
+}

--- a/test/rules/unnecessary_statements.dart
+++ b/test/rules/unnecessary_statements.dart
@@ -8,13 +8,13 @@ notReturned() {
   1; // LINT
   1 + 1; // LINT
   foo; // LINT
-  new MyClass(); // LINT
   new MyClass().foo; // LINT
   []; // LINT
   <dynamic, dynamic>{}; // LINT
   "blah"; // LINT
   ~1; // LINT
 
+  new MyClass(); // OK
   foo(); // OK
   new MyClass().foo(); // OK
   var x = 2; // OK
@@ -59,7 +59,6 @@ myfun() => new MyClass().foo; // OK
 expressionBranching() {
   null ?? 1 + 1; // LINT
   null ?? foo; // LINT
-  null ?? new MyClass(); // LINT
   null ?? new MyClass().foo; // LINT
   false || 1 + 1 == 2; // LINT
   false || foo == true; // LINT
@@ -78,7 +77,7 @@ expressionBranching() {
       ? foo() // OK
       : foo; // LINT
   someBool // OK
-      ? new MyClass() // LINT
+      ? new MyClass() // OK
       : foo(); // OK
   someBool // OK
       ? foo() // OK
@@ -93,9 +92,9 @@ expressionBranching() {
   foo() && foo == true; // LINT
   foo() ? 1 + 1 : foo(); // LINT
   foo() ? foo() : foo; // LINT
-  foo() ? new MyClass() : foo(); // LINT
   foo() ? foo() : new MyClass().foo; // LINT
 
+  null ?? new MyClass(); // OK
   null ?? foo(); // OK
   null ?? new MyClass().foo(); // OK
   false || foo(); // OK
@@ -104,6 +103,7 @@ expressionBranching() {
   true && new MyClass().foo(); // OK
   someBool ? foo() : new MyClass().foo(); // OK
   foo() ? foo() : new MyClass().foo(); // OK
+  foo() ? new MyClass() : foo(); // OK
 }
 
 inOtherStatements() {
@@ -114,11 +114,11 @@ inOtherStatements() {
     1 + 1; // LINT
   }
   for (foo; foo();) {} // LINT
-  for (; foo(); new MyClass()) {} // LINT
+  for (; foo(); 1 + 1) {} // LINT
   for (;
       foo();
       foo(), // OK
-      new MyClass(), // LINT
+      1 + 1, // LINT
       new MyClass().foo) {} // LINT
   do {
     new MyClass().foo; // LINT


### PR DESCRIPTION
Allow expression statements which clearly have side effects, and allow
expression statements being used as control flow for expressions that
have side effects.