### PR TITLE
0.1.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.48
+
+* new `avoid_field_initializers_in_const_classes` lint
+* miscellaneous documentation fixes
+* improved handling of cascades in `improve-unnecessary_statements`
+* new `avoid_field_initializers_in_const_classes` lint
+* new `avoid_js_rounded_ints` lint
+
 # 0.1.47
 
 * new `avoid_double_and_int_checks` lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 * new `avoid_field_initializers_in_const_classes` lint
 * miscellaneous documentation fixes
-* improved handling of cascades in `improve-unnecessary_statements`
-* new `avoid_field_initializers_in_const_classes` lint
+* improved handling of cascades in `unnecessary_statements`
 * new `avoid_js_rounded_ints` lint
 
 # 0.1.47

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.47
+version: 0.1.48
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.48

* new `avoid_field_initializers_in_const_classes` lint
* miscellaneous documentation fixes
* improved handling of cascades in `improve-unnecessary_statements`
* new `avoid_field_initializers_in_const_classes` lint
* new `avoid_js_rounded_ints` lint

@bwilkerson @a14n 