### PR TITLE
Prefer int literals over double literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# future
+
+* new lint: `prefer_int_literals`
+
 # 0.1.70
 
 * fix NPE in `prefer_iterable_whereType`

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -93,6 +93,7 @@ linter:
     - prefer_function_declarations_over_variables
     - prefer_generic_function_type_aliases
     - prefer_initializing_formals
+    - prefer_int_literals
     - prefer_interpolation_to_compose_strings
     - prefer_is_empty
     - prefer_is_not_empty

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -93,6 +93,7 @@ import 'package:linter/src/rules/prefer_foreach.dart';
 import 'package:linter/src/rules/prefer_function_declarations_over_variables.dart';
 import 'package:linter/src/rules/prefer_generic_function_type_aliases.dart';
 import 'package:linter/src/rules/prefer_initializing_formals.dart';
+import 'package:linter/src/rules/prefer_int_literals.dart';
 import 'package:linter/src/rules/prefer_interpolation_to_compose_strings.dart';
 import 'package:linter/src/rules/prefer_is_empty.dart';
 import 'package:linter/src/rules/prefer_is_not_empty.dart';
@@ -225,6 +226,7 @@ void registerLintRules() {
     ..register(new PreferFunctionDeclarationsOverVariables())
     ..register(new PreferGenericFunctionTypeAliases())
     ..register(new PreferInitializingFormals())
+    ..register(new PreferIntLiterals())
     ..register(new PreferInterpolationToComposeStrings())
     ..register(new PreferIterableWhereType())
     ..register(new PreferIsEmpty())

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -76,7 +76,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node == null) {
       return false;
     } else if (node is VariableDeclarationList) {
-      return node.type != null;
+      return node.type?.type?.name == 'double';
     } else if (node is ArgumentList) {
       // TODO(danrubel): Determine type associated with this argument
     } else if (node is Expression) {

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = 'Prefer int literals over double literals.';
+
+const _details = '''
+
+**DO** use int literals rather than the corresponding double literal.
+
+**BAD:**
+```
+const double myDouble = 8.0;
+final anotherDouble = myDouble + 7.0e2;
+main() {
+  someMethod(6.0);
+}
+```
+
+**GOOD:**
+```
+const double myDouble = 8;
+final anotherDouble = myDouble + 700;
+main() {
+  someMethod(6);
+}
+```
+
+''';
+
+class PreferIntLiterals extends LintRule implements NodeLintRule {
+  PreferIntLiterals()
+      : super(
+            name: 'prefer_int_literals',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    registry.addDoubleLiteral(this, new _Visitor(this));
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitDoubleLiteral(DoubleLiteral node) {
+    // Check if the double can be represented as an int
+    try {
+      double value = node.value;
+      if (value == null || value != value.truncate()) {
+        return;
+      }
+      // ignore: avoid_catching_errors
+    } on UnsupportedError catch (_) {
+      // The double cannot be represented as an int
+      return;
+    }
+
+    // Ensure that replacing the double would not change the semantics
+    if (isDoubleContext(node)) {
+      rule.reportLintForToken(node.literal);
+    }
+  }
+
+  bool isDoubleContext(AstNode child) {
+    final node = child.parent;
+    if (node == null) {
+      return false;
+    } else if (node is VariableDeclarationList) {
+      return node.type != null;
+    } else if (node is ArgumentList) {
+      // TODO(danrubel): Determine type associated with this argument
+    } else if (node is Expression) {
+      // TODO(danrubel): Determine type of expression
+    }
+    return isDoubleContext(node);
+  }
+}

--- a/test/rules/prefer_int_literals.dart
+++ b/test/rules/prefer_int_literals.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_int_literals`
+
+const double okDouble = 7.3; // OK
+const double shouldBeInt = 8.0; // LINT
+const inferredAsDouble = 8.0; // OK
+
+class A {
+  var w = 7.0e2; // OK
+  double x = 7.0e2; // LINT
+  double y = 7.1e2; // LINT
+  double z = 7.576e2; // OK
+  A(this.x);
+}
+
+// TODO(danrubel): Report lint in these other situations
+
+//class B extends A {
+//  B.one() : super(1.0); // LINT
+//  B.two() : super(2.3); // OK
+//  B.three() : super(3);
+//}
+//
+//void takesDouble(double value){}
+//
+//double other() {
+//  var inferredAsInt = 3;
+//  var inferredAsDouble1 = inferredAsInt + 3.0; // OK
+//  var inferredAsDouble2 = inferredAsDouble1 + 3.7; // OK
+//  var inferredAsDouble3 = inferredAsDouble2 + 3.0; // LINT
+//  takesDouble(3.0); // LINT
+//  return inferredAsDouble3;
+//}

--- a/test/rules/prefer_int_literals.dart
+++ b/test/rules/prefer_int_literals.dart
@@ -7,6 +7,8 @@
 const double okDouble = 7.3; // OK
 const double shouldBeInt = 8.0; // LINT
 const inferredAsDouble = 8.0; // OK
+Object inferredAsDouble2 = 8.0; // OK
+dynamic inferredAsDouble3 = 8.0; // OK
 
 class A {
   var w = 7.0e2; // OK


### PR DESCRIPTION
First cut at a prefer int literals lint. There are more situations in which this lint should report a double literal that should be converted, but AFAIK there are no false positives.