### PR TITLE
Change most of the lint rules to implement NodeLintRule and node processors.

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -17,7 +17,15 @@ export 'package:analyzer/src/generated/resolver.dart'
     show InheritanceManager, TypeProvider, TypeSystem;
 export 'package:analyzer/src/generated/source.dart' show LineInfo, Source;
 export 'package:analyzer/src/lint/linter.dart'
-    show DartLinter, LintRule, Group, Maturity, LinterOptions, LintFilter;
+    show
+        DartLinter,
+        LintRule,
+        Group,
+        Maturity,
+        LinterOptions,
+        LintFilter,
+        NodeLintRegistry,
+        NodeLintRule;
 export 'package:analyzer/src/lint/project.dart'
     show DartProject, ProjectVisitor;
 export 'package:analyzer/src/lint/pub.dart' show PubspecVisitor, PSEntry;

--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/dart/ast/ast.dart' show AstVisitor;
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
@@ -37,7 +36,8 @@ bool _isRequired(Element element) =>
     element.name == _REQUIRED_VAR_NAME &&
     element.library?.name == _META_LIB_NAME;
 
-class AlwaysPutRequiredNamedParametersFirst extends LintRule {
+class AlwaysPutRequiredNamedParametersFirst extends LintRule
+    implements NodeLintRule {
   AlwaysPutRequiredNamedParametersFirst()
       : super(
             name: 'always_put_required_named_parameters_first',
@@ -46,16 +46,19 @@ class AlwaysPutRequiredNamedParametersFirst extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFormalParameterList(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  Visitor(this.rule);
+  _Visitor(this.rule);
 
   @override
-  visitFormalParameterList(FormalParameterList node) {
+  void visitFormalParameterList(FormalParameterList node) {
     bool nonRequiredSeen = false;
     for (DefaultFormalParameter param
         in node.parameters.where((p) => p.isNamed)) {

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/dart/ast/ast.dart' show AstVisitor, TypedLiteral;
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
@@ -50,7 +49,8 @@ bool _isRequired(Element element) =>
     element.name == _REQUIRED_VAR_NAME &&
     element.library?.name == _META_LIB_NAME;
 
-class AlwaysRequireNonNullNamedParameters extends LintRule {
+class AlwaysRequireNonNullNamedParameters extends LintRule
+    implements NodeLintRule {
   AlwaysRequireNonNullNamedParameters()
       : super(
             name: 'always_require_non_null_named_parameters',
@@ -59,13 +59,16 @@ class AlwaysRequireNonNullNamedParameters extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFormalParameterList(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  Visitor(this.rule);
+  _Visitor(this.rule);
 
   void checkLiteral(TypedLiteral literal) {
     if (literal.typeArguments == null) {
@@ -74,7 +77,7 @@ class Visitor extends SimpleAstVisitor {
   }
 
   @override
-  visitFormalParameterList(FormalParameterList node) {
+  void visitFormalParameterList(FormalParameterList node) {
     final params = node.parameters
         // only named parameters
         .where((p) => p.isNamed)

--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -35,27 +35,28 @@ lookUpOrDefault(String name, Map map, defaultValue) {
 
 ''';
 
-class AvoidAnnotatingWithDynamic extends LintRule {
-  _Visitor _visitor;
+class AvoidAnnotatingWithDynamic extends LintRule implements NodeLintRule {
   AvoidAnnotatingWithDynamic()
       : super(
             name: 'avoid_annotating_with_dynamic',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addSimpleFormalParameter(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitSimpleFormalParameter(SimpleFormalParameter node) {
+  void visitSimpleFormalParameter(SimpleFormalParameter node) {
     final type = node.type;
     if (type is TypeName && type.name.name == 'dynamic') {
       rule.reportLint(node);

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/ast/ast.dart'
-    show AsExpression, AstNode, AstVisitor, NamedType;
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
@@ -59,7 +58,7 @@ HasScrollDirection scrollable = renderObject as dynamic;
 
 ''';
 
-class AvoidAs extends LintRule {
+class AvoidAs extends LintRule implements NodeLintRule {
   AvoidAs()
       : super(
             name: 'avoid_as',
@@ -68,15 +67,19 @@ class AvoidAs extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addAsExpression(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitAsExpression(AsExpression node) {
+  void visitAsExpression(AsExpression node) {
     // TODO(brianwilkerson) Use TypeAnnotation rather than AstNode below.
     AstNode typeAnnotation = node.type;
     if (typeAnnotation is NamedType && typeAnnotation.name.name != 'dynamic') {

--- a/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
+++ b/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
@@ -31,7 +31,8 @@ condition && boolExpression
 
 ''';
 
-class AvoidBoolLiteralsInConditionalExpressions extends LintRule {
+class AvoidBoolLiteralsInConditionalExpressions extends LintRule
+    implements NodeLintRule {
   AvoidBoolLiteralsInConditionalExpressions()
       : super(
             name: 'avoid_bool_literals_in_conditional_expressions',
@@ -40,16 +41,19 @@ class AvoidBoolLiteralsInConditionalExpressions extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addConditionalExpression(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
   @override
-  visitConditionalExpression(ConditionalExpression node) {
+  void visitConditionalExpression(ConditionalExpression node) {
     final typeProvider = getCompilationUnit(node).element.context.typeProvider;
     final thenExp = node.thenExpression;
     final elseExp = node.elseExpression;

--- a/lib/src/rules/avoid_catches_without_on_clauses.dart
+++ b/lib/src/rules/avoid_catches_without_on_clauses.dart
@@ -37,27 +37,28 @@ on Exception catch(e) {
 
 ''';
 
-class AvoidCatchesWithoutOnClauses extends LintRule {
-  _Visitor _visitor;
+class AvoidCatchesWithoutOnClauses extends LintRule implements NodeLintRule {
   AvoidCatchesWithoutOnClauses()
       : super(
             name: 'avoid_catches_without_on_clauses',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addCatchClause(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitCatchClause(CatchClause node) {
+  void visitCatchClause(CatchClause node) {
     if (node.onKeyword == null) {
       rule.reportLint(node);
     }

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -36,27 +36,28 @@ try {
 
 ''';
 
-class AvoidCatchingErrors extends LintRule {
-  _Visitor _visitor;
+class AvoidCatchingErrors extends LintRule implements NodeLintRule {
   AvoidCatchingErrors()
       : super(
             name: 'avoid_catching_errors',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addCatchClause(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitCatchClause(CatchClause node) {
+  void visitCatchClause(CatchClause node) {
     final exceptionType = node.exceptionType?.type;
     if (DartTypeUtilities.implementsInterface(
         exceptionType, 'Error', 'dart.core')) {

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -53,27 +53,29 @@ bool _isStaticMember(ClassMember classMember) {
   return false;
 }
 
-class AvoidClassesWithOnlyStaticMembers extends LintRule {
-  _Visitor _visitor;
+class AvoidClassesWithOnlyStaticMembers extends LintRule
+    implements NodeLintRule {
   AvoidClassesWithOnlyStaticMembers()
       : super(
             name: 'avoid_classes_with_only_static_members',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     if (node.members.isNotEmpty &&
         node.members.every(_isStaticMember) &&
         node.element.fields.any(_isNonConst)) {

--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -42,7 +42,7 @@ f(dynamic x) {
 
 ''';
 
-class AvoidDoubleAndIntChecks extends LintRule {
+class AvoidDoubleAndIntChecks extends LintRule implements NodeLintRule {
   AvoidDoubleAndIntChecks()
       : super(
             name: 'avoid_double_and_int_checks',
@@ -51,16 +51,19 @@ class AvoidDoubleAndIntChecks extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addIfStatement(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
   @override
-  visitIfStatement(IfStatement node) {
+  void visitIfStatement(IfStatement node) {
     final elseStatement = node.elseStatement;
     if (elseStatement is IfStatement) {
       final ifCondition = node.condition;

--- a/lib/src/rules/avoid_empty_else.dart
+++ b/lib/src/rules/avoid_empty_else.dart
@@ -22,7 +22,7 @@ else ;
 
 ''';
 
-class AvoidEmptyElse extends LintRule {
+class AvoidEmptyElse extends LintRule implements NodeLintRule {
   AvoidEmptyElse()
       : super(
             name: 'avoid_empty_else',
@@ -31,15 +31,19 @@ class AvoidEmptyElse extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addIfStatement(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitIfStatement(IfStatement node) {
+  void visitIfStatement(IfStatement node) {
     Statement elseStatement = node.elseStatement;
     if (elseStatement is EmptyStatement &&
         !elseStatement.semicolon.isSynthetic) {

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -30,27 +30,29 @@ people.forEach(print);
 ```
 ''';
 
-class AvoidFunctionLiteralInForeachMethod extends LintRule {
-  _Visitor _visitor;
+class AvoidFunctionLiteralInForeachMethod extends LintRule
+    implements NodeLintRule {
   AvoidFunctionLiteralInForeachMethod()
       : super(
             name: 'avoid_function_literals_in_foreach_calls',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodInvocation(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitMethodInvocation(MethodInvocation node) {
+  void visitMethodInvocation(MethodInvocation node) {
     if (node.target != null &&
         node.methodName.token.value() == 'forEach' &&
         node.argumentList.arguments.isNotEmpty &&

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -54,7 +54,7 @@ class LazyId {
 
 ''';
 
-class AvoidInitToNull extends LintRule {
+class AvoidInitToNull extends LintRule implements NodeLintRule {
   AvoidInitToNull()
       : super(
             name: 'avoid_init_to_null',
@@ -63,25 +63,30 @@ class AvoidInitToNull extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addVariableDeclaration(this, visitor);
+    registry.addDefaultFormalParameter(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitVariableDeclaration(VariableDeclaration node) {
-    if (!node.isConst &&
-        !node.isFinal &&
-        DartTypeUtilities.isNullLiteral(node.initializer)) {
+  void visitDefaultFormalParameter(DefaultFormalParameter node) {
+    if (DartTypeUtilities.isNullLiteral(node.defaultValue)) {
       rule.reportLint(node);
     }
   }
 
   @override
-  visitDefaultFormalParameter(DefaultFormalParameter node) {
-    if (DartTypeUtilities.isNullLiteral(node.defaultValue)) {
+  void visitVariableDeclaration(VariableDeclaration node) {
+    if (!node.isConst &&
+        !node.isFinal &&
+        DartTypeUtilities.isNullLiteral(node.initializer)) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/rules/avoid_js_rounded_ints.dart
+++ b/lib/src/rules/avoid_js_rounded_ints.dart
@@ -32,7 +32,7 @@ BigInt value = BigInt.parse('9007199254740995');
 
 ''';
 
-class AvoidJsRoundedInts extends LintRule {
+class AvoidJsRoundedInts extends LintRule implements NodeLintRule {
   AvoidJsRoundedInts()
       : super(
             name: 'avoid_js_rounded_ints',
@@ -41,20 +41,22 @@ class AvoidJsRoundedInts extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addIntegerLiteral(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
+  bool isRounded(int value) => value?.toDouble()?.toInt() != value;
   @override
-  visitIntegerLiteral(IntegerLiteral node) {
+  void visitIntegerLiteral(IntegerLiteral node) {
     if (isRounded(node.value)) {
       rule.reportLint(node);
     }
   }
-
-  bool isRounded(int value) => value?.toDouble()?.toInt() != value;
 }

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -70,27 +70,29 @@ bool _isParameterWithQuestionQuestion(
     node.operator.type == TokenType.QUESTION_QUESTION &&
     _isParameter(node.leftOperand, parameter);
 
-class AvoidNullChecksInEqualityOperators extends LintRule {
-  _Visitor _visitor;
+class AvoidNullChecksInEqualityOperators extends LintRule
+    implements NodeLintRule {
   AvoidNullChecksInEqualityOperators()
       : super(
             name: 'avoid_null_checks_in_equality_operators',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     final parameters = node.parameters?.parameters;
     if (node.name.token?.type == TokenType.EQ_EQ && parameters?.length == 1) {
       final parameter = DartTypeUtilities

--- a/lib/src/rules/avoid_relative_lib_imports.dart
+++ b/lib/src/rules/avoid_relative_lib_imports.dart
@@ -37,7 +37,7 @@ import '../lib/baz.dart';
 
 ''';
 
-class AvoidRelativeLibImports extends LintRule {
+class AvoidRelativeLibImports extends LintRule implements NodeLintRule {
   AvoidRelativeLibImports()
       : super(
             name: 'avoid_relative_lib_imports',
@@ -46,19 +46,16 @@ class AvoidRelativeLibImports extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addImportDirective(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
 
-  @override
-  visitImportDirective(ImportDirective node) {
-    if (isRelativeLibImport(node)) {
-      rule.reportLint(node.uri);
-    }
-  }
+  _Visitor(this.rule);
 
   bool isRelativeLibImport(ImportDirective node) {
     try {
@@ -71,5 +68,12 @@ class Visitor extends SimpleAstVisitor {
       // Ignore.
     }
     return false;
+  }
+
+  @override
+  void visitImportDirective(ImportDirective node) {
+    if (isRelativeLibImport(node)) {
+      rule.reportLint(node.uri);
+    }
   }
 }

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -5,7 +5,6 @@ import 'dart:math' as math;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
@@ -42,7 +41,7 @@ abstract class B extends A {
 
 ''';
 
-class AvoidRenamingMethodParameters extends LintRule {
+class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
   AvoidRenamingMethodParameters()
       : super(
             name: 'avoid_renaming_method_parameters',
@@ -51,16 +50,19 @@ class AvoidRenamingMethodParameters extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  Visitor(this.rule);
+  _Visitor(this.rule);
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     if (node.isStatic) return;
     if (node.documentationComment != null) return;
 

--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -26,7 +26,7 @@ void set speed(int ms);
 
 ''';
 
-class AvoidReturnTypesOnSetters extends LintRule {
+class AvoidReturnTypesOnSetters extends LintRule implements NodeLintRule {
   AvoidReturnTypesOnSetters()
       : super(
             name: 'avoid_return_types_on_setters',
@@ -35,15 +35,20 @@ class AvoidReturnTypesOnSetters extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitFunctionDeclaration(FunctionDeclaration node) {
+  void visitFunctionDeclaration(FunctionDeclaration node) {
     if (node.isSetter) {
       if (node.returnType != null) {
         rule.reportLint(node.returnType);
@@ -52,7 +57,7 @@ class Visitor extends SimpleAstVisitor {
   }
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     if (node.isSetter) {
       if (node.returnType != null) {
         rule.reportLint(node.returnType);

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -50,34 +50,36 @@ bool _isPrimitiveType(DartType type) =>
 bool _isReturnNull(AstNode node) =>
     node is ReturnStatement && DartTypeUtilities.isNullLiteral(node.expression);
 
-class AvoidReturningNull extends LintRule {
-  _Visitor _visitor;
+class AvoidReturningNull extends LintRule implements NodeLintRule {
   AvoidReturningNull()
       : super(
             name: 'avoid_returning_null',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionExpression(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitFunctionExpression(FunctionExpression node) {
+  void visitFunctionExpression(FunctionExpression node) {
     if (_isPrimitiveType(node.element.returnType)) {
       _visitFunctionBody(node.body);
     }
   }
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     if (_isPrimitiveType(node.element.returnType)) {
       _visitFunctionBody(node.body);
     }

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -48,27 +48,28 @@ bool _isReturnStatement(AstNode node) => node is ReturnStatement;
 bool _returnsThis(AstNode node) =>
     (node as ReturnStatement).expression is ThisExpression;
 
-class AvoidReturningThis extends LintRule {
-  _Visitor _visitor;
+class AvoidReturningThis extends LintRule implements NodeLintRule {
   AvoidReturningThis()
       : super(
             name: 'avoid_returning_this',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     if (node.isOperator) return;
     if (node.element.returnType !=
             (node.parent as ClassDeclaration).element?.type ||

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -50,27 +50,28 @@ bool _hasGetter(MethodDeclaration node) =>
 bool _hasInheritedSetter(MethodDeclaration node) =>
     DartTypeUtilities.lookUpInheritedConcreteSetter(node) != null;
 
-class AvoidSettersWithoutGetters extends LintRule {
-  _Visitor _visitor;
+class AvoidSettersWithoutGetters extends LintRule implements NodeLintRule {
   AvoidSettersWithoutGetters()
       : super(
             name: 'avoid_setters_without_getters',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
-  LintRule rule;
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     final methods = node.members.where(isMethod);
     for (MethodDeclaration method in methods) {
       if (method.isSetter &&

--- a/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
+++ b/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
@@ -24,7 +24,8 @@ o.m();
 
 ''';
 
-class AvoidSingleCascadeInExpressionStatements extends LintRule {
+class AvoidSingleCascadeInExpressionStatements extends LintRule
+    implements NodeLintRule {
   AvoidSingleCascadeInExpressionStatements()
       : super(
             name: 'avoid_single_cascade_in_expression_statements',
@@ -33,16 +34,19 @@ class AvoidSingleCascadeInExpressionStatements extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addCascadeExpression(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
   @override
-  visitCascadeExpression(CascadeExpression node) {
+  void visitCascadeExpression(CascadeExpression node) {
     if (node.cascadeSections.length == 1 &&
         node.parent is ExpressionStatement) {
       rule.reportLint(node);

--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -24,7 +24,7 @@ m(f(int v));
 
 ''';
 
-class AvoidTypesAsParameterNames extends LintRule {
+class AvoidTypesAsParameterNames extends LintRule implements NodeLintRule {
   AvoidTypesAsParameterNames()
       : super(
             name: 'avoid_types_as_parameter_names',
@@ -33,16 +33,19 @@ class AvoidTypesAsParameterNames extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFormalParameterList(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
   @override
-  visitFormalParameterList(FormalParameterList node) {
+  void visitFormalParameterList(FormalParameterList node) {
     if (node.parent is GenericFunctionType) return;
 
     // TODO(a14n) test that parameter name matches a existing type. No api to do

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -28,19 +28,19 @@ var names = people.map((person) => person.name);
 
 ''';
 
-class AvoidTypesOnClosureParameters extends LintRule {
-  _Visitor _visitor;
+class AvoidTypesOnClosureParameters extends LintRule implements NodeLintRule {
   AvoidTypesOnClosureParameters()
       : super(
             name: 'avoid_types_on_closure_parameters',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionExpression(this, visitor);
+  }
 }
 
 class AvoidTypesOnClosureParametersVisitor extends SimpleAstVisitor {
@@ -77,12 +77,13 @@ class AvoidTypesOnClosureParametersVisitor extends SimpleAstVisitor {
   }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitFunctionExpression(FunctionExpression node) {
+  void visitFunctionExpression(FunctionExpression node) {
     final visitor = new AvoidTypesOnClosureParametersVisitor(rule);
     visitor.visitFunctionExpression(node);
   }

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -33,7 +33,7 @@ typedef num Adder(num x, num y);
 
 ''';
 
-class CamelCaseTypes extends LintRule {
+class CamelCaseTypes extends LintRule implements NodeLintRule {
   CamelCaseTypes()
       : super(
             name: 'camel_case_types',
@@ -42,22 +42,27 @@ class CamelCaseTypes extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+    registry.addFunctionTypeAlias(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     if (!isCamelCase(node.name.toString())) {
       rule.reportLint(node.name);
     }
   }
 
   @override
-  visitFunctionTypeAlias(FunctionTypeAlias node) {
+  void visitFunctionTypeAlias(FunctionTypeAlias node) {
     if (!isCamelCase(node.name.toString())) {
       rule.reportLint(node.name);
     }

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
@@ -61,23 +60,23 @@ void someFunctionOK() {
 bool _isSubscription(DartType type) => DartTypeUtilities.implementsInterface(
     type, 'StreamSubscription', 'dart.async');
 
-class CancelSubscriptions extends LintRule {
-  _Visitor _visitor;
-
+class CancelSubscriptions extends LintRule implements NodeLintRule {
   CancelSubscriptions()
       : super(
             name: 'cancel_subscriptions',
             description: _desc,
             details: _details,
-            group: Group.errors) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFieldDeclaration(this, visitor);
+    registry.addVariableDeclarationStatement(this, visitor);
+  }
 }
 
-class _Visitor extends LeakDetectorVisitor {
+class _Visitor extends LeakDetectorProcessors {
   static const _cancelMethodName = 'cancel';
 
   @override

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -97,21 +97,20 @@ bool _isInvokedWithoutNullAwareOperator(Token token) =>
 
 /// Rule to lint consecutive invocations of methods or getters on the same
 /// reference that could be done with the cascade operator.
-class CascadeInvocations extends LintRule {
-  _Visitor _visitor;
-
+class CascadeInvocations extends LintRule implements NodeLintRule {
   /// Default constructor.
   CascadeInvocations()
       : super(
             name: 'cascade_invocations',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBlock(this, visitor);
+  }
 }
 
 /// A CascadableExpression is an object that is built from an expression and
@@ -242,13 +241,13 @@ class _CascadableExpression {
   }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
 
   @override
-  visitBlock(Block node) {
+  void visitBlock(Block node) {
     if (node.statements.length < 2) {
       return;
     }

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
@@ -63,23 +62,23 @@ bool _isSink(DartType type) =>
 bool _isSocket(DartType type) =>
     DartTypeUtilities.implementsInterface(type, 'Socket', 'dart.io');
 
-class CloseSinks extends LintRule {
-  _Visitor _visitor;
-
+class CloseSinks extends LintRule implements NodeLintRule {
   CloseSinks()
       : super(
             name: 'close_sinks',
             description: _desc,
             details: _details,
-            group: Group.errors) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFieldDeclaration(this, visitor);
+    registry.addVariableDeclarationStatement(this, visitor);
+  }
 }
 
-class _Visitor extends LeakDetectorVisitor {
+class _Visitor extends LeakDetectorProcessors {
   static const _closeMethodName = 'close';
   static const _destroyMethodName = 'destroy';
 

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -43,7 +43,7 @@ class Dice {
 
 ''';
 
-class ConstantIdentifierNames extends LintRule {
+class ConstantIdentifierNames extends LintRule implements NodeLintRule {
   ConstantIdentifierNames()
       : super(
             name: 'constant_identifier_names',
@@ -52,12 +52,18 @@ class ConstantIdentifierNames extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addEnumConstantDeclaration(this, visitor);
+    registry.addTopLevelVariableDeclaration(this, visitor);
+    registry.addVariableDeclarationList(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   checkIdentifier(SimpleIdentifier id) {
     if (!isLowerCamelCase(id.name)) {
@@ -66,17 +72,17 @@ class Visitor extends SimpleAstVisitor {
   }
 
   @override
-  visitEnumConstantDeclaration(EnumConstantDeclaration node) {
+  void visitEnumConstantDeclaration(EnumConstantDeclaration node) {
     checkIdentifier(node.name);
   }
 
   @override
-  visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
     visitVariableDeclarationList(node.variables);
   }
 
   @override
-  visitVariableDeclarationList(VariableDeclarationList node) {
+  void visitVariableDeclarationList(VariableDeclarationList node) {
     node.variables.forEach((VariableDeclaration v) {
       if (v.isConst) {
         checkIdentifier(v.name);

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -83,20 +83,21 @@ class BadBreak {
 
 ''';
 
-class ControlFlowInFinally extends LintRule {
-  _Visitor _visitor;
-
+class ControlFlowInFinally extends LintRule implements NodeLintRule {
   ControlFlowInFinally()
       : super(
             name: 'control_flow_in_finally',
             description: _desc,
             details: _details,
-            group: Group.errors) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBreakStatement(this, visitor);
+    registry.addContinueStatement(this, visitor);
+    registry.addReturnStatement(this, visitor);
+  }
 }
 
 /// Do not extend this class, it is meant to be used from
@@ -143,7 +144,7 @@ abstract class ControlFlowInFinallyBlockReporterMixin {
   }
 }
 
-class _Visitor extends SimpleAstVisitor
+class _Visitor extends SimpleAstVisitor<void>
     with ControlFlowInFinallyBlockReporterMixin {
   @override
   final LintRule rule;
@@ -151,17 +152,17 @@ class _Visitor extends SimpleAstVisitor
   _Visitor(this.rule);
 
   @override
-  visitBreakStatement(BreakStatement node) {
+  void visitBreakStatement(BreakStatement node) {
     reportIfFinallyAncestorExists(node, ancestor: node.target);
   }
 
   @override
-  visitContinueStatement(ContinueStatement node) {
+  void visitContinueStatement(ContinueStatement node) {
     reportIfFinallyAncestorExists(node, ancestor: node.target);
   }
 
   @override
-  visitReturnStatement(ReturnStatement node) {
+  void visitReturnStatement(ReturnStatement node) {
     reportIfFinallyAncestorExists(node);
   }
 }

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -48,7 +48,7 @@ try {
 
 ''';
 
-class EmptyCatches extends LintRule {
+class EmptyCatches extends LintRule implements NodeLintRule {
   EmptyCatches()
       : super(
             name: 'empty_catches',
@@ -57,12 +57,16 @@ class EmptyCatches extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addCatchClause(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
   void visitCatchClause(CatchClause node) {

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -36,7 +36,7 @@ class Point {
 
 ''';
 
-class EmptyConstructorBodies extends LintRule {
+class EmptyConstructorBodies extends LintRule implements NodeLintRule {
   EmptyConstructorBodies()
       : super(
             name: 'empty_constructor_bodies',
@@ -45,15 +45,19 @@ class EmptyConstructorBodies extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addConstructorDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitConstructorDeclaration(ConstructorDeclaration node) {
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
     if (node.body is BlockFunctionBody) {
       Block block = (node.body as BlockFunctionBody).block;
       if (block.statements.isEmpty) {

--- a/lib/src/rules/empty_statements.dart
+++ b/lib/src/rules/empty_statements.dart
@@ -40,7 +40,7 @@ if (complicated.expression.foo())
 
 ''';
 
-class EmptyStatements extends LintRule {
+class EmptyStatements extends LintRule implements NodeLintRule {
   EmptyStatements()
       : super(
             name: 'empty_statements',
@@ -49,15 +49,19 @@ class EmptyStatements extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addEmptyStatement(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitEmptyStatement(EmptyStatement node) {
+  void visitEmptyStatement(EmptyStatement node) {
     rule.reportLint(node);
   }
 }

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -45,7 +45,7 @@ class Better {
 
 ''';
 
-class HashAndEquals extends LintRule {
+class HashAndEquals extends LintRule implements NodeLintRule {
   HashAndEquals()
       : super(
             name: 'hash_and_equals',
@@ -54,15 +54,19 @@ class HashAndEquals extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     MethodDeclaration eq, hash;
     for (ClassMember member in node.members) {
       if (isEquals(member)) {

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/ast/ast.dart' show AstVisitor, ImportDirective;
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
@@ -56,7 +56,7 @@ bool samePackage(Uri uri1, Uri uri2) {
   return segments1[0] == segments2[0];
 }
 
-class ImplementationImports extends LintRule {
+class ImplementationImports extends LintRule implements NodeLintRule {
   ImplementationImports()
       : super(
             name: 'implementation_imports',
@@ -65,15 +65,19 @@ class ImplementationImports extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addImportDirective(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitImportDirective(ImportDirective node) {
+  void visitImportDirective(ImportDirective node) {
     Uri importUri = node?.uriSource?.uri;
     Uri sourceUri = node == null
         ? null

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 import 'package:linter/src/util/unrelated_types_visitor.dart';
@@ -121,23 +119,22 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 
 ''';
 
-class IterableContainsUnrelatedType extends LintRule {
-  _Visitor _visitor;
-
+class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
   IterableContainsUnrelatedType()
       : super(
             name: 'iterable_contains_unrelated_type',
             description: _desc,
             details: _details,
-            group: Group.errors) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodInvocation(this, visitor);
+  }
 }
 
-class _Visitor extends UnrelatedTypesVisitor {
+class _Visitor extends UnrelatedTypesProcessors {
   static final _DEFINITION =
       new InterfaceTypeDefinition('Iterable', 'dart.core');
 

--- a/lib/src/rules/join_return_with_assignment.dart
+++ b/lib/src/rules/join_return_with_assignment.dart
@@ -48,19 +48,19 @@ Element _getElementFromReturnStatement(Statement node) {
   return null;
 }
 
-class JoinReturnWithAssignment extends LintRule {
-  _Visitor _visitor;
+class JoinReturnWithAssignment extends LintRule implements NodeLintRule {
   JoinReturnWithAssignment()
       : super(
             name: 'join_return_with_assignment',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBlock(this, visitor);
+  }
 }
 
 class _AssignmentStatementVisitor extends SimpleAstVisitor {
@@ -92,12 +92,13 @@ class _AssignmentStatementVisitor extends SimpleAstVisitor {
   }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitBlock(Block node) {
+  void visitBlock(Block node) {
     final statements = node.statements;
     final length = statements.length;
     if (length < 2) {

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -34,7 +34,7 @@ supports symbolic imports.
 
 ''';
 
-class LibraryNames extends LintRule {
+class LibraryNames extends LintRule implements NodeLintRule {
   LibraryNames()
       : super(
             name: 'library_names',
@@ -43,15 +43,19 @@ class LibraryNames extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addLibraryDirective(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitLibraryDirective(LibraryDirective node) {
+  void visitLibraryDirective(LibraryDirective node) {
     if (!isLowerCaseUnderScoreWithDots(node.name.toString())) {
       rule.reportLint(node.name);
     }

--- a/lib/src/rules/library_prefixes.dart
+++ b/lib/src/rules/library_prefixes.dart
@@ -32,7 +32,7 @@ import 'package:javascript_utils/javascript_utils.dart' as jsUtils;
 
 ''';
 
-class LibraryPrefixes extends LintRule {
+class LibraryPrefixes extends LintRule implements NodeLintRule {
   LibraryPrefixes()
       : super(
             name: 'library_prefixes',
@@ -41,15 +41,19 @@ class LibraryPrefixes extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addImportDirective(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitImportDirective(ImportDirective node) {
+  void visitImportDirective(ImportDirective node) {
     if (node.prefix != null && !isValidLibraryPrefix(node.prefix.toString())) {
       rule.reportLint(node.prefix);
     }

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 import 'package:linter/src/util/unrelated_types_visitor.dart';
@@ -121,23 +119,22 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 
 ''';
 
-class ListRemoveUnrelatedType extends LintRule {
-  _Visitor _visitor;
-
+class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
   ListRemoveUnrelatedType()
       : super(
             name: 'list_remove_unrelated_type',
             description: _desc,
             details: _details,
-            group: Group.errors) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodInvocation(this, visitor);
+  }
 }
 
-class _Visitor extends UnrelatedTypesVisitor {
+class _Visitor extends UnrelatedTypesProcessors {
   static final _DEFINITION = new InterfaceTypeDefinition('List', 'dart.core');
 
   _Visitor(LintRule rule) : super(rule);

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -98,51 +98,53 @@ bool _onlyLiterals(Expression rawExpression) {
   return false;
 }
 
-class LiteralOnlyBooleanExpressions extends LintRule {
-  _Visitor _visitor;
-
+class LiteralOnlyBooleanExpressions extends LintRule implements NodeLintRule {
   LiteralOnlyBooleanExpressions()
       : super(
             name: 'literal_only_boolean_expressions',
             description: _desc,
             details: _details,
             group: Group.errors,
-            maturity: Maturity.experimental) {
-    _visitor = new _Visitor(this);
-  }
+            maturity: Maturity.experimental);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addDoStatement(this, visitor);
+    registry.addForStatement(this, visitor);
+    registry.addIfStatement(this, visitor);
+    registry.addWhileStatement(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
 
   @override
-  visitDoStatement(DoStatement node) {
+  void visitDoStatement(DoStatement node) {
     if (_onlyLiterals(node.condition)) {
       rule.reportLint(node);
     }
   }
 
   @override
-  visitForStatement(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     if (_onlyLiterals(node.condition)) {
       rule.reportLint(node);
     }
   }
 
   @override
-  visitIfStatement(IfStatement node) {
+  void visitIfStatement(IfStatement node) {
     if (_onlyLiterals(node.condition)) {
       rule.reportLint(node);
     }
   }
 
   @override
-  visitWhileStatement(WhileStatement node) {
+  void visitWhileStatement(WhileStatement node) {
     if (_onlyLiterals(node.condition)) {
       rule.reportLint(node);
     }

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -34,7 +34,7 @@ List<String> list = <String>[
 
 ''';
 
-class NoAdjacentStringsInList extends LintRule {
+class NoAdjacentStringsInList extends LintRule implements NodeLintRule {
   NoAdjacentStringsInList()
       : super(
             name: 'no_adjacent_strings_in_list',
@@ -43,13 +43,16 @@ class NoAdjacentStringsInList extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addListLiteral(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
 
-  Visitor(this.rule);
+  _Visitor(this.rule);
 
   @override
   void visitListLiteral(ListLiteral node) {

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -3,11 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:collection';
+
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/context/declared_variables.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/standard_resolution_map.dart';
-import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:linter/src/analyzer.dart';
 
@@ -44,7 +44,7 @@ switch (v) {
 String message(String value1, String value2) =>
     'Do not use more than one case with same value ($value1 and $value2)';
 
-class NoDuplicateCaseValues extends LintRule {
+class NoDuplicateCaseValues extends LintRule implements NodeLintRule {
   NoDuplicateCaseValues()
       : super(
             name: 'no_duplicate_case_values',
@@ -53,7 +53,10 @@ class NoDuplicateCaseValues extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addSwitchStatement(this, visitor);
+  }
 
   void reportLintWithDescription(AstNode node, String description) {
     if (node != null) {
@@ -71,10 +74,10 @@ class _LintCode extends LintCode {
   _LintCode._(String name, String message) : super(name, message);
 }
 
-class Visitor extends SimpleAstVisitor {
-  NoDuplicateCaseValues rule;
+class _Visitor extends SimpleAstVisitor<void> {
+  final NoDuplicateCaseValues rule;
 
-  Visitor(this.rule);
+  _Visitor(this.rule);
 
   @override
   void visitSwitchStatement(SwitchStatement node) {

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -43,27 +43,30 @@ Map<int, List<Person>> groupByZip(Iterable<Person> people) {
 
 ''';
 
-class OmitLocalVariableTypes extends LintRule {
-  _Visitor _visitor;
+class OmitLocalVariableTypes extends LintRule implements NodeLintRule {
   OmitLocalVariableTypes()
       : super(
             name: 'omit_local_variable_types',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addForEachStatement(this, visitor);
+    registry.addForStatement(this, visitor);
+    registry.addVariableDeclarationStatement(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitForEachStatement(ForEachStatement node) {
+  void visitForEachStatement(ForEachStatement node) {
     final staticType = node.loopVariable?.type;
     if (staticType == null) {
       return;
@@ -82,12 +85,12 @@ class _Visitor extends SimpleAstVisitor {
   }
 
   @override
-  visitForStatement(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     _visitVariableDeclarationList(node.variables);
   }
 
   @override
-  visitVariableDeclarationStatement(VariableDeclarationStatement node) {
+  void visitVariableDeclarationStatement(VariableDeclarationStatement node) {
     _visitVariableDeclarationList(node.variables);
   }
 

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -35,7 +35,7 @@ abstract class Predicate {
 
 ''';
 
-class OneMemberAbstracts extends LintRule {
+class OneMemberAbstracts extends LintRule implements NodeLintRule {
   OneMemberAbstracts()
       : super(
             name: 'one_member_abstracts',
@@ -44,15 +44,19 @@ class OneMemberAbstracts extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     if (node.isAbstract &&
         node.extendsClause == null &&
         node.members.length == 1) {

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -54,23 +54,22 @@ bool _isThrowable(DartType type) =>
     type.isDynamic ||
     DartTypeUtilities.implementsAnyInterface(type, _interfaceDefinitions);
 
-class OnlyThrowErrors extends LintRule {
-  _Visitor _visitor;
-
+class OnlyThrowErrors extends LintRule implements NodeLintRule {
   OnlyThrowErrors()
       : super(
             name: 'only_throw_errors',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addThrowExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -81,29 +81,28 @@ Iterable<InterfaceType> _findAllSupertypesAndMixins(
   return interfaces.where((i) => i != interface);
 }
 
-class OverriddenFields extends LintRule {
-  _Visitor _visitor;
-
+class OverriddenFields extends LintRule implements NodeLintRule {
   OverriddenFields()
       : super(
             name: 'overridden_fields',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFieldDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
 
   @override
-  visitFieldDeclaration(FieldDeclaration node) {
+  void visitFieldDeclaration(FieldDeclaration node) {
     if (node.isStatic) {
       return;
     }

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -58,7 +58,7 @@ Advice for writing good doc comments can be found in the
 
 ''';
 
-class PackageApiDocs extends LintRule implements ProjectVisitor {
+class PackageApiDocs extends LintRule implements ProjectVisitor, NodeLintRule {
   DartProject project;
 
   PackageApiDocs()
@@ -72,17 +72,29 @@ class PackageApiDocs extends LintRule implements ProjectVisitor {
   ProjectVisitor getProjectVisitor() => this;
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
-
-  @override
   visit(DartProject project) {
     this.project = project;
   }
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    var visitor = new _Visitor(this);
+    registry.addConstructorDeclaration(this, visitor);
+    registry.addFieldDeclaration(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
+    registry.addClassDeclaration(this, visitor);
+    registry.addEnumDeclaration(this, visitor);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addTopLevelVariableDeclaration(this, visitor);
+    registry.addClassTypeAlias(this, visitor);
+    registry.addFunctionTypeAlias(this, visitor);
+  }
 }
 
-class Visitor extends GeneralizingAstVisitor {
+class _Visitor extends GeneralizingAstVisitor {
   PackageApiDocs rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   DartProject get project => rule.project;
 

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -49,7 +49,8 @@ library my_package.src.private;
 bool matchesOrIsPrefixedBy(String name, String prefix) =>
     name == prefix || name.startsWith('$prefix.');
 
-class PackagePrefixedLibraryNames extends LintRule implements ProjectVisitor {
+class PackagePrefixedLibraryNames extends LintRule
+    implements ProjectVisitor, NodeLintRule {
   DartProject project;
 
   PackagePrefixedLibraryNames()
@@ -63,7 +64,10 @@ class PackagePrefixedLibraryNames extends LintRule implements ProjectVisitor {
   ProjectVisitor getProjectVisitor() => this;
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addLibraryDirective(this, visitor);
+  }
 
   @override
   visit(DartProject project) {
@@ -71,14 +75,14 @@ class PackagePrefixedLibraryNames extends LintRule implements ProjectVisitor {
   }
 }
 
-class Visitor extends SimpleAstVisitor {
-  PackagePrefixedLibraryNames rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final PackagePrefixedLibraryNames rule;
+
+  _Visitor(this.rule);
 
   DartProject get project => rule.project;
-
   @override
-  visitLibraryDirective(LibraryDirective node) {
+  void visitLibraryDirective(LibraryDirective node) {
     // If no project info is set, bail early.
     // https://github.com/dart-lang/linter/issues/154
     if (project == null) {

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -104,23 +104,23 @@ bool _preOrPostFixExpressionMutation(FormalParameter parameter, AstNode n) =>
         n.operand is SimpleIdentifier &&
         (n.operand as SimpleIdentifier).staticElement == parameter.element;
 
-class ParameterAssignments extends LintRule {
-  _Visitor _visitor;
-
+class ParameterAssignments extends LintRule implements NodeLintRule {
   ParameterAssignments()
       : super(
             name: 'parameter_assignments',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);

--- a/lib/src/rules/prefer_adjacent_string_concatenation.dart
+++ b/lib/src/rules/prefer_adjacent_string_concatenation.dart
@@ -28,27 +28,29 @@ raiseAlarm(
 
 ''';
 
-class PreferAdjacentStringConcatenation extends LintRule {
-  _Visitor _visitor;
+class PreferAdjacentStringConcatenation extends LintRule
+    implements NodeLintRule {
   PreferAdjacentStringConcatenation()
       : super(
             name: 'prefer_adjacent_string_concatenation',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBinaryExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitBinaryExpression(BinaryExpression node) {
+  void visitBinaryExpression(BinaryExpression node) {
     if (node.operator.type.lexeme == '+' &&
         node.leftOperand is StringLiteral &&
         node.rightOperand is StringLiteral) {

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -27,27 +27,28 @@ var addresses = {};
 
 ''';
 
-class PreferCollectionLiterals extends LintRule {
-  _Visitor _visitor;
+class PreferCollectionLiterals extends LintRule implements NodeLintRule {
   PreferCollectionLiterals()
       : super(
             name: 'prefer_collection_literals',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addInstanceCreationExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitInstanceCreationExpression(InstanceCreationExpression node) {
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
     if (node.constructorName.name == null &&
         node.argumentList.arguments.isEmpty &&
         (DartTypeUtilities.isClass(node.staticType, 'List', 'dart.core') ||

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -69,27 +69,28 @@ Element _getElementInCondition(Expression rawExpression) {
   return null;
 }
 
-class PreferConditionalAssignment extends LintRule {
-  _Visitor _visitor;
+class PreferConditionalAssignment extends LintRule implements NodeLintRule {
   PreferConditionalAssignment()
       : super(
             name: 'prefer_conditional_assignment',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addIfStatement(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitIfStatement(IfStatement node) {
+  void visitIfStatement(IfStatement node) {
     if (node.elseStatement != null) {
       return;
     }

--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
@@ -52,23 +51,22 @@ void accessA() {
 
 ''';
 
-class PreferConstConstructors extends LintRule {
-  _Visitor _visitor;
-
+class PreferConstConstructors extends LintRule implements NodeLintRule {
   PreferConstConstructors()
       : super(
             name: 'prefer_const_constructors',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addInstanceCreationExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);

--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
@@ -37,39 +36,40 @@ class A {
 
 ''';
 
-class PreferConstDeclarations extends LintRule {
-  _Visitor _visitor;
-
+class PreferConstDeclarations extends LintRule implements NodeLintRule {
   PreferConstDeclarations()
       : super(
             name: 'prefer_const_declarations',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFieldDeclaration(this, visitor);
+    registry.addTopLevelVariableDeclaration(this, visitor);
+    registry.addVariableDeclarationStatement(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
 
   @override
-  visitFieldDeclaration(FieldDeclaration node) {
+  void visitFieldDeclaration(FieldDeclaration node) {
     if (!node.isStatic) return;
     _visitVariableDeclarationList(node.fields);
   }
 
   @override
-  visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) =>
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) =>
       _visitVariableDeclarationList(node.variables);
 
   @override
-  visitVariableDeclarationStatement(VariableDeclarationStatement node) =>
+  void visitVariableDeclarationStatement(VariableDeclarationStatement node) =>
       _visitVariableDeclarationList(node.variables);
 
   _visitVariableDeclarationList(VariableDeclarationList node) {

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -2,10 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library linter.src.rules.prefer_const_literals_to_create_immutables;
-
-import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/dart/ast/ast.dart' show AstVisitor;
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
@@ -52,7 +49,8 @@ bool _isImmutable(Element element) =>
     element.name == _IMMUTABLE_VAR_NAME &&
     element.library?.name == _META_LIB_NAME;
 
-class PreferConstLiteralsToCreateImmutables extends LintRule {
+class PreferConstLiteralsToCreateImmutables extends LintRule
+    implements NodeLintRule {
   PreferConstLiteralsToCreateImmutables()
       : super(
             name: 'prefer_const_literals_to_create_immutables',
@@ -61,13 +59,17 @@ class PreferConstLiteralsToCreateImmutables extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addListLiteral(this, visitor);
+    registry.addMapLiteral(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  Visitor(this.rule);
+  _Visitor(this.rule);
 
   @override
   void visitListLiteral(ListLiteral node) => _visitTypedLiteral(node);

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -52,27 +52,29 @@ bool _hasNewInvocation(DartType returnType, FunctionBody body) {
       .any(_isInstanceCreationExpression);
 }
 
-class PreferConstructorsInsteadOfStaticMethods extends LintRule {
-  _Visitor _visitor;
+class PreferConstructorsInsteadOfStaticMethods extends LintRule
+    implements NodeLintRule {
   PreferConstructorsInsteadOfStaticMethods()
       : super(
             name: 'prefer_constructors_over_static_methods',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     final returnType = node.returnType?.type;
     if (node.isStatic &&
         returnType == (node.parent as ClassDeclaration).element.type &&

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -25,7 +25,7 @@ m({a = 1})
 
 ''';
 
-class PreferEqualForDefaultValues extends LintRule {
+class PreferEqualForDefaultValues extends LintRule implements NodeLintRule {
   PreferEqualForDefaultValues()
       : super(
             name: 'prefer_equal_for_default_values',
@@ -34,16 +34,19 @@ class PreferEqualForDefaultValues extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addDefaultFormalParameter(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
   @override
-  visitDefaultFormalParameter(DefaultFormalParameter node) {
+  void visitDefaultFormalParameter(DefaultFormalParameter node) {
     if (node.isNamed && node.separator?.type == TokenType.COLON) {
       rule.reportLintForToken(node.separator);
     }

--- a/lib/src/rules/prefer_expression_function_bodies.dart
+++ b/lib/src/rules/prefer_expression_function_bodies.dart
@@ -51,27 +51,28 @@ containsValue(String value) => getValues().contains(value);
 
 ''';
 
-class PreferExpressionFunctionBodies extends LintRule {
-  _Visitor _visitor;
+class PreferExpressionFunctionBodies extends LintRule implements NodeLintRule {
   PreferExpressionFunctionBodies()
       : super(
             name: 'prefer_expression_function_bodies',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBlockFunctionBody(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitBlockFunctionBody(BlockFunctionBody node) {
+  void visitBlockFunctionBody(BlockFunctionBody node) {
     final statements = node.block.statements;
     if (statements.length != 1) {
       return;

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -68,7 +68,7 @@ class GoodMutable {
 
 ''';
 
-class PreferFinalFields extends LintRule {
+class PreferFinalFields extends LintRule implements NodeLintRule {
   PreferFinalFields()
       : super(
             name: 'prefer_final_fields',
@@ -77,11 +77,16 @@ class PreferFinalFields extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addCompilationUnit(this, visitor);
+    registry.addFieldDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   final Set<Element> _mutatedElements = new HashSet<Element>();
 
   _Visitor(this.rule);

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -45,23 +45,24 @@ void mutableCase() {
 
 ''';
 
-class PreferFinalLocals extends LintRule {
-  _Visitor _visitor;
+class PreferFinalLocals extends LintRule implements NodeLintRule {
   PreferFinalLocals()
       : super(
             name: 'prefer_final_locals',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addVariableDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override

--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -35,27 +35,29 @@ void main() {
 
 ''';
 
-class PreferFunctionDeclarationsOverVariables extends LintRule {
-  _Visitor _visitor;
+class PreferFunctionDeclarationsOverVariables extends LintRule
+    implements NodeLintRule {
   PreferFunctionDeclarationsOverVariables()
       : super(
             name: 'prefer_function_declarations_over_variables',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addVariableDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitVariableDeclaration(VariableDeclaration node) {
+  void visitVariableDeclaration(VariableDeclaration node) {
     if (node.initializer is FunctionExpression) {
       FunctionBody function = node.getAncestor((a) => a is FunctionBody);
       if (function == null ||

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -32,7 +32,8 @@ typedef F = void Function();
 
 ''';
 
-class PreferGenericFunctionTypeAliases extends LintRule {
+class PreferGenericFunctionTypeAliases extends LintRule
+    implements NodeLintRule {
   PreferGenericFunctionTypeAliases()
       : super(
             name: 'prefer_generic_function_type_aliases',
@@ -41,16 +42,19 @@ class PreferGenericFunctionTypeAliases extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionTypeAlias(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
   @override
-  visitFunctionTypeAlias(FunctionTypeAlias node) {
+  void visitFunctionTypeAlias(FunctionTypeAlias node) {
     rule.reportLint(node);
   }
 }

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -65,27 +65,28 @@ Iterable<Element> _getParameters(ConstructorDeclaration node) =>
 Element _getRightElement(AssignmentExpression assignment) => DartTypeUtilities
     .getCanonicalElementFromIdentifier(assignment.rightHandSide);
 
-class PreferInitializingFormals extends LintRule {
-  _Visitor _visitor;
+class PreferInitializingFormals extends LintRule implements NodeLintRule {
   PreferInitializingFormals()
       : super(
             name: 'prefer_initializing_formals',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addConstructorDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitConstructorDeclaration(ConstructorDeclaration node) {
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
     final parameters = _getParameters(node);
     final parametersUsedOnce = new Set<Element>();
     final parametersUsedMoreThanOnce = new Set<Element>();

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -29,7 +29,8 @@ and read than concatenation.
 
 ''';
 
-class PreferInterpolationToComposeStrings extends LintRule {
+class PreferInterpolationToComposeStrings extends LintRule
+    implements NodeLintRule {
   PreferInterpolationToComposeStrings()
       : super(
             name: 'prefer_interpolation_to_compose_strings',
@@ -38,17 +39,21 @@ class PreferInterpolationToComposeStrings extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBinaryExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   final skippedNodes = new Set<AstNode>();
 
   _Visitor(this.rule);
 
   @override
-  visitBinaryExpression(BinaryExpression node) {
+  void visitBinaryExpression(BinaryExpression node) {
     if (skippedNodes.contains(node)) {
       return;
     }

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/ast/ast.dart'
     show
         AstNode,
-        AstVisitor,
         PrefixExpression,
         PrefixedIdentifier,
         PropertyAccess,
@@ -41,7 +40,7 @@ if (!sources.isEmpty) {
 
 ''';
 
-class PreferIsNotEmpty extends LintRule {
+class PreferIsNotEmpty extends LintRule implements NodeLintRule {
   PreferIsNotEmpty()
       : super(
             name: 'prefer_is_not_empty',
@@ -50,19 +49,23 @@ class PreferIsNotEmpty extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addSimpleIdentifier(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitSimpleIdentifier(SimpleIdentifier identifier) {
+  void visitSimpleIdentifier(SimpleIdentifier node) {
     AstNode isEmptyAccess;
     SimpleIdentifier isEmptyIdentifier;
 
-    AstNode parent = identifier.parent;
+    AstNode parent = node.parent;
     if (parent is PropertyAccess) {
       isEmptyIdentifier = parent.propertyName;
       isEmptyAccess = parent;

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -25,7 +25,7 @@ iterable.whereType<MyClass>()
 
 ''';
 
-class PreferIterableWhereType extends LintRule {
+class PreferIterableWhereType extends LintRule implements NodeLintRule {
   PreferIterableWhereType()
       : super(
             name: 'prefer_iterable_whereType',
@@ -34,16 +34,19 @@ class PreferIterableWhereType extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodInvocation(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  Visitor(this.rule);
-
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  _Visitor(this.rule);
+
   @override
-  visitMethodInvocation(MethodInvocation node) {
+  void visitMethodInvocation(MethodInvocation node) {
     if (node.methodName.name != 'where') return;
     if (!DartTypeUtilities.implementsInterface(
         node.target.bestType, 'Iterable', 'dart.core')) {

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -55,24 +55,25 @@ class GoodClass {
 
 ''';
 
-class PreferTypingUninitializedVariables extends LintRule {
-  _Visitor _visitor;
-
+class PreferTypingUninitializedVariables extends LintRule
+    implements NodeLintRule {
   PreferTypingUninitializedVariables()
       : super(
             name: 'prefer_typing_uninitialized_variables',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addVariableDeclarationList(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override

--- a/lib/src/rules/pub/package_names.dart
+++ b/lib/src/rules/pub/package_names.dart
@@ -33,7 +33,8 @@ class PubPackageNames extends LintRule {
 }
 
 class Visitor extends PubspecVisitor {
-  LintRule rule;
+  final LintRule rule;
+
   Visitor(this.rule);
 
   @override

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -42,7 +42,7 @@ bool isJavaStyle(Comment comment) {
   return comment.tokens[0].lexeme.startsWith('/**');
 }
 
-class SlashForDocComments extends LintRule {
+class SlashForDocComments extends LintRule implements NodeLintRule {
   SlashForDocComments()
       : super(
             name: 'slash_for_doc_comments',
@@ -51,12 +51,26 @@ class SlashForDocComments extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+    registry.addClassTypeAlias(this, visitor);
+    registry.addConstructorDeclaration(this, visitor);
+    registry.addEnumConstantDeclaration(this, visitor);
+    registry.addEnumDeclaration(this, visitor);
+    registry.addFieldDeclaration(this, visitor);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addFunctionTypeAlias(this, visitor);
+    registry.addLibraryDirective(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
+    registry.addTopLevelVariableDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   checkComment(Comment comment) {
     if (comment != null && isJavaStyle(comment)) {
@@ -65,57 +79,57 @@ class Visitor extends SimpleAstVisitor {
   }
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitClassTypeAlias(ClassTypeAlias node) {
+  void visitClassTypeAlias(ClassTypeAlias node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitConstructorDeclaration(ConstructorDeclaration node) {
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitEnumConstantDeclaration(EnumConstantDeclaration node) {
+  void visitEnumConstantDeclaration(EnumConstantDeclaration node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitEnumDeclaration(EnumDeclaration node) {
+  void visitEnumDeclaration(EnumDeclaration node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitFieldDeclaration(FieldDeclaration node) {
+  void visitFieldDeclaration(FieldDeclaration node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitFunctionDeclaration(FunctionDeclaration node) {
+  void visitFunctionDeclaration(FunctionDeclaration node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitFunctionTypeAlias(FunctionTypeAlias node) {
+  void visitFunctionTypeAlias(FunctionTypeAlias node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitLibraryDirective(LibraryDirective node) {
+  void visitLibraryDirective(LibraryDirective node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     checkComment(node.documentationComment);
   }
 
   @override
-  visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
     checkComment(node.documentationComment);
   }
 }

--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -30,7 +30,7 @@ abstract class Visitor {
 
 ''';
 
-class SortConstructorsFirst extends LintRule {
+class SortConstructorsFirst extends LintRule implements NodeLintRule {
   SortConstructorsFirst()
       : super(
             name: 'sort_constructors_first',
@@ -39,17 +39,21 @@ class SortConstructorsFirst extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration decl) {
+  void visitClassDeclaration(ClassDeclaration node) {
     // Sort members by offset.
-    List<ClassMember> members = decl.members.toList()
+    List<ClassMember> members = node.members.toList()
       ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
 
     bool seenMethod = false;

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -32,7 +32,7 @@ class _PriorityItem {
 
 ''';
 
-class SortUnnamedConstructorsFirst extends LintRule {
+class SortUnnamedConstructorsFirst extends LintRule implements NodeLintRule {
   SortUnnamedConstructorsFirst()
       : super(
             name: 'sort_unnamed_constructors_first',
@@ -41,17 +41,21 @@ class SortUnnamedConstructorsFirst extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration decl) {
+  void visitClassDeclaration(ClassDeclaration node) {
     // Sort members by offset.
-    List<ClassMember> members = decl.members.toList()
+    List<ClassMember> members = node.members.toList()
       ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
 
     bool seenConstructor = false;

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -45,7 +45,7 @@ View(Style style, List children)
 
 ''';
 
-class SuperGoesLast extends LintRule {
+class SuperGoesLast extends LintRule implements NodeLintRule {
   SuperGoesLast()
       : super(
             name: 'super_goes_last',
@@ -54,16 +54,19 @@ class SuperGoesLast extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addConstructorDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
 
-  Visitor(this.rule);
+  _Visitor(this.rule);
 
   @override
-  visitConstructorDeclaration(ConstructorDeclaration node) {
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
     var last = node.initializers.length - 1;
 
     for (int i = 0; i <= last; ++i) {

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -69,7 +69,7 @@ class Bad {
 
 ''';
 
-class TestTypesInEquals extends LintRule {
+class TestTypesInEquals extends LintRule implements NodeLintRule {
   TestTypesInEquals()
       : super(
             name: 'test_types_in_equals',
@@ -78,16 +78,19 @@ class TestTypesInEquals extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addAsExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
 
   @override
-  visitAsExpression(AsExpression node) {
+  void visitAsExpression(AsExpression node) {
     MethodDeclaration declaration =
         node.getAncestor((n) => n is MethodDeclaration);
     if (!_isEqualsOverride(declaration) ||

--- a/lib/src/rules/throw_in_finally.dart
+++ b/lib/src/rules/throw_in_finally.dart
@@ -48,23 +48,22 @@ class BadThrow {
 
 ''';
 
-class ThrowInFinally extends LintRule {
-  _Visitor _visitor;
-
+class ThrowInFinally extends LintRule implements NodeLintRule {
   ThrowInFinally()
       : super(
             name: 'throw_in_finally',
             description: _desc,
             details: _details,
-            group: Group.errors) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addThrowExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor
+class _Visitor extends SimpleAstVisitor<void>
     with ControlFlowInFinallyBlockReporterMixin {
   @override
   final LintRule rule;
@@ -72,7 +71,7 @@ class _Visitor extends SimpleAstVisitor
   _Visitor(this.rule);
 
   @override
-  visitThrowExpression(ThrowExpression node) {
+  void visitThrowExpression(ThrowExpression node) {
     reportIfFinallyAncestorExists(node);
   }
 }

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -35,7 +35,7 @@ class Point {
 
 ''';
 
-class TypeInitFormals extends LintRule {
+class TypeInitFormals extends LintRule implements NodeLintRule {
   TypeInitFormals()
       : super(
             name: 'type_init_formals',
@@ -44,15 +44,19 @@ class TypeInitFormals extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFieldFormalParameter(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitFieldFormalParameter(FieldFormalParameter node) {
+  void visitFieldFormalParameter(FieldFormalParameter node) {
     if (node.type != null) {
       rule.reportLint(node.type);
     }

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -36,7 +36,7 @@ void main() async {
 
 ''';
 
-class UnawaitedFutures extends LintRule {
+class UnawaitedFutures extends LintRule implements NodeLintRule {
   UnawaitedFutures()
       : super(
             name: 'unawaited_futures',
@@ -45,12 +45,16 @@ class UnawaitedFutures extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addExpressionStatement(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
   void visitExpressionStatement(ExpressionStatement node) {

--- a/lib/src/rules/unnecessary_brace_in_string_interps.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interps.dart
@@ -33,7 +33,7 @@ final RegExp identifierPart = new RegExp(r'^[a-zA-Z0-9_]');
 bool isIdentifierPart(Token token) =>
     token is StringToken && token.lexeme.startsWith(identifierPart);
 
-class UnnecessaryBraceInStringInterps extends LintRule {
+class UnnecessaryBraceInStringInterps extends LintRule implements NodeLintRule {
   UnnecessaryBraceInStringInterps()
       : super(
             name: 'unnecessary_brace_in_string_interps',
@@ -42,15 +42,19 @@ class UnnecessaryBraceInStringInterps extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addStringInterpolation(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitStringInterpolation(StringInterpolation node) {
+  void visitStringInterpolation(StringInterpolation node) {
     var expressions = node.elements.where((e) => e is InterpolationExpression);
     for (InterpolationExpression expression in expressions) {
       if (expression.expression is SimpleIdentifier) {

--- a/lib/src/rules/unnecessary_getters.dart
+++ b/lib/src/rules/unnecessary_getters.dart
@@ -39,7 +39,7 @@ class Box {
 
 ''';
 
-class UnnecessaryGetters extends LintRule {
+class UnnecessaryGetters extends LintRule implements NodeLintRule {
   UnnecessaryGetters()
       : super(
             name: 'unnecessary_getters',
@@ -48,15 +48,19 @@ class UnnecessaryGetters extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     Map<String, MethodDeclaration> getters = {};
     Map<String, MethodDeclaration> setters = {};
 

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -49,7 +49,7 @@ class Box {
 
 ''';
 
-class UnnecessaryGettersSetters extends LintRule {
+class UnnecessaryGettersSetters extends LintRule implements NodeLintRule {
   UnnecessaryGettersSetters()
       : super(
             name: 'unnecessary_getters_setters',
@@ -58,15 +58,19 @@ class UnnecessaryGettersSetters extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitClassDeclaration(ClassDeclaration node) {
+  void visitClassDeclaration(ClassDeclaration node) {
     Map<String, MethodDeclaration> getters = {};
     Map<String, MethodDeclaration> setters = {};
 

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -60,24 +60,24 @@ bool _isNonFinalField(AstNode node) =>
         (_isNonFinalElement(node.methodName.bestElement))) ||
     (node is SimpleIdentifier && _isNonFinalElement(node.bestElement));
 
-class UnnecessaryLambdas extends LintRule {
-  _Visitor _visitor;
-
+class UnnecessaryLambdas extends LintRule implements NodeLintRule {
   UnnecessaryLambdas()
       : super(
             name: 'unnecessary_lambdas',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -31,7 +31,7 @@ x ??= null;
 
 ''';
 
-class UnnecessaryNullAwareAssignments extends LintRule {
+class UnnecessaryNullAwareAssignments extends LintRule implements NodeLintRule {
   UnnecessaryNullAwareAssignments()
       : super(
             name: 'unnecessary_null_aware_assignments',
@@ -40,16 +40,19 @@ class UnnecessaryNullAwareAssignments extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addAssignmentExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
 
   @override
-  visitAssignmentExpression(AssignmentExpression node) {
+  void visitAssignmentExpression(AssignmentExpression node) {
     if (node.operator.type == TokenType.QUESTION_QUESTION_EQ &&
         DartTypeUtilities.isNullLiteral(node.rightHandSide)) {
       rule.reportLint(node);

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -30,7 +30,8 @@ var y = null ?? 1;
 
 ''';
 
-class UnnecessaryNullInIfNullOperators extends LintRule {
+class UnnecessaryNullInIfNullOperators extends LintRule
+    implements NodeLintRule {
   UnnecessaryNullInIfNullOperators()
       : super(
             name: 'unnecessary_null_in_if_null_operators',
@@ -39,16 +40,19 @@ class UnnecessaryNullInIfNullOperators extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBinaryExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
 
   @override
-  visitBinaryExpression(BinaryExpression node) {
+  void visitBinaryExpression(BinaryExpression node) {
     if (node.operator.type == TokenType.QUESTION_QUESTION &&
         (DartTypeUtilities.isNullLiteral(node.rightOperand) ||
             DartTypeUtilities.isNullLiteral(node.leftOperand))) {

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -24,7 +24,7 @@ a = (b);
 
 ''';
 
-class UnnecessaryParenthesis extends LintRule {
+class UnnecessaryParenthesis extends LintRule implements NodeLintRule {
   UnnecessaryParenthesis()
       : super(
             name: 'unnecessary_parenthesis',
@@ -33,15 +33,19 @@ class UnnecessaryParenthesis extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addParenthesizedExpression(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
-  LintRule rule;
-  Visitor(this.rule);
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
 
   @override
-  visitParenthesizedExpression(ParenthesizedExpression node) {
+  void visitParenthesizedExpression(ParenthesizedExpression node) {
     if (node.expression is SimpleIdentifier) {
       rule.reportLint(node);
       return;

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -46,7 +46,7 @@ return myvar;
 
 ''';
 
-class UnnecessaryStatements extends LintRule {
+class UnnecessaryStatements extends LintRule implements NodeLintRule {
   UnnecessaryStatements()
       : super(
             name: 'unnecessary_statements',
@@ -55,16 +55,29 @@ class UnnecessaryStatements extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() =>
-      new _Visitor(new _ReportNoClearEffectVisitor(this));
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(new _ReportNoClearEffectVisitor(this));
+    registry.addExpressionStatement(this, visitor);
+    registry.addForStatement(this, visitor);
+    registry.addCascadeExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final _ReportNoClearEffectVisitor reportNoClearEffect;
+
   _Visitor(this.reportNoClearEffect);
+  @override
+  void visitCascadeExpression(CascadeExpression node) {
+    for (var section in node.cascadeSections) {
+      if (section is PropertyAccess && section.bestType is FunctionType) {
+        reportNoClearEffect.rule.reportLint(section);
+      }
+    }
+  }
 
   @override
-  visitExpressionStatement(ExpressionStatement node) {
+  void visitExpressionStatement(ExpressionStatement node) {
     if (node.parent is FunctionBody) {
       return;
     }
@@ -72,41 +85,18 @@ class _Visitor extends SimpleAstVisitor {
   }
 
   @override
-  visitForStatement(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     node.initialization?.accept(reportNoClearEffect);
     node.updaters?.forEach((u) {
       u.accept(reportNoClearEffect);
     });
   }
-
-  @override
-  visitCascadeExpression(CascadeExpression node) {
-    for (var section in node.cascadeSections) {
-      if (section is PropertyAccess && section.bestType is FunctionType) {
-        reportNoClearEffect.rule.reportLint(section);
-      }
-    }
-  }
 }
 
 class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
   final LintRule rule;
+
   _ReportNoClearEffectVisitor(this.rule);
-
-  @override
-  visitMethodInvocation(MethodInvocation node) {
-    // Has a clear effect
-  }
-
-  @override
-  visitSuperConstructorInvocation(SuperConstructorInvocation node) {
-    // Has a clear effect
-  }
-
-  @override
-  visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
-    // Has a clear effect
-  }
 
   @override
   visitAssignmentExpression(AssignmentExpression node) {
@@ -119,8 +109,50 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
   }
 
   @override
+  visitBinaryExpression(BinaryExpression node) {
+    switch (node.operator.lexeme) {
+      case '??':
+      case '||':
+      case '&&':
+        // these are OK when used for control flow
+        node.rightOperand.accept(this);
+        return;
+    }
+
+    super.visitBinaryExpression(node);
+  }
+
+  @override
   visitCascadeExpression(CascadeExpression node) {
     // Has a clear effect
+  }
+
+  @override
+  visitConditionalExpression(ConditionalExpression node) {
+    node.thenExpression.accept(this);
+    node.elseExpression.accept(this);
+  }
+
+  @override
+  visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitInstanceCreationExpression(InstanceCreationExpression node) {
+    // A few APIs use this for side effects, like Timer. Also, for constructors
+    // that have side effects, they should have tests. Those tests will often
+    // include an instantiation expression statement with nothing else.
+  }
+
+  @override
+  visitMethodInvocation(MethodInvocation node) {
+    // Has a clear effect
+  }
+
+  @override
+  visitNode(AstNode expression) {
+    rule.reportLint(expression);
   }
 
   @override
@@ -143,39 +175,12 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
   }
 
   @override
-  visitThrowExpression(ThrowExpression node) {
+  visitSuperConstructorInvocation(SuperConstructorInvocation node) {
     // Has a clear effect
   }
 
   @override
-  visitInstanceCreationExpression(InstanceCreationExpression node) {
-    // A few APIs use this for side effects, like Timer. Also, for constructors
-    // that have side effects, they should have tests. Those tests will often
-    // include an instantiation expression statement with nothing else.
-  }
-
-  @override
-  visitConditionalExpression(ConditionalExpression node) {
-    node.thenExpression.accept(this);
-    node.elseExpression.accept(this);
-  }
-
-  @override
-  visitBinaryExpression(BinaryExpression node) {
-    switch (node.operator.lexeme) {
-      case '??':
-      case '||':
-      case '&&':
-        // these are OK when used for control flow
-        node.rightOperand.accept(this);
-        return;
-    }
-
-    super.visitBinaryExpression(node);
-  }
-
-  @override
-  visitNode(AstNode expression) {
-    rule.reportLint(expression);
+  visitThrowExpression(ThrowExpression node) {
+    // Has a clear effect
   }
 }

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -51,19 +51,19 @@ class Box {
 
 ''';
 
-class UnnecessaryThis extends LintRule {
-  _Visitor _visitor;
+class UnnecessaryThis extends LintRule implements NodeLintRule {
   UnnecessaryThis()
       : super(
             name: 'unnecessary_this',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    var visitor = new _Visitor(this);
+    registry.addCompilationUnit(this, visitor);
+  }
 }
 
 class _UnnecessaryThisVisitor extends ScopedVisitor {
@@ -103,12 +103,13 @@ class _UnnecessaryThisVisitor extends ScopedVisitor {
   }
 }
 
-class _Visitor extends SimpleAstVisitor {
-  LintRule rule;
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitCompilationUnit(CompilationUnit node) {
+  void visitCompilationUnit(CompilationUnit node) {
     new _UnnecessaryThisVisitor(rule, node).visitCompilationUnit(node);
   }
 }

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -132,23 +132,22 @@ bool _hasNonComparableOperands(BinaryExpression node) =>
     DartTypeUtilities.unrelatedTypes(
         node.leftOperand.bestType, node.rightOperand.bestType);
 
-class UnrelatedTypeEqualityChecks extends LintRule {
-  _Visitor _visitor;
-
+class UnrelatedTypeEqualityChecks extends LintRule implements NodeLintRule {
   UnrelatedTypeEqualityChecks()
       : super(
             name: 'unrelated_type_equality_checks',
             description: _desc,
             details: _details,
-            group: Group.errors) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addBinaryExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   static const String _dartCoreLibraryName = 'dart.core';
   static const String _boolClassName = 'bool';
 

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -38,27 +38,28 @@ try {
 
 ''';
 
-class UseRethrowWhenPossible extends LintRule {
-  _Visitor _visitor;
+class UseRethrowWhenPossible extends LintRule implements NodeLintRule {
   UseRethrowWhenPossible()
       : super(
             name: 'use_rethrow_when_possible',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addThrowExpression(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitThrowExpression(ThrowExpression node) {
+  void visitThrowExpression(ThrowExpression node) {
     final element =
         DartTypeUtilities.getCanonicalElementFromIdentifier(node.expression);
     if (element != null) {

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -32,27 +32,28 @@ button.visible = false;
 bool _hasInheritedMethod(MethodDeclaration node) =>
     DartTypeUtilities.lookUpInheritedMethod(node) != null;
 
-class UseSettersToChangeAProperty extends LintRule {
-  _Visitor _visitor;
+class UseSettersToChangeAProperty extends LintRule implements NodeLintRule {
   UseSettersToChangeAProperty()
       : super(
             name: 'use_setters_to_change_properties',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     if (node.isSetter ||
         node.isGetter ||
         _hasInheritedMethod(node) ||

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -55,27 +55,28 @@ bool _beginsWithAsOrTo(String name) {
 bool _isVoid(TypeName returnType) =>
     returnType != null && returnType.name.name == 'void';
 
-class UseToAndAsIfApplicable extends LintRule {
-  _Visitor _visitor;
+class UseToAndAsIfApplicable extends LintRule implements NodeLintRule {
   UseToAndAsIfApplicable()
       : super(
             name: 'use_to_and_as_if_applicable',
             description: _desc,
             details: _details,
-            group: Group.style) {
-    _visitor = new _Visitor(this);
-  }
+            group: Group.style);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addMethodDeclaration(this, visitor);
+  }
 }
 
-class _Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override
-  visitMethodDeclaration(MethodDeclaration node) {
+  void visitMethodDeclaration(MethodDeclaration node) {
     if (!node.isGetter &&
         node.parameters.parameters.isEmpty &&
         !_isVoid(node.returnType) &&

--- a/lib/src/rules/valid_regexps.dart
+++ b/lib/src/rules/valid_regexps.dart
@@ -30,7 +30,7 @@ print(new RegExp('[(]').hasMatch('foo()'));
 
 ''';
 
-class ValidRegExps extends LintRule {
+class ValidRegExps extends LintRule implements NodeLintRule {
   ValidRegExps()
       : super(
             name: 'valid_regexps',
@@ -39,15 +39,19 @@ class ValidRegExps extends LintRule {
             group: Group.errors);
 
   @override
-  AstVisitor getVisitor() => new Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addInstanceCreationExpression(this, visitor);
+  }
 }
 
-class Visitor extends SimpleAstVisitor {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  Visitor(this.rule);
+
+  _Visitor(this.rule);
 
   @override
-  visitInstanceCreationExpression(InstanceCreationExpression node) {
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
     ClassElement element = resolutionMap
         .staticElementForConstructorReference(node)
         ?.enclosingElement;

--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -171,7 +171,7 @@ typedef _Predicate _PredicateBuilder(VariableDeclaration v);
 
 typedef void _VisitVariableDeclaration(VariableDeclaration node);
 
-abstract class LeakDetectorVisitor extends SimpleAstVisitor {
+abstract class LeakDetectorProcessors extends SimpleAstVisitor<void> {
   static final _variablePredicateBuilders = <_PredicateBuilder>[_hasReturn];
   static final _fieldPredicateBuilders = <_PredicateBuilder>[
     _hasConstructorFieldInitializers,
@@ -180,7 +180,7 @@ abstract class LeakDetectorVisitor extends SimpleAstVisitor {
 
   final LintRule rule;
 
-  LeakDetectorVisitor(this.rule);
+  LeakDetectorProcessors(this.rule);
 
   @protected
   Map<DartTypePredicate, String> get predicates;

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -58,16 +58,18 @@ bool _isParameterizedMethodInvocation(
 
 typedef bool _InterfaceTypePredicate(InterfaceType type);
 
-/// Base class for visitors used in rules where we want to lint about invoking
+/// Base class for visitor used in rules where we want to lint about invoking
 /// methods on generic classes where the parameter is unrelated to the parameter
 /// type of the class. Extending this visitor is as simple as knowing the method,
 /// class and library that uniquely define the target, i.e. implement only
 /// [definition] and [methodName].
-abstract class UnrelatedTypesVisitor extends SimpleAstVisitor {
+abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
   final LintRule rule;
-  UnrelatedTypesVisitor(this.rule);
+
+  UnrelatedTypesProcessors(this.rule);
 
   InterfaceTypeDefinition get definition;
+
   String get methodName;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/linter
 environment:
   sdk: '>=2.0.0-dev <2.0.0'
 dependencies:
-  analyzer: ^0.31.2-alpha.0
+  analyzer: ^0.31.2-alpha.2
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -93,6 +93,7 @@ void updateRuleRegistry(String ruleName) {
   print('  pub run test -N $ruleName');
 }
 
+/// TODO(scheglov) Update to implement NodeLintRule, _Visitor, etc.
 String _generateClass(String ruleName, String className) => """
 // Copyright (c) $_thisYear, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a


### PR DESCRIPTION
See [the corresponding analyzer change](https://dart-review.googlesource.com/c/sdk/+/52644) for numbers of performance improvements.

Note, that `_Processors` extend `SimpleAstVisitor`, but we do not pass it anywhere as a visitor. Instead we pass references to separate methods.  But by extending and specifying `@override` we get consistency between visitors and processors.