### PR TITLE
Merge version 0.1.51 back into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.1.51-dev
+# 0.1.51
 
-* unrelated_type_equality_checks now allows comparison between `Int64` or `Int32` and `int`
+* `unrelated_type_equality_checks` now allows comparison between `Int64` or `Int32` and `int`
+* `unnecessary_parenthesis` improved to handle cascades _in_ cascades
 
 # 0.1.50
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.50
+version: 0.1.51
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
The only differences between master and this branched version was updates to the changelog and the pubspec.yaml.

It seems to me that the fork of 0.1.51 into a separate branch was unintentional, just because the commit with title 0.1.51 was missing the changelog and pubspec changes.  Feel free to revert this merge's effect on the tree if it isn't desired.

# 0.1.51

* `unrelated_type_equality_checks` now allows comparison between `Int64` or `Int32` and `int`
* `unnecessary_parenthesis` improved to handle cascades _in_ cascades