### PR TITLE
Improve `use_string_buffer` test coverage.

### DIFF
--- a/test/rules/use_string_buffers.dart
+++ b/test/rules/use_string_buffers.dart
@@ -70,6 +70,34 @@ void bar() {
   }
 }
 
+void bar2() {
+  String buffer = '';
+  do {
+    buffer += 'a'; // LINT
+  } while (buffer.length < 10);
+}
+
+void bar3() {
+  String buffer = '';
+  for (final s in [ 'a', 'b']) {
+    buffer += s; // LINT
+  }
+}
+
+void bar4() {
+  String buffer = '';
+  for (final s in [ 'a', 'b']) {
+    (buffer += s); // LINT
+  }
+}
+
+void bar5() {
+  for (final s in [ 'a', 'b']) {
+    String str;
+    str += s; // OK
+  }
+}
+
 class B {
   operator +(B other) => this;
 


### PR DESCRIPTION
@bwilkerson 

As discussed, I'm exploring (and may open an issue to track) why `s = s + 'foo'` is OK in the foreach case.  In the meantime, this at least gets the logic better under coverage.