### PR TITLE
Add Effective Dart analysis options list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ you could lint your package like this:
 
     $ dartanalyzer --options analysis_options.yaml .
     
-and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose the rules you want to enable for your package, we have provided a [complete list of rules][lints], a list of the [lints according to Effective Dart][effective-dart-lints] and a list of the [lints that are enforced internally at Google][google-lints].
+and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose the rules you want to enable for your package, we have provided a [complete list of rules][lints], an up-to-date list of the [lints according to the Effective Dart guide][effective-dart-lints] and a list of the [lints that are enforced internally at Google][google-lints].
 
 If a specific lint warning should be ignored, it can be flagged with a comment.  For example, 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ you could lint your package like this:
 
     $ dartanalyzer --options analysis_options.yaml .
     
-and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose the rules you want to enable for your package, we have provided both a [complete list of rules][lints] and a list of the [lints that are enforced internally at Google][google-lints].
+and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose the rules you want to enable for your package, we have provided a [complete list of rules][lints], a list of the [lints according to Effective Dart][effective-dart-lints] and a list of the [lints that are enforced internally at Google][google-lints].
 
 If a specific lint warning should be ignored, it can be flagged with a comment.  For example, 
 
@@ -66,5 +66,6 @@ Please file feature requests and bugs at the [issue tracker][tracker].
 [tracker]: https://github.com/dart-lang/linter/issues
 [lints]: http://dart-lang.github.io/linter/lints/
 [google-lints]: /example/google.yaml
+[effective-dart-lints]: /example/effective-dart.yaml
 [options_file]: https://www.dartlang.org/guides/language/analysis-options#the-analysis-options-file
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ you could lint your package like this:
 
     $ dartanalyzer --options analysis_options.yaml .
     
-and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose the rules you want to enable for your package, we have provided a [complete list of rules][lints], an up-to-date list of the [lints according to the Effective Dart guide][effective-dart-lints] and a list of the [lints that are enforced internally at Google][google-lints].
+and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose the rules you want to enable for your package, we have provided a [complete list of rules][lints], a growing list of [lints according to the Effective Dart guide][effective-dart-lints] and a list of the [lints that are enforced internally at Google][google-lints].
 
 If a specific lint warning should be ignored, it can be flagged with a comment.  For example, 
 

--- a/example/effective-dart.yaml
+++ b/example/effective-dart.yaml
@@ -2,10 +2,10 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 #
-# List of rules following the Effective Dart guide.
+# A living list of rules following the Effective Dart guide.
 # https://www.dartlang.org/guides/language/effective-dart
 #
-# This is a living document that will evolve over time according to the guide.
+# Note: not everything suggested in the guide has a rule associated with it.
 
 linter:
   rules:

--- a/example/effective-dart.yaml
+++ b/example/effective-dart.yaml
@@ -1,5 +1,11 @@
+# Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+#
 # List of rules following the Effective Dart guide.
 # https://www.dartlang.org/guides/language/effective-dart
+#
+# This is a living document that will evolve over time according to the guide.
 
 linter:
   rules:

--- a/example/effective-dart.yaml
+++ b/example/effective-dart.yaml
@@ -1,0 +1,160 @@
+# List of rules following the Effective Dart guide.
+# https://www.dartlang.org/guides/language/effective-dart
+
+linter:
+  rules:
+  # --- STYLE
+  # identifiers
+    - camel_case_types
+    - library_names
+    - file_names
+    - library_prefixes
+    - non_constant_identifier_names
+    - constant_identifier_names # prefer
+  # ordering
+    - directives_ordering
+  # formating
+    - lines_longer_than_80_chars # avoid
+    - curly_braces_in_flow_control_structures
+  # --- DOCUMENTATION
+  # comments
+  # doc comments
+    - slash_for_doc_comments
+    - package_api_docs # prefer
+    - comment_references
+  # markdown
+  # writing
+  # --- USAGE
+  # libraries
+    - implementation_imports
+    - avoid_relative_lib_imports
+  # strings
+    - prefer_adjacent_string_concatenation
+    - prefer_interpolation_to_compose_strings # prefer
+    - unnecessary_brace_in_string_interps # avoid
+  # collections
+    - prefer_collection_literals
+    - avoid_function_literals_in_foreach_calls # avoid
+    - prefer_iterable_whereType
+  # functions
+    - prefer_function_declarations_over_variables
+    - unnecessary_lambdas
+  # parameters
+    - prefer_equal_for_default_values
+  # variables
+    - avoid_init_to_null
+  # members
+    - unnecessary_getters_setters
+    - prefer_final_fields
+    #- prefer_expression_function_bodies # consider
+    - unnecessary_this
+    - prefer_typing_uninitialized_variables
+  # constructors
+    - prefer_initializing_formals
+    - type_init_formals
+    - empty_constructor_bodies
+    - unnecessary_new
+    - unnecessary_const
+  # error handling
+    - avoid_catches_without_on_clauses # avoid
+    - use_rethrow_when_possible
+  # asynchrony
+  # --- DESIGN
+  # names
+    - use_to_and_as_if_applicable
+  # libraries
+  # classes
+    - one_member_abstracts # avoid
+    - avoid_classes_with_only_static_members # avoid
+    - public_member_api_docs
+  # constructors
+    - prefer_constructors_over_static_methods
+  # members
+    - use_setters_to_change_properties
+    - avoid_setters_without_getters
+    - avoid_returning_null # avoid
+    - avoid_returning_this # avoid
+  # types
+    - type_annotate_public_apis # prefer
+    - omit_local_variable_types # avoid
+    - avoid_types_on_closure_parameters # avoid
+    - avoid_return_types_on_setters
+    - prefer_generic_function_type_aliases
+    - avoid_private_typedef_functions # prefer
+  # parameters
+    - avoid_positional_boolean_parameters # avoid
+  # equality
+    - hash_and_equals
+    - avoid_null_checks_in_equality_operators
+
+# Rules that are not used:
+#
+#    - always_declare_return_types
+#    - always_put_control_body_on_new_line
+#    - always_put_required_named_parameters_first
+#    - always_require_non_null_named_parameters
+#    - always_specify_types
+#    - annotate_overrides
+#    - avoid_annotating_with_dynamic
+#    - avoid_as
+#    - avoid_bool_literals_in_conditional_expressions
+#    - avoid_catching_errors
+#    - avoid_double_and_int_checks
+#    - avoid_empty_else
+#    - avoid_field_initializers_in_const_classes
+#    - avoid_js_rounded_ints
+#    - avoid_renaming_method_parameters
+#    - avoid_single_cascade_in_expression_statements
+#    - avoid_slow_async_io
+#    - avoid_types_as_parameter_names
+#    - avoid_unused_constructor_parameters
+#    - await_only_futures
+#    - cancel_subscriptions
+#    - cascade_invocations
+#    - close_sinks
+#    - control_flow_in_finally
+#    - empty_catches
+#    - empty_statements
+#    - invariant_booleans
+#    - iterable_contains_unrelated_type
+#    - join_return_with_assignment
+#    - list_remove_unrelated_type
+#    - literal_only_boolean_expressions
+#    - no_adjacent_strings_in_list
+#    - no_duplicate_case_values
+#    - null_closures
+#    - only_throw_errors
+#    - overridden_fields
+#    - package_names
+#    - package_prefixed_library_names
+#    - parameter_assignments
+#    - prefer_asserts_in_initializer_lists
+#    - prefer_bool_in_asserts
+#    - prefer_conditional_assignment
+#    - prefer_const_constructors
+#    - prefer_const_constructors_in_immutables
+#    - prefer_const_declarations
+#    - prefer_const_literals_to_create_immutables
+#    - prefer_contains
+#    - prefer_expression_function_bodies
+#    - prefer_final_locals
+#    - prefer_foreach
+#    - prefer_is_empty
+#    - prefer_is_not_empty
+#    - prefer_single_quotes
+#    - recursive_getters
+#    - sort_constructors_first
+#    - sort_unnamed_constructors_first
+#    - super_goes_last
+#    - test_types_in_equals
+#    - throw_in_finally
+#    - unawaited_futures
+#    - unnecessary_null_aware_assignments
+#    - unnecessary_null_in_if_null_operators
+#    - unnecessary_overrides
+#    - unnecessary_parenthesis
+#    - unnecessary_statements
+#    - unrelated_type_equality_checks
+#    - use_string_buffers
+#    - valid_regexps
+#    - void_checks


### PR DESCRIPTION
As is described in #288, I have tried to set a list of options describing Effective Dart analysis options. I have also included (in comments) unuses options so it will be simplier to see what can be added / what is missing.

All rules are sorted in sections and subsections according to Effective Dart, so it will be easier to sync the rules in time.