### PR TITLE
New lint: prefer_async_when_returning_futures

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -71,6 +71,7 @@ linter:
     - package_prefixed_library_names
     - parameter_assignments
     - prefer_adjacent_string_concatenation
+    - prefer_async_when_returning_futures
     - prefer_asserts_in_initializer_lists
     - prefer_bool_in_asserts
     - prefer_collection_literals

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -72,6 +72,7 @@ import 'package:linter/src/rules/package_prefixed_library_names.dart';
 import 'package:linter/src/rules/parameter_assignments.dart';
 import 'package:linter/src/rules/prefer_adjacent_string_concatenation.dart';
 import 'package:linter/src/rules/prefer_asserts_in_initializer_lists.dart';
+import 'package:linter/src/rules/prefer_async_when_returning_futures.dart';
 import 'package:linter/src/rules/prefer_bool_in_asserts.dart';
 import 'package:linter/src/rules/prefer_collection_literals.dart';
 import 'package:linter/src/rules/prefer_conditional_assignment.dart';
@@ -197,6 +198,7 @@ void registerLintRules() {
     ..register(new PackagePrefixedLibraryNames())
     ..register(new ParameterAssignments())
     ..register(new PreferAdjacentStringConcatenation())
+    ..register(new PreferAsyncWhenReturningFutures())
     ..register(new PreferBoolInAsserts())
     ..register(new PreferCollectionLiterals())
     ..register(new PreferConditionalAssignment())

--- a/lib/src/rules/prefer_async_when_returning_futures.dart
+++ b/lib/src/rules/prefer_async_when_returning_futures.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Declare methods that return Futures as async.';
+
+const _details = r'''
+
+**DO** declare methods that return Futures as async.
+
+If a method returns a `Future` callers will expect that it will report failures
+through `Future`'s `onError` rather than by throwing an exception.
+
+Exceptions thrown in an `async` function will be translated into a `Future`
+error automatically so declaring all functions that return `Future`s as async
+will guarantee this behavior.
+
+**BAD:**
+```
+Future<String> getValue(Map<String, String> values, String key) {
+  if (values.containsKey(key)) {
+    return Future.value(values[key]);
+  } else {
+    return Future.value(null);
+  }
+}
+```
+
+**GOOD:**
+```
+Future<String> getValue(Map<String, String> values, String key) async {
+  if (values.containsKey(key)) {
+    return values[key];
+  } else {
+    return null;
+  }
+}
+```
+
+''';
+
+class PreferAsyncWhenReturningFutures extends LintRule implements NodeLintRule {
+  PreferAsyncWhenReturningFutures()
+      : super(
+            name: 'prefer_async_when_returning_futures',
+            description: _desc,
+            details: _details,
+            group: Group.errors,
+            maturity: Maturity.experimental);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    if (node.returnType != null &&
+        node.returnType.type.isDartAsyncFuture &&
+        !node.functionExpression.body.isAsynchronous) {
+      rule.reportLint(node.name);
+    }
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    if (node.body.length == 1 &&
+        node.body.beginToken.type == TokenType.SEMICOLON) {
+      // This is an abstract declaration.
+      return;
+    }
+
+    if (node.returnType != null &&
+        node.returnType.type.isDartAsyncFuture &&
+        !node.body.isAsynchronous) {
+      rule.reportLint(node.name);
+    }
+  }
+}

--- a/test/rules/prefer_async_when_returning_futures.dart
+++ b/test/rules/prefer_async_when_returning_futures.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_async_when_returning_futures`
+
+import 'dart:async';
+
+Future<int> f1() { // LINT
+  return new Future<int>.value(42);
+}
+
+Future<int> f2() async { // OK
+  return 42;
+}
+
+f3() { // OK
+  return 42;
+}
+
+f4() { // OK
+  return Future<int>.value(42);
+}
+
+abstract class C {
+  Future<int> m1() { // LINT
+    return new Future<int>.value(42);
+  }
+
+  Future<int> m2() async { // OK
+    return 42;
+  }
+
+  Future<int> m3(); // OK
+
+  m4(); // OK
+
+  m5() { // OK
+    return Future<int>.value(42);
+  }
+
+  Future<int> get g1 { // LINT
+    return Future<int>.value(42);
+  }
+  
+  Future<int> get g2 async { // OK
+    return 42;
+  }
+}
+
+void main() {
+  Future<int> c1() => Future.value(42); // LINT
+  Future<int> c2() async => 42; // OK
+}


### PR DESCRIPTION
Methods and functions that return Future<T> should be declared async so
that they don't inadvertently throw Exceptions rather than reporting
errors through Futures.

This is a rule we try to enforce through code review on the Fuchsia team but it would be better to have a lint.