### PR TITLE
0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.42
+
+* added support for external constructors in `avoid_unused_constructor_parameters`
+* added code reference resolution docs for `comment_references`
+
 # 0.1.41
 
 * broadened `args` package dependency to support versions `1.*`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.41
+version: 0.1.42
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.42

* added support for external constructors in `avoid_unused_constructor_parameters`
* added code reference resolution docs for `comment_references`

@a14n @scheglov 

FYI @bwilkerson 