### PR TITLE
0.1.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.63
+
+* updated `unawaited_futures` to ignore assignments within cascades
+* new lint: `sort_dependencies`
+
 # 0.1.62
 
 * new lint: `prefer_mixin`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.62
+version: 0.1.63
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.63

* updated `unawaited_futures` to ignore assignments within cascades
* new lint: `sort_dependencies`

/cc @bwilkerson @a14n 