### PR TITLE
0.1.56 🎆 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.56
+
+* fix to `avoid_positional_boolean_parameters` to ignore overridden methods
+* fix to `prefer_is_empty` to not evaluate constants beyond int literals
+* new lint: `null_closures`
+* new lint: `lines_longer_than_80_chars`
+
 # 0.1.55
 
 * fixed an issue in `const` error handling

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.55
+version: 0.1.56
 author: Dart Team <misc@dartlang.org>
 description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter


### PR DESCRIPTION
# 0.1.56

* fix to `avoid_positional_boolean_parameters` to ignore overridden methods
* fix to `prefer_is_empty` to not evaluate constants beyond int literals
* new lint: `null_closures`
* new lint: `lines_longer_than_80_chars`

/cc @bwilkerson @srawlins @a14n @davidmorgan 