### PR TITLE
0.1.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.40
+
+* `avoid_unused_constructor_parameters` updated to better handle redirecting factory constructors
+* `avoid_returning_this` improvements
+* `prefer_bool_in_asserts` improvements
+* miscellaneous documentation fixes
+
 # 0.1.39
 
 * `prefer_interpolation_to_compose_strings` updated to allow concatenation of two non-literal strings

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.39
+version: 0.1.40
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.40

* `avoid_unused_constructor_parameters` updated to better handle redirecting factory constructors
* `avoid_returning_this` improvements
* `prefer_bool_in_asserts` improvements
* miscellaneous documentation fixes

@bwilkerson @a14n 