### PR TITLE
fix some tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=2.1.0-dev.4.0 <3.0.0'
 
 dependencies:
   analyzer: ^0.33.0-alpha.0

--- a/test/rules/prefer_const_constructors.dart
+++ b/test/rules/prefer_const_constructors.dart
@@ -93,3 +93,13 @@ class I {
 
   I makeI() => I(foo: H()); // OK
 }
+
+class J<T> {
+  const J();
+
+  m<T>() {
+    J<T>(); // OK
+    new J<T>(); // OK
+    const J<int>(); // OK
+  }
+}

--- a/test/rules/prefer_const_constructors_in_immutables.dart
+++ b/test/rules/prefer_const_constructors_in_immutables.dart
@@ -76,7 +76,7 @@ class G {
 @immutable
 class H {
   final f;
-  H(f) : f = f ?? f == null; // OK
+  const H(f) : f = f ?? f == null; // OK
 }
 
 // no lint for class with final field initialized with new


### PR DESCRIPTION
This PR:

- bump sdk constraints to allows the change in `test/rules/prefer_const_constructors_in_immutables.dart`
- add a test for dart-lang/sdk#32544 : the analyzer bump has fixed the issue
- update `test/rules/prefer_const_constructors_in_immutables.dart` according to the update about const of  `==`

There's still a failing test on https://github.com/dart-lang/linter/blob/master/test/_data/synthetic/synthetic.dart I don't really know how to fix (and I'm tempted to remove it)