### PR TITLE
Handle external constructor in avoid_unused_constructor_parameters

### DIFF
--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -52,6 +52,7 @@ class _Visitor extends SimpleAstVisitor {
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
     if (node.redirectedConstructor != null) return;
+    if (node.externalKeyword != null) return;
 
     final _constructorVisitor = new _ConstructorVisitor(rule, node);
     node?.body?.visitChildren(_constructorVisitor);

--- a/test/rules/avoid_unused_constructor_parameters.dart
+++ b/test/rules/avoid_unused_constructor_parameters.dart
@@ -91,3 +91,8 @@ class M {
   factory M(int a, int b) => new M._internal(a); // LINT
   factory M.redirect(int n) = M._internal; // OK because target constructor have parameters
 }
+
+class N {
+  external N(int n); // OK
+  external factory N.named(int n); // OK
+}


### PR DESCRIPTION
Fixes #864