### PR TITLE
Fix false positive for `avoid_positional_boolean_parameters` on `[]=`

### DIFF
--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
@@ -34,6 +35,9 @@ new Button(ButtonState.enabled);
 
 bool _hasInheritedMethod(MethodDeclaration node) =>
     DartTypeUtilities.lookUpInheritedMethod(node) != null;
+
+bool _indexEqOp(MethodDeclaration node) =>
+    node.isOperator && node.name.token.type == TokenType.INDEX_EQ;
 
 bool _isNamedParameter(FormalParameter node) =>
     node.kind == ParameterKind.NAMED;
@@ -84,6 +88,7 @@ class _Visitor extends SimpleAstVisitor {
   visitMethodDeclaration(MethodDeclaration node) {
     if (!node.isSetter &&
         !node.element.isPrivate &&
+        !_indexEqOp(node) &&
         !_hasInheritedMethod(node)) {
       final parametersToLint =
           node.parameters?.parameters?.where(_isFormalParameterToLint);

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -36,9 +36,6 @@ new Button(ButtonState.enabled);
 bool _hasInheritedMethod(MethodDeclaration node) =>
     DartTypeUtilities.lookUpInheritedMethod(node) != null;
 
-bool _indexEqOp(MethodDeclaration node) =>
-    node.isOperator && node.name.token.type == TokenType.INDEX_EQ;
-
 bool _isNamedParameter(FormalParameter node) =>
     node.kind == ParameterKind.NAMED;
 
@@ -88,7 +85,7 @@ class _Visitor extends SimpleAstVisitor {
   visitMethodDeclaration(MethodDeclaration node) {
     if (!node.isSetter &&
         !node.element.isPrivate &&
-        !_indexEqOp(node) &&
+        !node.isOperator &&
         !_hasInheritedMethod(node)) {
       final parametersToLint =
           node.parameters?.parameters?.where(_isFormalParameterToLint);

--- a/test/rules/avoid_positional_boolean_parameters.dart
+++ b/test/rules/avoid_positional_boolean_parameters.dart
@@ -50,6 +50,11 @@ class C {
   void operator []=(int index, bool value) { // OK (#803)
   }
 
+  void operator +(bool value) { // OK (#803)
+  }
+
+  void operator -(bool value) { // OK (#803)
+  }
 }
 
 class D {

--- a/test/rules/avoid_positional_boolean_parameters.dart
+++ b/test/rules/avoid_positional_boolean_parameters.dart
@@ -46,6 +46,10 @@ class C {
   C.bad(bool a) { // LINT
     this.value = value;
   }
+
+  void operator []=(int index, bool value) { // OK (#803)
+  }
+
 }
 
 class D {


### PR DESCRIPTION
Fix false positive for `avoid_positional_boolean_parameters` on `[]=` ops.

Fixes: #803.

@a14n @bwilkerson 