### PR TITLE
Have avoid_returning_this rule ignore operators

### DIFF
--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -63,6 +63,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   visitMethodDeclaration(MethodDeclaration node) {
+    if (node.isOperator) return;
     if (node.returnType?.type !=
             (node.parent as ClassDeclaration).element?.type ||
         _hasInheritedMethod(node)) {

--- a/test/rules/avoid_returning_this.dart
+++ b/test/rules/avoid_returning_this.dart
@@ -28,6 +28,11 @@ class A {
     x++;
     return this;
   }
+
+  A operator +(int n) { // OK it is ok because it is an operator.
+    x += n;
+    return this;
+  }
 }
 
 class B extends A{


### PR DESCRIPTION
This modifies the avoid_returning_this rule to ignore MethodDeclaration nodes when they are defining operators.  See issue #791 for discussion.