### PR TITLE
Add missing pubspec mock methods.

### DIFF
--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -110,6 +110,16 @@ class MockPubVisitor implements PubspecVisitor {
   }
 
   @override
+  visitPackageDependencyOverrides(PSDependencyList dependencies) {
+    throw new Exception();
+  }
+
+  @override
+  visitPackageDependencyOverride(PSDependency dependency) {
+    throw new Exception();
+  }
+
+  @override
   visitPackageDescription(PSEntry description) {
     throw new Exception();
   }


### PR DESCRIPTION
These methods are needed when working with any version of the analyzer
including https://github.com/dart-lang/sdk/commit/abb392fc0d816b548e8ae69126f4e68e85e0ca3e.
They should be safe to use against earlier versions of the analyzer as
well, so there's no need to update the linter pubspec.