### PR TITLE
Fix mixin related bug in avoid_field_initializers_in_const_classes

### DIFF
--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -99,10 +99,13 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isStatic) return;
     if (!node.fields.isFinal) return;
     // only const class
-    if (node
-        .getAncestor<ClassDeclaration>((e) => e is ClassDeclaration)
-        .declaredElement
-        .constructors
+    ClassDeclaration classDeclaration =
+        node.getAncestor<ClassDeclaration>((e) => e is ClassDeclaration);
+    if (classDeclaration == null) {
+      // The field is declared in a mixin, and mixins can't have constructors.
+      return;
+    }
+    if (classDeclaration.declaredElement.constructors
         .every((e) => !e.isConst)) {
       return;
     }

--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -99,20 +99,15 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isStatic) return;
     if (!node.fields.isFinal) return;
     // only const class
-    ClassDeclaration classDeclaration =
-        node.getAncestor<ClassDeclaration>((e) => e is ClassDeclaration);
-    if (classDeclaration == null) {
-      // The field is declared in a mixin, and mixins can't have constructors.
-      return;
-    }
-    if (classDeclaration.declaredElement.constructors
-        .every((e) => !e.isConst)) {
-      return;
-    }
-
-    for (final variable in node.fields.variables) {
-      if (variable.initializer != null) {
-        rule.reportLint(variable);
+    AstNode parent = node.parent;
+    if (parent is ClassDeclaration) {
+      if (parent.declaredElement.constructors.every((e) => !e.isConst)) {
+        return;
+      }
+      for (final variable in node.fields.variables) {
+        if (variable.initializer != null) {
+          rule.reportLint(variable);
+        }
       }
     }
   }

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -83,12 +83,21 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
       type = node.target.staticType;
     } else {
       var classDeclaration =
-          (node.getAncestor((a) => a is ClassDeclaration) as ClassDeclaration);
-      type = classDeclaration == null
-          ? null
-          : resolutionMap
-              .elementDeclaredByClassDeclaration(classDeclaration)
-              ?.type;
+          (node.getAncestor((a) => a is ClassOrMixinDeclaration) as ClassOrMixinDeclaration);
+      if (classDeclaration == null) {
+        type = null;
+      } else if (classDeclaration is ClassDeclaration) {
+        type = resolutionMap
+            .elementDeclaredByClassDeclaration(classDeclaration)
+            ?.type;
+      } else if (classDeclaration is MixinDeclaration) {
+        type = null;
+        // TODO(brianwilkerson) Replace the line above with the following, after
+        // updating to a new analyzer release.
+//        type = resolutionMap
+//            .elementDeclaredByMixinDeclaration(classDeclaration)
+//            ?.type;
+      }
     }
     Expression argument = node.argumentList.arguments.first;
     if (type is InterfaceType &&

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -83,7 +83,8 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
       type = node.target.staticType;
     } else {
       var classDeclaration =
-          (node.getAncestor((a) => a is ClassOrMixinDeclaration) as ClassOrMixinDeclaration);
+          (node.getAncestor((a) => a is ClassOrMixinDeclaration)
+              as ClassOrMixinDeclaration);
       if (classDeclaration == null) {
         type = null;
       } else if (classDeclaration is ClassDeclaration) {

--- a/test/rules/avoid_field_initializers_in_const_classes.dart
+++ b/test/rules/avoid_field_initializers_in_const_classes.dart
@@ -44,3 +44,7 @@ class G {
   final g;
   const G(int length) : g = 'xyzzy'.length; // LINT
 }
+
+mixin M {
+  final a = const []; // OK
+}


### PR DESCRIPTION
I can't fix the second issue until we publish a new version of analyzer, but I left a TODO so we wouldn't forget. It needs to be fixed before 2.1, but not as high a priority as getting this fix in. I'd like to get this published and pulled into the SDK asap.