### PR TITLE
Add special cases for fixnum to unrelated_type_equality_checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.51-dev
+
+* unrelated_type_equality_checks now allows comparison between `Int64` or `Int32` and `int`
+
 # 0.1.50
 
 * migration of rules to use analyzer package `NodeLintRule` and `UnitLintRule` yielding significant performance gains all around

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -147,7 +147,7 @@ bool _hasNonComparableOperands(BinaryExpression node) {
   return !DartTypeUtilities.isNullLiteral(left) &&
       !DartTypeUtilities.isNullLiteral(right) &&
       DartTypeUtilities.unrelatedTypes(leftType, rightType) &&
-      (!_isCoreInt(rightType) || !_isFixNumIntX(leftType));
+      !(_isFixNumIntX(leftType) && _isCoreInt(rightType));
 }
 
 class UnrelatedTypeEqualityChecks extends LintRule implements NodeLintRule {

--- a/test/rules/unrelated_type_equality_checks.dart
+++ b/test/rules/unrelated_type_equality_checks.dart
@@ -4,6 +4,8 @@
 
 // test w/ `pub run test -N unrelated_type_equality_checks`
 
+import '../util/fake_fixnum.dart';
+
 void someFunction() {
   var x = '1';
   if (x == 1) print('someFunction'); // LINT
@@ -94,6 +96,30 @@ void someFunction14(DerivedClass4 instance) {
   var other = new DerivedClass5();
 
   if (other == instance) print('someFunction15'); // LINT
+}
+
+void someFunction15() {
+  var x = new Int32();
+
+  if (x == 0) print('someFunction15'); // OK
+}
+
+void someFunction16() {
+  var x = new Int32();
+
+  if (0 == x) print('someFunction16'); // LINT
+}
+
+void someFunction17() {
+  var x = new Int64();
+
+  if (x == 0) print('someFunction17'); // OK
+}
+
+void someFunction18() {
+  var x = new Int64();
+
+  if (0 == x) print('someFunction18'); // LINT
 }
 
 class ClassBase {}

--- a/test/util/fake_fixnum.dart
+++ b/test/util/fake_fixnum.dart
@@ -1,0 +1,5 @@
+library fixnum;
+
+class Int32 {}
+
+class Int64 {}


### PR DESCRIPTION
This suggestion for the unrelated_type_equality_checks lint follows analysis of a large body of Dart code; 80% of the failures for this lint were false positives related to `Int64` or `Int32`, the most common form by far being a check for whether an `Int64` value `== 0`.

The remaining 20% of failures were almost all useful, so with this tweak the lint has a very low false positive rate.