### PR TITLE
invariant_booleans: Exclude propositions with variables declared in for statements

### DIFF
--- a/test/rules/invariant_booleans.dart
+++ b/test/rules/invariant_booleans.dart
@@ -456,3 +456,25 @@ void bug658() {
   String text;
   if ((text?.length ?? 0) != 0) {}
 }
+
+void bug811_1() {
+  final bar = 0;
+  final foo = 10;
+
+  for (var i = 0; i < foo; ++i) {}
+
+  for (var i = 0; i < foo; i++) {} // OK
+
+  if (bar == 10) {}
+}
+
+void bug811_2() {
+  var bar = 0;
+  final foo = 10;
+
+  for (bar = 0; bar < foo; ++bar) {}
+
+  for (bar = 0; bar < foo; bar++) {}
+
+  if (bar < foo) {} // LINT
+}


### PR DESCRIPTION
They become meaningless outside the body of the for loop.

Fixes https://github.com/dart-lang/linter/issues/811