### PR TITLE
0.1.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.37
+
+* `avoid_positional_boolean_parameters` updated to allow booleans in operator declarations
+* `comment_references` fixed to handle incomplete references
+* `non_constant_identifier_names` updated to allow underscores around numbers
+
 # 0.1.36
 
 * new `avoid_unused_constructor_parameters` lint

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.36
+version: 0.1.37
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.37

* `avoid_positional_boolean_parameters` updated to allow booleans in operator declarations
* `comment_references` fixed to handle incomplete references
* `non_constant_identifier_names` updated to allow underscores around numbers

@bwilkerson 