### PR TITLE
Improve prefer_int_literal lint

### DIFF
--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -66,32 +66,46 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // Ensure that replacing the double would not change the semantics
-    if (isDoubleContext(node)) {
+    if (canReplaceWithIntLiteral(node)) {
       rule.reportLint(node);
     }
   }
 
-  bool isDoubleContext(AstNode child) {
-    final node = child.parent;
-    if (node == null) {
-      return false;
-    } else if (node is ArgumentList) {
-      if (child is Expression) {
-        return child.staticParameterElement?.type?.name == 'double';
+  /// Determine if the given literal can be replaced by an int literal.
+  bool canReplaceWithIntLiteral(DoubleLiteral literal) {
+    // TODO(danrubel): Consider moving this into analyzer
+    final AstNode parent = literal.parent;
+    if (parent is ArgumentList) {
+      return literal.staticParameterElement?.type?.name == 'double';
+    } else if (parent is NamedExpression) {
+      AstNode argList = parent.parent;
+      if (argList is ArgumentList) {
+        return parent.staticParameterElement?.type?.name == 'double';
       }
-      return false;
-    } else if (node is AssignmentExpression) {
-      return node.rightHandSide?.staticType?.name == 'double';
-    } else if (node is BinaryExpression) {
-      Expression operand = identical(child, node.rightOperand)
-          ? node.leftOperand
-          : node.rightOperand;
-      return operand is DoubleLiteral
-          ? isDoubleContext(node)
-          : operand?.staticType?.name == 'double';
-    } else if (node is VariableDeclarationList) {
-      return node.type?.type?.name == 'double';
+    } else if (parent is ExpressionFunctionBody) {
+      return hasDoubleReturnType(parent.parent);
+    } else if (parent is ReturnStatement) {
+      BlockFunctionBody body =
+          parent.getAncestor((a) => a is BlockFunctionBody);
+      return hasDoubleReturnType(body.parent);
+    } else if (parent is VariableDeclaration) {
+      AstNode varList = parent.parent;
+      if (varList is VariableDeclarationList) {
+        return varList.type?.type?.name == 'double';
+      }
     }
-    return isDoubleContext(node);
+    return false;
+  }
+
+  bool hasDoubleReturnType(AstNode node) {
+    if (node is FunctionExpression) {
+      var functDeclaration = node.parent;
+      if (functDeclaration is FunctionDeclaration) {
+        return functDeclaration.returnType?.type?.name == 'double';
+      }
+    } else if (node is MethodDeclaration) {
+      return node.returnType?.type?.name == 'double';
+    }
+    return false;
   }
 }

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -67,7 +67,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Ensure that replacing the double would not change the semantics
     if (isDoubleContext(node)) {
-      rule.reportLintForToken(node.literal);
+      rule.reportLint(node);
     }
   }
 
@@ -75,12 +75,22 @@ class _Visitor extends SimpleAstVisitor<void> {
     final node = child.parent;
     if (node == null) {
       return false;
+    } else if (node is ArgumentList) {
+      if (child is Expression) {
+        return child.staticParameterElement?.type?.name == 'double';
+      }
+      return false;
+    } else if (node is AssignmentExpression) {
+      return node.rightHandSide?.staticType?.name == 'double';
+    } else if (node is BinaryExpression) {
+      Expression operand = identical(child, node.rightOperand)
+          ? node.leftOperand
+          : node.rightOperand;
+      return operand is DoubleLiteral
+          ? isDoubleContext(node)
+          : operand?.staticType?.name == 'double';
     } else if (node is VariableDeclarationList) {
       return node.type?.type?.name == 'double';
-    } else if (node is ArgumentList) {
-      // TODO(danrubel): Determine type associated with this argument
-    } else if (node is Expression) {
-      // TODO(danrubel): Determine type of expression
     }
     return isDoubleContext(node);
   }

--- a/test/rules/prefer_int_literals.dart
+++ b/test/rules/prefer_int_literals.dart
@@ -9,6 +9,9 @@ const double shouldBeInt = 8.0; // LINT
 const inferredAsDouble = 8.0; // OK
 Object inferredAsDouble2 = 8.0; // OK
 dynamic inferredAsDouble3 = 8.0; // OK
+final inferredAsDouble4 = 8.0 + 7.0; // OK
+const double inferredAsDouble5 = 8.0 + // LINT
+    7.0; // LINT
 
 class A {
   var w = 7.0e2; // OK
@@ -16,23 +19,49 @@ class A {
   double y = 7.1e2; // LINT
   double z = 7.576e2; // OK
   A(this.x);
+  namedDouble(String s, {double d}) {}
+  namedDynamic(String s, {dynamic d}) {}
 }
 
 // TODO(danrubel): Report lint in these other situations
 
-//class B extends A {
-//  B.one() : super(1.0); // LINT
-//  B.two() : super(2.3); // OK
-//  B.three() : super(3);
-//}
-//
-//void takesDouble(double value){}
-//
-//double other() {
-//  var inferredAsInt = 3;
-//  var inferredAsDouble1 = inferredAsInt + 3.0; // OK
-//  var inferredAsDouble2 = inferredAsDouble1 + 3.7; // OK
-//  var inferredAsDouble3 = inferredAsDouble2 + 3.0; // LINT
-//  takesDouble(3.0); // LINT
-//  return inferredAsDouble3;
-//}
+class B extends A {
+  B.one() : super(1.0); // LINT
+  B.two() : super(2.3); // OK
+  B.three() : super(3);
+  namedParam1() {
+    namedDouble('should be int', d: 1.0); // LINT
+  }
+
+  namedParam2() {
+    namedDynamic('should stay double', d: 1.0); // OK
+  }
+}
+
+void takesDouble(double value) {}
+
+double other() {
+  takesDouble(3.0); // LINT
+
+  double myDouble1 = 5.0; // LINT
+  myDouble1 = myDouble1 + 3.7; // OK
+  myDouble1 = 4.0 + myDouble1; // LINT
+  myDouble1 = 4.0 - myDouble1; // LINT
+  myDouble1 = 4.0 * myDouble1 / myDouble1; // LINT
+  myDouble1 = 5.7 * myDouble1 / myDouble1; // OK
+
+  var inferredAsInt = 3;
+
+  var inferredAsDouble1 = inferredAsInt + 3.0; // OK
+  var inferredAsDouble2 = inferredAsDouble1 + 3.7; // OK
+  inferredAsDouble1 = inferredAsInt + 3.0; // OK
+  inferredAsDouble2 = inferredAsDouble1 + 3.7; // OK
+
+  // These next 4 could be LINT but static type info is not available
+  var inferredAsDouble3 = inferredAsDouble2 + 3.0; // OK
+  var inferredAsDouble4 = inferredAsDouble3 - 3.0; // OK
+  inferredAsDouble3 = inferredAsDouble2 + 3.0; // OK
+  inferredAsDouble4 = inferredAsDouble3 - 3.0; // OK
+
+  return 6.0 + myDouble1 + inferredAsDouble4; // LINT
+}

--- a/test/rules/prefer_int_literals.dart
+++ b/test/rules/prefer_int_literals.dart
@@ -5,13 +5,15 @@
 // test w/ `pub run test -N prefer_int_literals`
 
 const double okDouble = 7.3; // OK
-const double shouldBeInt = 8.0; // LINT
+const double shouldBeInt1 = 8.0; // LINT
+
+// TODO(danrubel): Consider linting these as well
+const double shouldBeInt2 = 8.0 + 7.0; // OK
+
 const inferredAsDouble = 8.0; // OK
 Object inferredAsDouble2 = 8.0; // OK
 dynamic inferredAsDouble3 = 8.0; // OK
 final inferredAsDouble4 = 8.0 + 7.0; // OK
-const double inferredAsDouble5 = 8.0 + // LINT
-    7.0; // LINT
 
 class A {
   var w = 7.0e2; // OK
@@ -23,12 +25,11 @@ class A {
   namedDynamic(String s, {dynamic d}) {}
 }
 
-// TODO(danrubel): Report lint in these other situations
-
 class B extends A {
   B.one() : super(1.0); // LINT
   B.two() : super(2.3); // OK
   B.three() : super(3);
+
   namedParam1() {
     namedDouble('should be int', d: 1.0); // LINT
   }
@@ -36,20 +37,39 @@ class B extends A {
   namedParam2() {
     namedDynamic('should stay double', d: 1.0); // OK
   }
+
+  double typedMethodReturn1() => 6.0; // LINT
+  double typedMethodReturn2() {
+    typedMethodReturn1();
+    return 6.0; // LINT
+  }
+
+  untypedMethodReturn1() => 6.0; // OK
+  untypedMethodReturn2() {
+    untypedMethodReturn1();
+    return 6.0; // OK
+  }
 }
 
 void takesDouble(double value) {}
 
-double other() {
+void typedVar() {
   takesDouble(3.0); // LINT
 
   double myDouble1 = 5.0; // LINT
+
   myDouble1 = myDouble1 + 3.7; // OK
-  myDouble1 = 4.0 + myDouble1; // LINT
-  myDouble1 = 4.0 - myDouble1; // LINT
-  myDouble1 = 4.0 * myDouble1 / myDouble1; // LINT
   myDouble1 = 5.7 * myDouble1 / myDouble1; // OK
 
+  // TODO(danrubel): Consider if these can be converted to an int literal
+  myDouble1 = 4.0 + myDouble1; // OK
+  myDouble1 = myDouble1 + 4.0; // OK
+  myDouble1 = myDouble1 - 4.0; // OK
+  myDouble1 = myDouble1 * 4.0; // OK
+  myDouble1 = myDouble1 / 4.0; // OK
+}
+
+void untypedVar() {
   var inferredAsInt = 3;
 
   var inferredAsDouble1 = inferredAsInt + 3.0; // OK
@@ -57,11 +77,65 @@ double other() {
   inferredAsDouble1 = inferredAsInt + 3.0; // OK
   inferredAsDouble2 = inferredAsDouble1 + 3.7; // OK
 
-  // These next 4 could be LINT but static type info is not available
+  // No static type info is not available for these
   var inferredAsDouble3 = inferredAsDouble2 + 3.0; // OK
   var inferredAsDouble4 = inferredAsDouble3 - 3.0; // OK
   inferredAsDouble3 = inferredAsDouble2 + 3.0; // OK
   inferredAsDouble4 = inferredAsDouble3 - 3.0; // OK
 
-  return 6.0 + myDouble1 + inferredAsDouble4; // LINT
+  int largeInt = 1 << 61 + 1;
+  double largeDouble1 = largeInt * 360.0; // OK
+  var largeDouble2 = largeInt * 360.0; // OK
+
+  largeDouble1 = largeDouble1 + largeDouble2 + inferredAsDouble4;
+}
+
+double typedFunctReturn1() => 6.0; // LINT
+double typedFunctReturn2(List<bool> b) {
+  if (b[0]) return 6.0; // LINT
+  if (b[1]) {
+    return 6.0; // LINT
+  }
+  typedFunctReturn1();
+  return 6.0; // LINT
+}
+
+untypedFunctReturn1() => 6.0; // OK
+untypedFunctReturn2(List<bool> b) {
+  if (b[0]) return 6.0; // OK
+  if (b[1]) {
+    return 6.0; // OK
+  }
+
+  double typedInnerReturn1() => 6.0; // LINT
+  double typedInnerReturn2() {
+    typedInnerReturn1();
+    return 6.0; // LINT
+  }
+
+  typedInnerReturn2();
+
+  untypedInnerReturn1() => 6.0; // OK
+  untypedInnerReturn2() {
+    untypedInnerReturn1();
+    return 6.0; // OK
+  }
+
+  untypedInnerReturn2();
+
+  untypedFunctReturn1();
+  return 6.0; // OK
+}
+
+double typedExpressionReturn() {
+  double myDouble = 6;
+
+  // TODO(danrubel): Consider if this can be converted to an int literal
+  return 6.0 + myDouble; // OK
+}
+
+linter_issue_1227() {
+  int i = 1 << 61 + 1;
+  var value1 = 360.0 * i; // OK
+  return value1;
 }


### PR DESCRIPTION
This improves the prefer_int_literal lint to detect double literals that can be converted in argument lists and binary expressions.