### PR TITLE
Refactor NullClosures to be more performant, checking method names first

### DIFF
--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/generated/utilities_general.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
@@ -88,76 +89,120 @@ class NonNullableFunction {
   final List<int> positional;
   final List<String> named;
 
-  // Lazily instantiated, only when this function is found to be called.
-  InterfaceTypeDefinition _typeDefinition;
-
   NonNullableFunction(this.library, this.type, this.name,
       {this.positional = const <int>[], this.named = const <String>[]});
 
-  InterfaceTypeDefinition get typeDefinition =>
-      _typeDefinition ??= new InterfaceTypeDefinition(type, library);
+  @override
+  int get hashCode =>
+      JenkinsSmiHash.hash3(library.hashCode, type.hashCode, name.hashCode);
+
+  /// Two [NonNullableFunction] objects are equal if their [library], [type],
+  /// and [name] are equal, for the purpose of discovering whether a function
+  /// invocation is among a collection of non-nullable functions.
+  @override
+  bool operator ==(Object other) =>
+      other is NonNullableFunction && other.hashCode == hashCode;
 }
 
 List<NonNullableFunction> _constructorsWithNonNullableArguments =
     <NonNullableFunction>[
-  new NonNullableFunction('dart.async', 'Future', null, positional: [0]),
-  new NonNullableFunction('dart.async', 'Future', 'microtask', positional: [0]),
-  new NonNullableFunction('dart.async', 'Future', 'sync', positional: [0]),
-  new NonNullableFunction('dart.async', 'Timer', null, positional: [1]),
-  new NonNullableFunction('dart.async', 'Timer', 'periodic', positional: [1]),
-  new NonNullableFunction('dart.core', 'List', 'generate', positional: [1]),
+  NonNullableFunction('dart.async', 'Future', null, positional: [0]),
+  NonNullableFunction('dart.async', 'Future', 'microtask', positional: [0]),
+  NonNullableFunction('dart.async', 'Future', 'sync', positional: [0]),
+  NonNullableFunction('dart.async', 'Timer', null, positional: [1]),
+  NonNullableFunction('dart.async', 'Timer', 'periodic', positional: [1]),
+  NonNullableFunction('dart.core', 'List', 'generate', positional: [1]),
 ];
 
 List<NonNullableFunction> _staticFunctionsWithNonNullableArguments =
     <NonNullableFunction>[
-  new NonNullableFunction('dart.async', null, 'scheduleMicrotask',
-      positional: [0]),
-  new NonNullableFunction('dart.async', 'Future', 'doWhile', positional: [0]),
-  new NonNullableFunction('dart.async', 'Future', 'forEach', positional: [1]),
-  new NonNullableFunction('dart.async', 'Future', 'wait', named: ['cleanUp']),
-  new NonNullableFunction('dart.async', 'Timer', 'run', positional: [0]),
+  NonNullableFunction('dart.async', null, 'scheduleMicrotask', positional: [0]),
+  NonNullableFunction('dart.async', 'Future', 'doWhile', positional: [0]),
+  NonNullableFunction('dart.async', 'Future', 'forEach', positional: [1]),
+  NonNullableFunction('dart.async', 'Future', 'wait', named: ['cleanUp']),
+  NonNullableFunction('dart.async', 'Timer', 'run', positional: [0]),
 ];
 
-List<NonNullableFunction> _instanceMethodsWithNonNullableArguments =
-    <NonNullableFunction>[
-  new NonNullableFunction('dart.async', 'Future', 'then',
-      positional: [0], named: ['onError']),
-  new NonNullableFunction('dart.async', 'Future', 'complete', positional: [0]),
-  new NonNullableFunction('dart.collection', 'Queue', 'removeWhere',
-      positional: [0]),
-  new NonNullableFunction('dart.collection', 'Queue', 'retainWhere',
-      positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'any', positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'every', positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'expand', positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'firstWhere',
-      positional: [0], named: ['orElse']),
-  new NonNullableFunction('dart.core', 'Iterable', 'forEach', positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'fold', positional: [1]),
-  new NonNullableFunction('dart.core', 'Iterable', 'lastWhere',
-      positional: [0], named: ['orElse']),
-  new NonNullableFunction('dart.core', 'Iterable', 'map', positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'reduce', positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'singleWhere',
-      positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'skipWhile',
-      positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'takeWhile',
-      positional: [0]),
-  new NonNullableFunction('dart.core', 'Iterable', 'where', positional: [0]),
-  new NonNullableFunction('dart.core', 'List', 'removeWhere', positional: [0]),
-  new NonNullableFunction('dart.core', 'List', 'retainWhere', positional: [0]),
-  new NonNullableFunction('dart.core', 'Map', 'forEach', positional: [0]),
-  new NonNullableFunction('dart.core', 'Map', 'putIfAbsent', positional: [1]),
-  new NonNullableFunction('dart.core', 'Set', 'removeWhere', positional: [0]),
-  new NonNullableFunction('dart.core', 'Set', 'retainWhere', positional: [0]),
-  new NonNullableFunction('dart.core', 'String', 'replaceAllMapped',
-      positional: [1]),
-  new NonNullableFunction('dart.core', 'String', 'replaceFirstMapped',
-      positional: [1]),
-  new NonNullableFunction('dart.core', 'String', 'splitMapJoin',
-      named: ['onMatch', 'onNonMatch']),
-];
+final Map<String, Set<NonNullableFunction>>
+    _instanceMethodsWithNonNullableArguments = {
+  'any': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'any', positional: [0]),
+  ]),
+  'complete': Set.of([
+    NonNullableFunction('dart.async', 'Future', 'complete', positional: [0]),
+  ]),
+  'every': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'every', positional: [0]),
+  ]),
+  'expand': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'expand', positional: [0]),
+  ]),
+  'firstWhere': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'firstWhere',
+        positional: [0], named: ['orElse']),
+  ]),
+  'forEach': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'forEach', positional: [0]),
+    NonNullableFunction('dart.core', 'Map', 'forEach', positional: [0]),
+  ]),
+  'fold': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'fold', positional: [1]),
+  ]),
+  'lastWhere': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'lastWhere',
+        positional: [0], named: ['orElse']),
+  ]),
+  'map': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'map', positional: [0]),
+  ]),
+  'putIfAbsent': Set.of([
+    NonNullableFunction('dart.core', 'Map', 'putIfAbsent', positional: [1]),
+  ]),
+  'reduce': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'reduce', positional: [0]),
+  ]),
+  'removeWhere': Set.of([
+    NonNullableFunction('dart.collection', 'Queue', 'removeWhere',
+        positional: [0]),
+    NonNullableFunction('dart.core', 'List', 'removeWhere', positional: [0]),
+    NonNullableFunction('dart.core', 'Set', 'removeWhere', positional: [0]),
+  ]),
+  'replaceAllMapped': Set.of([
+    NonNullableFunction('dart.core', 'String', 'replaceAllMapped',
+        positional: [1]),
+  ]),
+  'replaceFirstMapped': Set.of([
+    NonNullableFunction('dart.core', 'String', 'replaceFirstMapped',
+        positional: [1]),
+  ]),
+  'retainWhere': Set.of([
+    NonNullableFunction('dart.collection', 'Queue', 'retainWhere',
+        positional: [0]),
+    NonNullableFunction('dart.core', 'List', 'retainWhere', positional: [0]),
+    NonNullableFunction('dart.core', 'Set', 'retainWhere', positional: [0]),
+  ]),
+  'singleWhere': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'singleWhere',
+        positional: [0]),
+  ]),
+  'skipWhile': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'skipWhile', positional: [0]),
+  ]),
+  'splitMapJoin': Set.of([
+    NonNullableFunction('dart.core', 'String', 'splitMapJoin',
+        named: ['onMatch', 'onNonMatch']),
+  ]),
+  'takeWhile': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'takeWhile', positional: [0]),
+  ]),
+  'then': Set.of([
+    NonNullableFunction('dart.async', 'Future', 'then',
+        positional: [0], named: ['onError']),
+  ]),
+  'where': Set.of([
+    NonNullableFunction('dart.core', 'Iterable', 'where', positional: [0]),
+  ]),
+};
 
 class NullClosures extends LintRule implements NodeLintRule {
   NullClosures()
@@ -169,7 +214,7 @@ class NullClosures extends LintRule implements NodeLintRule {
 
   @override
   void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+    final visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
@@ -185,9 +230,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     var constructorName = node.constructorName;
     var type = node.staticType;
     for (var constructor in _constructorsWithNonNullableArguments) {
-      if (DartTypeUtilities.extendsClass(
-          type, constructor.type, constructor.library)) {
-        if (constructorName?.name?.name == constructor.name) {
+      if (constructorName?.name?.name == constructor.name) {
+        if (DartTypeUtilities.extendsClass(
+            type, constructor.type, constructor.library)) {
           _checkNullArgForClosure(
               node.argumentList, constructor.positional, constructor.named);
         }
@@ -203,8 +248,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (element is ClassElement) {
       // Static function called, "target" is the class.
       for (var function in _staticFunctionsWithNonNullableArguments) {
-        if (element.name == function.type) {
-          if (methodName == function.name) {
+        if (methodName == function.name) {
+          if (element.name == function.type) {
             _checkNullArgForClosure(
                 node.argumentList, function.positional, function.named);
           }
@@ -213,16 +258,44 @@ class _Visitor extends SimpleAstVisitor<void> {
     } else {
       // Instance method called, "target" is the instance.
       DartType targetType = target?.staticType;
-      for (var method in _instanceMethodsWithNonNullableArguments) {
-        if (DartTypeUtilities.implementsAnyInterface(
-            targetType, [method.typeDefinition])) {
-          if (methodName == method.name) {
-            _checkNullArgForClosure(
-                node.argumentList, method.positional, method.named);
-          }
-        }
+      var method = _getInstanceMethod(targetType, methodName);
+      if (method == null) {
+        return;
+      }
+      _checkNullArgForClosure(
+          node.argumentList, method.positional, method.named);
+    }
+  }
+
+  NonNullableFunction _getInstanceMethod(DartType type, String methodName) {
+    var possibleMethods = _instanceMethodsWithNonNullableArguments[methodName];
+    if (possibleMethods == null) {
+      return null;
+    }
+
+    if (type is! InterfaceType) {
+      return null;
+    }
+
+    getMethod(String library, String className) => possibleMethods
+        .lookup(NonNullableFunction(library, className, methodName));
+
+    var method = getMethod(type.element.library.name, type.name);
+    if (method != null) {
+      return method;
+    }
+
+    ClassElement element = type.element;
+    if (element.isSynthetic) {
+      return null;
+    }
+    for (var supertype in element.allSupertypes) {
+      method = getMethod(supertype.element.library.name, supertype.name);
+      if (method != null) {
+        return method;
       }
     }
+    return null;
   }
 
   void _checkNullArgForClosure(


### PR DESCRIPTION
This improves the speed of NullClosures, especially instance method checks, largely by comparing method names first. Also by using a Map so that all instance methods do not need to be walked.