### PR TITLE
0.1.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.58
+
+* roll-back to explicit uses of `new` and `const` to be compatible w/ VMs running `--no-preview-dart-2`
+
 # 0.1.57
 
 * fix to `lines_longer_than_80_chars` to handle CRLF endings

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.57
+version: 0.1.58
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.58

* roll-back to explicit uses of `new` and `const` to be compatible w/ VMs running `--no-preview-dart-2`

/cc @bwilkerson 

FYI @a14n @devoncarew 