### PR TITLE
add avoid_field_initializers_in_const_classes

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -16,6 +16,7 @@ linter:
     - avoid_classes_with_only_static_members
     - avoid_double_and_int_checks
     - avoid_empty_else
+    - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null
     - avoid_js_rounded_ints

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -17,6 +17,7 @@ import 'package:linter/src/rules/avoid_catching_errors.dart';
 import 'package:linter/src/rules/avoid_classes_with_only_static_members.dart';
 import 'package:linter/src/rules/avoid_double_and_int_checks.dart';
 import 'package:linter/src/rules/avoid_empty_else.dart';
+import 'package:linter/src/rules/avoid_field_initializers_in_const_classes.dart';
 import 'package:linter/src/rules/avoid_function_literals_in_foreach_calls.dart';
 import 'package:linter/src/rules/avoid_init_to_null.dart';
 import 'package:linter/src/rules/avoid_js_rounded_ints.dart';
@@ -135,6 +136,7 @@ void registerLintRules() {
     ..register(new AvoidClassesWithOnlyStaticMembers())
     ..register(new AvoidDoubleAndIntChecks())
     ..register(new AvoidEmptyElse())
+    ..register(new AvoidFieldInitializersInConstClasses())
     ..register(new AvoidFunctionLiteralInForeachMethod())
     ..register(new AvoidInitToNull())
     ..register(new AvoidJsRoundedInts())

--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Avoid field initializers in const classes.';
+
+const _details = r'''
+
+**AVOID** field initializers in const classes.
+
+Instead of `final x = const expr;`, you should write `get x => const expr;` and
+not allocate a useless field.
+
+**BAD:**
+```
+class A {
+  final a = const [];
+  const A();
+}
+```
+
+**GOOD:**
+```
+class A {
+  get a => const [];
+  const A();
+}
+```
+
+''';
+
+class AvoidFieldInitializersInConstClasses extends LintRule {
+  AvoidFieldInitializersInConstClasses()
+      : super(
+            name: 'avoid_field_initializers_in_const_classes',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  AstVisitor getVisitor() => new Visitor(this);
+}
+
+class Visitor extends SimpleAstVisitor {
+  Visitor(this.rule);
+
+  final LintRule rule;
+
+  @override
+  visitFieldDeclaration(FieldDeclaration node) {
+    if (node.isStatic) return;
+    if (!node.fields.isFinal) return;
+    // only const class
+    if (node
+        .getAncestor<ClassDeclaration>((e) => e is ClassDeclaration)
+        .element
+        .constructors
+        .every((e) => !e.isConst)) {
+      return;
+    }
+
+    for (final variable in node.fields.variables) {
+      if (variable.initializer != null) {
+        rule.reportLint(variable);
+      }
+    }
+  }
+
+  @override
+  visitConstructorFieldInitializer(ConstructorFieldInitializer node) {
+    final ConstructorDeclaration constructor = node.parent;
+    if (constructor.constKeyword == null) return;
+    // no lint if several constructors
+    final constructorCount = constructor
+        .getAncestor<ClassDeclaration>((e) => e is ClassDeclaration)
+        .members
+        .where((e) => e is ConstructorDeclaration)
+        .length;
+    if (constructorCount > 1) return;
+
+    final visitor = new HasParameterReferenceVisitor(constructor
+        .parameters.parameters
+        .map((e) => e.identifier.name)
+        .toList());
+    visitor.visitConstructorFieldInitializer(node);
+    if (!visitor.useParameter) {
+      rule.reportLint(node);
+    }
+  }
+}
+
+class HasParameterReferenceVisitor extends RecursiveAstVisitor {
+  HasParameterReferenceVisitor(this.parameters);
+
+  List<String> parameters;
+
+  bool useParameter = false;
+
+  @override
+  visitSimpleIdentifier(SimpleIdentifier node) {
+    if (parameters.contains(node.name)) {
+      useParameter = true;
+    } else {
+      super.visitSimpleIdentifier(node);
+    }
+  }
+}

--- a/test/rules/avoid_field_initializers_in_const_classes.dart
+++ b/test/rules/avoid_field_initializers_in_const_classes.dart
@@ -34,3 +34,13 @@ class E {
   const E.c2() //
       : a = const {}; // OK
 }
+
+class F {
+  final a;
+  const F(int a) : this.a = 0; // LINT
+}
+
+class G {
+  final g;
+  const G(int length) : g = 'xyzzy'.length; // LINT
+}

--- a/test/rules/avoid_field_initializers_in_const_classes.dart
+++ b/test/rules/avoid_field_initializers_in_const_classes.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_field_initializers_in_const_classes`
+
+class A {
+  final a = const []; // LINT
+  const A();
+}
+
+class B {
+  final a;
+  const B() //
+      : a = const []; // LINT
+}
+
+class C {
+  final a;
+  const C(this.a); // OK
+}
+
+class D {
+  final a;
+  const D(b) //
+      : a = b; // OK
+}
+
+// no lint if several constructors
+class E {
+  final a;
+  const E.c1() //
+      : a = const []; // OK
+  const E.c2() //
+      : a = const {}; // OK
+}


### PR DESCRIPTION
Lint created from https://github.com/dart-lang/sdk/issues/32789#issuecomment-379657135:

>Also, you should never have a final field with an initializer expression in a const class. Instead of `final x = const expr;`, you should write `get x => const expr;` and not allocate a useless field.