### PR TITLE
Revert "fix link in package_api_docs rule"

### DIFF
--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -54,7 +54,7 @@ class Bar {
 ```
 
 Advice for writing good doc comments can be found in the
-[Doc Writing Guidelines](https://www.dartlang.org/guides/language/effective-dart/documentation).
+[Doc Writing Guidelines](https://www.dartlang.org/articles/doc-comment-guidelines).
 
 ''';
 


### PR DESCRIPTION
Reverts dart-lang/linter#870 due to broken build.