### PR TITLE
Fix a type error related to mocks

### DIFF
--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -134,7 +134,7 @@ void defineLinterEngineTests() {
         var reporter = new MockReporter();
         new SourceLinter(new LinterOptions([rule]), reporter: reporter)
           ..lintPubspecSource(contents: 'author: foo');
-        verify(reporter.exception(any)).called(1);
+        expect(reporter.exceptions, hasLength(1));
       });
     });
 

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -52,7 +52,23 @@ class MockLinterOptions extends Mock implements LinterOptions {}
 
 class MockPubVisitor extends Mock implements PubspecVisitor {}
 
-class MockReporter extends Mock implements Reporter {}
+class MockReporter implements Reporter {
+  List<LinterException> exceptions = <LinterException>[];
+
+  List<String> warnings = <String>[];
+
+  MockReporter();
+
+  @override
+  void exception(LinterException exception) {
+    exceptions.add(exception);
+  }
+
+  @override
+  void warn(String message) {
+    warnings.add(message);
+  }
+}
 
 class MockRule extends Mock implements LintRule {}
 


### PR DESCRIPTION
mockito has changed, but I don't see why we were using it in this case anyway, so I converted this mock to not use it in order to get around a type error.