### PR TITLE
0.1.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.50
+
+* migration of rules to use analyzer package `NodeLintRule` and `UnitLintRule` yielding significant performance gains all around
+* specific performance improvements for `prefer_final_fields` (~6x)
+* addressed no such method calls in `void_checks`
+* improved lint reporting for various lints
+
 # 0.1.49
 
 * new `void_checks` lint

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.49
+version: 0.1.50
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.50

* migration of rules to use analyzer package `NodeLintRule` and `UnitLintRule` yielding significant performance gains all around
* specific performance improvements for `prefer_final_fields` (~6x)
* addressed no such method calls in `void_checks`
* improved lint reporting for various lints

@scheglov @bwilkerson 

FYI @a14n 