### PR TITLE
Include CONST_WITH_TYPE_PARAMETERS into HasConstErrorListener.

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -338,6 +338,7 @@ class HasConstErrorListener extends AnalysisErrorListener {
     CompileTimeErrorCode.CONST_EVAL_THROWS_IDBZE,
     CompileTimeErrorCode.CONST_WITH_NON_CONST,
     CompileTimeErrorCode.CONST_WITH_NON_CONSTANT_ARGUMENT,
+    CompileTimeErrorCode.CONST_WITH_TYPE_PARAMETERS,
     CompileTimeErrorCode.INVALID_CONSTANT,
     CompileTimeErrorCode.MISSING_CONST_IN_LIST_LITERAL,
     CompileTimeErrorCode.MISSING_CONST_IN_MAP_LITERAL,


### PR DESCRIPTION
This complements https://dart-review.googlesource.com/c/sdk/+/73283 to fix the linter part of the https://github.com/dart-lang/sdk/issues/33612