### PR TITLE
0.1.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.47
+
+* new `avoid_double_and_int_checks` lint
+* fix to handle uninitialized vars in `prefer_const_declarations`
+* fix for generic function type handling in `avoid_types_as_parameter_names`
+* new `prefer_iterable_whereType` lint
+* new `prefer_generic_function_type_aliases` lint
+* Dart 2 compatibility fixes
+
 # 0.1.46
 
 * performance fixes for library prefix testing (`library_prefixes`)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.46
+version: 0.1.47
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter
@@ -17,7 +17,7 @@ dev_dependencies:
   cli_util: ^0.1.2
   dart_style: ^1.0.0
   grinder: ^0.8.0
-  markdown: ^0.11.0
+  markdown: '>=0.11.0 <2.0.0'
   matcher: ^0.12.0
   path: '>=0.9.0 <2.0.0'
   test: ^0.12.24+1


### PR DESCRIPTION
# 0.1.47

* new `avoid_double_and_int_checks` lint
* fix to handle uninitialized vars in `prefer_const_declarations`
* fix for generic function type handling in `avoid_types_as_parameter_names`
* new `prefer_iterable_whereType` lint
* new `prefer_generic_function_type_aliases` lint
* Dart 2 compatibility fixes


@bwilkerson @a14n 