### PR TITLE
remove dist: trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dart:
   - dev
 sudo: false
 script: ./tool/travis.sh
-dist: trusty
 env:
   - LINTER_BOT=main
   - LINTER_BOT=benchmark


### PR DESCRIPTION
Been default for a bit:

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

/cc @devoncarew @bwilkerson 