### PR TITLE
sort_constructors_first applies for all members

### DIFF
--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -6,16 +6,17 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = r'Sort constructor declarations before method declarations.';
+const _desc = r'Sort constructor declarations before other members.';
 
 const _details = r'''
 
-**DO** sort constructor declarations before method declarations.
+**DO** sort constructor declarations before other members.
 
 **GOOD:**
 ```
 abstract class Animation<T> {
-  const Animation();
+  const Animation(this.value);
+  double value;
   void addListener(VoidCallback listener);
 }
 ```
@@ -23,6 +24,7 @@ abstract class Animation<T> {
 **BAD:**
 ```
 abstract class Visitor {
+  double value;
   visitSomething(Something s);
   Visitor();
 }
@@ -52,15 +54,14 @@ class Visitor extends SimpleAstVisitor {
     List<ClassMember> members = decl.members.toList()
       ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
 
-    bool seenMethod = false;
+    bool other = false;
     for (ClassMember member in members) {
       if (member is ConstructorDeclaration) {
-        if (seenMethod) {
+        if (other) {
           rule.reportLint(member.returnType);
         }
-      }
-      if (member is MethodDeclaration) {
-        seenMethod = true;
+      } else {
+        other = true;
       }
     }
   }

--- a/test/rules/sort_constructors_first.dart
+++ b/test/rules/sort_constructors_first.dart
@@ -19,3 +19,13 @@ abstract class C {
   C(); //LINT
   C.named(); //LINT
 }
+
+abstract class D {
+  final a;
+  D(); //LINT
+}
+
+abstract class E {
+  static final a;
+  E(); //LINT
+}


### PR DESCRIPTION
According to [Flutter style guide: Constructors come first in a class](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#constructors-come-first-in-a-class).

>The default (unnamed) constructor should come first, then the named constructors. They should come before anything else (including, e.g., constants or static methods).