### PR TITLE
0.1.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.60
+
+* new lint: `avoid_void_async`
+* `unwaited_futures` updated to check cascades
+
 # 0.1.59
 
 * relaxed `void_checks` (allowing `T Function()` to be assigned to `void Function()`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.1.60
 
 * new lint: `avoid_void_async`
-* `unwaited_futures` updated to check cascades
+* `unawaited_futures` updated to check cascades
 
 # 0.1.59
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.59
+version: 0.1.60
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.60

* new lint: `avoid_void_async`
* `unawaited_futures` updated to check cascades

/cc @bwilkerson @MichaelRFairhurst @a14n 