### PR TITLE
0.1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.61
+
+* new lint: `flutter_style_todos`
+* improved handling of constant expressions with generic type params
+* NPE fix for `invariant_booleans`
+* Google lints example moved to `package:pedantic`
+* improved docs for `unawaited_futures`
+
 # 0.1.60
 
 * new lint: `avoid_void_async`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.60
+version: 0.1.61
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.61

* new lint: `flutter_style_todos`
* improved handling of constant expressions with generic type params
* NPE fix for `invariant_booleans`
* Google lints example moved to `package:pedantic`
* improved docs for `unawaited_futures`

/cc @bwilkerson @a14n 