### PR TITLE
Update library prefix checking to allow leading `$`s (#294).

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -18,7 +18,7 @@ final _pubspec = new RegExp(r'^[_]?pubspec\.yaml$');
 
 final _underscores = new RegExp(r'^[_]+$');
 
-final _validLibraryPrefix = new RegExp(r'^(_)*([a-z]+([_]?[a-z0-9]+)*)+$');
+final _validLibraryPrefix = new RegExp(r'^(_|\$)?(_)*([a-z]+([_]?[a-z0-9]+)*)+$');
 
 /// Check if this [string] is formatted in `CamelCase`.
 bool isCamelCase(String string) => CamelCaseString.isCamelCase(string);

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -184,7 +184,10 @@ defineRuleUnitTests() {
         'p21',
         'p1ll0',
         '_foo',
-        '__foo'
+        r'$foo',
+        '__foo',
+        r'$_foo',
+        r'$__foo',
       ];
       testEach(good, isValidLibraryPrefix, isTrue);
 
@@ -197,8 +200,13 @@ defineRuleUnitTests() {
         'F_B',
         '1',
         '1b',
+        r'foo$',
+        r'f$oo',
+        r'$$foo',
+        r'$_$foo',
+        r'_$foo',
       ];
-      testEach(bad, isLowerCaseUnderScore, isFalse);
+      testEach(bad, isValidLibraryPrefix, isFalse);
     });
 
     group('lower_case_underscores', () {

--- a/test/rules/library_prefixes.dart
+++ b/test/rules/library_prefixes.dart
@@ -5,6 +5,7 @@
 // test w/ `pub run test -N library_prefixes`
 
 import 'dart:async' as _async; //OK
+import 'dart:collection' as $collection; //OK
 import 'dart:math' as dartMath; //LINT [23:8]
 
 main() {


### PR DESCRIPTION
Fixes: #294.

@bwilkerson 