### PR TITLE
0.1.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.1.51-dev
+# 0.1.51
 
-* unrelated_type_equality_checks now allows comparison between `Int64` or `Int32` and `int`
+* `unrelated_type_equality_checks` now allows comparison between `Int64` or `Int32` and `int`
+* `unnecessary_parenthesis` improved to handle cascades _in_ cascades
 
 # 0.1.50
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.50
+version: 0.1.51
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.51

* `unrelated_type_equality_checks` now allows comparison between `Int64` or `Int32` and `int`
* `unnecessary_parenthesis` improved to handle cascades _in_ cascades

/cc @bwilkerson @a14n 

FYI: @davidmorgan 