### PR TITLE
Fix broken markdown doc links (#840).

### DIFF
--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -11,8 +11,7 @@ const _desc = r'Avoid using `as`.';
 
 const _details = r'''
 
-From the [flutter style guide]
-(https://github.com/flutter/engine/blob/master/sky/specs/style-guide.md):
+From the [flutter style guide](https://github.com/flutter/engine/blob/master/sky/specs/style-guide.md):
 
 **AVOID** using `as`.
 

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -11,8 +11,7 @@ const _desc = r"Don't explicitly initialize variables to null.";
 
 const _details = r'''
 
-From [effective dart]
-(https://www.dartlang.org/effective-dart/usage/#dont-explicitly-initialize-variables-to-null):
+From [effective dart](https://www.dartlang.org/effective-dart/usage/#dont-explicitly-initialize-variables-to-null):
 
 **DON'T** explicitly initialize variables to null.
 

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -10,8 +10,8 @@ import 'package:linter/src/analyzer.dart';
 const _desc = r'Adhere to Effective Dart Guide directives sorting conventions.';
 const _details = r'''
 
-**DO** follow the conventions in the [Effective Dart Guide]
-(https://www.dartlang.org/guides/language/effective-dart/style#ordering)
+**DO** follow the conventions in the 
+[Effective Dart Guide](https://www.dartlang.org/guides/language/effective-dart/style#ordering)
 
 **DO** place “dart:” imports before other imports.
 

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -11,8 +11,7 @@ const _desc = r"Don't import implementation files from another package.";
 
 const _details = r'''
 
-From the the [pub package layout doc]
-(https://www.dartlang.org/tools/pub/package-layout.html#implementation-files):
+From the the [pub package layout doc](https://www.dartlang.org/tools/pub/package-layout.html#implementation-files):
 
 **DON'T** import implementation files from another package.
 

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -13,8 +13,7 @@ const _details = r'''
 
 **DO** provide doc comments for all public APIs.
 
-As described in the [pub package layout doc]
-(https://www.dartlang.org/tools/pub/package-layout.html#implementation-files),
+As described in the [pub package layout doc](https://www.dartlang.org/tools/pub/package-layout.html#implementation-files),
 public APIs consist in everything in your package's `lib` folder, minus
 implementation files in `lib/src`, adding elements explicitly exported with an
 `export` directive.
@@ -55,8 +54,7 @@ class Bar {
 ```
 
 Advice for writing good doc comments can be found in the
-[Doc Writing Guidelines]
-(https://www.dartlang.org/articles/doc-comment-guidelines).
+[Doc Writing Guidelines](https://www.dartlang.org/articles/doc-comment-guidelines).
 
 ''';
 


### PR DESCRIPTION
Fixes: #840.

@devoncarew 