### PR TITLE
Test to verify optionalTypeArgs are respected in generic methods.

### DIFF
--- a/test/rules/always_specify_types.dart
+++ b/test/rules/always_specify_types.dart
@@ -38,6 +38,15 @@ e(final int x) {}
 @optionalTypeArgs
 class P<T> { }
 
+@optionalTypeArgs
+void g<T>() {}
+
+//https://github.com/dart-lang/linter/issues/851
+void test() {
+  g<dynamic>(); //OK
+  g(); //OK
+}
+
 main() {
   var x = ''; //LINT [3:3]
   for (var i = 0; i < 10; ++i) {  //LINT [8:3]


### PR DESCRIPTION
See: https://github.com/dart-lang/linter/issues/851

@bwilkerson 

