### PR TITLE
Add source formatting validation to test/all.

### DIFF
--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -6,7 +6,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = r"Prefer single quotes where they won't require escape sequences.";
+const _desc =
+    r"Prefer single quotes where they won't require escape sequences.";
 
 const _details = '''
 

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -6,8 +6,7 @@ import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc =
-    r'Await future-returning functions inside async function bodies.';
+const _desc = r'Await future-returning functions inside async function bodies.';
 
 const _details = r'''
 

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -7,7 +7,8 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
-const _desc = r'Avoid wrapping fields in getters and setters just to be "safe".';
+const _desc =
+    r'Avoid wrapping fields in getters and setters just to be "safe".';
 
 const _details = r'''
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -6,8 +6,8 @@ import 'package:linter/src/ast.dart';
 
 final _identifier = new RegExp(r'^([(_|$)a-zA-Z]+([_a-zA-Z0-9])*)$');
 
-final _lowerCamelCase =
-    new RegExp(r'^(_)*[?$a-z][a-z0-9?$]*(([A-Z][a-z0-9?$]*)|([_][0-9][a-z0-9?$]*))*$');
+final _lowerCamelCase = new RegExp(
+    r'^(_)*[?$a-z][a-z0-9?$]*(([A-Z][a-z0-9?$]*)|([_][0-9][a-z0-9?$]*))*$');
 
 final _lowerCaseUnderScore = new RegExp(r'^([a-z]+([_]?[a-z0-9]+)*)+$');
 
@@ -18,7 +18,8 @@ final _pubspec = new RegExp(r'^[_]?pubspec\.yaml$');
 
 final _underscores = new RegExp(r'^[_]+$');
 
-final _validLibraryPrefix = new RegExp(r'^(_|\$)?(_)*([a-z]+([_]?[a-z0-9]+)*)+$');
+final _validLibraryPrefix =
+    new RegExp(r'^(_|\$)?(_)*([a-z]+([_]?[a-z0-9]+)*)+$');
 
 /// Check if this [string] is formatted in `CamelCase`.
 bool isCamelCase(String string) => CamelCaseString.isCamelCase(string);

--- a/test/all.dart
+++ b/test/all.dart
@@ -10,6 +10,7 @@ import 'integration_test.dart' as integration_test;
 import 'mocks.dart';
 import 'rule_test.dart' as rule_test;
 import 'utils_test.dart' as utils_test;
+import 'validate_format_test.dart' as validate_format;
 
 main() {
   // Redirect output.
@@ -20,4 +21,5 @@ main() {
   integration_test.main();
   rule_test.main();
   utils_test.main();
+  validate_format.main();
 }

--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -51,17 +51,16 @@ defineTests() {
       when(info.errors).thenReturn([error]);
       var out = new CollectingSink();
 
-      var reporter = new SimpleFormatter([info], null, out,
-          fileCount: 1, elapsedMs: 13)..write();
+      var reporter =
+          new SimpleFormatter([info], null, out, fileCount: 1, elapsedMs: 13)
+            ..write();
 
       test('count', () {
         expect(reporter.errorCount, 1);
       });
 
       test('write', () {
-        expect(
-            out.buffer.toString().trim(),
-            '''/foo/bar/baz.dart 3:3 [test] MSG
+        expect(out.buffer.toString().trim(), '''/foo/bar/baz.dart 3:3 [test] MSG
 
 1 file analyzed, 1 issue found, in 13 ms.''');
       });
@@ -69,7 +68,8 @@ defineTests() {
       test('stats', () {
         out.buffer.clear();
         new SimpleFormatter([info], null, out,
-            fileCount: 1, showStatistics: true, elapsedMs: 13)..write();
+            fileCount: 1, showStatistics: true, elapsedMs: 13)
+          ..write();
         expect(out.buffer.toString(),
             startsWith('''/foo/bar/baz.dart 3:3 [test] MSG
 
@@ -114,7 +114,8 @@ mock_code                               1
 
       group('filtered', () {
         var reporter = new SimpleFormatter([info], new _RejectingFilter(), out,
-            fileCount: 1, elapsedMs: 13)..write();
+            fileCount: 1, elapsedMs: 13)
+          ..write();
 
         test('error count', () {
           expect(reporter.errorCount, 0);
@@ -134,10 +135,10 @@ mock_code                               1
         test('write', () {
           out.buffer.clear();
           new SimpleFormatter([info], null, out,
-              fileCount: 1, machineOutput: true, elapsedMs: 13)..write();
+              fileCount: 1, machineOutput: true, elapsedMs: 13)
+            ..write();
 
-          expect(
-              out.buffer.toString().trim(),
+          expect(out.buffer.toString().trim(),
               '''MockErrorCode|MockErrorType|MockError|/foo/bar/baz.dart|3|3|13|MSG
 
 1 file analyzed, 1 issue found, in 13 ms.''');

--- a/test/validate_format_test.dart
+++ b/test/validate_format_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/validate_format_test.dart
+++ b/test/validate_format_test.dart
@@ -4,13 +4,18 @@ import 'package:test/test.dart';
 
 main() {
   test('validate source formatting', () async {
-    ProcessResult result = await Process
-        .run('dartfmt', ['--dry-run', '--set-exit-if-changed', '.']);
-    List<String> violations = result.stdout.toString().split('\n')
-      ..removeWhere(formattingIgnored);
-    expect(violations, isEmpty, reason: '''Some files need formatting. 
+    try {
+      ProcessResult result = await Process
+          .run('dartfmt', ['--dry-run', '--set-exit-if-changed', '.']);
+      List<String> violations = result.stdout.toString().split('\n')
+        ..removeWhere(formattingIgnored);
+      expect(violations, isEmpty, reason: '''Some files need formatting. 
   
 Run `dartfmt` and (re)commit.''');
+    } on ProcessException {
+      // This occurs, notably, on appveyor.
+      print('[WARNING] format validation skipped -- `dartfmt` not on PATH');
+    }
   });
 }
 

--- a/test/validate_format_test.dart
+++ b/test/validate_format_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/validate_format_test.dart
+++ b/test/validate_format_test.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+main() {
+  test('validate source formatting', () async {
+    ProcessResult result = await Process
+        .run('dartfmt', ['--dry-run', '--set-exit-if-changed', '.']);
+    List<String> violations = result.stdout.toString().split('\n')
+      ..removeWhere(formattingIgnored);
+    expect(violations, isEmpty, reason: '''Some files need formatting. 
+  
+Run `dartfmt` and (re)commit.''');
+  });
+}
+
+bool formattingIgnored(String location) =>
+    location.isEmpty ||
+    location.startsWith('test/_data/') ||
+    location.startsWith('test/rules/');


### PR DESCRIPTION
Fail build if `dartfmt` does not report clean on all but test data files.

Sample output:

```
package:test                         expect
test/validate_format_test.dart 11:5  main.<fn>
===== asynchronous gap ===========================
dart:async                           _Completer.completeError
test/validate_format_test.dart       main.<fn>
===== asynchronous gap ===========================
dart:async                           _asyncThenWrapperHelper
test/validate_format_test.dart 6:47  main.<fn>

Expected: empty
  Actual: ['lib/src/utils.dart']
Some files need formatting. 
  
Run `dartfmt` and (re)commit.
```

Follow-up from: https://github.com/dart-lang/linter/pull/897#discussion_r168846347

@bwilkerson 


