### PR TITLE
add lint import_prefix_names

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -48,6 +48,7 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
+    - import_prefix_names
     - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -49,6 +49,7 @@ import 'package:linter/src/rules/empty_constructor_bodies.dart';
 import 'package:linter/src/rules/empty_statements.dart';
 import 'package:linter/src/rules/hash_and_equals.dart';
 import 'package:linter/src/rules/implementation_imports.dart';
+import 'package:linter/src/rules/import_prefix_names.dart';
 import 'package:linter/src/rules/invariant_booleans.dart';
 import 'package:linter/src/rules/iterable_contains_unrelated_type.dart';
 import 'package:linter/src/rules/join_return_with_assignment.dart';
@@ -168,6 +169,7 @@ void registerLintRules() {
     ..register(new EmptyStatements())
     ..register(new HashAndEquals())
     ..register(new ImplementationImports())
+    ..registerDefault(new ImportPrefixNames())
     ..register(new InvariantBooleans())
     ..register(new IterableContainsUnrelatedType())
     ..register(new JoinReturnWithAssignment())

--- a/lib/src/rules/import_prefix_names.dart
+++ b/lib/src/rules/import_prefix_names.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/utils.dart';
+
+const _desc = r'DO name import prefixes using lowercase_with_underscores.';
+
+const _details = r'''
+**DO** name import prefixes using lowercase_with_underscores.
+
+**BAD:**
+```
+import 'dart:math' as Math;
+import 'package:angular_components/angular_components'
+    as angularComponents;
+import 'package:js/js.dart' as JS;
+```
+
+**GOOD:**
+```
+import 'dart:math' as math;
+import 'package:angular_components/angular_components'
+    as angular_components;
+import 'package:js/js.dart' as js;
+```
+''';
+
+class ImportPrefixNames extends LintRule implements NodeLintRule {
+  ImportPrefixNames()
+      : super(
+            name: 'import_prefix_names',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addImportDirective(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  visitImportDirective(ImportDirective node) {
+    if (node.prefix != null && !isLowerCaseUnderScore(node.prefix.toString())) {
+      rule.reportLint(node.prefix);
+    }
+  }
+}

--- a/test/rules/import_prefix_names.dart
+++ b/test/rules/import_prefix_names.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N import_prefix_names`
+
+import 'dart:io' as IO; // LINT
+import 'dart:io' as io; // OK
+import 'dart:io' as IO_io; // LINT
+import 'dart:io' as io_io; // OK


### PR DESCRIPTION
https://www.dartlang.org/guides/language/effective-dart/style#do-name-import-prefixes-using-lowercase_with_underscores