### PR TITLE
Fix title and header for lint index.html.

### DIFF
--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -207,7 +207,7 @@ class Indexer {
    <head>
       <meta charset="utf-8">
       <meta http-equiv="X-UA-Compatible" content="chrome=1">
-      <title>Dart Lint</title>
+      <title>Linter for Dart</title>
       <link rel="stylesheet" href="../stylesheets/styles.css">
       <link rel="stylesheet" href="../stylesheets/pygment_trac.css">
       <script src="javascripts/scale.fix.js"></script>
@@ -220,7 +220,7 @@ class Indexer {
       <div class="wrapper">
          <header>
             <a href="http://dart-lang.github.io/linter/">
-               <h1>Dart Lint</h1>
+               <h1>Linter for Dart</h1>
             </a>
             <p>Lint Rules</p>
             <p class="view"><a href="https://github.com/dart-lang/linter">View the Project on GitHub <small>dartlang/linter</small></a></p>


### PR DESCRIPTION
Currently:

![image](https://user-images.githubusercontent.com/67586/35947510-0b6bd7f8-0c1d-11e8-94a1-a7ca0b32076a.png)

but should be consistent with the homepage:

![image](https://user-images.githubusercontent.com/67586/35947523-1aeaaeac-0c1d-11e8-846f-452cea3189b2.png)

This tweak makes it so!

@bwilkerson 