### PR TITLE
Fix `comment_references` in the face of incomplete references (#819)

### DIFF
--- a/lib/src/rules/comment_references.dart
+++ b/lib/src/rules/comment_references.dart
@@ -68,7 +68,7 @@ class Visitor extends SimpleAstVisitor {
                   rule.lintCode, nameOffset, reference.length);
             }
           }
-          leftIndex = comment.indexOf('[', rightIndex);
+          leftIndex = rightIndex < 0 ? -1 : comment.indexOf('[', rightIndex);
         }
       }
     }

--- a/test/rules/comment_references.dart
+++ b/test/rules/comment_references.dart
@@ -24,3 +24,9 @@ class A {
   /// Writes [y]. #LINT
   void write(int x) {}
 }
+
+/// [
+/// ^--- Should not crash (#819).
+class B {
+
+}


### PR DESCRIPTION
Fixes: #819 

@bwilkerson 