### PR TITLE
0.1.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.49
+
+* new `void_checks` lint
+
 # 0.1.48
 
 * new `avoid_field_initializers_in_const_classes` lint

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.48
+version: 0.1.49
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.49

* new `void_checks` lint

(Also removes dependence on `MockLineInfo` and `MockLineInfo_Location`.)

@bwilkerson @a14n 