### PR TITLE
Make trusty default distro explicit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dart:
   - dev
 sudo: false
 script: ./tool/travis.sh
+dist: trusty
 env:
   - LINTER_BOT=main
   - LINTER_BOT=benchmark


### PR DESCRIPTION
Making the default explicit, silences this build spam:

![image](https://user-images.githubusercontent.com/67586/28947034-abc7a5e6-7862-11e7-893e-7e916f7a38c7.png)

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default

@bwilkerson