### PR TITLE
fix an issue with the public_member_api_docs lint

### DIFF
--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -115,10 +115,15 @@ class _Visitor extends GeneralizingAstVisitor {
   /// Return true if the given node is declared in a compilation unit that is in
   /// a `lib/` folder.
   bool _isDefinedInLib(CompilationUnit compilationUnit) {
-    Uri uri = compilationUnit?.element?.source?.uri;
+    String fullName = compilationUnit?.element?.source?.fullName;
+    if (fullName == null) {
+      return false;
+    }
 
+    // TODO(devoncarew): Change to using the resource provider on the context
+    // when that is available.
     ResourceProvider resourceProvider = PhysicalResourceProvider.INSTANCE;
-    File file = resourceProvider.getFile(uri.toFilePath());
+    File file = resourceProvider.getFile(fullName);
     Folder folder = file.parent;
 
     // Look for a pubspec.yaml file.


### PR DESCRIPTION
- fix an exception in the public_member_api_docs (in `uri.toFilePath()`; fix https://github.com/dart-lang/linter/issues/822)

@pq @scheglov @bwilkerson 