### PR TITLE
Update library prefix matcher; inline APIs (#684,#769).

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -41,31 +41,6 @@ class Analyzer {
           projectRoot: projectRoot,
           packageName: packageName);
 
-  /// Check if this [string] is formatted in `CamelCase`.
-  bool isCamelCase(String string) => CamelCaseString.isCamelCase(string);
-
-  /// Returns `true` if this [name] is a legal Dart identifier.
-  bool isIdentifier(String name) => util.isIdentifier(name);
-
-  /// Check if this [string] consists only of `_`s.
-  bool isJustUnderscores(String string) => util.isJustUnderscores(string);
-
-  /// Returns `true` if this [id] is `lowerCamelCase`.
-  bool isLowerCamelCase(String id) => util.isLowerCamelCase(id);
-
-  /// Returns `true` if this [id] is `lower_camel_case_with_underscores`.
-  bool isLowerCaseUnderScore(String id) => util.isLowerCaseUnderScore(id);
-
-  /// Returns `true` if this [id] is `lower_camel_case_with_underscores_or.dots`.
-  bool isLowerCaseUnderScoreWithDots(String id) =>
-      util.isLowerCaseUnderScoreWithDots(id);
-
-  /// Returns `true` if this [fileName] is a Pubspec file.
-  bool isPubspecFileName(String fileName) => util.isPubspecFileName(fileName);
-
-  /// Returns `true` if the given code unit [c] is upper case.
-  bool isUpperCase(int c) => util.isUpperCase(c);
-
   /// Register this [lint] with the analyzer's rule registry.
   void register(LintRule lint) {
     Registry.ruleRegistry.register(lint);

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 /// Returns direct children of [parent].
 List<Element> getChildren(Element parent, [String name]) {
@@ -139,8 +140,7 @@ bool isSimpleSetter(MethodDeclaration setter) {
 }
 
 /// Returns `true` if the given [id] is a valid Dart identifier.
-bool isValidDartIdentifier(String id) =>
-    !isKeyWord(id) && Analyzer.facade.isIdentifier(id);
+bool isValidDartIdentifier(String id) => !isKeyWord(id) && isIdentifier(id);
 
 /// Returns `true` if the keyword associated with this token is `var`.
 bool isVar(Token token) => isKeyword(token, Keyword.VAR);

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -17,6 +17,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 const desc = 'Specify type annotations.';
 
@@ -141,8 +142,7 @@ class Visitor extends SimpleAstVisitor {
 
   @override
   visitSimpleFormalParameter(SimpleFormalParameter param) {
-    if (param.type == null &&
-        !Analyzer.facade.isJustUnderscores(param.identifier.name)) {
+    if (param.type == null && !isJustUnderscores(param.identifier.name)) {
       if (param.keyword != null) {
         rule.reportLintForToken(param.keyword);
       } else {

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 const desc = 'Name types using UpperCamelCase.';
 
@@ -31,8 +32,6 @@ typedef num Adder(num x, num y);
 ```
 ''';
 
-bool isUpperCamelCase(String s) => Analyzer.facade.isCamelCase(s);
-
 class CamelCaseTypes extends LintRule {
   CamelCaseTypes()
       : super(
@@ -51,14 +50,14 @@ class Visitor extends SimpleAstVisitor {
 
   @override
   visitClassDeclaration(ClassDeclaration node) {
-    if (!isUpperCamelCase(node.name.toString())) {
+    if (!isCamelCase(node.name.toString())) {
       rule.reportLint(node.name);
     }
   }
 
   @override
   visitFunctionTypeAlias(FunctionTypeAlias node) {
-    if (!isUpperCamelCase(node.name.toString())) {
+    if (!isCamelCase(node.name.toString())) {
       rule.reportLint(node.name);
     }
   }

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 const desc = r'Prefer using lowerCamelCase for constant names.';
 
@@ -57,7 +58,7 @@ class Visitor extends SimpleAstVisitor {
   Visitor(this.rule);
 
   checkIdentifier(SimpleIdentifier id) {
-    if (!Analyzer.facade.isLowerCamelCase(id.name)) {
+    if (!isLowerCamelCase(id.name)) {
       rule.reportLint(id);
     }
   }

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 const desc = r'Avoid empty catch blocks.';
 
@@ -67,7 +68,7 @@ class Visitor extends SimpleAstVisitor {
     // Skip exceptions named with underscores.
     SimpleIdentifier exceptionParameter = node.exceptionParameter;
     if (exceptionParameter != null &&
-        Analyzer.facade.isJustUnderscores(exceptionParameter.name)) {
+        isJustUnderscores(exceptionParameter.name)) {
       return;
     }
 

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 const desc =
     'Name libraries and source files using `lowercase_with_underscores`.';
@@ -49,7 +50,7 @@ class Visitor extends SimpleAstVisitor {
 
   @override
   visitLibraryDirective(LibraryDirective node) {
-    if (!Analyzer.facade.isLowerCaseUnderScoreWithDots(node.name.toString())) {
+    if (!isLowerCaseUnderScoreWithDots(node.name.toString())) {
       rule.reportLint(node.name);
     }
   }

--- a/lib/src/rules/library_prefixes.dart
+++ b/lib/src/rules/library_prefixes.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 const desc =
     r'Use `lowercase_with_underscores` when specifying a library prefix.';
@@ -49,8 +50,7 @@ class Visitor extends SimpleAstVisitor {
 
   @override
   visitImportDirective(ImportDirective node) {
-    if (node.prefix != null &&
-        !Analyzer.facade.isLowerCaseUnderScore(node.prefix.toString())) {
+    if (node.prefix != null && !isValidLibraryPrefix(node.prefix.toString())) {
       rule.reportLint(node.prefix);
     }
   }

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -7,8 +7,7 @@ import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc =
-    r'Boolean expression composed only with literals.';
+const _desc = r'Boolean expression composed only with literals.';
 
 const _details = r'''
 

--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
 
 const desc = r'Name non-constant identifiers using lowerCamelCase.';
 
@@ -45,11 +46,11 @@ class Visitor extends SimpleAstVisitor {
   Visitor(this.rule);
 
   checkIdentifier(SimpleIdentifier id, {bool underscoresOk: false}) {
-    if (underscoresOk && Analyzer.facade.isJustUnderscores(id.name)) {
+    if (underscoresOk && isJustUnderscores(id.name)) {
       // For example, `___` is OK in a callback.
       return;
     }
-    if (!Analyzer.facade.isLowerCamelCase(id.name)) {
+    if (!isLowerCamelCase(id.name)) {
       rule.reportLint(id);
     }
   }

--- a/lib/src/rules/pub/package_names.dart
+++ b/lib/src/rules/pub/package_names.dart
@@ -4,6 +4,7 @@
 
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
+import 'package:linter/src/utils.dart';
 
 const desc = 'Use `lowercase_with_underscores` for package names.';
 
@@ -18,9 +19,6 @@ Package names should be all lowercase, with underscores to separate words,
 Also, make sure the name is a valid Dart identifier -- that it doesn't start
 with digits and isn't a reserved word.
 ''';
-
-bool isValidPackageName(String id) =>
-    Analyzer.facade.isLowerCaseUnderScore(id) && isValidDartIdentifier(id);
 
 class PubPackageNames extends LintRule {
   PubPackageNames()

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
+import 'package:linter/src/utils.dart';
 
 const desc = r'Type annotate public APIs.';
 
@@ -120,8 +121,7 @@ class _VisitorHelper extends RecursiveAstVisitor {
 
   @override
   visitSimpleFormalParameter(SimpleFormalParameter param) {
-    if (param.type == null &&
-        !Analyzer.facade.isJustUnderscores(param.identifier.name)) {
+    if (param.type == null && !isJustUnderscores(param.identifier.name)) {
       rule.reportLint(param);
     }
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:linter/src/ast.dart';
+
+final _identifier = new RegExp(r'^([(_|$)a-zA-Z]+([_a-zA-Z0-9])*)$');
+
+final _lowerCamelCase =
+    new RegExp(r'^(_)*[?$a-z][a-z0-9?$]*([A-Z][a-z0-9?$]*)*$');
+
+final _lowerCaseUnderScore = new RegExp(r'^([a-z]+([_]?[a-z0-9]+)*)+$');
+
+final _lowerCaseUnderScoreWithDots =
+    new RegExp(r'^[a-z][_a-z0-9]*(\.[a-z][_a-z0-9]*)*$');
+
+final _pubspec = new RegExp(r'^[_]?pubspec\.yaml$');
+
+final _underscores = new RegExp(r'^[_]+$');
+
+final _validLibraryPrefix = new RegExp(r'^(_)*([a-z]+([_]?[a-z0-9]+)*)+$');
+
+/// Check if this [string] is formatted in `CamelCase`.
+bool isCamelCase(String string) => CamelCaseString.isCamelCase(string);
+
+/// Returns `true` if this [fileName] is a Dart file.
+bool isDartFileName(String fileName) => fileName.endsWith('.dart');
+
+/// Returns `true` if this [name] is a legal Dart identifier.
+bool isIdentifier(String name) => _identifier.hasMatch(name);
+
+/// Returns `true` of the given [name] is composed only of `_`s.
+bool isJustUnderscores(String name) => _underscores.hasMatch(name);
+
+/// Returns `true` if this [id] is `lowerCamelCase`.
+bool isLowerCamelCase(String id) =>
+    id.length == 1 && isUpperCase(id.codeUnitAt(0)) ||
+    id == '_' ||
+    _lowerCamelCase.hasMatch(id);
+
+/// Returns `true` if this [id] is `lower_camel_case_with_underscores`.
+bool isLowerCaseUnderScore(String id) => _lowerCaseUnderScore.hasMatch(id);
+
+/// Returns `true` if this [id] is `lower_camel_case_with_underscores_or.dots`.
+bool isLowerCaseUnderScoreWithDots(String id) =>
+    _lowerCaseUnderScoreWithDots.hasMatch(id);
+
+/// Returns `true` if this [fileName] is a Pubspec file.
+bool isPubspecFileName(String fileName) => _pubspec.hasMatch(fileName);
+
+/// Returns `true` if the given code unit [c] is upper case.
+bool isUpperCase(int c) => c >= 0x40 && c <= 0x5A;
+
+/// Returns true if this [libraryPrefix] is valid.
+bool isValidLibraryPrefix(String libraryPrefix) =>
+    _validLibraryPrefix.hasMatch(libraryPrefix);
+
+/// Returns true if this [id] is a valid package name.
+bool isValidPackageName(String id) =>
+    isLowerCaseUnderScore(id) && isValidDartIdentifier(id);
+
+class CamelCaseString {
+  static final _camelCaseMatcher = new RegExp(r'[A-Z][a-z]*');
+  static final _camelCaseTester = new RegExp(r'^([_$]*)([A-Z?$]+[a-z0-9]*)+$');
+
+  final String value;
+  CamelCaseString(this.value) {
+    if (!isCamelCase(value)) {
+      throw new ArgumentError('$value is not CamelCase');
+    }
+  }
+
+  String get humanized => _humanize(value);
+
+  @override
+  String toString() => value;
+
+  static bool isCamelCase(String name) => _camelCaseTester.hasMatch(name);
+
+  static String _humanize(String camelCase) =>
+      _camelCaseMatcher.allMatches(camelCase).map((m) => m.group(0)).join(' ');
+}

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -19,7 +19,7 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 import 'package:linter/src/formatter.dart';
 import 'package:linter/src/rules.dart';
-import 'package:linter/src/rules/camel_case_types.dart';
+import 'package:linter/src/utils.dart';
 import 'package:linter/src/rules/implementation_imports.dart';
 import 'package:linter/src/rules/package_prefixed_library_names.dart';
 import 'package:path/path.dart' as p;
@@ -149,10 +149,8 @@ defineRuleUnitTests() {
       testEach(bad, isValidDartIdentifier, isFalse);
     });
     group('pubspec', () {
-      testEach(['pubspec.yaml', '_pubspec.yaml'],
-          Analyzer.facade.isPubspecFileName, isTrue);
-      testEach(['__pubspec.yaml', 'foo.yaml'],
-          Analyzer.facade.isPubspecFileName, isFalse);
+      testEach(['pubspec.yaml', '_pubspec.yaml'], isPubspecFileName, isTrue);
+      testEach(['__pubspec.yaml', 'foo.yaml'], isPubspecFileName, isFalse);
     });
 
     group('camel case', () {
@@ -171,14 +169,41 @@ defineRuleUnitTests() {
           'Foo\$Generated',
           'Foo\$Generated\$Bar'
         ];
-        testEach(good, isUpperCamelCase, isTrue);
+        testEach(good, isCamelCase, isTrue);
         var bad = ['fooBar', 'foo', 'f', '_f', 'F_B'];
-        testEach(bad, isUpperCamelCase, isFalse);
+        testEach(bad, isCamelCase, isFalse);
       });
     });
+    group('library prefixes', () {
+      var good = [
+        'foo_bar',
+        'foo',
+        'foo_bar_baz',
+        'p',
+        'p1',
+        'p21',
+        'p1ll0',
+        '_foo',
+        '__foo'
+      ];
+      testEach(good, isValidLibraryPrefix, isTrue);
+
+      var bad = [
+        'JSON',
+        'JS',
+        'Math',
+        'jsUtils',
+        'foo_Bar',
+        'F_B',
+        '1',
+        '1b',
+      ];
+      testEach(bad, isLowerCaseUnderScore, isFalse);
+    });
+
     group('lower_case_underscores', () {
       var good = ['foo_bar', 'foo', 'foo_bar_baz', 'p', 'p1', 'p21', 'p1ll0'];
-      testEach(good, Analyzer.facade.isLowerCaseUnderScore, isTrue);
+      testEach(good, isLowerCaseUnderScore, isTrue);
 
       var bad = [
         'Foo',
@@ -192,7 +217,7 @@ defineRuleUnitTests() {
         '1',
         '1b',
       ];
-      testEach(bad, Analyzer.facade.isLowerCaseUnderScore, isFalse);
+      testEach(bad, isLowerCaseUnderScore, isFalse);
     });
     group('qualified lower_case_underscores', () {
       var good = [
@@ -210,10 +235,10 @@ defineRuleUnitTests() {
         'a.b.c',
         'p2.src.acme'
       ];
-      testEach(good, Analyzer.facade.isLowerCaseUnderScoreWithDots, isTrue);
+      testEach(good, isLowerCaseUnderScoreWithDots, isTrue);
 
       var bad = ['Foo', 'fooBar.', '.foo_Bar', '_f', 'F_B', 'JS', 'JSON'];
-      testEach(bad, Analyzer.facade.isLowerCaseUnderScoreWithDots, isFalse);
+      testEach(bad, isLowerCaseUnderScoreWithDots, isFalse);
     });
     group('lowerCamelCase', () {
       var good = [
@@ -232,17 +257,17 @@ defineRuleUnitTests() {
         'foo\$Generated',
         'foo\$Generated\$Bar'
       ];
-      testEach(good, Analyzer.facade.isLowerCamelCase, isTrue);
+      testEach(good, isLowerCamelCase, isTrue);
 
       var bad = ['Foo', 'foo_', 'foo_bar', '_X'];
-      testEach(bad, Analyzer.facade.isLowerCamelCase, isFalse);
+      testEach(bad, isLowerCamelCase, isFalse);
     });
     group('isUpperCase', () {
       var caps = new List<int>.generate(26, (i) => 'A'.codeUnitAt(0) + i);
-      testEachInt(caps, Analyzer.facade.isUpperCase, isTrue);
+      testEachInt(caps, isUpperCase, isTrue);
 
       var bad = ['a', '1', 'z'].map((c) => c.codeUnitAt(0));
-      testEachInt(bad, Analyzer.facade.isUpperCase, isFalse);
+      testEachInt(bad, isUpperCase, isFalse);
     });
     group('libary_name_prefixes', () {
       testEach(

--- a/test/rules/constant_identifier_names.dart
+++ b/test/rules/constant_identifier_names.dart
@@ -4,7 +4,7 @@
 
 // test w/ `pub run test -N constant_identifier_names`
 
-const DEFALT_TIMEOUT = 1000; //LINT
+const DEFAULT_TIMEOUT = 1000; //LINT
 const PI = 3.14; //LINT
 
 class Z {

--- a/test/rules/library_prefixes.dart
+++ b/test/rules/library_prefixes.dart
@@ -4,8 +4,10 @@
 
 // test w/ `pub run test -N library_prefixes`
 
+import 'dart:async' as _async; //OK
 import 'dart:math' as dartMath; //LINT [23:8]
 
 main() {
   print(dartMath.PI);
+  print(_async.Timer);
 }


### PR DESCRIPTION
* Updates library prefix matching to allow leading `_`s.
* Inlines matcher regexps (decoupling from analyzer; see also, https://github.com/dart-lang/sdk/commit/1c5101e4a65484c2f3f28e4d11c1fee48c9b4c51).

Fixes: #684
Fixes: #769

@bwilkerson 

FYI @natebosch 