### PR TITLE
Handle undefined classes in rule (sdk issue 32494)

### DIFF
--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -83,8 +83,13 @@ class Visitor extends SimpleAstVisitor {
     }
   }
 
-  bool _hasImmutableAnnotation(ClassElement clazz) {
-    final inheritedAndSelfTypes = _getSelfAndInheritedTypes(clazz.type);
+  bool _hasImmutableAnnotation(DartType type) {
+    if (type is! InterfaceType) {
+      // This happens when we find an instance creation expression for a class
+      // that cannot be resolved.
+      return false;
+    }
+    final inheritedAndSelfTypes = _getSelfAndInheritedTypes(type);
     final inheritedAndSelfAnnotations = inheritedAndSelfTypes
         .map((type) => type.element)
         .expand((c) => c.metadata)
@@ -107,7 +112,7 @@ class Visitor extends SimpleAstVisitor {
       node = node.parent;
     }
     if (!(node is InstanceCreationExpression &&
-        _hasImmutableAnnotation(node.bestType.element))) {
+        _hasImmutableAnnotation(node.bestType))) {
       return;
     }
 

--- a/test/rules/prefer_const_literals_to_create_immutables.dart
+++ b/test/rules/prefer_const_literals_to_create_immutables.dart
@@ -86,3 +86,6 @@ var m13 = new A({1: 1.0}); // LINT
 var m14 = new A({1: ''}); // LINT
 var m15 = new A({1: null}); // LINT
 
+// ignore: undefined_class
+var e1 = new B([]); // OK
+


### PR DESCRIPTION
The rule prefer_const_literals_to_create_immutables is throwing an exception when presented with invalid code involving an instance creation expression for which the class could not be resolved. This fixes that.