### PR TITLE
Prevent an NPE when dealing with incomplete/invalid code

### DIFF
--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -142,7 +142,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitSimpleFormalParameter(SimpleFormalParameter param) {
-    if (param.type == null && !isJustUnderscores(param.identifier.name)) {
+    if (param.type == null &&
+        param.identifier != null &&
+        !isJustUnderscores(param.identifier.name)) {
       if (param.keyword != null) {
         rule.reportLintForToken(param.keyword);
       } else {

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -59,8 +59,8 @@ String get enumerateErrorRules => rules
     .join('\n\n');
 
 String get enumerateGroups => Group.builtin
-    .map((Group g) => '<li><strong>${g
-        .name}</strong> - ${markdownToHtml(g.description)}</li>')
+    .map((Group g) =>
+        '<li><strong>${g.name}</strong> - ${markdownToHtml(g.description)}</li>')
     .join('\n');
 
 String get enumeratePubRules => rules
@@ -120,8 +120,7 @@ String qualify(LintRule r) =>
     (r.maturity == Maturity.stable ? '' : ' (${r.maturity.name})');
 
 String toDescription(LintRule r) =>
-    '<strong><a href = "${r.name}.html">${qualify(
-        r)}</a></strong><br/>${markdownToHtml(r.description)}';
+    '<strong><a href = "${r.name}.html">${qualify(r)}</a></strong><br/>${markdownToHtml(r.description)}';
 
 class Generator {
   LintRule rule;


### PR DESCRIPTION
This also formats and sorts a couple of unrelated files. The only substantive change is in `lib/src/rules/always_specify_types.dart`.