### PR TITLE
Allow underscores around numbers in `non_constant_identifier_names`.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -7,7 +7,7 @@ import 'package:linter/src/ast.dart';
 final _identifier = new RegExp(r'^([(_|$)a-zA-Z]+([_a-zA-Z0-9])*)$');
 
 final _lowerCamelCase =
-    new RegExp(r'^(_)*[?$a-z][a-z0-9?$]*([A-Z][a-z0-9?$]*)*$');
+    new RegExp(r'^(_)*[?$a-z][a-z0-9?$]*(([A-Z][a-z0-9?$]*)|([_][0-9][a-z0-9?$]*))*$');
 
 final _lowerCaseUnderScore = new RegExp(r'^([a-z]+([_]?[a-z0-9]+)*)+$');
 

--- a/test/rules/non_constant_identifier_names.dart
+++ b/test/rules/non_constant_identifier_names.dart
@@ -7,6 +7,13 @@
 String YO = ''; //LINT
 const Z = 4; //OK
 
+//OK (#687):
+var cell_0_0;
+var cell_0_1;
+var cell_1_0;
+var cell_1_1;
+var cell_10_11;
+
 abstract class A {
   int _x; //OK
   int __x; //OK


### PR DESCRIPTION
Better late than never!

@srawlins.

Fixes: #687.

