### PR TITLE
0.1.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.67
+
+* miscellaneous mixin support fixes
+* update to `sort_constructors_first` to apply to all members
+* update `unnecessary_this` to work on field initializers
+
 # 0.1.66
 
 * broadened SDK version constraint

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.66
+version: 0.1.67
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.67

* miscellaneous mixin support fixes
* update to `sort_constructors_first` to apply to all members
* update `unnecessary_this` to work on field initializers

/cc @bwilkerson @a14n 