### PR TITLE
Remove MockLineInfo

### DIFF
--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/lint/linter.dart';
+import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/formatter.dart';
 import 'package:test/test.dart';
 
@@ -27,8 +28,7 @@ defineTests() {
     });
 
     group('reporter', () {
-      var lineInfo =
-          new MockLineInfo(defaultLocation: new MockLineInfo_Location(3, 3));
+      var lineInfo = new LineInfo([3, 6, 9]);
 
       var type = new MockErrorType()..displayName = 'test';
 
@@ -36,7 +36,7 @@ defineTests() {
 
       var source = new MockSource()..fullName = '/foo/bar/baz.dart';
 
-      var error = new AnalysisError(source, -1, -1, code);
+      var error = new AnalysisError(source, 10, 3, code);
 
       var info = new AnalysisErrorInfoImpl([error], lineInfo);
 
@@ -51,7 +51,7 @@ defineTests() {
       });
 
       test('write', () {
-        expect(out.buffer.toString().trim(), '''/foo/bar/baz.dart 3:3 [test] MSG
+        expect(out.buffer.toString().trim(), '''/foo/bar/baz.dart 3:2 [test] MSG
 
 1 file analyzed, 1 issue found, in 13 ms.''');
       });
@@ -62,7 +62,7 @@ defineTests() {
             fileCount: 1, showStatistics: true, elapsedMs: 13)
           ..write();
         expect(out.buffer.toString(),
-            startsWith('''/foo/bar/baz.dart 3:3 [test] MSG
+            startsWith('''/foo/bar/baz.dart 3:2 [test] MSG
 
 1 file analyzed, 1 issue found, in 13 ms.
 
@@ -76,8 +76,7 @@ mock_code                               1
     });
 
     group('reporter', () {
-      var lineInfo =
-          new MockLineInfo(defaultLocation: new MockLineInfo_Location(3, 3));
+      var lineInfo = new LineInfo([3, 6, 9]);
 
       var type = new MockErrorType()..displayName = 'test';
 
@@ -87,7 +86,7 @@ mock_code                               1
 
       var source = new MockSource()..fullName = '/foo/bar/baz.dart';
 
-      var error = new AnalysisError(source, 0, 13, code);
+      var error = new AnalysisError(source, 12, 13, code);
 
       var info = new AnalysisErrorInfoImpl([error], lineInfo);
 
@@ -120,7 +119,7 @@ mock_code                               1
             ..write();
 
           expect(out.buffer.toString().trim(),
-              '''MockErrorSeverity|MockErrorType|MockError|/foo/bar/baz.dart|3|3|13|MSG
+              '''MockErrorSeverity|MockErrorType|MockError|/foo/bar/baz.dart|3|4|13|MSG
 
 1 file analyzed, 1 issue found, in 13 ms.''');
         });

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -88,51 +88,6 @@ class MockIOSink implements IOSink {
   void writeln([Object obj = '']) {}
 }
 
-class MockLineInfo implements LineInfo {
-  MockLineInfo_Location defaultLocation;
-
-  MockLineInfo({this.defaultLocation});
-
-  @override
-  int get lineCount {
-    throw new StateError('Unexpected invocation of lineCount');
-  }
-
-  @override
-  List<int> get lineStarts {
-    throw new StateError('Unexpected invocation of lineStarts');
-  }
-
-  @override
-  LineInfo_Location getLocation(int offset) {
-    if (defaultLocation != null) {
-      return defaultLocation;
-    }
-    throw new StateError('Unexpected invocation of getLocation');
-  }
-
-  @override
-  int getOffsetOfLine(int lineNumber) {
-    throw new StateError('Unexpected invocation of getOffsetOfLine');
-  }
-
-  @override
-  int getOffsetOfLineAfter(int offset) {
-    throw new StateError('Unexpected invocation of getOffsetOfLineAfter');
-  }
-}
-
-// ignore: camel_case_types
-class MockLineInfo_Location implements LineInfo_Location {
-  @override
-  int lineNumber;
-
-  @override
-  int columnNumber;
-
-  MockLineInfo_Location(this.lineNumber, this.columnNumber);
-}
-
 class MockPubVisitor implements PubspecVisitor {
   @override
   visitPackageAuthor(PSEntry author) {


### PR DESCRIPTION
This reduces linters dependencies on analyzer and makes it possible for this part of analyzer's API to move forward.