### PR TITLE
Improve rule details and overall rule consistency

### DIFF
--- a/lib/src/rules/always_declare_return_types.dart
+++ b/lib/src/rules/always_declare_return_types.dart
@@ -8,12 +8,16 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Declare method return types.';
+const _desc = r'Declare method return types.';
 
-const details = '''
+const _details = r'''
+
 **DO** declare method return types.
 
 When declaring a method or function *always* specify a return type.
+Declaring return types for functions helps improve your codebase by allowing
+the analyzer to more adequately check your code for errors that could occur
+during runtime.
 
 **BAD:**
 ```
@@ -38,14 +42,15 @@ class _Foo {
 
 typedef bool predicate(Object o);
 ```
+
 ''';
 
 class AlwaysDeclareReturnTypes extends LintRule {
   AlwaysDeclareReturnTypes()
       : super(
             name: 'always_declare_return_types',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/always_declare_return_types.dart
+++ b/lib/src/rules/always_declare_return_types.dart
@@ -15,9 +15,9 @@ const _details = r'''
 **DO** declare method return types.
 
 When declaring a method or function *always* specify a return type.
-Declaring return types for functions helps improve your codebase by allowing
-the analyzer to more adequately check your code for errors that could occur
-during runtime.
+Declaring return types for functions helps improve your codebase by allowing the
+analyzer to more adequately check your code for errors that could occur during
+runtime.
 
 **BAD:**
 ```

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -12,11 +12,11 @@ const _details = r'''
 
 From the [flutter style guide](https://flutter.io/style-guide/):
 
-**DO** separate the control structre expression from its statement.
+**DO** separate the control structure expression from its statement.
 
 Don't put the statement part of an `if`, `for`, `while`, `do` on the same line
-as the expression, even if it is short. (Doing so makes it unobvious that there
-is relevant code there. This is especially important for early returns.)
+as the expression, even if it is short.  Doing so makes it unclear that there
+is relevant code there.  This is especially important for early returns.
 
 **GOOD:**
 ```

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -6,12 +6,13 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Separate the control structure expression from its statement.';
+const _desc = r'Separate the control structure expression from its statement.';
 
-const details = '''
+const _details = r'''
+
 From the [flutter style guide](https://flutter.io/style-guide/):
 
-**DO** Separate the control structre expression from its statement.
+**DO** separate the control structre expression from its statement.
 
 Don't put the statement part of an `if`, `for`, `while`, `do` on the same line
 as the expression, even if it is short. (Doing so makes it unobvious that there
@@ -41,14 +42,15 @@ else print('ok')
 
 while (condition) i += 1;
 ```
+
 ''';
 
 class AlwaysPutControlBodyOnNewLine extends LintRule {
   AlwaysPutControlBodyOnNewLine()
       : super(
             name: 'always_put_control_body_on_new_line',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -8,9 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Put @required named parameters first.';
+const _desc = r'Put @required named parameters first.';
 
-const details = '''
+const _details = r'''
+
 **DO** specify `@required` on named parameter before other named parameters.
 
 **GOOD:**
@@ -22,6 +23,7 @@ m({@required a, b, c}) ;
 ```
 m({b, c, @required a}) ;
 ```
+
 ''';
 
 /// The name of `meta` library, used to define analysis annotations.
@@ -39,8 +41,8 @@ class AlwaysPutRequiredNamedParametersFirst extends LintRule {
   AlwaysPutRequiredNamedParametersFirst()
       : super(
             name: 'always_put_required_named_parameters_first',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -10,9 +10,10 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = 'Use @required.';
+const _desc = r'Use @required.';
 
-const details = '''
+const _details = r'''
+
 **DO** specify `@required` on named parameter without default value on which an
 assert(param != null) is done.
 
@@ -52,8 +53,8 @@ class AlwaysRequireNonNullNamedParameters extends LintRule {
   AlwaysRequireNonNullNamedParameters()
       : super(
             name: 'always_require_non_null_named_parameters',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -36,6 +36,7 @@ m1({a}) {
 ```
 
 NOTE: Only asserts at the start of the bodies will be taken into account.
+
 ''';
 
 /// The name of `meta` library, used to define analysis annotations.

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -29,7 +29,7 @@ From the [flutter style guide](https://flutter.io/style-guide/):
 
 Avoid `var` when specifying that a type is unknown and short-hands that elide
 type annotations.  Use `dynamic` if you are being explicit that the type is
-unknown. Use `Object` if you are being explicit that you want an object that
+unknown.  Use `Object` if you are being explicit that you want an object that
 implements `==` and `hashCode`.
 
 **GOOD:**

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -19,9 +19,10 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc = 'Specify type annotations.';
+const _desc = r'Specify type annotations.';
 
-const details = '''
+const _details = r'''
+
 From the [flutter style guide](https://flutter.io/style-guide/):
 
 **DO** specify type annotations.
@@ -64,6 +65,7 @@ main() {
   Key s = new Key(); // OK!
 }
 ```
+
 ''';
 
 /// The name of `meta` library, used to define analysis annotations.
@@ -91,8 +93,8 @@ class AlwaysSpecifyTypes extends LintRule {
   AlwaysSpecifyTypes()
       : super(
             name: 'always_specify_types',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -8,10 +8,14 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Annotate overridden members.';
+const _desc = r'Annotate overridden members.';
 
-const details = r'''
+const _details = r'''
+
 **DO** annotate overridden methods and fields.
+
+This practice improves code readability and helps protect against
+unintentionally overriding superclass members.
 
 **GOOD:**
 ```
@@ -38,14 +42,15 @@ class Lucky extends Cat {
   final int lives = 14;
 }
 ```
+
 ''';
 
 class AnnotateOverrides extends LintRule {
   AnnotateOverrides()
       : super(
             name: 'annotate_overrides',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -12,6 +12,9 @@ const _details = r'''
 
 **AVOID** annotating with dynamic when not required.
 
+As `dynamic` is the assumed return value of a function or method, it is usually
+not necessary to annotate it.
+
 **BAD:**
 ```
 dynamic lookUpOrDefault(String name, Map map, dynamic defaultValue) {

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -17,8 +17,8 @@ From the [flutter style guide]
 **AVOID** using `as`.
 
 If you know the type is correct, use an assertion or assign to a more
-narrowly-typed variable (this avoids the type check in release mode; `as`
-is not compiled out in release mode). If you don't know whether the type is
+narrowly-typed variable (this avoids the type check in release mode; `as` is not
+compiled out in release mode).  If you don't know whether the type is
 correct, check using `is` (this avoids the exception that `as` raises).
 
 **BAD:**

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/ast.dart'
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Avoid using `as`.';
+const _desc = r'Avoid using `as`.';
 
-const details = r'''
+const _details = r'''
+
 From the [flutter style guide]
 (https://github.com/flutter/engine/blob/master/sky/specs/style-guide.md):
 
@@ -19,7 +20,6 @@ If you know the type is correct, use an assertion or assign to a more
 narrowly-typed variable (this avoids the type check in release mode; `as`
 is not compiled out in release mode). If you don't know whether the type is
 correct, check using `is` (this avoids the exception that `as` raises).
-
 
 **BAD:**
 ```
@@ -64,8 +64,8 @@ class AvoidAs extends LintRule {
   AvoidAs()
       : super(
             name: 'avoid_as',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/avoid_catches_without_on_clauses.dart
+++ b/lib/src/rules/avoid_catches_without_on_clauses.dart
@@ -12,6 +12,9 @@ const _details = r'''
 
 **AVOID** catches without on clauses.
 
+Using catch clauses without on clauses make your code prone to encountering
+unexpected errors that won't be thrown (and thus will go unnoticed).
+
 **BAD:**
 ```
 try {

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -13,6 +13,10 @@ const _details = r'''
 
 **DON’T** explicitly catch Error or types that implement it.
 
+Errors differ from Exceptions in that Errors can be analyzed and prevented
+prior to runtime. It should almost never be necessary to catch an error at
+runtime.
+
 **BAD:**
 ```
 try {

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -7,11 +7,11 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Don’t explicitly catch Error or types that implement it.';
+const _desc = r"Don't explicitly catch Error or types that implement it.";
 
 const _details = r'''
 
-**DON’T** explicitly catch Error or types that implement it.
+**DON'T** explicitly catch Error or types that implement it.
 
 Errors differ from Exceptions in that Errors can be analyzed and prevented prior
 to runtime.  It should almost never be necessary to catch an error at runtime.

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -13,9 +13,8 @@ const _details = r'''
 
 **DON’T** explicitly catch Error or types that implement it.
 
-Errors differ from Exceptions in that Errors can be analyzed and prevented
-prior to runtime. It should almost never be necessary to catch an error at
-runtime.
+Errors differ from Exceptions in that Errors can be analyzed and prevented prior
+to runtime.  It should almost never be necessary to catch an error at runtime.
 
 **BAD:**
 ```

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -13,6 +13,10 @@ const _details = r'''
 
 **AVOID** defining a class that contains only static members.
 
+Creating classes with the sole purpose of providing utility or otherwise static
+methods is discouraged. Dart allows functions to be exist outside of classes
+for this very reason.
+
 **BAD:**
 ```
 class DateUtils {

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -14,8 +14,8 @@ const _details = r'''
 **AVOID** defining a class that contains only static members.
 
 Creating classes with the sole purpose of providing utility or otherwise static
-methods is discouraged. Dart allows functions to be exist outside of classes
-for this very reason.
+methods is discouraged.  Dart allows functions to exist outside of classes for
+this very reason.
 
 **BAD:**
 ```

--- a/lib/src/rules/avoid_empty_else.dart
+++ b/lib/src/rules/avoid_empty_else.dart
@@ -6,10 +6,11 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Avoid empty else statements.';
+const _desc = r'Avoid empty else statements.';
 
-const details = r'''
-Avoid empty else statements.
+const _details = r'''
+
+**AVOID** empty else statements.
 
 **BAD:**
 ```
@@ -18,14 +19,15 @@ if (x > y)
 else ;
   print("2");
 ```
+
 ''';
 
 class AvoidEmptyElse extends LintRule {
   AvoidEmptyElse()
       : super(
             name: 'avoid_empty_else',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -26,14 +26,8 @@ for (var person in people) {
   ...
 }
 ```
-
-**GOOD:**
-```
-for (var person in people) {
-  ...
-}
-```
 people.forEach(print);
+
 ''';
 
 class AvoidFunctionLiteralInForeachMethod extends LintRule {

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -7,11 +7,11 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Avoid using Iterable.forEach() with a function literal.';
+const _desc = r'Avoid using `forEach` with a function literal.';
 
 const _details = r'''
 
-**AVOID** using Iterable.forEach() with a function literal.
+**AVOID** using `forEach` with a function literal.
 
 **BAD:**
 ```

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = r"Don't explicitly initialize variables to null.";
+const _desc = r"Don't explicitly initialize variables to null.";
 
-const details = r'''
+const _details = r'''
+
 From [effective dart]
 (https://www.dartlang.org/effective-dart/usage/#dont-explicitly-initialize-variables-to-null):
 
@@ -19,7 +20,6 @@ In Dart, a variable or field that is not explicitly initialized automatically
 gets initialized to null. This is reliably specified by the language. There's
 no concept of "uninitialized memory" in Dart. Adding `= null` is redundant and
 unneeded.
-
 
 **GOOD:**
 ```
@@ -59,8 +59,8 @@ class AvoidInitToNull extends LintRule {
   AvoidInitToNull()
       : super(
             name: 'avoid_init_to_null',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -17,8 +17,8 @@ From [effective dart]
 **DON'T** explicitly initialize variables to null.
 
 In Dart, a variable or field that is not explicitly initialized automatically
-gets initialized to null. This is reliably specified by the language. There's
-no concept of "uninitialized memory" in Dart. Adding `= null` is redundant and
+gets initialized to null.  This is reliably specified by the language.  There's
+no concept of "uninitialized memory" in Dart.  Adding `= null` is redundant and
 unneeded.
 
 **GOOD:**

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -15,7 +15,7 @@ const _details = r'''
 
 **DON’T** check for null in custom == operators.
 
-As null is a special type, no class can be equivalent to it. Thus, it is
+As null is a special type, no class can be equivalent to it.  Thus, it is
 redundant to check whether the other instance is null. 
 
 **BAD:**

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -15,6 +15,9 @@ const _details = r'''
 
 **DON’T** check for null in custom == operators.
 
+As null is a special type, no class can be equivalent to it. Thus, it is
+redundant to check whether the other instance is null. 
+
 **BAD:**
 ```
 class Person {

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -9,11 +9,11 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Don’t check for null in custom == operators.';
+const _desc = r"Don't check for null in custom == operators.";
 
 const _details = r'''
 
-**DON’T** check for null in custom == operators.
+**DON'T** check for null in custom == operators.
 
 As null is a special type, no class can be equivalent to it.  Thus, it is
 redundant to check whether the other instance is null. 

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -15,7 +15,7 @@ const _details = r'''
 **AVOID** positional boolean parameters.
 
 Positional boolean parameters are a bad practice because they are very
-ambiguous. Using named boolean parameters is much more readable because it
+ambiguous.  Using named boolean parameters is much more readable because it
 inherently describes what the boolean value represents.
 
 **BAD:**

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -14,6 +14,10 @@ const _details = r'''
 
 **AVOID** positional boolean parameters.
 
+Positional boolean parameters are a bad practice because they are very
+ambiguous. Using named boolean parameters is much more readable because it
+inherently describes what the boolean value represents.
+
 **BAD:**
 ```
 new Task(true);

--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -6,10 +6,13 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Avoid return types on setters.';
+const _desc = r'Avoid return types on setters.';
 
-const details = r'''
+const _details = r'''
+
 **AVOID** return types on setters.
+
+As setters do not return a value, setting the return type of one is redundant.
 
 **GOOD:**
 ```
@@ -20,14 +23,15 @@ set speed(int ms);
 ```
 void set speed(int ms);
 ```
+
 ''';
 
 class AvoidReturnTypesOnSetters extends LintRule {
   AvoidReturnTypesOnSetters()
       : super(
             name: 'avoid_return_types_on_setters',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -12,7 +12,7 @@ const _details = r'''
 
 **AVOID** return types on setters.
 
-As setters do not return a value, setting the return type of one is redundant.
+As setters do not return a value, declaring the return type of one is redundant.
 
 **GOOD:**
 ```

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -9,15 +9,17 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
 const _desc =
-    r'Avoid returning null from members whose return type is bool, double, int, or num.';
+    r'Avoid returning null from members whose return type is bool, double, int,'
+    r' or num.';
 
 const _details = r'''
 
-**AVOID** returning null from members whose return type is bool, double, int, or num.
+**AVOID** returning null from members whose return type is bool, double, int,
+or num.
 
 Functions that return primitive types such as bool, double, int, and num are
-generally expected to return non-nullable values. Thus, returning null
-where a primitive type was expected can lead to runtime exceptions.
+generally expected to return non-nullable values.  Thus, returning null where a
+primitive type was expected can lead to runtime exceptions.
 
 **BAD:**
 ```

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -15,6 +15,10 @@ const _details = r'''
 
 **AVOID** returning null from members whose return type is bool, double, int, or num.
 
+Functions that return primitive types such as bool, double, int, and num are
+generally expected to return non-nullable values. Thus, returning null
+where a primitive type was expected can lead to runtime exceptions.
+
 **BAD:**
 ```
 bool getBool() => null;

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -14,8 +14,8 @@ const _details = r'''
 
 **AVOID** returning this from methods just to enable a fluent interface.
 
-Returning `this` from a method is redundant; Dart has a cascade operator
-which allows method chaining universally.
+Returning `this` from a method is redundant; Dart has a cascade operator which
+allows method chaining universally.
 
 **BAD:**
 ```

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -14,6 +14,9 @@ const _details = r'''
 
 **AVOID** returning this from methods just to enable a fluent interface.
 
+Returning `this` from a method is redundant; Dart has a cascade operator
+which allows method chaining universally.
+
 **BAD:**
 ```
 var buffer = new StringBuffer()

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -12,7 +12,7 @@ const _desc = r'Avoid setters without getters.';
 
 const _details = r'''
 
-**DON’T** define a setter without a corresponding getter.
+**DON'T** define a setter without a corresponding getter.
 
 Defining a setter without defining a corresponding getter can lead to logical
 inconsistencies.  Doing this could allow you to set a property to some value,

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -15,7 +15,7 @@ const _details = r'''
 **DON’T** define a setter without a corresponding getter.
 
 Defining a setter without defining a corresponding getter can lead to logical
-inconsistencies. Doing this could allow you to set a property to some value,
+inconsistencies.  Doing this could allow you to set a property to some value,
 but then upon observing the property's value, it could easily be different.
 
 **BAD:**

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -14,6 +14,10 @@ const _details = r'''
 
 **DON’T** define a setter without a corresponding getter.
 
+Defining a setter without defining a corresponding getter can lead to logical
+inconsistencies. Doing this could allow you to set a property to some value,
+but then upon observing the property's value, it could easily be different.
+
 **BAD:**
 ```
 class Bad {

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -47,6 +47,7 @@ Future<Null> someFunction() async {
   if (file.lastModifiedSync().isBefore(now)) print('before'); // OK
 }
 ```
+
 ''';
 
 class AvoidSlowAsyncIo extends LintRule {

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -9,12 +9,12 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Avoid slow async dart:io methods.';
+const _desc = r'Avoid slow async `dart:io` methods.';
 
 const _details = r'''
 
-**AVOID** using the following asynchronous file I/O methods
-because they are much slower than their synchronous counterparts.
+**AVOID** using the following asynchronous file I/O methods because they are
+much slower than their synchronous counterparts.
 
 * `File.lastModified`
 * `File.exists`

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -12,6 +12,10 @@ const _details = r'''
 
 **AVOID** annotating types on function expressions.
 
+Annotating types in function expressions is usually unnecessary because
+function expressions are almost always used on multiple values of the same
+type, thus making the practice redundant.
+
 **BAD:**
 ```
 var names = people.map((Person person) => person.name);

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -6,15 +6,15 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = r'Avoid annotating types on function expression parameters.';
+const _desc = r'Avoid annotating types for function expression parameters.';
 
 const _details = r'''
 
-**AVOID** annotating types on function expressions.
+**AVOID** annotating types for function expression paremeters.
 
-Annotating types in function expressions is usually unnecessary because
-function expressions are almost always used on multiple values of the same
-type, thus making the practice redundant.
+Annotating types for function expression parameters is usually unnecessary
+because the parameter types can almost always be inferred from the context,
+thus making the practice redundant.
 
 **BAD:**
 ```

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -9,10 +9,11 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = 'Await only futures.';
+const _desc = r'Await only futures.';
 
-const details = '''
-**AVOID** await on anything other than a future.
+const _details = r'''
+
+**AVOID** using await on anything other than a future.
 
 **BAD:**
 ```
@@ -27,6 +28,7 @@ main() async {
   print(await new Future.value(23));
 }
 ```
+
 ''';
 
 class AwaitOnlyFutures extends LintRule {
@@ -35,8 +37,8 @@ class AwaitOnlyFutures extends LintRule {
   AwaitOnlyFutures()
       : super(
             name: 'await_only_futures',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style) {
     _visitor = new _Visitor(this);
   }

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -15,8 +15,8 @@ From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 **DO** name types using UpperCamelCase.
 
-Classes and typedefs should capitalize the first letter of each word
-(including the first word), and use no separators.
+Classes and typedefs should capitalize the first letter of each word (including
+the first word), and use no separators.
 
 **GOOD:**
 ```

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc = 'Name types using UpperCamelCase.';
+const _desc = r'Name types using UpperCamelCase.';
 
-const details = '''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 **DO** name types using UpperCamelCase.
@@ -18,7 +19,6 @@ Classes and typedefs should capitalize the first letter of each word
 (including the first word), and use no separators.
 
 **GOOD:**
-
 ```
 class SliderMenu {
   // ...
@@ -30,14 +30,15 @@ class HttpRequest {
 
 typedef num Adder(num x, num y);
 ```
+
 ''';
 
 class CamelCaseTypes extends LintRule {
   CamelCaseTypes()
       : super(
             name: 'camel_case_types',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -12,8 +12,10 @@ const _desc = r'Cancel instances of dart.async.StreamSubscription.';
 
 const _details = r'''
 
-**DO** Invoke `cancel` on instances of `dart.async.StreamSubscription` to avoid
-memory leaks and unexpected behaviors.
+**DO** Invoke `cancel` on instances of `dart.async.StreamSubscription`.
+
+Cancelling instances of StreamSubscription prevents memory leaks and
+unexpected behavior.
 
 **BAD:**
 ```
@@ -53,6 +55,7 @@ void someFunctionOK() {
   _subscriptionB.cancel();
 }
 ```
+
 ''';
 
 bool _isSubscription(DartType type) => DartTypeUtilities.implementsInterface(

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -12,10 +12,10 @@ const _desc = r'Cancel instances of dart.async.StreamSubscription.';
 
 const _details = r'''
 
-**DO** Invoke `cancel` on instances of `dart.async.StreamSubscription`.
+**DO** invoke `cancel` on instances of `dart.async.StreamSubscription`.
 
-Cancelling instances of StreamSubscription prevents memory leaks and
-unexpected behavior.
+Cancelling instances of StreamSubscription prevents memory leaks and unexpected
+behavior.
 
 **BAD:**
 ```

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -14,7 +14,7 @@ const _desc = r'Cascade consecutive method invocations on the same reference.';
 const _details = r'''
 
 **DO** Use the cascading style when succesively invoking methods on the same
- reference.
+reference.
 
 **BAD:**
 ```

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -14,8 +14,7 @@ const _details = r'''
 
 **DO** invoke `close` on instances of `dart.core.Sink`.
 
-Closing instances of StreamSubscription prevents memory leaks and
-unexpected behavior.
+Closing instances of Sink prevents memory leaks and unexpected behavior.
 
 **BAD:**
 ```

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -12,8 +12,10 @@ const _desc = r'Close instances of `dart.core.Sink`.';
 
 const _details = r'''
 
-**DO** invoke `close` on instances of `dart.core.Sink` to avoid memory leaks and
-unexpected behaviors.
+**DO** invoke `close` on instances of `dart.core.Sink`.
+
+Closing instances of StreamSubscription prevents memory leaks and
+unexpected behavior.
 
 **BAD:**
 ```
@@ -53,6 +55,7 @@ void someFunctionOK() {
   _sinkFOK.close();
 }
 ```
+
 ''';
 
 bool _isSink(DartType type) =>

--- a/lib/src/rules/comment_references.dart
+++ b/lib/src/rules/comment_references.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Only reference in scope identifiers in doc comments.';
+const _desc = r'Only reference in scope identifiers in doc comments.';
 
-const details = r'''
+const _details = r'''
+
 **DO** reference only in scope identifiers in doc comments.
 
 If you surround things like variable, method, or type names in square brackets,
@@ -31,14 +32,15 @@ On the other hand, assuming `outOfScopeId` is out of scope:
 ```
 void f(int outOfScopeId) { ... }
 ```
+
 ''';
 
 class CommentReferences extends LintRule {
   CommentReferences()
       : super(
             name: 'comment_references',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -40,6 +40,7 @@ class Dice {
 }
 
 ```
+
 ''';
 
 class ConstantIdentifierNames extends LintRule {

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -7,16 +7,16 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc = r'Prefer using lowerCamelCase for constant names.';
+const _desc = r'Prefer using lowerCamelCase for constant names.';
 
-const details = r'''
+const _details = r'''
+
 **PREFER** using lowerCamelCase for constant names.
 
 In new code, use `lowerCamelCase` for constant variables, including enum values.
 
 In existing code that uses `ALL_CAPS_WITH_UNDERSCORES` for constants, you may
 continue to use all caps to stay consistent.
-
 
 **GOOD:**
 ```
@@ -38,6 +38,7 @@ final URL_SCHEME = new RegExp('^([a-z]+):');
 class Dice {
   static final NUMBER_GENERATOR = new Random();
 }
+
 ```
 ''';
 
@@ -45,8 +46,8 @@ class ConstantIdentifierNames extends LintRule {
   ConstantIdentifierNames()
       : super(
             name: 'constant_identifier_names',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -6,14 +6,14 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = r'Avoid control flow in `finally` block.';
+const _desc = r'Avoid control flow in finally blocks.';
 
 const _details = r'''
 
 **AVOID** control flow leaving finally blocks.
 
-Using control flow in finally blocks will inevitably cause unexpected
-behavior that is hard to debug.
+Using control flow in finally blocks will inevitably cause unexpected behavior
+that is hard to debug.
 
 **GOOD:**
 ```

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -6,10 +6,13 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Avoid control flow in `finally` block.';
+const _desc = r'Avoid control flow in `finally` block.';
 
-const details = r'''
-**AVOID** control flow leaving finally blocks. This will cause unexpected
+const _details = r'''
+
+**AVOID** control flow leaving finally blocks.
+
+Using control flow in finally blocks will inevitably cause unexpected
 behavior that is hard to debug.
 
 **GOOD:**
@@ -77,6 +80,7 @@ class BadBreak {
   }
 }
 ```
+
 ''';
 
 class ControlFlowInFinally extends LintRule {
@@ -85,8 +89,8 @@ class ControlFlowInFinally extends LintRule {
   ControlFlowInFinally()
       : super(
             name: 'control_flow_in_finally',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors) {
     _visitor = new _Visitor(this);
   }

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -10,7 +10,8 @@ import 'package:linter/src/analyzer.dart';
 const _desc = r'Adhere to Effective Dart Guide directives sorting conventions.';
 const _details = r'''
 
-**DO** follow the conventions in the [Effective Dart Guide](https://www.dartlang.org/guides/language/effective-dart/style#ordering)
+**DO** follow the conventions in the [Effective Dart Guide]
+(https://www.dartlang.org/guides/language/effective-dart/style#ordering)
 
 **DO** place “dart:” imports before other imports.
 

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -8,8 +8,9 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
 const _desc = r'Adhere to Effective Dart Guide directives sorting conventions.';
-const _details =
-    r'''**DO** follow the conventions in the [Effective Dart Guide](https://www.dartlang.org/guides/language/effective-dart/style#ordering)
+const _details = r'''
+
+**DO** follow the conventions in the [Effective Dart Guide](https://www.dartlang.org/guides/language/effective-dart/style#ordering)
 
 **DO** place “dart:” imports before other imports.
 

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -7,13 +7,13 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc = r'Avoid empty catch blocks.';
+const _desc = r'Avoid empty catch blocks.';
 
-const details = r'''
+const _details = r'''
 
 **AVOID** empty catch blocks.
 
-In general empty catch blocks should be avoided.  In cases where they are
+In general, empty catch blocks should be avoided.  In cases where they are
 intended, a comment should be provided to explain why exceptions are being
 caught and suppressed. Alternatively, the exception identifier can be named with
 underscores (e.g., `_`) to indicate that we intend to skip it.
@@ -45,14 +45,15 @@ try {
   doSomething(e);
 }
 ```
+
 ''';
 
 class EmptyCatches extends LintRule {
   EmptyCatches()
       : super(
             name: 'empty_catches',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -15,7 +15,7 @@ const _details = r'''
 
 In general, empty catch blocks should be avoided.  In cases where they are
 intended, a comment should be provided to explain why exceptions are being
-caught and suppressed. Alternatively, the exception identifier can be named with
+caught and suppressed.  Alternatively, the exception identifier can be named with
 underscores (e.g., `_`) to indicate that we intend to skip it.
 
 **BAD:**

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -6,19 +6,19 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Use `;` instead of `{}` for empty constructor bodies.';
+const _desc = r'Use `;` instead of `{}` for empty constructor bodies.';
 
-const details = '''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
-**DO** use ; instead of {} for empty constructor bodies.
+**DO** use `;` instead of `{}` for empty constructor bodies.
 
 In Dart, a constructor with an empty body can be terminated with just a
 semicolon. This is required for const constructors. For consistency and
 brevity, other constructors should also do this.
 
 **GOOD:**
-
 ```
 class Point {
   int x, y;
@@ -27,21 +27,21 @@ class Point {
 ```
 
 **BAD:**
-
 ```
 class Point {
   int x, y;
   Point(this.x, this.y) {}
 }
 ```
+
 ''';
 
 class EmptyConstructorBodies extends LintRule {
   EmptyConstructorBodies()
       : super(
             name: 'empty_constructor_bodies',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -15,7 +15,7 @@ From the [style guide](https://www.dartlang.org/articles/style-guide/):
 **DO** use `;` instead of `{}` for empty constructor bodies.
 
 In Dart, a constructor with an empty body can be terminated with just a
-semicolon. This is required for const constructors. For consistency and
+semicolon.  This is required for const constructors.  For consistency and
 brevity, other constructors should also do this.
 
 **GOOD:**

--- a/lib/src/rules/empty_statements.dart
+++ b/lib/src/rules/empty_statements.dart
@@ -6,14 +6,15 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Avoid empty statements.';
+const _desc = r'Avoid empty statements.';
 
-const details = r'''
+const _details = r'''
+
 **AVOID** empty statments.
 
-Empty statements are almost always indicate a bug.
+Empty statements almost always indicate a bug.
 
-For example.
+For example,
 
 **BAD:**
 ```
@@ -36,14 +37,15 @@ Better to avoid the empty statement altogether.
 if (complicated.expression.foo())
   bar();
 ```
+
 ''';
 
 class EmptyStatements extends LintRule {
   EmptyStatements()
       : super(
             name: 'empty_statements',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -7,11 +7,14 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc = r'Always override `hashCode` if overriding `==`.';
+const _desc = r'Always override `hashCode` if overriding `==`.';
 
-const details = r'''
+const _details = r'''
 
 **DO** override `hashCode` if overriding `==`.
+
+Every object in Dart should have a `hashCode`. This is necessary so that
+every Dart object can have its `hashCode` used as a key in a map.
 
 **BAD:**
 ```
@@ -44,8 +47,8 @@ class HashAndEquals extends LintRule {
   HashAndEquals()
       : super(
             name: 'hash_and_equals',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -13,8 +13,10 @@ const _details = r'''
 
 **DO** override `hashCode` if overriding `==`.
 
-Every object in Dart should have a `hashCode`. This is necessary so that
-every Dart object can have its `hashCode` used as a key in a map.
+Every object in Dart has a `hashCode`.  Both the `==` operator and the
+`hashCode` property of objects must be consistent in order for a common hash
+map implementation to function properly.  Thus, when overriding `==`, the
+`hashCode` should also be overriden to maintain consistency.
 
 **BAD:**
 ```

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -11,21 +11,21 @@ const _desc = r"Don't import implementation files from another package.";
 
 const _details = r'''
 
-**DON'T** import implementation files from another package.
-
 From the the [pub package layout doc]
 (https://www.dartlang.org/tools/pub/package-layout.html#implementation-files):
 
+**DON'T** import implementation files from another package.
+
 The libraries inside `lib` are publicly visible: other packages are free to
-import them. But much of a package's code is internal implementation libraries
-that should only be imported and used by the package itself. Those go inside a
-subdirectory of `lib` called `src`. You can create subdirectories in there if
+import them.  But much of a package's code is internal implementation libraries
+that should only be imported and used by the package itself.  Those go inside a
+subdirectory of `lib` called `src`.  You can create subdirectories in there if
 it helps you organize things.
 
 You are free to import libraries that live in `lib/src` from within other Dart
 code in the same package (like other libraries in `lib`, scripts in `bin`,
 and tests) but you should never import from another package's `lib/src`
-directory. Those files are not part of the package’s public API, and they
+directory.  Those files are not part of the package’s public API, and they
 might change in ways that could break your code.
 
 **BAD:**

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = "Don't import implementation files from another package.";
+const _desc = r"Don't import implementation files from another package.";
 
-const details = '''
+const _details = r'''
+
 **DON'T** import implementation files from another package.
 
 From the the [pub package layout doc]
@@ -27,12 +28,12 @@ and tests) but you should never import from another package's `lib/src`
 directory. Those files are not part of the package’s public API, and they
 might change in ways that could break your code.
 
-**Bad:**
-
+**BAD:**
 ```
 // In 'road_runner'
 import 'package:acme/lib/src/internals.dart;
 ```
+
 ''';
 
 bool isImplementation(Uri uri) {
@@ -60,8 +61,8 @@ class ImplementationImports extends LintRule {
   ImplementationImports()
       : super(
             name: 'implementation_imports',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -25,7 +25,7 @@ it helps you organize things.
 You are free to import libraries that live in `lib/src` from within other Dart
 code in the same package (like other libraries in `lib`, scripts in `bin`,
 and tests) but you should never import from another package's `lib/src`
-directory.  Those files are not part of the package’s public API, and they
+directory.  Those files are not part of the package's public API, and they
 might change in ways that could break your code.
 
 **BAD:**

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -14,16 +14,16 @@ import 'package:linter/src/util/dart_type_utilities.dart';
 import 'package:linter/src/util/tested_expressions.dart';
 
 const _desc =
-    r'Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".';
+    r'Conditions should not unconditionally evaluate to `true` or to `false`.';
 
 const _details = r'''
 
 **DON'T** test for conditions that can be inferred at compile time or test the
 same condition twice.
 
-Conditional statements using a condition which cannot be anything but `false` have
-the effect of making blocks of code non-functional. If the condition cannot
-evaluate to anything but `true`, the conditional statement is completely
+Conditional statements using a condition which cannot be anything but `false`
+have the effect of making blocks of code non-functional.  If the condition
+cannot evaluate to anything but `true`, the conditional statement is completely
 redundant, and makes the code less readable.
 It is quite likely that the code does not match the programmer's intent.
 Either the condition should be removed or it should be updated so that it does

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -20,18 +20,19 @@ const _details = r'''
 
 **DON'T** test for conditions that can be inferred at compile time or test the
 same condition twice.
-Conditional statements using a condition which cannot be anything but FALSE have
+
+Conditional statements using a condition which cannot be anything but `false` have
 the effect of making blocks of code non-functional. If the condition cannot
-evaluate to anything but TRUE, the conditional statement is completely
+evaluate to anything but `true`, the conditional statement is completely
 redundant, and makes the code less readable.
 It is quite likely that the code does not match the programmer's intent.
 Either the condition should be removed or it should be updated so that it does
-not always evaluate to TRUE or FALSE and does not perform redundant tests.
+not always evaluate to `true` or `false` and does not perform redundant tests.
 This rule will hint to the test conflicting with the linted one.
 
 **BAD:**
 ```
-//foo can't be both equal and not equal to bar in the same expression
+// foo can't be both equal and not equal to bar in the same expression
 if(foo == bar && something && foo != bar) {...}
 ```
 
@@ -40,7 +41,7 @@ if(foo == bar && something && foo != bar) {...}
 void compute(int foo) {
   if (foo == 4) {
     doSomething();
-    // We know foo is equal to 4 at this point, so the next condition is always false
+    // we know foo is equal to 4 at this point, so the next condition is always false
     if (foo > 4) {...}
     ...
   }

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -13,13 +13,10 @@ const _desc = r'Invocation of Iterable<E>.contains with references of unrelated'
 
 const _details = r'''
 
-**DON'T** invoke `contains` on `Iterable` with an instance of different type than
-the parameter type.
+**DON'T** invoke `contains` on `Iterable` with an instance of different type
+than the parameter type.
 
-Doing this will invoke `==` on its elements and most likely will
-return `false`. Strictly speaking it could evaluate to true since in Dart it
-is possible for an `Iterable` to contain elements of type unrelated to its
-parameter type, but this practice also should be avoided.
+Doing this will invoke `==` on its elements and most likely will return `false`.
 
 **BAD:**
 ```

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -13,10 +13,12 @@ const _desc = r'Invocation of Iterable<E>.contains with references of unrelated'
 
 const _details = r'''
 
-**DON'T** Invoke `contains` on `Iterable` with an instance of different type than
-the parameter type since it will invoke `==` on its elements and most likely will
+**DON'T** invoke `contains` on `Iterable` with an instance of different type than
+the parameter type.
+
+Doing this will invoke `==` on its elements and most likely will
 return `false`. Strictly speaking it could evaluate to true since in Dart it
-is possible for an Iterable to contain elements of type unrelated to its
+is possible for an `Iterable` to contain elements of type unrelated to its
 parameter type, but this practice also should be avoided.
 
 **BAD:**
@@ -119,6 +121,7 @@ abstract class Mixin {}
 
 class DerivedClass3 extends ClassBase implements Mixin {}
 ```
+
 ''';
 
 class IterableContainsUnrelatedType extends LintRule {

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -15,8 +15,8 @@ const _details = r'''
 **DO** name libraries and source files using `lowercase_with_underscores`.
 
 Some file systems are not case-sensitive, so many projects require filenames
-to be all lowercase. Using a separate character allows names to still be
-readable in that form. Using underscores as the separator ensures that the name
+to be all lowercase.  Using a separate character allows names to still be
+readable in that form.  Using underscores as the separator ensures that the name
 is still a valid Dart identifier, which may be helpful if the language later
 supports symbolic imports.
 

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -7,10 +7,11 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc =
-    'Name libraries and source files using `lowercase_with_underscores`.';
+const _desc =
+    r'Name libraries and source files using `lowercase_with_underscores`.';
 
-const details = r'''
+const _details = r'''
+
 **DO** name libraries and source files using `lowercase_with_underscores`.
 
 Some file systems are not case-sensitive, so many projects require filenames
@@ -30,14 +31,15 @@ supports symbolic imports.
 * `SliderMenu.dart`
 * `filesystem.dart`
 * `library peg-parser;`
+
 ''';
 
 class LibraryNames extends LintRule {
   LibraryNames()
       : super(
             name: 'library_names',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/library_prefixes.dart
+++ b/lib/src/rules/library_prefixes.dart
@@ -7,14 +7,14 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc =
+const _desc =
     r'Use `lowercase_with_underscores` when specifying a library prefix.';
 
-const details = r'''
+const _details = r'''
+
 **DO** use `lowercase_with_underscores` when specifying a library prefix.
 
 **GOOD:**
-
 ```
 import 'dart:math' as math;
 import 'dart:json' as json;
@@ -23,21 +23,21 @@ import 'package:javascript_utils/javascript_utils.dart' as js_utils;
 ```
 
 **BAD:**
-
 ```
 import 'dart:math' as Math;
 import 'dart:json' as JSON;
 import 'package:js/js.dart' as JS;
 import 'package:javascript_utils/javascript_utils.dart' as jsUtils;
 ```
+
 ''';
 
 class LibraryPrefixes extends LintRule {
   LibraryPrefixes()
       : super(
             name: 'library_prefixes',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -8,15 +8,17 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 import 'package:linter/src/util/unrelated_types_visitor.dart';
 
-const _desc = r'Invocation of List<E>.remove with references of unrelated'
-    r' types.';
+const _desc =
+    r'Invocation of `List<E>.remove` with references of unrelated types.';
 
 const _details = r'''
 
-**DON'T** Invoke `remove` on `List` with an instance of different type than
-the parameter type since it will invoke `==` on its elements and most likely will
+**DON'T** Invoke `.remove` on `List` with an instance of different type than
+the parameter type.
+
+Doing this will invoke `==` on its elements and most likely will
 return `false`. Strictly speaking it could evaluate to true since in Dart it
-is possible for an List to contain elements of type unrelated to its
+is possible for a `List` to contain elements of type unrelated to its
 parameter type, but this practice also should be avoided.
 
 **BAD:**
@@ -119,6 +121,7 @@ abstract class Mixin {}
 
 class DerivedClass3 extends ClassBase implements Mixin {}
 ```
+
 ''';
 
 class ListRemoveUnrelatedType extends LintRule {

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -8,18 +8,15 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 import 'package:linter/src/util/unrelated_types_visitor.dart';
 
-const _desc =
-    r'Invocation of `List<E>.remove` with references of unrelated types.';
+const _desc = r'Invocation of `remove` with references of unrelated types.';
 
 const _details = r'''
 
-**DON'T** Invoke `.remove` on `List` with an instance of different type than
+**DON'T** invoke `remove` on `List` with an instance of different type than
 the parameter type.
 
 Doing this will invoke `==` on its elements and most likely will
-return `false`. Strictly speaking it could evaluate to true since in Dart it
-is possible for a `List` to contain elements of type unrelated to its
-parameter type, but this practice also should be avoided.
+return `false`.
 
 **BAD:**
 ```

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -15,7 +15,7 @@ const _details = r'''
 inferred at compile time.
 
 Conditional statements using a condition which cannot be anything but FALSE have
-the effect of making blocks of code non-functional. If the condition cannot
+the effect of making blocks of code non-functional.  If the condition cannot
 evaluate to anything but `true`, the conditional statement is completely
 redundant, and makes the code less readable.
 It is quite likely that the code does not match the programmer's intent.

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -13,13 +13,14 @@ const _details = r'''
 
 **DON'T** test for conditions composed only by literals, since the value can be
 inferred at compile time.
+
 Conditional statements using a condition which cannot be anything but FALSE have
 the effect of making blocks of code non-functional. If the condition cannot
-evaluate to anything but TRUE, the conditional statement is completely
+evaluate to anything but `true`, the conditional statement is completely
 redundant, and makes the code less readable.
 It is quite likely that the code does not match the programmer's intent.
 Either the condition should be removed or it should be updated so that it does
-not always evaluate to TRUE or FALSE.
+not always evaluate to `true` or `false`.
 
 **BAD:**
 ```

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -6,14 +6,15 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Do not use adjacent strings in list.';
+const _desc = r"Don't use adjacent strings in list.";
 
-const details = r'''
-**DO NOT** use adjacent strings in list. This can be
-sign of forgotten comma.
+const _details = r'''
+
+**DON'T** use adjacent strings in list.
+
+This can be sign of forgotten comma.
 
 **GOOD:**
-
 ```
 List<String> list = <String>[
   'a' +
@@ -23,7 +24,6 @@ List<String> list = <String>[
 ```
 
 **BAD:**
-
 ```
 List<String> list = <String>[
   'a'
@@ -31,14 +31,15 @@ List<String> list = <String>[
   'c',
 ];
 ```
+
 ''';
 
 class NoAdjacentStringsInList extends LintRule {
   NoAdjacentStringsInList()
       : super(
             name: 'no_adjacent_strings_in_list',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -11,17 +11,15 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Do not use more than one case with same value.';
+const _desc = r"Don't use more than one case with same value.";
 
-String message(String value1, String value2) =>
-    'Do not use more than one case with same value ($value1 and $value2)';
+const _details = r'''
 
-const details = r'''
-**DO NOT** use more than one case with same value. This can be
-of typo or changed value of constant.
+**DON'T** use more than one case with same value.
+
+This is usually a typo or changed value of constant.
 
 **GOOD:**
-
 ```
 const int A = 1;
 switch (v) {
@@ -31,7 +29,6 @@ switch (v) {
 ```
 
 **BAD:**
-
 ```
 const int A = 1;
 switch (v) {
@@ -41,14 +38,18 @@ switch (v) {
   case 2:
 }
 ```
+
 ''';
+
+String message(String value1, String value2) =>
+    'Do not use more than one case with same value ($value1 and $value2)';
 
 class NoDuplicateCaseValues extends LintRule {
   NoDuplicateCaseValues()
       : super(
             name: 'no_duplicate_case_values',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc = r'Name non-constant identifiers using lowerCamelCase.';
+const _desc = r'Name non-constant identifiers using lowerCamelCase.';
 
-const details = r'''
+const _details = r'''
+
 **DO** name non-constant identifiers using lowerCamelCase.
 
 Class members, top-level definitions, variables, parameters, named parameters
@@ -17,7 +18,6 @@ and named constructors should capitalize the first letter of each word
 except the first word, and use no separators.
 
 **GOOD:**
-
 ```
 var item;
 
@@ -27,14 +27,15 @@ align(clearItems) {
   // ...
 }
 ```
+
 ''';
 
 class NonConstantIdentifierNames extends LintRule {
   NonConstantIdentifierNames()
       : super(
             name: 'non_constant_identifier_names',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -8,11 +8,14 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Omit the types for local variables.';
+const _desc = r'Consider omitting the types for local variables.';
 
 const _details = r'''
 
 **CONSIDER** omitting the types for local variables.
+
+Usually, the types of local variables can be easily inferred, so it isn't
+necessary to annotate them.
 
 **BAD:**
 ```

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -8,11 +8,11 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Consider omitting the types for local variables.';
+const _desc = r'Omit type annotations for local variables.';
 
 const _details = r'''
 
-**CONSIDER** omitting the types for local variables.
+**CONSIDER** omitting type annotations for local variables.
 
 Usually, the types of local variables can be easily inferred, so it isn't
 necessary to annotate them.

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -16,8 +16,8 @@ From the [style guide](https://www.dartlang.org/articles/style-guide/):
 **AVOID** defining a one-member abstract class when a simple function will do.
 
 Unlike Java, Dart has first-class functions, closures, and a nice light syntax
-for using them. If all you need is something like a callback, just use a
-function. If you're defining an class and it only has a single abstract member
+for using them.  If all you need is something like a callback, just use a
+function.  If you're defining an class and it only has a single abstract member
 with a meaningless name like `call` or `invoke`, there is a good chance
 you just want a function.
 

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -6,10 +6,11 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc =
-    'Avoid defining a one-member abstract class when a simple function will do.';
+const _desc =
+    r'Avoid defining a one-member abstract class when a simple function will do.';
 
-const details = '''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 **AVOID** defining a one-member abstract class when a simple function will do.
@@ -31,14 +32,15 @@ abstract class Predicate {
   bool test(item);
 }
 ```
+
 ''';
 
 class OneMemberAbstracts extends LintRule {
   OneMemberAbstracts()
       : super(
             name: 'one_member_abstracts',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -19,6 +19,10 @@ const _details = r'''
 **DO** throw only instances of classes that extend `dart.core.Error` or
 `dart.core.Exception`.
 
+Throwing instances that do not extend `Error` or `Exception` is a bad practice;
+doing this is usually a hack for something that should be implemented more
+thoroughly.
+
 **BAD:**
 ```
 void throwString() {
@@ -33,6 +37,7 @@ void throwArgumentError() {
   throw error; // OK
 }
 ```
+
 ''';
 
 const _errorClassName = 'Error';

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -8,11 +8,14 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Do not override fields.';
+const _desc = r"Don't override fields.";
 
-const details = r'''
+const _details = r'''
 
-**DO** Do not override fields.
+**DON'T** override fields.
+
+Overriding fields is almost always done unintentionally. Even if it is
+intentional, it is a bad practice.
 
 **BAD:**
 ```
@@ -59,6 +62,7 @@ class LogPrintHandler implements BaseLoggingHandler {
   Derived transformer; // OK
 }
 ```
+
 ''';
 
 Iterable<InterfaceType> _findAllSupertypesAndMixins(
@@ -83,8 +87,8 @@ class OverriddenFields extends LintRule {
   OverriddenFields()
       : super(
             name: 'overridden_fields',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style) {
     _visitor = new _Visitor(this);
   }

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -14,8 +14,8 @@ const _details = r'''
 
 **DON'T** override fields.
 
-Overriding fields is almost always done unintentionally. Even if it is
-intentional, it is a bad practice.
+Overriding fields is almost always done unintentionally.  Regardless, it is a
+bad practice to do so.
 
 **BAD:**
 ```

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc = r'Provide doc comments for all public APIs.';
+const _desc = r'Provide doc comments for all public APIs.';
 
-const details = r'''
+const _details = r'''
+
 **DO** provide doc comments for all public APIs.
 
 As described in the [pub package layout doc]
@@ -27,7 +28,7 @@ class Foo { }
 
 class _Foo { }
 ```
-it's API includes:
+its API includes:
 
 * `Foo` (but not `_Foo`)
 * `Bar` (exported) and
@@ -35,7 +36,7 @@ it's API includes:
 
 All public API members should be documented with `///` doc-style comments.
 
-**Good:**
+**GOOD:**
 ```
 /// A Foo.
 abstract class Foo {
@@ -46,7 +47,7 @@ abstract class Foo {
 }
 ```
 
-**Bad:**
+**BAD:**
 ```
 class Bar {
   void bar();
@@ -56,6 +57,7 @@ class Bar {
 Advice for writing good doc comments can be found in the
 [Doc Writing Guidelines]
 (https://www.dartlang.org/articles/doc-comment-guidelines).
+
 ''';
 
 class PackageApiDocs extends LintRule implements ProjectVisitor {
@@ -64,8 +66,8 @@ class PackageApiDocs extends LintRule implements ProjectVisitor {
   PackageApiDocs()
       : super(
             name: 'package_api_docs',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -7,10 +7,11 @@ import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc =
+const _desc =
     r'Prefix library names with the package name and a dot-separated path.';
 
-const details = r'''
+const _details = r'''
+
 **DO** prefix library names with the package name and a dot-separated path.
 
 This guideline helps avoid the warnings you get when two libraries have the
@@ -25,7 +26,6 @@ For example, say the package name is `my_package`. Here are the library names
 for various files in the package:
 
 **GOOD:**
-
 ```
 // In lib/my_package.dart
 library my_package;
@@ -42,6 +42,7 @@ library my_package.example.foo.bar;
 // In lib/src/private.dart
 library my_package.src.private;
 ```
+
 ''';
 
 bool matchesOrIsPrefixedBy(String name, String prefix) =>
@@ -53,8 +54,8 @@ class PackagePrefixedLibraryNames extends LintRule implements ProjectVisitor {
   PackagePrefixedLibraryNames()
       : super(
             name: 'package_prefixed_library_names',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -14,15 +14,16 @@ const _details = r'''
 
 **DO** prefix library names with the package name and a dot-separated path.
 
-This guideline helps avoid the warnings you get when two libraries have the
-same name. Here are the rules we recommend:
+This guideline helps avoid the warnings you get when two libraries have the same
+name.  Here are the rules we recommend:
 
 * Prefix all library names with the package name.
 * Make the entry library have the same name as the package.
-* For all other libraries in a package, after the package name add the dot-separated path to the library's Dart file.
+* For all other libraries in a package, after the package name add the
+dot-separated path to the library's Dart file.
 * For libraries under `lib`, omit the top directory name.
 
-For example, say the package name is `my_package`. Here are the library names
+For example, say the package name is `my_package`.  Here are the library names
 for various files in the package:
 
 **GOOD:**

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -13,7 +13,11 @@ const _desc =
 
 const _details = r'''
 
-**DO NOT** assign new values to parameters of methods or functions.
+**DON'T** assign new values to parameters of methods or functions.
+
+Assigning new values to parameters is generally a bad practice unless an
+operator such as `??=` is used. Otherwise, arbitrarily reassigning parameters
+is usually a mistake.
 
 **BAD:**
 ```
@@ -74,6 +78,7 @@ class A {
   }
 }
 ```
+
 ''';
 
 bool _isDefaultFormalParameterWithDefaultValue(FormalParameter parameter) =>

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -16,7 +16,7 @@ const _details = r'''
 **DON'T** assign new values to parameters of methods or functions.
 
 Assigning new values to parameters is generally a bad practice unless an
-operator such as `??=` is used. Otherwise, arbitrarily reassigning parameters
+operator such as `??=` is used.  Otherwise, arbitrarily reassigning parameters
 is usually a mistake.
 
 **BAD:**

--- a/lib/src/rules/prefer_adjacent_string_concatenation.dart
+++ b/lib/src/rules/prefer_adjacent_string_concatenation.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = 'Use adjacent strings to concatenate string literals.';
+const _desc = r'Use adjacent strings to concatenate string literals.';
 
 const _details = r'''
 

--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -10,9 +10,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Prefer put asserts in initializer list.';
+const _desc = r'Prefer put asserts in initializer list.';
 
-const details = '''
+const _details = r'''
+
 **WARNING** Putting asserts in initializer lists is only possible using an
 experimental language feature that might be removed.
 
@@ -34,14 +35,15 @@ class A {
   }
 }
 ```
+
 ''';
 
 class PreferAssertsInInitializerLists extends LintRule {
   PreferAssertsInInitializerLists()
       : super(
             name: 'prefer_asserts_in_initializer_lists',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = r'Prefer put asserts in initializer list.';
+const _desc = r'Prefer putting asserts in initializer list.';
 
 const _details = r'''
 

--- a/lib/src/rules/prefer_bool_in_asserts.dart
+++ b/lib/src/rules/prefer_bool_in_asserts.dart
@@ -8,10 +8,14 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = 'Prefer bool as assert condition.';
+const _desc = r'Prefer using a boolean as the assert condition.';
 
-const details = '''
-**DO** use bool as assert condition.
+const _details = r'''
+
+**DO** use a boolean for assert conditions.
+
+Not using booleans in assert conditions can lead to code where it isn't clear
+what the intention of the assert statement is.
 
 **BAD:**
 ```
@@ -28,14 +32,15 @@ assert(() {
   return true;
 }());
 ```
+
 ''';
 
 class PreferBoolInAsserts extends LintRule {
   PreferBoolInAsserts()
       : super(
             name: 'prefer_bool_in_asserts',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -15,8 +15,8 @@ const _details = r'''
 
 **PREFER** using `??=` over testing for null.
 
-As Dart has the `??=` operator, it is advisable to use it where applicable
-to improve the brevity of your code.
+As Dart has the `??=` operator, it is advisable to use it where applicable to
+improve the brevity of your code.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -9,11 +9,14 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Prefer ??= over testing for null.';
+const _desc = r'Prefer using `??=` over testing for null.';
 
 const _details = r'''
 
-**PREFER** ??= over testing for null.
+**PREFER** using `??=` over testing for null.
+
+As Dart has the `??=` operator, it is advisable to use it where applicable
+to improve the brevity of your code.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -13,9 +13,12 @@ import 'package:linter/src/analyzer.dart';
 const _desc = r'Prefer const with constant constructors.';
 
 const _details = r'''
-**DO** prefer `const` for instantiating constant constructors.
 
-**GOOD**
+**PREFER** using `const` for instantiating constant constructors.
+
+If a const constructor is available, it is preferable to use it.
+
+**GOOD:**
 ```
 class A {
   const A();
@@ -26,7 +29,7 @@ void accessA() {
 }
 ```
 
-**GOOD**
+**GOOD:**
 ```
 class A {
   final int x;
@@ -37,7 +40,7 @@ class A {
 A foo(int x) => new A(x);
 ```
 
-**BAD**
+**BAD:**
 ```
 class A {
   const A();
@@ -47,6 +50,7 @@ void accessA() {
   A a = new A();
 }
 ```
+
 ''';
 
 class PreferConstConstructors extends LintRule {

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -13,9 +13,15 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/generated/resolver.dart'; // ignore: implementation_imports
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Prefer declare const constructors on @immutable classes.';
+const _desc = r'Prefer declare const constructors on `@immutable` classes.';
 
-const details = '''
+const _details = r'''
+
+**PREFER** declaring const constructors on `@immutable` classes.
+
+If a class is immutable, it is usually a good idea to make its constructor
+a const constructor.
+
 **GOOD:**
 ```
 @immutable
@@ -33,6 +39,7 @@ class A {
   A(this.a);
 }
 ```
+
 ''';
 
 /// The name of `meta` library, used to define analysis annotations.
@@ -50,8 +57,8 @@ class PreferConstConstructorsInImmutables extends LintRule {
   PreferConstConstructorsInImmutables()
       : super(
             name: 'prefer_const_constructors_in_immutables',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -19,8 +19,8 @@ const _details = r'''
 
 **PREFER** declaring const constructors on `@immutable` classes.
 
-If a class is immutable, it is usually a good idea to make its constructor
-a const constructor.
+If a class is immutable, it is usually a good idea to make its constructor a
+const constructor.
 
 **GOOD:**
 ```

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -15,6 +15,9 @@ const _details = r'''
 
 **PREFER** defining constructors instead of static methods to create instances.
 
+In most cases, it makes more sense to use a named constructor rather than
+a static method because it makes instantiation clearer.
+
 **BAD:**
 ```
 class Point {

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -15,8 +15,8 @@ const _details = r'''
 
 **PREFER** defining constructors instead of static methods to create instances.
 
-In most cases, it makes more sense to use a named constructor rather than
-a static method because it makes instantiation clearer.
+In most cases, it makes more sense to use a named constructor rather than a
+static method because it makes instantiation clearer.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -17,12 +17,12 @@ const _desc = r'Use contains for `List` and `String` instances.';
 
 const _details = r'''
 
-**DON'T** use `.indexOf` to see if a collection contains an element.
+**DON'T** use `indexOf` to see if a collection contains an element.
 
-Calling `.indexOf` to see if a collection contains something is difficult to
-read and may have poor performance.
+Calling `indexOf` to see if a collection contains something is difficult to read
+and may have poor performance.
 
-Instead, prefer `.contains`.
+Instead, prefer `contains`.
 
 **GOOD:**
 ```

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -13,15 +13,14 @@ import 'package:analyzer/error/listener.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const alwaysFalse =
-    'Always false because indexOf is always greater or equal -1.';
-const alwaysTrue = 'Always true because indexOf is always greater or equal -1.';
+const _desc = r'Use contains for `List` and `String` instances.';
 
-const desc = 'Use contains for Lists and Strings.';
-const details = '''
-**DO NOT** use `.indexOf` to see if a collection contains an element.
+const _details = r'''
 
-Calling `.indexOf` to see if a collection contains something is difficult to read and may have poor performance.
+**DON'T** use `.indexOf` to see if a collection contains an element.
+
+Calling `.indexOf` to see if a collection contains something is difficult to
+read and may have poor performance.
 
 Instead, prefer `.contains`.
 
@@ -34,7 +33,12 @@ if (!lunchBox.contains('sandwich') return 'so hungry...';
 ```
 if (lunchBox.indexOf('sandwich') == -1 return 'so hungry...';
 ```
+
 ''';
+
+const alwaysFalse =
+    'Always false because indexOf is always greater or equal -1.';
+const alwaysTrue = 'Always true because indexOf is always greater or equal -1.';
 
 const useContains = 'Use contains instead of indexOf';
 
@@ -42,8 +46,8 @@ class PreferContainsOverIndexOf extends LintRule {
   PreferContainsOverIndexOf()
       : super(
             name: 'prefer_contains',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -18,6 +18,10 @@ const _details = r'''
 **DO** prefer declaring private fields as final if they are not reassigned later
  in the class.
 
+Declaring fields as final when possible is a good practice because it
+helps avoid accidental reassignments and allows the compiler to do
+optimizations.
+
 **BAD:**
 ```
 class BadImmutable {
@@ -62,6 +66,7 @@ class GoodMutable {
   }
 }
 ```
+
 ''';
 
 class PreferFinalFields extends LintRule {

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -16,11 +16,10 @@ const _desc = r'Private field could be final.';
 const _details = r'''
 
 **DO** prefer declaring private fields as final if they are not reassigned later
- in the class.
+in the class.
 
-Declaring fields as final when possible is a good practice because it
-helps avoid accidental reassignments and allows the compiler to do
-optimizations.
+Declaring fields as final when possible is a good practice because it helps
+avoid accidental reassignments and allows the compiler to do optimizations.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -11,7 +11,12 @@ const _desc =
 
 const _details = r'''
 
-**DO** prefer declaring variables as final if they are not reassigned later in the code.
+**DO** prefer declaring variables as final if they are not reassigned later in
+the code.
+
+Declaring variables as final when possible is a good practice because it
+helps avoid accidental reassignments and allows the compiler to do
+optimizations.
 
 **BAD:**
 ```
@@ -38,6 +43,7 @@ void mutableCase() {
   print(label);
 }
 ```
+
 ''';
 
 class PreferFinalLocals extends LintRule {

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -14,9 +14,8 @@ const _details = r'''
 **DO** prefer declaring variables as final if they are not reassigned later in
 the code.
 
-Declaring variables as final when possible is a good practice because it
-helps avoid accidental reassignments and allows the compiler to do
-optimizations.
+Declaring variables as final when possible is a good practice because it helps
+avoid accidental reassignments and allows the compiler to do optimizations.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -8,11 +8,16 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Use forEach call to only apply a function to all the elements.';
+const _desc = r'Use `.forEach` to only apply a function to all the elements.';
 
 const _details = r'''
 
-**DO** use forEach call if you are only going to apply a function or a method to all the elements of an iterable.
+**DO** use `.forEach` if you are only going to apply a function or a method
+to all the elements of an iterable.
+
+Using `.forEach` when you are only going to apply a function or method to all
+elements of an iterable is a good practice because it makes your code more
+terse.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -8,14 +8,14 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Use `.forEach` to only apply a function to all the elements.';
+const _desc = r'Use `forEach` to only apply a function to all the elements.';
 
 const _details = r'''
 
-**DO** use `.forEach` if you are only going to apply a function or a method
+**DO** use `forEach` if you are only going to apply a function or a method
 to all the elements of an iterable.
 
-Using `.forEach` when you are only going to apply a function or method to all
+Using `forEach` when you are only going to apply a function or method to all
 elements of an iterable is a good practice because it makes your code more
 terse.
 

--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -12,8 +12,8 @@ const _details = r'''
 
 **DO** use a function declaration to bind a function to a name.
 
-As Dart allows local function declarations, it is a good practice to use them
-in the place of function literals.
+As Dart allows local function declarations, it is a good practice to use them in
+the place of function literals.
 
 **BAD:**
 ```

--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -12,6 +12,9 @@ const _details = r'''
 
 **DO** use a function declaration to bind a function to a name.
 
+As Dart allows local function declarations, it is a good practice to use them
+in the place of function literals.
+
 **BAD:**
 ```
 void main() {

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -14,6 +14,8 @@ const _details = r'''
 
 **DO** use initializing formals when possible.
 
+Using initializing formals when possible makes your code more terse.
+
 **BAD:**
 ```
 class Point {

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -14,6 +14,9 @@ const _details = r'''
 
 **PREFER** using interpolation to compose strings and values.
 
+Using interpolation when composing strings and values is usually easier to write
+and read than concatenation.
+
 **BAD:**
 ```
 'Hello, ' + name + '! You are ' + (year - birth) + ' years old.';

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -12,15 +12,11 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Use isEmpty for Iterables and Maps.';
+const _desc = r'Use isEmpty for Iterables and Maps.';
 
-const useIsNotEmpty = 'Use isNotEmpty instead of length';
-const useIsEmpty = 'Use isEmpty instead of length';
-const alwaysFalse = 'Always false because length is always greater or equal 0.';
-const alwaysTrue = 'Always true because length is always greater or equal 0.';
+const _details = r'''
 
-const details = '''
-**DO NOT** use `.length` to see if a collection is empty.
+**DON'T** use `.length` to see if a collection is empty.
 
 The `Iterable` contract does not require that a collection know its length or be
 able to provide it in constant time. Calling `.length` just to see if the
@@ -40,7 +36,13 @@ if (words.isNotEmpty) return words.join(' ');
 if (lunchBox.length == 0) return 'so hungry...';
 if (words.length != 0) return words.join(' ');
 ```
+
 ''';
+
+const useIsNotEmpty = 'Use isNotEmpty instead of length';
+const useIsEmpty = 'Use isEmpty instead of length';
+const alwaysFalse = 'Always false because length is always greater or equal 0.';
+const alwaysTrue = 'Always true because length is always greater or equal 0.';
 
 class _LintCode extends LintCode {
   static final registry = <String, LintCode>{};
@@ -55,8 +57,8 @@ class PreferIsEmpty extends LintRule {
   PreferIsEmpty()
       : super(
             name: 'prefer_is_empty',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -23,7 +23,7 @@ able to provide it in constant time.  Calling `length` just to see if the
 collection contains anything can be painfully slow.
 
 Instead, there are faster and more readable getters: `isEmpty` and
-`isNotEmpty`.  Use the one that doesn’t require you to negate the result.
+`isNotEmpty`.  Use the one that doesn't require you to negate the result.
 
 **GOOD:**
 ```

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -12,18 +12,18 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = r'Use isEmpty for Iterables and Maps.';
+const _desc = r'Use `isEmpty` for Iterables and Maps.';
 
 const _details = r'''
 
-**DON'T** use `.length` to see if a collection is empty.
+**DON'T** use `length` to see if a collection is empty.
 
 The `Iterable` contract does not require that a collection know its length or be
-able to provide it in constant time. Calling `.length` just to see if the
+able to provide it in constant time.  Calling `length` just to see if the
 collection contains anything can be painfully slow.
 
-Instead, there are faster and more readable getters: `.isEmpty` and
-`.isNotEmpty`. Use the one that doesn’t require you to negate the result.
+Instead, there are faster and more readable getters: `isEmpty` and
+`isNotEmpty`.  Use the one that doesn’t require you to negate the result.
 
 **GOOD:**
 ```

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -16,13 +16,14 @@ import 'package:analyzer/dart/element/element.dart' show Element;
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc = 'Use isNotEmpty for Iterables and Maps.';
+const _desc = r'Use `.isNotEmpty` for Iterables and Maps.';
 
-const details = '''
-**PREFER** `x.isNotEmpty` to `!x.isEmpty` for Iterables and Maps.
+const _details = r'''
+
+**PREFER** `x.isNotEmpty` to `!x.isEmpty` for `Iterable` and `Map` instances.
 
 When testing whether an iterable or map is empty, prefer `isNotEmpty` over
-`!isEmpty`.
+`!isEmpty` to improve code readability.
 
 **GOOD:**
 ```
@@ -37,14 +38,15 @@ if (!sources.isEmpty) {
   process(sources);
 }
 ```
+
 ''';
 
 class PreferIsNotEmpty extends LintRule {
   PreferIsNotEmpty()
       : super(
             name: 'prefer_is_not_empty',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -16,7 +16,7 @@ import 'package:analyzer/dart/element/element.dart' show Element;
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const _desc = r'Use `.isNotEmpty` for Iterables and Maps.';
+const _desc = r'Use `isNotEmpty` for Iterables and Maps.';
 
 const _details = r'''
 

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -16,8 +16,8 @@ That means strings with an apostrophe may use double quotes so that the
 apostrophe isn't escaped (note: we don't lint the other way around, ie, a single
 quoted string with an escaped apostrophe is not flagged).
 
-It's also rare, but possible, to have strings within string interpolations. In
-this case, its much more readable to use a double quote somewhere. So double
+It's also rare, but possible, to have strings within string interpolations.  In
+this case, its much more readable to use a double quote somewhere.  So double
 quotes are allowed either within, or containing, an interpolated string literal.
 Arguably strings within string interpolations should be its own type of lint.
 

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = "Prefer single quotes where they won't require escape sequences.";
+const _desc = r"Prefer single quotes where they won't require escape sequences.";
 
 const _details = '''
 
@@ -16,7 +16,7 @@ That means strings with an apostrophe may use double quotes so that the
 apostrophe isn't escaped (note: we don't lint the other way around, ie, a single
 quoted string with an escaped apostrophe is not flagged).
 
-Its also rare, but possible, to have strings within string interpolations. In
+It's also rare, but possible, to have strings within string interpolations. In
 this case, its much more readable to use a double quote somewhere. So double
 quotes are allowed either within, or containing, an interpolated string literal.
 Arguably strings within string interpolations should be its own type of lint.

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -9,8 +9,12 @@ import 'package:linter/src/analyzer.dart';
 const _desc = r'Prefer typing uninitialized variables and fields.';
 
 const _details = r'''
+
 **PREFER** specifying a type annotation for uninitialized variables
- and fields.
+and fields.
+
+Forgoing type annotations for uninitialized variables is a bad practice because
+you may accidentally assign them to a type that you didn't originally intend to.
 
 **BAD:**
 ```
@@ -49,6 +53,7 @@ class GoodClass {
   }
 }
 ```
+
 ''';
 
 class PreferTypingUninitializedVariables extends LintRule {

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -10,8 +10,7 @@ const _desc = r'Prefer typing uninitialized variables and fields.';
 
 const _details = r'''
 
-**PREFER** specifying a type annotation for uninitialized variables
-and fields.
+**PREFER** specifying a type annotation for uninitialized variables and fields.
 
 Forgoing type annotations for uninitialized variables is a bad practice because
 you may accidentally assign them to a type that you didn't originally intend to.

--- a/lib/src/rules/pub/package_names.dart
+++ b/lib/src/rules/pub/package_names.dart
@@ -5,26 +5,27 @@
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/utils.dart';
 
-const desc = 'Use `lowercase_with_underscores` for package names.';
+const _desc = r'Use `lowercase_with_underscores` for package names.';
 
-const details = '''
+const _details = r'''
+
+From the [Pubspec format description](https://www.dartlang.org/tools/pub/pubspec.html):
+
 **DO** use `lowercase_with_underscores` for package names.
-
-From the [Pubspec format description]
-(https://www.dartlang.org/tools/pub/pubspec.html):
 
 Package names should be all lowercase, with underscores to separate words,
 `just_like_this`. Use only basic Latin letters and Arabic digits: [a-z0-9_].
 Also, make sure the name is a valid Dart identifier -- that it doesn't start
 with digits and isn't a reserved word.
+
 ''';
 
 class PubPackageNames extends LintRule {
   PubPackageNames()
       : super(
             name: 'package_names',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.pub);
 
   @override

--- a/lib/src/rules/pub/package_names.dart
+++ b/lib/src/rules/pub/package_names.dart
@@ -14,7 +14,7 @@ From the [Pubspec format description](https://www.dartlang.org/tools/pub/pubspec
 **DO** use `lowercase_with_underscores` for package names.
 
 Package names should be all lowercase, with underscores to separate words,
-`just_like_this`. Use only basic Latin letters and Arabic digits: [a-z0-9_].
+`just_like_this`.  Use only basic Latin letters and Arabic digits: [a-z0-9_].
 Also, make sure the name is a valid Dart identifier -- that it doesn't start
 with digits and isn't a reserved word.
 

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -12,15 +12,16 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 import 'package:path/path.dart' as path;
 
-const desc = r'Document all public members.';
+const _desc = r'Document all public members.';
 
-const details = r'''
+const _details = r'''
+
 **DO** document all public members.
 
 All non-overriding public members should be documented with `///` doc-style
 comments.
 
-**Good:**
+**GOOD:**
 ```
 /// A good thing.
 abstract class Good {
@@ -31,7 +32,7 @@ abstract class Good {
 }
 ```
 
-**Bad:**
+**BAD:**
 ```
 class Bad {
   void meh() { }
@@ -42,7 +43,7 @@ In case a public member overrides a member it is up to the declaring member
 to provide documentation.  For example, in the following, `Sub` needn't
 document `init` (though it certainly may, if there's need).
 
-**Good:**
+**GOOD:**
 ```
 /// Base of all things.
 abstract class Base {
@@ -60,6 +61,7 @@ class Sub extends Base {
 Note that consistent with `dartdoc`, an exception to the rule is made when
 documented getters have corresponding undocumented setters. In this case the
 setters inherit the docs from the getters.
+
 ''';
 
 // TODO(devoncarew): This lint is very slow - we should profile and optimize it.
@@ -72,8 +74,8 @@ class PublicMemberApiDocs extends LintRule {
   PublicMemberApiDocs()
       : super(
             name: 'public_member_api_docs',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -59,7 +59,7 @@ class Sub extends Base {
 ```
 
 Note that consistent with `dartdoc`, an exception to the rule is made when
-documented getters have corresponding undocumented setters. In this case the
+documented getters have corresponding undocumented setters.  In this case the
 setters inherit the docs from the getters.
 
 ''';

--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -14,7 +14,7 @@ const _details = r'''
 
 **DON'T** create recursive getters.
 
-Recursive getters are getters which return themselves as a value. This is
+Recursive getters are getters which return themselves as a value.  This is
 usually a typo.
 
 **BAD:**

--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -8,27 +8,30 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Property getter recursivlely returns itself.';
+const _desc = r'Property getter recursively returns itself.';
 
 const _details = r'''
 
-**DON'T** Return the property itself in a getter body, this can be due to a typo.
+**DON'T** create recursive getters.
+
+Recursive getters are getters which return themselves as a value. This is
+usually a typo.
 
 **BAD:**
 ```
-  int get field => field; // LINT
+int get field => field; // LINT
 ```
 
 **BAD:**
 ```
-  int get otherField {
-    return otherField; // LINT
-  }
+int get otherField {
+  return otherField; // LINT
+}
 ```
 
 **GOOD:**
 ```
-  int get field => _field;
+int get field => _field;
 ```
 
 ''';

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -6,12 +6,13 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Prefer to use /// for doc comments.';
+const _desc = r'Prefer using /// for doc comments.';
 
-const details = r'''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
-**PREFER** to use `///` for doc comments.
+**PREFER** using `///` for doc comments.
 
 Although Dart supports two syntaxes of doc comments (`///` and `/**`), we
 prefer using `///` for doc comments.
@@ -27,7 +28,9 @@ void parse(List options) {
   // ...
 }
 ```
+
 Within a doc comment, you can use markdown for formatting.
+
 ''';
 
 bool isJavaStyle(Comment comment) {
@@ -43,8 +46,8 @@ class SlashForDocComments extends LintRule {
   SlashForDocComments()
       : super(
             name: 'slash_for_doc_comments',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -6,9 +6,9 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Sort constructor declarations before method declarations.';
+const _desc = r'Sort constructor declarations before method declarations.';
 
-const details = r'''
+const _details = r'''
 
 **DO** sort constructor declarations before method declarations.
 
@@ -27,14 +27,15 @@ abstract class Visitor {
   Visitor();
 }
 ```
+
 ''';
 
 class SortConstructorsFirst extends LintRule {
   SortConstructorsFirst()
       : super(
             name: 'sort_constructors_first',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -6,12 +6,13 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Sort unnamed constructor declarations first.';
+const _desc = r'Sort unnamed constructor declarations first.';
 
-const details = r'''
+const _details = r'''
+
 **DO** sort unnamed constructor declarations first, before named ones.
 
-**Good:**
+**GOOD:**
 ```
 abstract class CancelableFuture<T> implements Future<T>  {
   factory CancelableFuture(computation()) => ...
@@ -20,23 +21,23 @@ abstract class CancelableFuture<T> implements Future<T>  {
 }
 ```
 
-**Bad:**
+**BAD:**
 ```
 class _PriorityItem {
   factory _PriorityItem.forName(bool isStatic, String name, _MemberKind kind) => ...
   _PriorityItem(this.isStatic, this.kind, this.isPrivate);
   ...
 }
-
 ```
+
 ''';
 
 class SortUnnamedConstructorsFirst extends LintRule {
   SortUnnamedConstructorsFirst()
       : super(
             name: 'sort_unnamed_constructors_first',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -16,15 +16,14 @@ From the [style guide](https://www.dartlang.org/articles/style-guide/):
 **DO** place the `super` call last in a constructor initialization list.
 
 Field initializers are evaluated in the order that they appear in the
-constructor initialization list. If you place a `super()` call in the
-middle of an initializer list, the superclass's initializers will be evaluated
-right then before evaluating the rest of the subclass's initializers.
+constructor initialization list.  If you place a `super()` call in the middle of
+an initializer list, the superclass's initializers will be evaluated right then
+before evaluating the rest of the subclass's initializers.
 
 What it doesn't mean is that the superclass's constructor body will be executed
-then. That always happens after all initializers are run regardless of where
-`super` appears. It's vanishingly rare that the order of initializers
-matters, so the placement of `super` in the list almost never matters
-either.
+then.  That always happens after all initializers are run regardless of where
+`super` appears.  It's vanishingly rare that the order of initializers matters,
+so the placement of `super` in the list almost never matters either.
 
 Getting in the habit of placing it last improves consistency, visually
 reinforces when the superclass's constructor body is run, and may help

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -6,13 +6,14 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc =
-    'Place the super() call last in a constructor initialization list.';
+const _desc =
+    r'Place the `super` call last in a constructor initialization list.';
 
-const details = '''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
-**DO** place the `super()` call last in a constructor initialization list.
+**DO** place the `super` call last in a constructor initialization list.
 
 Field initializers are evaluated in the order that they appear in the
 constructor initialization list. If you place a `super()` call in the
@@ -21,8 +22,8 @@ right then before evaluating the rest of the subclass's initializers.
 
 What it doesn't mean is that the superclass's constructor body will be executed
 then. That always happens after all initializers are run regardless of where
-`super()` appears. It's vanishingly rare that the order of initializers
-matters, so the placement of `super()` in the list almost never matters
+`super` appears. It's vanishingly rare that the order of initializers
+matters, so the placement of `super` in the list almost never matters
 either.
 
 Getting in the habit of placing it last improves consistency, visually
@@ -42,14 +43,15 @@ View(Style style, List children)
     : super(style),
       _children = children {
 ```
+
 ''';
 
 class SuperGoesLast extends LintRule {
   SuperGoesLast()
       : super(
             name: 'super_goes_last',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -8,12 +8,14 @@ import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Test type arguments in operator ==(Object other).';
+const _desc = r'Test type arguments in operator ==(Object other).';
 
-const details = r'''
-**ALWAYS** test type arguments in operator ==(Object other).
-Not doing so might result in Null Pointer Exceptions which will be unexpected
-for consumers of your class.
+const _details = r'''
+
+**DO** test type arguments in operator ==(Object other).
+
+Not testing types so might result in null pointer exceptions which will be
+unexpected for consumers of your class.
 
 **GOOD:**
 ```
@@ -64,14 +66,15 @@ class Bad {
   }
 }
 ```
+
 ''';
 
 class TestTypesInEquals extends LintRule {
   TestTypesInEquals()
       : super(
             name: 'test_types_in_equals',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/throw_in_finally.dart
+++ b/lib/src/rules/throw_in_finally.dart
@@ -7,11 +7,14 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules/control_flow_in_finally.dart';
 
-const desc = r'Avoid `throw` in finally block.';
+const _desc = r'Avoid `throw` in finally block.';
 
-const details = r'''
-**AVOID** throwing exceptions in finally blocks. This will cause unexpected
-behavior that is hard to debug.
+const _details = r'''
+
+**AVOID** throwing exceptions in finally blocks.
+
+Throwing exceptions in finally blocks will inevitably cause unexpected behavior
+that is hard to debug.
 
 **GOOD:**
 ```
@@ -42,6 +45,7 @@ class BadThrow {
   }
 }
 ```
+
 ''';
 
 class ThrowInFinally extends LintRule {
@@ -50,8 +54,8 @@ class ThrowInFinally extends LintRule {
   ThrowInFinally()
       : super(
             name: 'throw_in_finally',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors) {
     _visitor = new _Visitor(this);
   }

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -8,9 +8,10 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 import 'package:linter/src/utils.dart';
 
-const desc = r'Type annotate public APIs.';
+const _desc = r'Type annotate public APIs.';
 
-const details = r'''
+const _details = r'''
+
 From [effective dart](https://www.dartlang.org/effective-dart/design/#do-type-annotate-public-apis):
 
 **DO** type annotate public APIs.
@@ -36,9 +37,7 @@ install(id, destination) {
 Here, it's unclear what `id` is. A string? And what is `destination`? A string
 or a `File` object? Is this method synchronous or asynchronous?
 
-
 **GOOD:**
-
 ```
 Future<bool> install(PackageId id, String destination) {
   // ...
@@ -46,14 +45,15 @@ Future<bool> install(PackageId id, String destination) {
 ```
 
 With types, all of this is clarified.
+
 ''';
 
 class TypeAnnotatePublicApis extends LintRule {
   TypeAnnotatePublicApis()
       : super(
             name: 'type_annotate_public_apis',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -21,7 +21,7 @@ Annotating the parameter and return types of public methods and functions helps
 users understand what the API expects and what it provides.
 
 Note that if a public API accepts a range of values that Dart's type system
-cannot express, then it is acceptable to leave that untyped. In that case, the
+cannot express, then it is acceptable to leave that untyped.  In that case, the
 implicit `dynamic` is the correct type for the API.
 
 For code internal to a library (either private, or things like nested functions)
@@ -34,7 +34,7 @@ install(id, destination) {
 }
 ```
 
-Here, it's unclear what `id` is. A string? And what is `destination`? A string
+Here, it's unclear what `id` is.  A string? And what is `destination`? A string
 or a `File` object? Is this method synchronous or asynchronous?
 
 **GOOD:**

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -6,9 +6,10 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = "Don't type annotate initializing formals.";
+const _desc = "Don't type annotate initializing formals.";
 
-const details = r'''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 **DON'T** type annotate initializing formals.
@@ -31,14 +32,15 @@ class Point {
   Point(int this.x, int this.y);
 }
 ```
+
 ''';
 
 class TypeInitFormals extends LintRule {
   TypeInitFormals()
       : super(
             name: 'type_init_formals',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -14,7 +14,7 @@ From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 **DON'T** type annotate initializing formals.
 
-If a constructor parameter is using `this`. to initialize a field, then the
+If a constructor parameter is using `this.x` to initialize a field, then the
 type of the parameter is understood to be the same type as the field.
 
 **GOOD:**

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -6,18 +6,18 @@ import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc =
-    'Await for future expression statements inside async function bodies.';
+const _desc =
+    r'Await future-returning functions inside async function bodies.';
 
-const details = r'''
-**DO** await for Future return value of expression statements, or explicitly
-ignore those cases.
+const _details = r'''
+
+**DO** await functions that return a `Future` inside of an async function body.
 
 It's easy to forget await in async methods as naming conventions usually don't
 tell us if a method is sync or async (except for some in `dart:io`).
 
 **GOOD:**
-```dart
+```
 Future doSomething() => ...;
 
 void main() async {
@@ -29,19 +29,20 @@ void main() async {
 ```
 
 **BAD:**
-```dart
+```
 void main() async {
   doSomething(); // Likely a bug.
 }
 ```
+
 ''';
 
 class UnawaitedFutures extends LintRule {
   UnawaitedFutures()
       : super(
             name: 'unawaited_futures',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/unnecessary_brace_in_string_interps.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interps.dart
@@ -7,23 +7,25 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Avoid using braces in interpolation when not needed.';
+const _desc = r'Avoid using braces in interpolation when not needed.';
 
-const details = r'''
+const _details = r'''
+
 **AVOID** using braces in interpolation when not needed.
 
 If you're just interpolating a simple identifier, and it's not immediately
 followed by more alphanumeric text, the `{}` can and should be omitted.
 
 **GOOD:**
-```dart
+```
 print("Hi, $name!");
 ```
 
 **BAD:**
-```dart
+```
 print("Hi, ${name}!");
 ```
+
 ''';
 
 final RegExp identifierPart = new RegExp(r'^[a-zA-Z0-9_]');
@@ -35,8 +37,8 @@ class UnnecessaryBraceInStringInterps extends LintRule {
   UnnecessaryBraceInStringInterps()
       : super(
             name: 'unnecessary_brace_in_string_interps',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/unnecessary_getters.dart
+++ b/lib/src/rules/unnecessary_getters.dart
@@ -7,10 +7,12 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc =
-    'Prefer using a public final field instead of a private field with a public getter.';
+const _desc =
+    r'Prefer using a public final field instead of a private field with a public'
+    r'getter.';
 
-const details = '''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 **PREFER** using a public final field instead of a private field with a public
@@ -21,7 +23,6 @@ If you have a field that outside code should be able to see but not assign to
 that works in many cases is to just mark it `final`.
 
 **GOOD:**
-
 ```
 class Box {
   final contents = [];
@@ -29,21 +30,21 @@ class Box {
 ```
 
 **BAD:**
-
 ```
 class Box {
   var _contents;
   get contents => _contents;
 }
 ```
+
 ''';
 
 class UnnecessaryGetters extends LintRule {
   UnnecessaryGetters()
       : super(
             name: 'unnecessary_getters',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -15,15 +15,15 @@ From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 *AVOID** wrapping fields in getters and setters just to be "safe".
 
-In Java and C#, it's common to hide all fields behind getters and setters
-(or properties in C#), even if the implementation just forwards to the field.
-That way, if you ever need to do more work in those members, you can without
-needing to touch the callsites. This is because calling a getter method is
-different than accessing a field in Java, and accessing a property isn't
-binary-compatible with accessing a raw field in C#.
+In Java and C#, it's common to hide all fields behind getters and setters (or
+properties in C#), even if the implementation just forwards to the field.  That
+way, if you ever need to do more work in those members, you can without needing
+to touch the callsites.  This is because calling a getter method is different
+than accessing a field in Java, and accessing a property isn't binary-compatible
+with accessing a raw field in C#.
 
-Dart doesn't have this limitation. Fields and getters/setters are completely
-indistinguishable. You can expose a field in a class and later wrap it in a
+Dart doesn't have this limitation.  Fields and getters/setters are completely
+indistinguishable.  You can expose a field in a class and later wrap it in a
 getter and setter without having to touch any code that uses that field.
 
 **GOOD:**

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -7,9 +7,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const desc = 'Avoid wrapping fields in getters and setters just to be "safe".';
+const _desc = r'Avoid wrapping fields in getters and setters just to be "safe".';
 
-const details = '''
+const _details = r'''
+
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
 *AVOID** wrapping fields in getters and setters just to be "safe".
@@ -44,14 +45,15 @@ class Box {
   }
 }
 ```
+
 ''';
 
 class UnnecessaryGettersSetters extends LintRule {
   UnnecessaryGettersSetters()
       : super(
             name: 'unnecessary_getters_setters',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -13,7 +13,7 @@ const _desc = r"Don't create a lambda when a tear-off will do.";
 
 const _details = r'''
 
-**DON’T** create a lambda when a tear-off will do.
+**DON'T** create a lambda when a tear-off will do.
 
 **BAD:**
 ```

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -8,32 +8,35 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = 'Avoid null in null-aware assignment.';
+const _desc = r'Avoid null in null-aware assignment.';
 
-const details = '''
-Avoid null in null-aware assignment. `a ??= null` can be removed.
+const _details = r'''
+
+**AVOID** `null` in null-aware assignment.
+
+Using `null` on the right-hand side of a null-aware assignment effectively makes
+the assignment redundant.
 
 **GOOD:**
-
 ```
 var x;
 x ??= 1;
 ```
 
 **BAD:**
-
 ```
 var x;
 x ??= null;
 ```
+
 ''';
 
 class UnnecessaryNullAwareAssignments extends LintRule {
   UnnecessaryNullAwareAssignments()
       : super(
             name: 'unnecessary_null_aware_assignments',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -8,32 +8,34 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const desc = 'Avoid null in if null operator.';
+const _desc = r'Avoid using `null` in `if null` operators.';
 
-const details = '''
-Avoid null as operand in if null operator. `a ?? null` and `null ?? a` can both
-be replaced by `a`.
+const _details = r'''
+
+**AVOID** using `null` as an operand in `if null` operators.
+
+Using `null` in an `if null` operator is redundant, regardless of which side
+`null` is used on.
 
 **GOOD:**
-
 ```
 var x = a ?? 1;
 ```
 
 **BAD:**
-
 ```
 var x = a ?? null;
 var y = null ?? 1;
 ```
+
 ''';
 
 class UnnecessaryNullInIfNullOperators extends LintRule {
   UnnecessaryNullInIfNullOperators()
       : super(
             name: 'unnecessary_null_in_if_null_operators',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.style);
 
   @override

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -9,7 +9,8 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
 const _desc =
-    r"Don't override a method to do a super method invocation with the same parameters.";
+    r"Don't override a method to do a super method invocation with the same"
+    r" parameters.";
 
 const _details = r'''
 
@@ -43,6 +44,7 @@ super method,
 * if documentation comments are present on the method.
 
 `noSuchMethod` is a special method and is not checked by this rule.
+
 ''';
 
 class UnnecessaryOverrides extends LintRule {

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -6,15 +6,16 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = 'Statements should have a clear effect.';
+const _desc = r'Avoid using unnecessary statements.';
 
-const details = r'''
-**AVOID** unnecessary statements.
+const _details = r'''
+
+**AVOID** using unnecessary statements.
 
 Statements which have no clear effect are usually unnecessary, or should be
 broken up.
 
-For example.
+For example,
 
 **BAD:**
 ```
@@ -41,14 +42,15 @@ methodTwo();
 foo ? bar() : baz();
 return myvar;
 ```
+
 ''';
 
 class UnnecessaryStatements extends LintRule {
   UnnecessaryStatements()
       : super(
             name: 'unnecessary_statements',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -26,11 +26,11 @@ methodOne() + methodTwo();
 foo ? bar : baz;
 ```
 
-While the getter may trigger a side-effect, it is not usually obvious. And while
+While the getter may trigger a side-effect, it is not usually obvious.  Though
 the added methods have a clear effect, the addition itself does not unless there
 is some magical overload of the + operator.
 
-Usually code like this indicates an incomplete thought, and is a bug. For
+Usually code like this indicates an incomplete thought, and is a bug.  For
 instance, the getter was likely supposed to be a function call.
 
 **GOOD:**

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -11,13 +11,13 @@ import 'package:analyzer/src/generated/resolver.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Don’t access members with `this` unless avoiding shadowing.';
+const _desc = r"Don't access members with `this` unless avoiding shadowing.";
 
 const _details = r'''
 
 From the [style guide](https://www.dartlang.org/articles/style-guide/):
 
-**DON’T** use `this` when not needed to avoid shadowing.
+**DON'T** use `this` when not needed to avoid shadowing.
 
 **BAD:**
 ```

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -11,10 +11,14 @@ import 'package:analyzer/src/generated/resolver.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Don’t use this. when not needed to avoid shadowing.';
+const _desc = r'Don’t access members with `this` unless avoiding shadowing.';
 
 const _details = r'''
-**DON’T** use this. when not needed to avoid shadowing.
+
+From the [style guide](https://www.dartlang.org/articles/style-guide/):
+
+**DON’T** use `this` when not needed to avoid shadowing.
+
 **BAD:**
 ```
 class Box {
@@ -24,6 +28,7 @@ class Box {
   }
 }
 ```
+
 **GOOD:**
 ```
 class Box {
@@ -33,6 +38,7 @@ class Box {
   }
 }
 ```
+
 **GOOD:**
 ```
 class Box {
@@ -42,6 +48,7 @@ class Box {
   }
 }
 ```
+
 ''';
 
 class UnnecessaryThis extends LintRule {

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -9,14 +9,15 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const String _desc = r'Equality operator (==) invocation with references of'
-    r' unrelated types.';
+const _desc =
+    r'Equality operator `==` invocation with references of unrelated types.';
 
-const String _details = r'''
+const _details = r'''
 
 **DON'T** Compare references of unrelated types for equality.
+
 Comparing references of a type where neither is a subtype of the other most
-likely will return false and might not reflect programmer's intent.
+likely will return `false` and might not reflect programmer's intent.
 
 **BAD:**
 ```
@@ -122,6 +123,7 @@ abstract class Mixin {}
 
 class DerivedClass2 extends ClassBase with Mixin {}
 ```
+
 ''';
 
 bool _hasNonComparableOperands(BinaryExpression node) =>

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -13,6 +13,9 @@ const _details = r'''
 
 **DO** use rethrow to rethrow a caught exception.
 
+As Dart provides rethrow as a feature, it should be used to improve terseness
+and readability.
+
 **BAD:**
 ```
 try {

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -15,6 +15,9 @@ const _details = r'''
 
 **DO** use string buffer to compose strings.
 
+In most cases, using a string buffer is preferred for composing strings due to
+its improved performance.
+
 **BAD:**
 ```
 String foo() {

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -12,6 +12,8 @@ const _desc =
 
 const _details = r'''
 
+From the [design guide](https://www.dartlang.org/guides/language/effective-dart/design):
+
 **PREFER** naming a method to___() if it copies the object’s state to a new object.
 
 **PREFER** naming a method as___() if it returns a different representation backed by the original object.

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -14,7 +14,7 @@ const _details = r'''
 
 From the [design guide](https://www.dartlang.org/guides/language/effective-dart/design):
 
-**PREFER** naming a method to___() if it copies the object’s state to a new object.
+**PREFER** naming a method to___() if it copies the object's state to a new object.
 
 **PREFER** naming a method as___() if it returns a different representation backed by the original object.
 

--- a/lib/src/rules/valid_regexps.dart
+++ b/lib/src/rules/valid_regexps.dart
@@ -8,9 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const desc = r'Use valid regular expression syntax.';
+const _desc = r'Use valid regular expression syntax.';
 
-const details = r'''
+const _details = r'''
+
 **DO** use valid regular expression syntax when creating regular expression
 instances.
 
@@ -19,21 +20,22 @@ at runtime so should be avoided.
 
 **BAD:**
 ```
-print(new RegExp('(').hasMatch('foo()')); //u-oh
+print(new RegExp('(').hasMatch('foo()'));
 ```
 
 **GOOD:**
 ```
-print(new RegExp('[(]').hasMatch('foo()')); //ok
+print(new RegExp('[(]').hasMatch('foo()'));
 ```
+
 ''';
 
 class ValidRegExps extends LintRule {
   ValidRegExps()
       : super(
             name: 'valid_regexps',
-            description: desc,
-            details: details,
+            description: _desc,
+            details: _details,
             group: Group.errors);
 
   @override


### PR DESCRIPTION
As suggested by #736...

Though it was rather painful, I went through every single rule and tried to improve consistency and add more description in the details.  I tried to use my best judgement to infer what the preferred standards were, so let me know if something's off.

I forwent adding details to rules if I didn't feel it was necessary to elaborate.

Also, I saw some instances where a "smart apostrophe" was used; I wasn't sure whether or not to use it.