### PR TITLE
update unwaited_futures to check cascades

### DIFF
--- a/test/rules/unawaited_futures.dart
+++ b/test/rules/unawaited_futures.dart
@@ -11,19 +11,48 @@ Future fut() => null;
 foo1() {
   fut();
 }
+
 foo2() async {
   fut(); //LINT
 
   // ignore: unawaited_futures
   fut();
 }
-foo3() async { await fut(); }
-foo4() async { var x = fut(); }
+
+foo3() async {
+  await fut();
+}
+
+foo4() async {
+  var x = fut();
+}
+
 foo5() async {
   new Future.delayed(d); //LINT
   new Future.delayed(d, bar);
 }
+
 foo6() async {
   var map = <String, Future>{};
   map.putIfAbsent('foo', fut());
+}
+
+foo7() async {
+  _Foo()
+    ..doAsync() //LINT
+    ..doSync();
+}
+
+foo8() {
+  // Fire and forget should not be reported per existing functionality
+  _Foo()
+    ..doAsync()
+    ..doSync();
+}
+
+class _Foo {
+  Future<void> doAsync() async {}
+  void doSync() => null;
+  Future<void> get asyncProperty => doAsync();
+  List<Future<void>> get futures => [doAsync()];
 }


### PR DESCRIPTION
During a refactor of some of our code we changed some functions which returned a void to now return a `Future<void>`. The code which called this method was used in a cascade like this:
```dart
object
  ..write('foo') // originally synchronous
  ..save();
```

After the migration, the above example did not trigger the unwaited_futures lint rule and showed up as a bug in our code because we were expecting `write` to finish before `save`. With the change `write` became a future which needed to finish before `save`.

This lint rule visits cascades to verify that there are no unwaited futures which could result in unexpected bugs. The rule still only triggers if you are inside of an async function to match the existing functionality.

