### PR TITLE
Issue 34570. MethodDeclaration can be also in MixinDeclaration.

### DIFF
--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 
@@ -66,13 +67,14 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isStatic) return;
     if (node.documentationComment != null) return;
 
-    ClassDeclaration clazz = node.parent;
+    Declaration classNode = node.parent;
+    ClassElement classElement = classNode.declaredElement;
 
-    if (clazz.declaredElement.isPrivate) return;
+    if (classElement.isPrivate) return;
     if (!isDefinedInLib(getCompilationUnit(node))) return;
 
-    final parentMethod = clazz.declaredElement
-        .lookUpInheritedMethod(node.name.name, clazz.declaredElement.library);
+    final parentMethod = classElement.lookUpInheritedMethod(
+        node.name.name, classElement.library);
 
     if (parentMethod == null) return;
 


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/34570

We could use `ClassOrMixinDeclaration`, but it is not available in `linter` yet.