### PR TITLE
Rewrite collecting mutated fields in 'prefer_final_fields' to use AST visitor.

### DIFF
--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -134,24 +134,21 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    var variables = fields.variables;
-    for (int i = 0; i < variables.length; i++) {
-      final variable = variables[i];
+    fields.variables.forEach((VariableDeclaration variable) {
       final element = variable.element;
-
       if (!element.isPrivate) {
-        continue;
+        return;
       }
 
       if (variable.initializer == null) {
-        continue;
+        return;
       }
 
       if (_mutatedFields.contains(element)) {
-        continue;
+        return;
       }
 
       rule.reportLint(variable);
-    }
+    });
   }
 }


### PR DESCRIPTION
This makes this lint use about `750 ms` vs. `4500 ms` it used to use during analyzing Flutter repo, i.e. 6 times faster.

But using AST visitor is not really cheap itself, it just better than what was used before. For comparison, if we don't run this visitor at all, the lint uses just `51 ms`. The way to avoid running the whole new visitor is to repeat what we did with lints - run a single AST visitor and let all lints to participate in pre-preprocessing CompilationUnit before running lints generation. More complexity, yes, but faster.