### PR TITLE
Improve avoid_double_and_int_checks doc example

### DIFF
--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -20,10 +20,23 @@ either `int` or `double`.
 
 **BAD:**
 ```
-f(num x) {
+f(dynamic x) {
   if (x is double) {
     ...
   } else if (x is int) {
+    ...
+  } else {
+    ...
+  }
+}
+```
+
+**GOOD:**
+```
+f(dynamic x) {
+  if (x is num) {
+    ...
+  } else {
     ...
   }
 }

--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -20,12 +20,10 @@ either `int` or `double`.
 
 **BAD:**
 ```
-f(dynamic x) {
+f(num x) {
   if (x is double) {
     ...
   } else if (x is int) {
-    ...
-  } else {
     ...
   }
 }


### PR DESCRIPTION
I've tweaked the example to add a GOOD case with `x is num` as an alternative. This could be a helpful suggestion in some cases.