### PR TITLE
Fix no such method call in `void_checks`.

### DIFF
--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -72,8 +72,10 @@ class Visitor extends SimpleAstVisitor {
   @override
   visitInstanceCreationExpression(InstanceCreationExpression node) {
     final args = node.argumentList.arguments;
-    final parameters = node.staticElement.parameters;
-    _checkArgs(args, parameters);
+    final parameters = node.staticElement?.parameters;
+    if (parameters != null) {
+      _checkArgs(args, parameters);
+    }
   }
 
   @override


### PR DESCRIPTION
Without this fix, benchmarking reporting an exception:

```
Exception while using a TimedAstVisitor to visit a InstanceCreationExpressionImpl in ArgumentListImpl in MethodInvocationImpl in CascadeExpressionImpl in ExpressionStatementImpl in BlockImpl in BlockFunctionBodyImpl in FunctionExpressionImpl in FunctionDeclarationImpl in CompilationUnitImpl
```

which we traced back to accessing `parameters` on an unresolved node.

@a14n 