### PR TITLE
Allow two non-literals in `prefer_interpolation_to_compose_strings`

### DIFF
--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -53,6 +53,12 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
     if (node.operator.type == TokenType.PLUS) {
+      //OK(#735): str1 + str2
+      if (node.leftOperand is! StringLiteral &&
+          node.rightOperand is! StringLiteral) {
+        return;
+      }
+      //OK: 'foo' + 'bar'
       if (node.leftOperand is StringLiteral &&
           node.rightOperand is StringLiteral) {
         return;

--- a/test/rules/prefer_interpolation_to_compose_strings.dart
+++ b/test/rules/prefer_interpolation_to_compose_strings.dart
@@ -22,4 +22,7 @@ void main() {
     pad = pad + ' '; // LINT
   }
 
+  var str1 = 'Hello';
+  var str2 = 'World';
+  var str3 = str1 + str2; // OK (#735)
 }


### PR DESCRIPTION
Allow concatenation of two non-literal strings in `prefer_interpolation_to_compose_strings`.

Fixes: #735

@bwilkerson @alexeieleusis 