### PR TITLE
Test cases for `literal_only_boolean_expressions`.

### DIFF
--- a/test/rules/literal_only_boolean_expressions.dart
+++ b/test/rules/literal_only_boolean_expressions.dart
@@ -17,6 +17,9 @@ void bad() {
   if (true && 1 != 0 || 3 < 4) {} // LINT
   if (1 != 0 || 3 < 4 && true) {} // LINT
   if (null ?? m()) {} // LINT
+  while(!true) {} //LINT
+  do {} while(false); // LINT
+  for ( ; true; ) { } //LINT
 }
 
 bool m() => true;


### PR DESCRIPTION
Addressing missed cases flagged by coveralls:

https://coveralls.io/builds/12658358/source?filename=lib%2Fsrc%2Frules%2Fliteral_only_boolean_expressions.dart

@bwilkerson @alexeieleusis 