### PR TITLE
Highlight a smaller range for violations of await_only_futures

### DIFF
--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -59,7 +59,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         DartTypeUtilities.extendsClass(type, 'Future', 'dart.async') ||
         DartTypeUtilities.implementsInterface(type, 'Future', 'dart.async') ||
         DartTypeUtilities.isClass(type, 'FutureOr', 'dart.async'))) {
-      rule.reportLint(node);
+      rule.reportLintForToken(node.awaitKeyword);
     }
   }
 }


### PR DESCRIPTION
Because the expression following the keyword can be arbitrarily large, it would be better to highlight just the keyword.