### PR TITLE
Stop passing strong parameter to SummaryBuilder constructor.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.0.0-dev <3.0.0'
 
 dependencies:
-  analyzer: ^0.32.2
+  analyzer: ^0.32.5
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/test/mock_sdk.dart
+++ b/test/mock_sdk.dart
@@ -402,7 +402,7 @@ class HtmlElement {}
     List<Source> librarySources = sdkLibraries
         .map((SdkLibrary library) => mapDartUri(library.shortName))
         .toList();
-    return new SummaryBuilder(librarySources, context, true).build();
+    return new SummaryBuilder(librarySources, context).build();
   }
 }
 


### PR DESCRIPTION
The analyzer only supports strong mode now, and analyzer version
0.33.* will remove this constructor parameter.  As of analyzer version
0.32.5, the parameter is optional, so we can stop passing it now.