### PR TITLE
Bump SDK constraint to >=2.0.0-dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter
 environment:
-  sdk: '>=1.12.0 <2.0.0'
+  sdk: '>=2.0.0-dev <2.0.0'
 dependencies:
   analyzer: ^0.31.2-alpha.0
   args: '>=0.12.1 <2.0.0'


### PR DESCRIPTION
Track `analyzer` SDK constrain lower bound.

Follow-up from: https://github.com/dart-lang/linter/pull/911#issuecomment-369888397.

@bwilkerson @a14n 

