### PR TITLE
expand SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: Style linter for Dart.
 homepage: https://github.com/dart-lang/linter
 
 environment:
-  sdk: ^2.0.0
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.33.0-alpha.0 < 0.33.0'


### PR DESCRIPTION
Make pub happy:

```
Missing requirements:
* ^ version constraints aren't allowed for SDK constraints since older versions of pub don't support them.
```

/cc @bwilkerson 