### PR TITLE
Ensure rule descriptions are well-formed.

### DIFF
--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Annotate overridden members';
+const desc = r'Annotate overridden members.';
 
 const details = r'''
 **DO** annotate overridden methods and fields.

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = r"Don't explicitly initialize variables to null";
+const desc = r"Don't explicitly initialize variables to null.";
 
 const details = r'''
 From [effective dart]

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc = r'Always override `hashCode` if overriding `==`';
+const desc = r'Always override `hashCode` if overriding `==`.';
 
 const details = r'''
 

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -14,7 +14,7 @@ import 'package:linter/src/util/dart_type_utilities.dart';
 import 'package:linter/src/util/tested_expressions.dart';
 
 const _desc =
-    r'Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"';
+    r'Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".';
 
 const _details = r'''
 

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:linter/src/analyzer.dart';
 
 const _desc =
-    r'Boolean expression composed only with literals';
+    r'Boolean expression composed only with literals.';
 
 const _details = r'''
 

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Do not use adjacent strings in list';
+const desc = 'Do not use adjacent strings in list.';
 
 const details = r'''
 **DO NOT** use adjacent strings in list. This can be

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -11,7 +11,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Do not use more the one case with same value';
+const desc = 'Do not use more the one case with same value.';
 
 String message(String value1, String value2) =>
     'Do not use more the one case with same value ($value1 and $value2)';

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -12,7 +12,7 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
 const _desc =
-    r'Only throw instances of classes extending either Exception or Error';
+    r'Only throw instances of classes extending either Exception or Error.';
 
 const _details = r'''
 

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc = r'Provide doc comments for all public APIs';
+const desc = r'Provide doc comments for all public APIs.';
 
 const details = r'''
 **DO** provide doc comments for all public APIs.

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = "Prefer single quotes where they won't require escape sequences";
+const _desc = "Prefer single quotes where they won't require escape sequences.";
 
 const _details = '''
 

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -9,7 +9,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc = r'Document all public members';
+const desc = r'Document all public members.';
 
 const details = r'''
 **DO** document all public members.

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Prefer to use /// for doc comments';
+const desc = r'Prefer to use /// for doc comments.';
 
 const details = r'''
 From the [style guide](https://www.dartlang.org/articles/style-guide/):

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Sort unnamed constructor declarations first';
+const desc = r'Sort unnamed constructor declarations first.';
 
 const details = r'''
 **DO** sort unnamed constructor declarations first, before named ones.

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = 'Avoid null in null-aware assignment';
+const desc = 'Avoid null in null-aware assignment.';
 
 const details = '''
 Avoid null in null-aware assignment. `a ??= null` can be removed.

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = 'Avoid null in if null operator';
+const desc = 'Avoid null in if null operator.';
 
 const details = '''
 Avoid null as operand in if null operator. `a ?? null` and `null ?? a` can both

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Use rethrow to rethrow a caught exception';
+const _desc = r'Use rethrow to rethrow a caught exception.';
 
 const _details = r'''
 

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -57,6 +57,16 @@ defineRuleTests() {
         }
       }
     });
+    group('format', () {
+      registerLintRules();
+      for (LintRule rule in Registry.ruleRegistry.rules) {
+        test('`${rule.name}` description', () {
+          expect(rule.description.endsWith('.'), isTrue,
+              reason:
+                  "Rule description for ${rule.name} should end with a '.'");
+        });
+      }
+    });
   });
 }
 


### PR DESCRIPTION
* new test asserting rule descriptions are ‘.’ terminated
* fixes for ill-formed descriptions

@bwilkerson 