### PR TITLE
0.1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.46
+
+* performance fixes for library prefix testing (`library_prefixes`)
+* new `avoid_bool_literals_in_conditional_expressions` lint
+* new `prefer_equal_for_default_values` lint
+* new `avoid_private_typedef_functions` lint
+* new `avoid_single_cascade_in_expression_statements` lint
+
 # 0.1.45
 
 * fix for `invariant_booleans` when analyzing for loops with no condition

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.45
+version: 0.1.46
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.46

* performance fixes for library prefix testing (`library_prefixes`)
* new `avoid_bool_literals_in_conditional_expressions` lint
* new `prefer_equal_for_default_values` lint
* new `avoid_private_typedef_functions` lint
* new `avoid_single_cascade_in_expression_statements` lint

/cc @bwilkerson @a14n 