### PR TITLE
Fix void_checks when argument is not resolved to a parameter.

### DIFF
--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -140,10 +140,13 @@ class _Visitor extends SimpleAstVisitor<void> {
   void _checkArgs(
       NodeList<Expression> args, List<ParameterElement> parameters) {
     for (final arg in args) {
-      final type = arg.bestParameterElement.type;
-      final expression = arg is NamedExpression ? arg.expression : arg;
-      if (!_isFunctionRef(type, expression)) {
-        _check(type, expression?.bestType, expression);
+      final parameterElement = arg.bestParameterElement;
+      if (parameterElement != null) {
+        final type = parameterElement.type;
+        final expression = arg is NamedExpression ? arg.expression : arg;
+        if (!_isFunctionRef(type, expression)) {
+          _check(type, expression?.bestType, expression);
+        }
       }
     }
   }

--- a/test/rules/void_checks.dart
+++ b/test/rules/void_checks.dart
@@ -176,3 +176,8 @@ allow_expression_fonction_body() {
   f = () => i; // OK
   f = () => i++; // OK
 }
+
+missing_parameter_for_argument() {
+  void foo() {}
+  foo(0);
+}


### PR DESCRIPTION
This was breaking at:
```dart
void main() {
  void foo() {}
  foo(0);
}
```