### PR TITLE
Relax void checks: allow T Function() to be assigned to void Function().

### DIFF
--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -132,8 +132,6 @@ class _Visitor extends SimpleAstVisitor<void> {
             !type.isAssignableTo(_futureDynamicType) &&
             !type.isAssignableTo(_futureOrDynamicType)) {
       rule.reportLint(node);
-    } else if (expectedType is FunctionType && type is FunctionType) {
-      _check(expectedType.returnType, type.returnType, node);
     }
   }
 

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -71,9 +71,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
     final type = node.leftHandSide?.bestType;
-    if (!_isFunctionRef(type, node.rightHandSide)) {
-      _check(type, node.rightHandSide?.bestType, node);
-    }
+    _check(type, node.rightHandSide?.bestType, node,
+        checkedNode: node.rightHandSide);
   }
 
   @override
@@ -113,16 +112,21 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (parent is FunctionExpression) {
       final type = parent.bestType;
       if (type is FunctionType) {
-        _check(type.returnType, node.expression?.bestType, node);
+        _check(type.returnType, node.expression?.bestType, node,
+            checkedNode: node.expression);
       }
     } else if (parent is MethodDeclaration) {
-      _check(parent.element.returnType, node.expression?.bestType, node);
+      _check(parent.element.returnType, node.expression?.bestType, node,
+          checkedNode: node.expression);
     } else if (parent is FunctionDeclaration) {
-      _check(parent.element.returnType, node.expression?.bestType, node);
+      _check(parent.element.returnType, node.expression?.bestType, node,
+          checkedNode: node.expression);
     }
   }
 
-  void _check(DartType expectedType, DartType type, AstNode node) {
+  void _check(DartType expectedType, DartType type, AstNode node,
+      {AstNode checkedNode}) {
+    checkedNode ??= node;
     if (expectedType == null || type == null) {
       return;
     } else if (expectedType.isVoid &&
@@ -132,6 +136,12 @@ class _Visitor extends SimpleAstVisitor<void> {
             !type.isAssignableTo(_futureDynamicType) &&
             !type.isAssignableTo(_futureOrDynamicType)) {
       rule.reportLint(node);
+    } else if (checkedNode is FunctionExpression &&
+        checkedNode.body is! ExpressionFunctionBody &&
+        expectedType is FunctionType &&
+        type is FunctionType) {
+      _check(expectedType.returnType, type.returnType, node,
+          checkedNode: checkedNode);
     }
   }
 
@@ -142,16 +152,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (parameterElement != null) {
         final type = parameterElement.type;
         final expression = arg is NamedExpression ? arg.expression : arg;
-        if (!_isFunctionRef(type, expression)) {
-          _check(type, expression?.bestType, expression);
-        }
+        _check(type, expression?.bestType, expression);
       }
     }
   }
-
-  bool _isFunctionRef(DartType type, Expression arg) =>
-      type is FunctionType &&
-      (arg is SimpleIdentifier ||
-          arg is PrefixedIdentifier ||
-          arg is FunctionExpression && arg.body is ExpressionFunctionBody);
 }

--- a/test/rules/void_checks.dart
+++ b/test/rules/void_checks.dart
@@ -112,7 +112,7 @@ async_function() {
 
 inference() {
   f(void Function() f) {}
-  f(() // OK
+  f(() // LINT
       {
     return 1; // OK
   });
@@ -124,7 +124,7 @@ generics_with_function() {
       {
     return 1;
   });
-  f<void>(() // OK
+  f<void>(() // LINT
       {
     return 1;
   });
@@ -149,12 +149,29 @@ function_ref_are_ok() {
 }
 
 allow_functionWithReturnType_forFunctionWithout() {
-  forget(void Function() f) {}
-  int foo() => 1;
-  String bar() => "bar";
+  takeVoidFn(void Function() f) {}
+  void Function() voidFn;
 
-  forget(foo); // OK
-  forget(bar); // OK
+  int nonVoidFn() => 1;
+
+  takeVoidFn(nonVoidFn); // OK
+  voidFn = nonVoidFn; // OK
+  void Function() returnsVoidFn() {
+    return nonVoidFn; // OK
+  }
+}
+
+allow_functionWithReturnType_forFunctionWithout_asComplexExpr() {
+  takeVoidFn(void Function() f) {}
+  void Function() voidFn;
+
+  List<int Function()> listNonVoidFn;
+
+  takeVoidFn(listNonVoidFn[0]); // OK
+  voidFn = listNonVoidFn[0]; // OK
+  void Function() returnsVoidFn() {
+    return listNonVoidFn[0]; // OK
+  }
 }
 
 allow_Null_for_void() {

--- a/test/rules/void_checks.dart
+++ b/test/rules/void_checks.dart
@@ -112,7 +112,7 @@ async_function() {
 
 inference() {
   f(void Function() f) {}
-  f(() //LINT
+  f(() // OK
       {
     return 1; // OK
   });
@@ -124,7 +124,7 @@ generics_with_function() {
       {
     return 1;
   });
-  f<void>(() // LINT
+  f<void>(() // OK
       {
     return 1;
   });
@@ -146,6 +146,15 @@ function_ref_are_ok() {
   fB(f: a1.m5); // OK
   final a2 = new A<void>();
   fA(a2.m5); // OK
+}
+
+allow_functionWithReturnType_forFunctionWithout() {
+  forget(void Function() f) {}
+  int foo() => 1;
+  String bar() => "bar";
+
+  forget(foo); // OK
+  forget(bar); // OK
 }
 
 allow_Null_for_void() {


### PR DESCRIPTION
See #1107. This is likely too strict and should be relaxed.