### PR TITLE
Enable `previewDart2` everywhere.

### DIFF
--- a/bin/linter.dart
+++ b/bin/linter.dart
@@ -17,7 +17,7 @@ import 'package:linter/src/formatter.dart';
 import 'package:linter/src/rules.dart';
 
 Future main(List<String> args) async {
-  await runLinter(args, new LinterOptions());
+  await runLinter(args, new LinterOptions()..previewDart2 = true);
 }
 
 const processFileFailedExitCode = 65;

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -112,8 +112,8 @@ void defineLinterEngineTests() {
     group('lint driver', () {
       test('pubspec', () {
         bool visited;
-        var options =
-            new LinterOptions([new MockLinter((n) => visited = true)]);
+        var options = new LinterOptions([new MockLinter((n) => visited = true)])
+          ..previewDart2 = true;
         new SourceLinter(options).lintPubspecSource(contents: 'name: foo_bar');
         expect(visited, isTrue);
       });

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -84,7 +84,7 @@ defineTests() {
             new File('test/_data/p4/_packages').absolute.path;
         await dartlint.runLinter(
             ['--packages', packagesFilePath, 'test/_data/p4'],
-            new LinterOptions([]));
+            new LinterOptions([])..previewDart2 = true);
         expect(collectingOut.trim(),
             startsWith('3 files analyzed, 0 issues found, in'));
       });
@@ -434,7 +434,7 @@ defineTests() {
         await dartlint.runLinter([
           'test/_data/always_require_non_null_named_parameters',
           '--rules=always_require_non_null_named_parameters'
-        ], new LinterOptions());
+        ], new LinterOptions()..previewDart2 = true);
         expect(exitCode, 1);
         expect(
             collectingOut.trim(),
@@ -460,7 +460,7 @@ defineTests() {
         await dartlint.runLinter([
           'test/_data/prefer_asserts_in_initializer_lists',
           '--rules=prefer_asserts_in_initializer_lists'
-        ], new LinterOptions());
+        ], new LinterOptions()..previewDart2 = true);
         expect(exitCode, 1);
         expect(
             collectingOut.trim(),
@@ -486,7 +486,7 @@ defineTests() {
         await dartlint.runLinter([
           'test/_data/prefer_const_constructors_in_immutables',
           '--rules=prefer_const_constructors_in_immutables'
-        ], new LinterOptions());
+        ], new LinterOptions()..previewDart2 = true);
         expect(exitCode, 1);
         expect(
             collectingOut.trim(),
@@ -514,7 +514,7 @@ defineTests() {
           '--rules=avoid_relative_lib_imports',
           '--packages',
           'test/_data/avoid_relative_lib_imports/_packages'
-        ], new LinterOptions());
+        ], new LinterOptions()..previewDart2 = true);
         expect(exitCode, 1);
         expect(
             collectingOut.trim(),

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -334,6 +334,7 @@ testRule(String ruleName, File file, {bool debug: false}) {
     }
 
     LinterOptions options = new LinterOptions([rule])
+      ..previewDart2 = true
       ..mockSdk = new MockSdk(memoryResourceProvider)
       ..resourceProvider = resourceProvider
       ..packageConfigPath = packageConfigPath;


### PR DESCRIPTION
We're in a funny state where some tests enable `previewDart2` while others don't.  This flips the bit everywhere.  (Soon enough this will be on by default and we can remove all of these explicit settings.)

Note that this introduces a break in `prefer_const_constructors`, which I think is right; see also: #1035.

/cc @bwilkerson @a14n 