### PR TITLE
0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * new `avoid_relative_lib_imports` lint
 * new `unnecessary_parenthesis` lint
+* fix to `prefer_const_literals_to_create_immutables` to handle undefined classes gracefully
 * updates to `prefer_const_declarations` to support optional `new` and `const`
 * `prefer_const_declarations` updated to check locals
 * fixes to `invariant_booleans`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.44
+
+* new `avoid_relative_lib_imports` lint
+* new `unnecessary_parenthesis` lint
+* updates to `prefer_const_declarations` to support optional `new` and `const`
+* `prefer_const_declarations` updated to check locals
+* fixes to `invariant_booleans`
+* bumped SDK lower bound to `2.0.0-dev`
+* build and workflow improvements: rule template fixes; formatting and header validation
+* miscellaneous documentation fixes
+
 # 0.1.43
 
 * new `prefer_const_declarations.dart` lint

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.43
+version: 0.1.44
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.44

* new `avoid_relative_lib_imports` lint
* new `unnecessary_parenthesis` lint
* updates to `prefer_const_declarations` to support optional `new` and `const`
* `prefer_const_declarations` updated to check locals
* fixes to `invariant_booleans`
* bumped SDK lower bound to `2.0.0-dev`
* build and workflow improvements: rule template fixes; formatting and header validation
* miscellaneous documentation fixes

See: #915 

/cc @a14n @bwilkerson 