### PR TITLE
migrate `prefer_foreach` and `public_member_api_docs` to NodeLintRule (#1241)

### DIFF
--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -42,20 +42,20 @@ myList.forEach(foo().f); // But this one invokes foo() just once.
 
 ''';
 
-class PreferForeach extends LintRule {
-  _Visitor _visitor;
+class PreferForeach extends LintRule implements NodeLintRule {
   PreferForeach()
       : super(
             name: 'prefer_foreach',
             description: _desc,
             details: _details,
             group: Group.style,
-            maturity: Maturity.experimental) {
-    _visitor = new _Visitor(this);
-  }
+            maturity: Maturity.experimental);
 
   @override
-  AstVisitor getVisitor() => _visitor;
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addForEachStatement(this, visitor);
+  }
 }
 
 class _PreferForEachVisitor extends SimpleAstVisitor {

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -67,7 +67,7 @@ setters inherit the docs from the getters.
 // of the actual API surface area of a package - including that defined by
 // exports - and linting against that.
 
-class PublicMemberApiDocs extends LintRule {
+class PublicMemberApiDocs extends LintRule implements NodeLintRule {
   PublicMemberApiDocs()
       : super(
             name: 'public_member_api_docs',
@@ -76,7 +76,18 @@ class PublicMemberApiDocs extends LintRule {
             group: Group.style);
 
   @override
-  AstVisitor getVisitor() => new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+    registry.addClassTypeAlias(this, visitor);
+    registry.addCompilationUnit(this, visitor);
+    registry.addConstructorDeclaration(this, visitor);
+    registry.addEnumConstantDeclaration(this, visitor);
+    registry.addEnumDeclaration(this, visitor);
+    registry.addFieldDeclaration(this, visitor);
+    registry.addFunctionTypeAlias(this, visitor);
+    registry.addTopLevelVariableDeclaration(this, visitor);
+  }
 }
 
 class _Visitor extends GeneralizingAstVisitor {

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -90,7 +90,7 @@ class PublicMemberApiDocs extends LintRule implements NodeLintRule {
   }
 }
 
-class _Visitor extends GeneralizingAstVisitor {
+class _Visitor extends SimpleAstVisitor {
   InheritanceManager manager;
   bool isInLibFolder;
 


### PR DESCRIPTION
Fixes: #1241.

/cc @scheglov @stereotype441 