### PR TITLE
Fail benchmarking on errors.

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -17,9 +17,6 @@ echo ""
 if [ "$LINTER_BOT" = "benchmark" ]; then
   echo "Running the linter benchmark..."
 
-  # The actual lints can have errors - we don't want to fail the benchmark bot.
-  set +e
-
   # Benchmark linter with all lints enabled.
   dart bin/linter.dart --benchmark -q -c example/all.yaml .
 


### PR DESCRIPTION
Update the build to fail on non-zero exit codes.

NOTE: it's still not properly failing since logged errors in `_computeLints` are not causing a non-zero exit.

@bwilkerson 