### PR TITLE
Improve reporting of `prefer_final_locals`

### DIFF
--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -76,7 +76,7 @@ class _Visitor extends SimpleAstVisitor {
     FunctionBody function = node.getAncestor((a) => a is FunctionBody);
     if (function != null &&
         !function.isPotentiallyMutatedInScope(node.element)) {
-      rule.reportLint(node);
+      rule.reportLint(node.name);
     }
   }
 }


### PR DESCRIPTION
```
  var options = parser.parse(args);
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

=>

```
  var options = parser.parse(args);
      ^^^^^^^
```

@bwilkerson @a14n 