### PR TITLE
fix issue with avoid_types_as_parameter_names

### DIFF
--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -43,6 +43,8 @@ class Visitor extends SimpleAstVisitor {
 
   @override
   visitFormalParameterList(FormalParameterList node) {
+    if (node.parent is GenericFunctionType) return;
+
     // TODO(a14n) test that parameter name matches a existing type. No api to do
     // that for now.
     for (final parameter in node.parameters) {

--- a/test/rules/avoid_types_as_parameter_names.dart
+++ b/test/rules/avoid_types_as_parameter_names.dart
@@ -27,3 +27,5 @@ m4(f(num a, {int})) => null; // LINT
 m5(f(double a, [bool])) => null; // LINT
 m6(int Function(int) f)=> null; // OK
 m7(f(Undefined)) => null; // LINT
+
+final void Function(Object, [StackTrace]) onError = null; // OK


### PR DESCRIPTION
Generic function types were not handled correctly