### PR TITLE
Fix grind.dart

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,3 @@ dev_dependencies:
   mockito: ^1.0.0
   path: '>=0.9.0 <2.0.0'
   test: ^0.12.24+1
-  unscripted: ^0.6.2

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -12,14 +12,14 @@ import 'rule.dart';
 main(args) => grind(args);
 
 @Task('Generate lint rule docs.')
-docs(GrinderContext context) {
+docs() {
   TaskArgs args = context.invocation.arguments;
   String dir = args.getOption('dir');
   generateDocs(dir);
 }
 
 @Task('Generate a lint rule stub.')
-rule(GrinderContext context) {
+rule() {
   TaskArgs args = context.invocation.arguments;
   String name = args.getOption('name');
   generateRule(name, outDir: Directory.current.path);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -12,7 +12,7 @@ import 'rule.dart';
 main(args) => grind(args);
 
 @Task('Generate lint rule docs.')
-docs(TaskArgs args) {
+docs(GrinderContext context) {
   TaskArgs args = context.invocation.arguments;
   String dir = args.getOption('dir');
   generateDocs(dir);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -5,33 +5,22 @@
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
-import 'package:unscripted/unscripted.dart';
 
 import 'doc.dart';
 import 'rule.dart';
 
-main([List<String> args]) {
-  _addTask('rule',
-      parser: (String name) =>
-          generateRule(name, outDir: Directory.current.path),
-      description: 'Generate a lint rule stub.',
-      valueHelp: 'Name of rule to generate.');
+main(args) => grind(args);
 
-  _addTask('docs',
-      parser: generateDocs,
-      description: 'Generate lint rule docs.',
-      valueHelp: 'Documentation `lints/` directory.');
-
-  grind(args);
+@Task('Generate lint rule docs.')
+docs(TaskArgs args) {
+  TaskArgs args = context.invocation.arguments;
+  String dir = args.getOption('dir');
+  generateDocs(dir);
 }
 
-_addTask(String name, {String description, Parser parser, String valueHelp}) {
-  addTask(new GrinderTask(name, taskFunction: () {
-    String value = context.invocation.positionals.first;
-    parser(value);
-  },
-      description: description,
-      positionals: [new Positional(valueHelp: valueHelp)]));
+@Task('Generate a lint rule stub.')
+rule(GrinderContext context) {
+  TaskArgs args = context.invocation.arguments;
+  String name = args.getOption('name');
+  generateRule(name, outDir: Directory.current.path);
 }
-
-typedef void Parser(String s);


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/linter/issues/886

While this works, the ergonomics aren't great.

I'd prefer `grind rule foo` but I think that's not how grind works.  Also: it would be great to not lose `valueHelp`.

@devoncarew: can you point me to any examples that show help for args?  How is that done in the "new" world?

cc @bwilkerson 