### PR TITLE
Create rule avoid_unused_constructor_parameters

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -24,6 +24,7 @@ linter:
     - avoid_setters_without_getters
     - avoid_slow_async_io
     - avoid_types_on_closure_parameters
+    - avoid_unused_constructor_parameters
     - await_only_futures
     - camel_case_types
     - cancel_subscriptions

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -25,6 +25,7 @@ import 'package:linter/src/rules/avoid_returning_this.dart';
 import 'package:linter/src/rules/avoid_setters_without_getters.dart';
 import 'package:linter/src/rules/avoid_slow_async_io.dart';
 import 'package:linter/src/rules/avoid_types_on_closure_parameters.dart';
+import 'package:linter/src/rules/avoid_unused_constructor_parameters.dart';
 import 'package:linter/src/rules/await_only_futures.dart';
 import 'package:linter/src/rules/camel_case_types.dart';
 import 'package:linter/src/rules/cancel_subscriptions.dart';
@@ -127,6 +128,7 @@ void registerLintRules() {
     ..register(new AvoidReturningThis())
     ..register(new AvoidSettersWithoutGetters())
     ..register(new AvoidSlowAsyncIo())
+    ..register(new AvoidUnusedConstructorParameters())
     ..register(new AwaitOnlyFutures())
     ..registerDefault(new CamelCaseTypes())
     ..register(new CancelSubscriptions())

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -11,8 +11,8 @@ const _details = r'''
 
 **BAD:**
 ```
-class Bad {
-  Bad(int unusedParameter, [String unusedPositional]) {};
+class BadOne {
+  Bad(int unusedParameter, [String unusedPositional]);
 }
 ```
 

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -55,8 +55,7 @@ class _Visitor extends SimpleAstVisitor {
     node?.body?.visitChildren(_constructorVisitor);
     node?.initializers?.forEach((i) => i.visitChildren(_constructorVisitor));
 
-    final unusedParameters = _constructorVisitor.unusedParameters;
-    if (unusedParameters.isNotEmpty) rule.reportLint(unusedParameters.first);
+    _constructorVisitor.unusedParameters.forEach(rule.reportLint);
   }
 }
 

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -1,0 +1,65 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Avoid defining unused paramters in constructors.';
+
+const _details = r'''
+
+**AVOID** defining unused parameters in constructors.
+
+**BAD:**
+```
+class Bad {
+  Bad(int unusedParameter, [String unusedPositional]) {};
+}
+```
+
+''';
+
+class AvoidUnusedConstructorParameters extends LintRule {
+  _Visitor _visitor;
+  AvoidUnusedConstructorParameters()
+      : super(
+            name: 'avoid_unused_constructor_parameters',
+            description: _desc,
+            details: _details,
+            group: Group.style) {
+    _visitor = new _Visitor(this);
+  }
+
+  @override
+  AstVisitor getVisitor() => _visitor;
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
+    final _constructorVisitor = new _ConstructorVisitor(rule, node);
+    node?.body?.visitChildren(_constructorVisitor);
+    node?.initializers?.forEach((i) => i.visitChildren(_constructorVisitor));
+
+    final unusedParameters = _constructorVisitor.unusedParameters;
+    if (unusedParameters.isNotEmpty) rule.reportLint(unusedParameters.first);
+  }
+}
+
+class _ConstructorVisitor extends RecursiveAstVisitor {
+  final LintRule rule;
+  final ConstructorDeclaration element;
+  final Set<FormalParameter> unusedParameters;
+
+  _ConstructorVisitor(this.rule, this.element)
+      : unusedParameters = element.parameters.parameters
+            .where((p) => (p.element is! FieldFormalParameterElement))
+            .toSet();
+
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    unusedParameters.removeWhere((p) => node.bestElement == p.element);
+  }
+}

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -12,7 +12,15 @@ const _details = r'''
 **BAD:**
 ```
 class BadOne {
-  Bad(int unusedParameter, [String unusedPositional]);
+  BadOne(int unusedParameter, [String unusedPositional]);
+}
+
+class BadTwo {
+  int c;
+
+  BadTwo(int a, int b, int x) {
+    c = a + b;
+  }
 }
 ```
 

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';

--- a/test/rules/avoid_unused_constructor_parameters.dart
+++ b/test/rules/avoid_unused_constructor_parameters.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_unused_constructor_parameters`
+
+class A {
+  A(); // OK
+}
+
+class B {
+  int a;
+  int b;
+
+  B(this.a, [this.b]); // OK because field formal parameters are being used
+}
+
+class C {
+  int a;
+  int b;
+
+  C({this.a, this.b}); // OK because field formal parameters are being used
+}
+
+class D {
+  D(int a, [int b = 5]); // LINT
+}
+
+class E {
+  int c;
+
+  E(int a, {int b = 10}) { // OK because all parameters are used
+    c = a + b;
+  }
+}
+
+class F {
+  int n;
+
+  F(int a, [int b = 10, int c = 42]) { // LINT
+    n = a + 42;
+  }
+}
+
+class G {
+  int c;
+  int d;
+
+  G(int a, {int b, this.c}) { // OK all non-formal parameters are used
+    d = a + b;
+  }
+}
+
+class H {
+  int c;
+
+  H(int a, int b) : c = a + b; // OK because parameters are used in initializer
+}
+
+class I extends H {
+  I(int a, int b) : super(a, b); // OK because paramters are used in initializer
+}
+
+class J extends H {
+  int d;
+
+  J(int a, int b, int c) : super(a, b) { // OK because all parameters are used
+    d = a * b * c;
+  }
+}
+
+class K {
+  int a;
+  int b;
+
+  K(this.a, {this.b, int c}); // LINT
+}

--- a/test/rules/avoid_unused_constructor_parameters.dart
+++ b/test/rules/avoid_unused_constructor_parameters.dart
@@ -23,7 +23,8 @@ class C {
 }
 
 class D {
-  D(int a, [int b = 5]); // LINT
+  D(int a, // LINT
+    [int b = 5]); // LINT
 }
 
 class E {
@@ -37,7 +38,8 @@ class E {
 class F {
   int n;
 
-  F(int a, [int b = 10, int c = 42]) { // LINT
+  F(int a, [int b = 10, // LINT
+    int c = 42]) { // LINT
     n = a + 42;
   }
 }
@@ -74,4 +76,17 @@ class K {
   int b;
 
   K(this.a, {this.b, int c}); // LINT
+}
+
+class L {
+  int c;
+
+  L(int a, int b) : c = a + b;
+  L.named(int a, int b, int c) : this(a, b); // LINT
+}
+
+class M {
+  M._internal(int n); // LINT
+
+  factory M(int a, int b) => new M._internal(a); // LINT
 }

--- a/test/rules/avoid_unused_constructor_parameters.dart
+++ b/test/rules/avoid_unused_constructor_parameters.dart
@@ -46,7 +46,7 @@ class G {
   int c;
   int d;
 
-  G(int a, {int b, this.c}) { // OK all non-formal parameters are used
+  G(int a, {int b, this.c}) { // OK because all non-field-formal parameters are used
     d = a + b;
   }
 }
@@ -58,7 +58,7 @@ class H {
 }
 
 class I extends H {
-  I(int a, int b) : super(a, b); // OK because paramters are used in initializer
+  I(int a, int b) : super(a, b); // OK because parameters are used in initializer
 }
 
 class J extends H {


### PR DESCRIPTION
This rule, as per #799, lints instances within constructors where parameters are defined but not used.