### PR TITLE
Disable prefer_mixin

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -99,7 +99,7 @@ linter:
     - prefer_is_empty
     - prefer_is_not_empty
 #    - prefer_iterable_whereType # under review (see #1068)
-    - prefer_mixin
+#    - prefer_mixin
     - prefer_single_quotes
 #    - prefer_typing_uninitialized_variables # under review (see #1068)
 #    - prefer_void_to_null # under review (see #1068)


### PR DESCRIPTION
Disable a lint that was accidentally enabled. We can't use the new mixin syntax yet because it isn't fully supported, so there's no way to "fix" the linted code.