### PR TITLE
Begin making use of the analyzer's LinterContext API.

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -32,10 +32,11 @@ export 'package:analyzer/src/lint/linter.dart'
         LintRule,
         Group,
         Maturity,
+        LinterContext,
         LinterOptions,
         LintFilter,
         NodeLintRegistry,
-        NodeLintRule;
+        NodeLintRuleWithContext;
 export 'package:analyzer/src/lint/project.dart'
     show DartProject, ProjectVisitor;
 export 'package:analyzer/src/lint/pub.dart' show PubspecVisitor, PSEntry;

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -297,23 +297,23 @@ class _ElementVisitorAdapter extends GeneralizingElementVisitor {
   }
 }
 
-bool hasErrorWithConstantVerifier(AstNode node) {
+bool hasErrorWithConstantVerifier(LinterContext context, AstNode node) {
   final cu = getCompilationUnit(node);
   final listener = new HasConstErrorListener();
   node.accept(new ConstantVerifier(
       new ErrorReporter(listener, cu.declaredElement.source),
       cu.declaredElement.library,
-      cu.declaredElement.context.typeProvider,
-      cu.declaredElement.context.declaredVariables));
+      context.typeProvider,
+      context.declaredVariables));
   return listener.hasConstError;
 }
 
-bool hasErrorWithConstantVisitor(AstNode node) {
+bool hasErrorWithConstantVisitor(LinterContext context, AstNode node) {
   final cu = getCompilationUnit(node);
   final listener = new HasConstErrorListener();
   node.accept(new ConstantVisitor(
-      new ConstantEvaluationEngine(cu.declaredElement.context.typeProvider,
-          cu.declaredElement.context.declaredVariables),
+      new ConstantEvaluationEngine(
+          context.typeProvider, context.declaredVariables),
       new ErrorReporter(listener, cu.declaredElement.source)));
   return listener.hasConstError;
 }

--- a/lib/src/rules/always_declare_return_types.dart
+++ b/lib/src/rules/always_declare_return_types.dart
@@ -44,7 +44,8 @@ typedef bool predicate(Object o);
 
 ''';
 
-class AlwaysDeclareReturnTypes extends LintRule implements NodeLintRule {
+class AlwaysDeclareReturnTypes extends LintRule
+    implements NodeLintRuleWithContext {
   AlwaysDeclareReturnTypes()
       : super(
             name: 'always_declare_return_types',
@@ -53,7 +54,8 @@ class AlwaysDeclareReturnTypes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -45,7 +45,8 @@ while (condition) i += 1;
 
 ''';
 
-class AlwaysPutControlBodyOnNewLine extends LintRule implements NodeLintRule {
+class AlwaysPutControlBodyOnNewLine extends LintRule
+    implements NodeLintRuleWithContext {
   AlwaysPutControlBodyOnNewLine()
       : super(
             name: 'always_put_control_body_on_new_line',
@@ -54,7 +55,8 @@ class AlwaysPutControlBodyOnNewLine extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForEachStatement(this, visitor);

--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -25,7 +25,7 @@ m({b, c, @required a}) ;
 ''';
 
 class AlwaysPutRequiredNamedParametersFirst extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AlwaysPutRequiredNamedParametersFirst()
       : super(
             name: 'always_put_required_named_parameters_first',
@@ -34,7 +34,8 @@ class AlwaysPutRequiredNamedParametersFirst extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFormalParameterList(this, visitor);
   }

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -38,7 +38,7 @@ NOTE: Only asserts at the start of the bodies will be taken into account.
 ''';
 
 class AlwaysRequireNonNullNamedParameters extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AlwaysRequireNonNullNamedParameters()
       : super(
             name: 'always_require_non_null_named_parameters',
@@ -47,7 +47,8 @@ class AlwaysRequireNonNullNamedParameters extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFormalParameterList(this, visitor);
   }

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -79,7 +79,7 @@ bool _isOptionalTypeArgs(Element element) =>
     element.name == _OPTIONAL_TYPE_ARGS_VAR_NAME &&
     element.library?.name == _META_LIB_NAME;
 
-class AlwaysSpecifyTypes extends LintRule implements NodeLintRule {
+class AlwaysSpecifyTypes extends LintRule implements NodeLintRuleWithContext {
   AlwaysSpecifyTypes()
       : super(
             name: 'always_specify_types',
@@ -88,7 +88,8 @@ class AlwaysSpecifyTypes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addDeclaredIdentifier(this, visitor);
     registry.addListLiteral(this, visitor);

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -45,7 +45,7 @@ class Lucky extends Cat {
 
 ''';
 
-class AnnotateOverrides extends LintRule implements NodeLintRule {
+class AnnotateOverrides extends LintRule implements NodeLintRuleWithContext {
   AnnotateOverrides()
       : super(
             name: 'annotate_overrides',
@@ -54,7 +54,8 @@ class AnnotateOverrides extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCompilationUnit(this, visitor);
     registry.addFieldDeclaration(this, visitor);

--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -35,7 +35,8 @@ lookUpOrDefault(String name, Map map, defaultValue) {
 
 ''';
 
-class AvoidAnnotatingWithDynamic extends LintRule implements NodeLintRule {
+class AvoidAnnotatingWithDynamic extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidAnnotatingWithDynamic()
       : super(
             name: 'avoid_annotating_with_dynamic',
@@ -44,7 +45,8 @@ class AvoidAnnotatingWithDynamic extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addSimpleFormalParameter(this, visitor);
   }

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -58,7 +58,7 @@ HasScrollDirection scrollable = renderObject as dynamic;
 
 ''';
 
-class AvoidAs extends LintRule implements NodeLintRule {
+class AvoidAs extends LintRule implements NodeLintRuleWithContext {
   AvoidAs()
       : super(
             name: 'avoid_as',
@@ -67,7 +67,8 @@ class AvoidAs extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addAsExpression(this, visitor);
   }

--- a/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
+++ b/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
-import 'package:linter/src/ast.dart';
 
 const _desc = r'Avoid bool literals in conditional expressions.';
 
@@ -32,7 +31,7 @@ condition && boolExpression
 ''';
 
 class AvoidBoolLiteralsInConditionalExpressions extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidBoolLiteralsInConditionalExpressions()
       : super(
             name: 'avoid_bool_literals_in_conditional_expressions',
@@ -41,8 +40,9 @@ class AvoidBoolLiteralsInConditionalExpressions extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addConditionalExpression(this, visitor);
   }
 }
@@ -50,12 +50,13 @@ class AvoidBoolLiteralsInConditionalExpressions extends LintRule
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitConditionalExpression(ConditionalExpression node) {
-    final typeProvider =
-        getCompilationUnit(node).declaredElement.context.typeProvider;
+    final typeProvider = context.typeProvider;
     final thenExp = node.thenExpression;
     final elseExp = node.elseExpression;
 

--- a/lib/src/rules/avoid_catches_without_on_clauses.dart
+++ b/lib/src/rules/avoid_catches_without_on_clauses.dart
@@ -37,7 +37,8 @@ on Exception catch(e) {
 
 ''';
 
-class AvoidCatchesWithoutOnClauses extends LintRule implements NodeLintRule {
+class AvoidCatchesWithoutOnClauses extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidCatchesWithoutOnClauses()
       : super(
             name: 'avoid_catches_without_on_clauses',
@@ -46,7 +47,8 @@ class AvoidCatchesWithoutOnClauses extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCatchClause(this, visitor);
   }

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -36,7 +36,7 @@ try {
 
 ''';
 
-class AvoidCatchingErrors extends LintRule implements NodeLintRule {
+class AvoidCatchingErrors extends LintRule implements NodeLintRuleWithContext {
   AvoidCatchingErrors()
       : super(
             name: 'avoid_catching_errors',
@@ -45,7 +45,8 @@ class AvoidCatchingErrors extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCatchClause(this, visitor);
   }

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -54,7 +54,7 @@ bool _isStaticMember(ClassMember classMember) {
 }
 
 class AvoidClassesWithOnlyStaticMembers extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidClassesWithOnlyStaticMembers()
       : super(
             name: 'avoid_classes_with_only_static_members',
@@ -63,7 +63,8 @@ class AvoidClassesWithOnlyStaticMembers extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -6,7 +6,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
-import 'package:linter/src/ast.dart';
 
 const _desc = r'Avoid double and int checks.';
 
@@ -42,7 +41,8 @@ f(dynamic x) {
 
 ''';
 
-class AvoidDoubleAndIntChecks extends LintRule implements NodeLintRule {
+class AvoidDoubleAndIntChecks extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidDoubleAndIntChecks()
       : super(
             name: 'avoid_double_and_int_checks',
@@ -51,8 +51,9 @@ class AvoidDoubleAndIntChecks extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addIfStatement(this, visitor);
   }
 }
@@ -60,7 +61,9 @@ class AvoidDoubleAndIntChecks extends LintRule implements NodeLintRule {
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitIfStatement(IfStatement node) {
@@ -69,8 +72,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       final ifCondition = node.condition;
       final elseCondition = elseStatement.condition;
       if (ifCondition is IsExpression && elseCondition is IsExpression) {
-        final typeProvider =
-            getCompilationUnit(node).declaredElement.context.typeProvider;
+        final typeProvider = context.typeProvider;
         final ifExpression = ifCondition.expression;
         final elseIsExpression = elseCondition.expression;
         if (ifExpression is SimpleIdentifier &&

--- a/lib/src/rules/avoid_empty_else.dart
+++ b/lib/src/rules/avoid_empty_else.dart
@@ -22,7 +22,7 @@ else ;
 
 ''';
 
-class AvoidEmptyElse extends LintRule implements NodeLintRule {
+class AvoidEmptyElse extends LintRule implements NodeLintRuleWithContext {
   AvoidEmptyElse()
       : super(
             name: 'avoid_empty_else',
@@ -31,7 +31,8 @@ class AvoidEmptyElse extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addIfStatement(this, visitor);
   }

--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -36,7 +36,7 @@ class A {
 ''';
 
 class AvoidFieldInitializersInConstClasses extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidFieldInitializersInConstClasses()
       : super(
             name: 'avoid_field_initializers_in_const_classes',
@@ -45,7 +45,8 @@ class AvoidFieldInitializersInConstClasses extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addConstructorFieldInitializer(this, visitor);

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -31,7 +31,7 @@ people.forEach(print);
 ''';
 
 class AvoidFunctionLiteralInForeachMethod extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidFunctionLiteralInForeachMethod()
       : super(
             name: 'avoid_function_literals_in_foreach_calls',
@@ -40,7 +40,8 @@ class AvoidFunctionLiteralInForeachMethod extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }

--- a/lib/src/rules/avoid_implementing_value_types.dart
+++ b/lib/src/rules/avoid_implementing_value_types.dart
@@ -85,7 +85,8 @@ void main() {
 
 ''';
 
-class AvoidImplementingValueTypes extends LintRule implements NodeLintRule {
+class AvoidImplementingValueTypes extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidImplementingValueTypes()
       : super(
             name: 'avoid_implementing_value_types',
@@ -94,7 +95,8 @@ class AvoidImplementingValueTypes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -54,7 +54,7 @@ class LazyId {
 
 ''';
 
-class AvoidInitToNull extends LintRule implements NodeLintRule {
+class AvoidInitToNull extends LintRule implements NodeLintRuleWithContext {
   AvoidInitToNull()
       : super(
             name: 'avoid_init_to_null',
@@ -63,7 +63,8 @@ class AvoidInitToNull extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addVariableDeclaration(this, visitor);
     registry.addDefaultFormalParameter(this, visitor);

--- a/lib/src/rules/avoid_js_rounded_ints.dart
+++ b/lib/src/rules/avoid_js_rounded_ints.dart
@@ -32,7 +32,7 @@ BigInt value = BigInt.parse('9007199254740995');
 
 ''';
 
-class AvoidJsRoundedInts extends LintRule implements NodeLintRule {
+class AvoidJsRoundedInts extends LintRule implements NodeLintRuleWithContext {
   AvoidJsRoundedInts()
       : super(
             name: 'avoid_js_rounded_ints',
@@ -41,7 +41,8 @@ class AvoidJsRoundedInts extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addIntegerLiteral(this, visitor);
   }

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -71,7 +71,7 @@ bool _isParameterWithQuestionQuestion(
     _isParameter(node.leftOperand, parameter);
 
 class AvoidNullChecksInEqualityOperators extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidNullChecksInEqualityOperators()
       : super(
             name: 'avoid_null_checks_in_equality_operators',
@@ -80,7 +80,8 @@ class AvoidNullChecksInEqualityOperators extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -38,7 +38,7 @@ new Button(ButtonState.enabled);
 ''';
 
 class AvoidPositionalBooleanParameters extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidPositionalBooleanParameters()
       : super(
             name: 'avoid_positional_boolean_parameters',
@@ -48,7 +48,8 @@ class AvoidPositionalBooleanParameters extends LintRule
             maturity: Maturity.experimental);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCompilationUnit(this, visitor);
     registry.addConstructorDeclaration(this, visitor);

--- a/lib/src/rules/avoid_relative_lib_imports.dart
+++ b/lib/src/rules/avoid_relative_lib_imports.dart
@@ -37,7 +37,8 @@ import '../lib/baz.dart';
 
 ''';
 
-class AvoidRelativeLibImports extends LintRule implements NodeLintRule {
+class AvoidRelativeLibImports extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidRelativeLibImports()
       : super(
             name: 'avoid_relative_lib_imports',
@@ -46,7 +47,8 @@ class AvoidRelativeLibImports extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addImportDirective(this, visitor);
   }

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -42,7 +42,8 @@ abstract class B extends A {
 
 ''';
 
-class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
+class AvoidRenamingMethodParameters extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidRenamingMethodParameters()
       : super(
             name: 'avoid_renaming_method_parameters',
@@ -51,7 +52,8 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -26,7 +26,8 @@ void set speed(int ms);
 
 ''';
 
-class AvoidReturnTypesOnSetters extends LintRule implements NodeLintRule {
+class AvoidReturnTypesOnSetters extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidReturnTypesOnSetters()
       : super(
             name: 'avoid_return_types_on_setters',
@@ -35,7 +36,8 @@ class AvoidReturnTypesOnSetters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -50,7 +50,7 @@ bool _isPrimitiveType(DartType type) =>
 bool _isReturnNull(AstNode node) =>
     node is ReturnStatement && DartTypeUtilities.isNullLiteral(node.expression);
 
-class AvoidReturningNull extends LintRule implements NodeLintRule {
+class AvoidReturningNull extends LintRule implements NodeLintRuleWithContext {
   AvoidReturningNull()
       : super(
             name: 'avoid_returning_null',
@@ -59,7 +59,8 @@ class AvoidReturningNull extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionExpression(this, visitor);
     registry.addMethodDeclaration(this, visitor);

--- a/lib/src/rules/avoid_returning_null_for_future.dart
+++ b/lib/src/rules/avoid_returning_null_for_future.dart
@@ -18,7 +18,8 @@ developer simply forgot to put an `async` keyword on the function.
 
 ''';
 
-class AvoidReturningNullForFuture extends LintRule implements NodeLintRule {
+class AvoidReturningNullForFuture extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidReturningNullForFuture()
       : super(
             name: 'avoid_returning_null_for_future',
@@ -27,7 +28,8 @@ class AvoidReturningNullForFuture extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addExpressionFunctionBody(this, visitor);
     registry.addReturnStatement(this, visitor);

--- a/lib/src/rules/avoid_returning_null_for_void.dart
+++ b/lib/src/rules/avoid_returning_null_for_void.dart
@@ -41,7 +41,8 @@ Future<void> f2() async {
 
 ''';
 
-class AvoidReturningNullForVoid extends LintRule implements NodeLintRule {
+class AvoidReturningNullForVoid extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidReturningNullForVoid()
       : super(
             name: 'avoid_returning_null_for_void',
@@ -50,7 +51,8 @@ class AvoidReturningNullForVoid extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addExpressionFunctionBody(this, visitor);
     registry.addReturnStatement(this, visitor);

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -48,7 +48,7 @@ bool _isReturnStatement(AstNode node) => node is ReturnStatement;
 bool _returnsThis(AstNode node) =>
     (node as ReturnStatement).expression is ThisExpression;
 
-class AvoidReturningThis extends LintRule implements NodeLintRule {
+class AvoidReturningThis extends LintRule implements NodeLintRuleWithContext {
   AvoidReturningThis()
       : super(
             name: 'avoid_returning_this',
@@ -57,7 +57,8 @@ class AvoidReturningThis extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -50,7 +50,8 @@ bool _hasGetter(MethodDeclaration node) =>
 bool _hasInheritedSetter(MethodDeclaration node) =>
     DartTypeUtilities.lookUpInheritedConcreteSetter(node) != null;
 
-class AvoidSettersWithoutGetters extends LintRule implements NodeLintRule {
+class AvoidSettersWithoutGetters extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidSettersWithoutGetters()
       : super(
             name: 'avoid_setters_without_getters',
@@ -59,7 +60,8 @@ class AvoidSettersWithoutGetters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -28,7 +28,8 @@ class A<T> {
 
 ''';
 
-class AvoidShadowingTypeParameters extends LintRule implements NodeLintRule {
+class AvoidShadowingTypeParameters extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidShadowingTypeParameters()
       : super(
             name: 'avoid_shadowing_type_parameters',
@@ -37,7 +38,8 @@ class AvoidShadowingTypeParameters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
     registry.addFunctionDeclarationStatement(this, visitor);

--- a/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
+++ b/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
@@ -25,7 +25,7 @@ o.m();
 ''';
 
 class AvoidSingleCascadeInExpressionStatements extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidSingleCascadeInExpressionStatements()
       : super(
             name: 'avoid_single_cascade_in_expression_statements',
@@ -34,7 +34,8 @@ class AvoidSingleCascadeInExpressionStatements extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCascadeExpression(this, visitor);
   }

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -63,7 +63,7 @@ const List<String> _fileSystemEntityMethodNames = const <String>[
   'type',
 ];
 
-class AvoidSlowAsyncIo extends LintRule implements NodeLintRule {
+class AvoidSlowAsyncIo extends LintRule implements NodeLintRuleWithContext {
   AvoidSlowAsyncIo()
       : super(
             name: 'avoid_slow_async_io',
@@ -72,7 +72,8 @@ class AvoidSlowAsyncIo extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }

--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -24,7 +24,8 @@ m(f(int v));
 
 ''';
 
-class AvoidTypesAsParameterNames extends LintRule implements NodeLintRule {
+class AvoidTypesAsParameterNames extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidTypesAsParameterNames()
       : super(
             name: 'avoid_types_as_parameter_names',
@@ -33,7 +34,8 @@ class AvoidTypesAsParameterNames extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFormalParameterList(this, visitor);
   }

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -28,7 +28,8 @@ var names = people.map((person) => person.name);
 
 ''';
 
-class AvoidTypesOnClosureParameters extends LintRule implements NodeLintRule {
+class AvoidTypesOnClosureParameters extends LintRule
+    implements NodeLintRuleWithContext {
   AvoidTypesOnClosureParameters()
       : super(
             name: 'avoid_types_on_closure_parameters',
@@ -37,7 +38,8 @@ class AvoidTypesOnClosureParameters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionExpression(this, visitor);
   }

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -31,7 +31,7 @@ class BadTwo {
 ''';
 
 class AvoidUnusedConstructorParameters extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   AvoidUnusedConstructorParameters()
       : super(
             name: 'avoid_unused_constructor_parameters',
@@ -40,7 +40,8 @@ class AvoidUnusedConstructorParameters extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_void_async.dart
+++ b/lib/src/rules/avoid_void_async.dart
@@ -30,7 +30,7 @@ Future<void> f2() async => null;
 
 ''';
 
-class AvoidVoidAsync extends LintRule implements NodeLintRule {
+class AvoidVoidAsync extends LintRule implements NodeLintRuleWithContext {
   AvoidVoidAsync()
       : super(
             name: 'avoid_void_async',
@@ -39,7 +39,8 @@ class AvoidVoidAsync extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -30,7 +30,7 @@ main() async {
 
 ''';
 
-class AwaitOnlyFutures extends LintRule implements NodeLintRule {
+class AwaitOnlyFutures extends LintRule implements NodeLintRuleWithContext {
   AwaitOnlyFutures()
       : super(
             name: 'await_only_futures',
@@ -39,7 +39,8 @@ class AwaitOnlyFutures extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addAwaitExpression(this, visitor);
   }

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -33,7 +33,7 @@ typedef num Adder(num x, num y);
 
 ''';
 
-class CamelCaseTypes extends LintRule implements NodeLintRule {
+class CamelCaseTypes extends LintRule implements NodeLintRuleWithContext {
   CamelCaseTypes()
       : super(
             name: 'camel_case_types',
@@ -42,7 +42,8 @@ class CamelCaseTypes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -60,7 +60,7 @@ void someFunctionOK() {
 bool _isSubscription(DartType type) => DartTypeUtilities.implementsInterface(
     type, 'StreamSubscription', 'dart.async');
 
-class CancelSubscriptions extends LintRule implements NodeLintRule {
+class CancelSubscriptions extends LintRule implements NodeLintRuleWithContext {
   CancelSubscriptions()
       : super(
             name: 'cancel_subscriptions',
@@ -69,7 +69,8 @@ class CancelSubscriptions extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addVariableDeclarationStatement(this, visitor);

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -97,7 +97,7 @@ bool _isInvokedWithoutNullAwareOperator(Token token) =>
 
 /// Rule to lint consecutive invocations of methods or getters on the same
 /// reference that could be done with the cascade operator.
-class CascadeInvocations extends LintRule implements NodeLintRule {
+class CascadeInvocations extends LintRule implements NodeLintRuleWithContext {
   /// Default constructor.
   CascadeInvocations()
       : super(
@@ -107,7 +107,8 @@ class CascadeInvocations extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBlock(this, visitor);
   }

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -62,7 +62,7 @@ bool _isSink(DartType type) =>
 bool _isSocket(DartType type) =>
     DartTypeUtilities.implementsInterface(type, 'Socket', 'dart.io');
 
-class CloseSinks extends LintRule implements NodeLintRule {
+class CloseSinks extends LintRule implements NodeLintRuleWithContext {
   CloseSinks()
       : super(
             name: 'close_sinks',
@@ -71,7 +71,8 @@ class CloseSinks extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addVariableDeclarationStatement(this, visitor);

--- a/lib/src/rules/comment_references.dart
+++ b/lib/src/rules/comment_references.dart
@@ -45,7 +45,7 @@ references within square brackets can consist of either
 
 ''';
 
-class CommentReferences extends LintRule implements NodeLintRule {
+class CommentReferences extends LintRule implements NodeLintRuleWithContext {
   CommentReferences()
       : super(
             name: 'comment_references',
@@ -54,7 +54,8 @@ class CommentReferences extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addComment(this, visitor);
     registry.addCommentReference(this, visitor);

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -43,7 +43,8 @@ class Dice {
 
 ''';
 
-class ConstantIdentifierNames extends LintRule implements NodeLintRule {
+class ConstantIdentifierNames extends LintRule
+    implements NodeLintRuleWithContext {
   ConstantIdentifierNames()
       : super(
             name: 'constant_identifier_names',
@@ -52,7 +53,8 @@ class ConstantIdentifierNames extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addEnumConstantDeclaration(this, visitor);
     registry.addTopLevelVariableDeclaration(this, visitor);

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -83,7 +83,7 @@ class BadBreak {
 
 ''';
 
-class ControlFlowInFinally extends LintRule implements NodeLintRule {
+class ControlFlowInFinally extends LintRule implements NodeLintRuleWithContext {
   ControlFlowInFinally()
       : super(
             name: 'control_flow_in_finally',
@@ -92,7 +92,8 @@ class ControlFlowInFinally extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBreakStatement(this, visitor);
     registry.addContinueStatement(this, visitor);

--- a/lib/src/rules/curly_braces_in_flow_control_structures.dart
+++ b/lib/src/rules/curly_braces_in_flow_control_structures.dart
@@ -50,7 +50,7 @@ if (overflowChars != other.overflowChars)
 ''';
 
 class CurlyBracesInFlowControlStructures extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   CurlyBracesInFlowControlStructures()
       : super(
             name: 'curly_braces_in_flow_control_structures',
@@ -59,7 +59,8 @@ class CurlyBracesInFlowControlStructures extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForEachStatement(this, visitor);

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -166,7 +166,7 @@ String _thirdPartyPackageDirectiveBeforeOwn(String type) =>
     "Place 'third-party' 'package:' ${type}s before other ${type}s.";
 
 class DirectivesOrdering extends LintRule
-    implements ProjectVisitor, NodeLintRule {
+    implements ProjectVisitor, NodeLintRuleWithContext {
   DartProject project;
 
   DirectivesOrdering()
@@ -180,7 +180,8 @@ class DirectivesOrdering extends LintRule
   ProjectVisitor getProjectVisitor() => this;
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -48,7 +48,7 @@ try {
 
 ''';
 
-class EmptyCatches extends LintRule implements NodeLintRule {
+class EmptyCatches extends LintRule implements NodeLintRuleWithContext {
   EmptyCatches()
       : super(
             name: 'empty_catches',
@@ -57,7 +57,8 @@ class EmptyCatches extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCatchClause(this, visitor);
   }

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -36,7 +36,8 @@ class Point {
 
 ''';
 
-class EmptyConstructorBodies extends LintRule implements NodeLintRule {
+class EmptyConstructorBodies extends LintRule
+    implements NodeLintRuleWithContext {
   EmptyConstructorBodies()
       : super(
             name: 'empty_constructor_bodies',
@@ -45,7 +46,8 @@ class EmptyConstructorBodies extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }

--- a/lib/src/rules/empty_statements.dart
+++ b/lib/src/rules/empty_statements.dart
@@ -40,7 +40,7 @@ if (complicated.expression.foo())
 
 ''';
 
-class EmptyStatements extends LintRule implements NodeLintRule {
+class EmptyStatements extends LintRule implements NodeLintRuleWithContext {
   EmptyStatements()
       : super(
             name: 'empty_statements',
@@ -49,7 +49,8 @@ class EmptyStatements extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addEmptyStatement(this, visitor);
   }

--- a/lib/src/rules/file_names.dart
+++ b/lib/src/rules/file_names.dart
@@ -34,7 +34,7 @@ library.
 
 ''';
 
-class FileNames extends LintRule implements NodeLintRule {
+class FileNames extends LintRule implements NodeLintRuleWithContext {
   FileNames()
       : super(
             name: 'file_names',
@@ -43,7 +43,8 @@ class FileNames extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }

--- a/lib/src/rules/flutter_style_todos.dart
+++ b/lib/src/rules/flutter_style_todos.dart
@@ -22,7 +22,7 @@ const _details = r'''
 
 ''';
 
-class FlutterStyleTodos extends LintRule implements NodeLintRule {
+class FlutterStyleTodos extends LintRule implements NodeLintRuleWithContext {
   FlutterStyleTodos()
       : super(
             name: 'flutter_style_todos',
@@ -31,7 +31,8 @@ class FlutterStyleTodos extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -45,7 +45,7 @@ class Better {
 
 ''';
 
-class HashAndEquals extends LintRule implements NodeLintRule {
+class HashAndEquals extends LintRule implements NodeLintRuleWithContext {
   HashAndEquals()
       : super(
             name: 'hash_and_equals',
@@ -54,7 +54,8 @@ class HashAndEquals extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -56,7 +56,8 @@ bool samePackage(Uri uri1, Uri uri2) {
   return segments1[0] == segments2[0];
 }
 
-class ImplementationImports extends LintRule implements NodeLintRule {
+class ImplementationImports extends LintRule
+    implements NodeLintRuleWithContext {
   ImplementationImports()
       : super(
             name: 'implementation_imports',
@@ -65,7 +66,8 @@ class ImplementationImports extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addImportDirective(this, visitor);
   }

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -103,7 +103,7 @@ Iterable<Element> _getElementsInExpression(Expression node) =>
         .map(DartTypeUtilities.getCanonicalElementFromIdentifier)
         .where((e) => e != null);
 
-class InvariantBooleans extends LintRule implements NodeLintRule {
+class InvariantBooleans extends LintRule implements NodeLintRuleWithContext {
   InvariantBooleans()
       : super(
             name: 'invariant_booleans',
@@ -113,7 +113,8 @@ class InvariantBooleans extends LintRule implements NodeLintRule {
             maturity: Maturity.stable);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     var visitor = new _InvariantBooleansVisitor(this);
     registry.addCompilationUnit(this, visitor);
   }

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -119,7 +119,8 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 
 ''';
 
-class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
+class IterableContainsUnrelatedType extends LintRule
+    implements NodeLintRuleWithContext {
   IterableContainsUnrelatedType()
       : super(
             name: 'iterable_contains_unrelated_type',
@@ -128,7 +129,8 @@ class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }

--- a/lib/src/rules/join_return_with_assignment.dart
+++ b/lib/src/rules/join_return_with_assignment.dart
@@ -48,7 +48,8 @@ Element _getElementFromReturnStatement(Statement node) {
   return null;
 }
 
-class JoinReturnWithAssignment extends LintRule implements NodeLintRule {
+class JoinReturnWithAssignment extends LintRule
+    implements NodeLintRuleWithContext {
   JoinReturnWithAssignment()
       : super(
             name: 'join_return_with_assignment',
@@ -57,7 +58,8 @@ class JoinReturnWithAssignment extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBlock(this, visitor);
   }

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -32,7 +32,7 @@ file.
 
 ''';
 
-class LibraryNames extends LintRule implements NodeLintRule {
+class LibraryNames extends LintRule implements NodeLintRuleWithContext {
   LibraryNames()
       : super(
             name: 'library_names',
@@ -41,7 +41,8 @@ class LibraryNames extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addLibraryDirective(this, visitor);
   }

--- a/lib/src/rules/library_prefixes.dart
+++ b/lib/src/rules/library_prefixes.dart
@@ -32,7 +32,7 @@ import 'package:javascript_utils/javascript_utils.dart' as jsUtils;
 
 ''';
 
-class LibraryPrefixes extends LintRule implements NodeLintRule {
+class LibraryPrefixes extends LintRule implements NodeLintRuleWithContext {
   LibraryPrefixes()
       : super(
             name: 'library_prefixes',
@@ -41,7 +41,8 @@ class LibraryPrefixes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addImportDirective(this, visitor);
   }

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -119,7 +119,8 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 
 ''';
 
-class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
+class ListRemoveUnrelatedType extends LintRule
+    implements NodeLintRuleWithContext {
   ListRemoveUnrelatedType()
       : super(
             name: 'list_remove_unrelated_type',
@@ -128,7 +129,8 @@ class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -98,7 +98,8 @@ bool _onlyLiterals(Expression rawExpression) {
   return false;
 }
 
-class LiteralOnlyBooleanExpressions extends LintRule implements NodeLintRule {
+class LiteralOnlyBooleanExpressions extends LintRule
+    implements NodeLintRuleWithContext {
   LiteralOnlyBooleanExpressions()
       : super(
             name: 'literal_only_boolean_expressions',
@@ -108,7 +109,8 @@ class LiteralOnlyBooleanExpressions extends LintRule implements NodeLintRule {
             maturity: Maturity.experimental);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForStatement(this, visitor);

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -34,7 +34,8 @@ List<String> list = <String>[
 
 ''';
 
-class NoAdjacentStringsInList extends LintRule implements NodeLintRule {
+class NoAdjacentStringsInList extends LintRule
+    implements NodeLintRuleWithContext {
   NoAdjacentStringsInList()
       : super(
             name: 'no_adjacent_strings_in_list',
@@ -43,7 +44,8 @@ class NoAdjacentStringsInList extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addListLiteral(this, visitor);
   }

--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -30,7 +30,8 @@ align(clearItems) {
 
 ''';
 
-class NonConstantIdentifierNames extends LintRule implements NodeLintRule {
+class NonConstantIdentifierNames extends LintRule
+    implements NodeLintRuleWithContext {
   NonConstantIdentifierNames()
       : super(
             name: 'non_constant_identifier_names',
@@ -39,7 +40,8 @@ class NonConstantIdentifierNames extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
     registry.addFormalParameterList(this, visitor);

--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -204,7 +204,7 @@ final Map<String, Set<NonNullableFunction>>
   ]),
 };
 
-class NullClosures extends LintRule implements NodeLintRule {
+class NullClosures extends LintRule implements NodeLintRuleWithContext {
   NullClosures()
       : super(
             name: 'null_closures',
@@ -213,7 +213,8 @@ class NullClosures extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -43,7 +43,8 @@ Map<int, List<Person>> groupByZip(Iterable<Person> people) {
 
 ''';
 
-class OmitLocalVariableTypes extends LintRule implements NodeLintRule {
+class OmitLocalVariableTypes extends LintRule
+    implements NodeLintRuleWithContext {
   OmitLocalVariableTypes()
       : super(
             name: 'omit_local_variable_types',
@@ -52,7 +53,8 @@ class OmitLocalVariableTypes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addForEachStatement(this, visitor);
     registry.addForStatement(this, visitor);

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -35,7 +35,7 @@ abstract class Predicate {
 
 ''';
 
-class OneMemberAbstracts extends LintRule implements NodeLintRule {
+class OneMemberAbstracts extends LintRule implements NodeLintRuleWithContext {
   OneMemberAbstracts()
       : super(
             name: 'one_member_abstracts',
@@ -44,7 +44,8 @@ class OneMemberAbstracts extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -55,7 +55,7 @@ bool _isThrowable(DartType type) =>
     type.isDynamic ||
     DartTypeUtilities.implementsAnyInterface(type, _interfaceDefinitions);
 
-class OnlyThrowErrors extends LintRule implements NodeLintRule {
+class OnlyThrowErrors extends LintRule implements NodeLintRuleWithContext {
   OnlyThrowErrors()
       : super(
             name: 'only_throw_errors',
@@ -64,7 +64,8 @@ class OnlyThrowErrors extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addThrowExpression(this, visitor);
   }

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -95,7 +95,7 @@ Iterable<InterfaceType> _findAllSupertypesInMixin(ClassElement classElement) {
   return supertypes;
 }
 
-class OverriddenFields extends LintRule implements NodeLintRule {
+class OverriddenFields extends LintRule implements NodeLintRuleWithContext {
   OverriddenFields()
       : super(
             name: 'overridden_fields',
@@ -104,7 +104,8 @@ class OverriddenFields extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
   }

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -58,7 +58,8 @@ Advice for writing good doc comments can be found in the
 
 ''';
 
-class PackageApiDocs extends LintRule implements ProjectVisitor, NodeLintRule {
+class PackageApiDocs extends LintRule
+    implements ProjectVisitor, NodeLintRuleWithContext {
   DartProject project;
 
   PackageApiDocs()
@@ -77,7 +78,8 @@ class PackageApiDocs extends LintRule implements ProjectVisitor, NodeLintRule {
   }
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     var visitor = new _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
     registry.addFieldDeclaration(this, visitor);

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -50,7 +50,7 @@ bool matchesOrIsPrefixedBy(String name, String prefix) =>
     name == prefix || name.startsWith('$prefix.');
 
 class PackagePrefixedLibraryNames extends LintRule
-    implements ProjectVisitor, NodeLintRule {
+    implements ProjectVisitor, NodeLintRuleWithContext {
   DartProject project;
 
   PackagePrefixedLibraryNames()
@@ -64,7 +64,8 @@ class PackagePrefixedLibraryNames extends LintRule
   ProjectVisitor getProjectVisitor() => this;
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addLibraryDirective(this, visitor);
   }

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -106,7 +106,7 @@ bool _preOrPostFixExpressionMutation(FormalParameter parameter, AstNode n) =>
         (n.operand as SimpleIdentifier).staticElement ==
             parameter.declaredElement;
 
-class ParameterAssignments extends LintRule implements NodeLintRule {
+class ParameterAssignments extends LintRule implements NodeLintRuleWithContext {
   ParameterAssignments()
       : super(
             name: 'parameter_assignments',
@@ -115,7 +115,8 @@ class ParameterAssignments extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);

--- a/lib/src/rules/prefer_adjacent_string_concatenation.dart
+++ b/lib/src/rules/prefer_adjacent_string_concatenation.dart
@@ -29,7 +29,7 @@ raiseAlarm(
 ''';
 
 class PreferAdjacentStringConcatenation extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferAdjacentStringConcatenation()
       : super(
             name: 'prefer_adjacent_string_concatenation',
@@ -38,7 +38,8 @@ class PreferAdjacentStringConcatenation extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }

--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -37,7 +37,8 @@ class A {
 
 ''';
 
-class PreferAssertsInInitializerLists extends LintRule implements NodeLintRule {
+class PreferAssertsInInitializerLists extends LintRule
+    implements NodeLintRuleWithContext {
   PreferAssertsInInitializerLists()
       : super(
             name: 'prefer_asserts_in_initializer_lists',
@@ -46,7 +47,8 @@ class PreferAssertsInInitializerLists extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }

--- a/lib/src/rules/prefer_bool_in_asserts.dart
+++ b/lib/src/rules/prefer_bool_in_asserts.dart
@@ -34,7 +34,7 @@ assert(() {
 
 ''';
 
-class PreferBoolInAsserts extends LintRule implements NodeLintRule {
+class PreferBoolInAsserts extends LintRule implements NodeLintRuleWithContext {
   PreferBoolInAsserts()
       : super(
             name: 'prefer_bool_in_asserts',
@@ -43,9 +43,9 @@ class PreferBoolInAsserts extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
-    registry.addCompilationUnit(this, visitor);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addAssertStatement(this, visitor);
   }
 }
@@ -53,19 +53,15 @@ class PreferBoolInAsserts extends LintRule implements NodeLintRule {
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  _Visitor(this.rule);
+  _Visitor(this.rule, LinterContext context)
+      : boolType = context.typeProvider.boolType;
 
-  DartType boolType;
+  final DartType boolType;
   @override
   void visitAssertStatement(AssertStatement node) {
     if (!_unbound(node.condition.staticType).isAssignableTo(boolType)) {
       rule.reportLint(node.condition);
     }
-  }
-
-  @override
-  void visitCompilationUnit(CompilationUnit node) {
-    boolType = node.declaredElement.context.typeProvider.boolType;
   }
 
   DartType _unbound(DartType type) {

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -27,7 +27,8 @@ var addresses = {};
 
 ''';
 
-class PreferCollectionLiterals extends LintRule implements NodeLintRule {
+class PreferCollectionLiterals extends LintRule
+    implements NodeLintRuleWithContext {
   PreferCollectionLiterals()
       : super(
             name: 'prefer_collection_literals',
@@ -36,7 +37,8 @@ class PreferCollectionLiterals extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -69,7 +69,8 @@ Element _getElementInCondition(Expression rawExpression) {
   return null;
 }
 
-class PreferConditionalAssignment extends LintRule implements NodeLintRule {
+class PreferConditionalAssignment extends LintRule
+    implements NodeLintRuleWithContext {
   PreferConditionalAssignment()
       : super(
             name: 'prefer_conditional_assignment',
@@ -78,7 +79,8 @@ class PreferConditionalAssignment extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addIfStatement(this, visitor);
   }

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -53,7 +53,7 @@ bool _isImmutable(Element element) =>
     element.library?.name == _META_LIB_NAME;
 
 class PreferConstConstructorsInImmutables extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferConstConstructorsInImmutables()
       : super(
             name: 'prefer_const_constructors_in_immutables',
@@ -62,8 +62,9 @@ class PreferConstConstructorsInImmutables extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addConstructorDeclaration(this, visitor);
   }
 }
@@ -71,7 +72,9 @@ class PreferConstConstructorsInImmutables extends LintRule
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
@@ -134,7 +137,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     // put a fake const keyword and check if there's const error
     node.constKeyword = new KeywordToken(Keyword.CONST, node.offset);
     try {
-      hasConstError = hasErrorWithConstantVerifier(node);
+      hasConstError = hasErrorWithConstantVerifier(context, node);
     } finally {
       // restore const keyword
       node.constKeyword = null;

--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -36,7 +36,8 @@ class A {
 
 ''';
 
-class PreferConstDeclarations extends LintRule implements NodeLintRule {
+class PreferConstDeclarations extends LintRule
+    implements NodeLintRuleWithContext {
   PreferConstDeclarations()
       : super(
             name: 'prefer_const_declarations',
@@ -45,8 +46,9 @@ class PreferConstDeclarations extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addFieldDeclaration(this, visitor);
     registry.addTopLevelVariableDeclaration(this, visitor);
     registry.addVariableDeclarationStatement(this, visitor);
@@ -56,7 +58,9 @@ class PreferConstDeclarations extends LintRule implements NodeLintRule {
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
@@ -77,7 +81,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (!node.isFinal) return;
     if (node.variables.every((declaration) =>
         declaration.initializer != null &&
-        !hasErrorWithConstantVisitor(declaration.initializer))) {
+        !hasErrorWithConstantVisitor(context, declaration.initializer))) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -50,7 +50,7 @@ bool _isImmutable(Element element) =>
     element.library?.name == _META_LIB_NAME;
 
 class PreferConstLiteralsToCreateImmutables extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferConstLiteralsToCreateImmutables()
       : super(
             name: 'prefer_const_literals_to_create_immutables',
@@ -59,8 +59,9 @@ class PreferConstLiteralsToCreateImmutables extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addListLiteral(this, visitor);
     registry.addMapLiteral(this, visitor);
   }
@@ -69,7 +70,9 @@ class PreferConstLiteralsToCreateImmutables extends LintRule
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitListLiteral(ListLiteral node) => _visitTypedLiteral(node);
@@ -126,7 +129,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     final oldKeyword = literal.constKeyword;
     literal.constKeyword = new KeywordToken(Keyword.CONST, node.offset);
     try {
-      hasConstError = hasErrorWithConstantVerifier(literal);
+      hasConstError = hasErrorWithConstantVerifier(context, literal);
     } finally {
       // restore old keyword
       literal.constKeyword = oldKeyword;

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -52,7 +52,7 @@ bool _hasNewInvocation(DartType returnType, FunctionBody body) {
 }
 
 class PreferConstructorsInsteadOfStaticMethods extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferConstructorsInsteadOfStaticMethods()
       : super(
             name: 'prefer_constructors_over_static_methods',
@@ -61,7 +61,8 @@ class PreferConstructorsInsteadOfStaticMethods extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -41,7 +41,8 @@ if (lunchBox.indexOf('sandwich') == -1 return 'so hungry...';
 
 ''';
 
-class PreferContainsOverIndexOf extends LintRule implements NodeLintRule {
+class PreferContainsOverIndexOf extends LintRule
+    implements NodeLintRuleWithContext {
   PreferContainsOverIndexOf()
       : super(
             name: 'prefer_contains',
@@ -50,8 +51,9 @@ class PreferContainsOverIndexOf extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addSimpleIdentifier(this, visitor);
   }
 
@@ -75,7 +77,9 @@ class _LintCode extends LintCode {
 class _Visitor extends SimpleAstVisitor<void> {
   final PreferContainsOverIndexOf rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
@@ -123,7 +127,6 @@ class _Visitor extends SimpleAstVisitor<void> {
     final BinaryExpression binaryExpression = search;
     final Token operator = binaryExpression.operator;
 
-    final AnalysisContext context = propertyElement.context;
     final TypeProvider typeProvider = context.typeProvider;
     final TypeSystem typeSystem = context.typeSystem;
 

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -27,7 +27,8 @@ m({a = 1})
 
 ''';
 
-class PreferEqualForDefaultValues extends LintRule implements NodeLintRule {
+class PreferEqualForDefaultValues extends LintRule
+    implements NodeLintRuleWithContext {
   PreferEqualForDefaultValues()
       : super(
             name: 'prefer_equal_for_default_values',
@@ -36,7 +37,8 @@ class PreferEqualForDefaultValues extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addDefaultFormalParameter(this, visitor);
   }

--- a/lib/src/rules/prefer_expression_function_bodies.dart
+++ b/lib/src/rules/prefer_expression_function_bodies.dart
@@ -51,7 +51,8 @@ containsValue(String value) => getValues().contains(value);
 
 ''';
 
-class PreferExpressionFunctionBodies extends LintRule implements NodeLintRule {
+class PreferExpressionFunctionBodies extends LintRule
+    implements NodeLintRuleWithContext {
   PreferExpressionFunctionBodies()
       : super(
             name: 'prefer_expression_function_bodies',
@@ -60,7 +61,8 @@ class PreferExpressionFunctionBodies extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBlockFunctionBody(this, visitor);
   }

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -67,7 +67,7 @@ class GoodMutable {
 
 ''';
 
-class PreferFinalFields extends LintRule implements NodeLintRule {
+class PreferFinalFields extends LintRule implements NodeLintRuleWithContext {
   PreferFinalFields()
       : super(
             name: 'prefer_final_fields',
@@ -76,7 +76,8 @@ class PreferFinalFields extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addCompilationUnit(this, visitor);
     registry.addFieldDeclaration(this, visitor);

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -45,7 +45,7 @@ void mutableCase() {
 
 ''';
 
-class PreferFinalLocals extends LintRule implements NodeLintRule {
+class PreferFinalLocals extends LintRule implements NodeLintRuleWithContext {
   PreferFinalLocals()
       : super(
             name: 'prefer_final_locals',
@@ -54,7 +54,8 @@ class PreferFinalLocals extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addVariableDeclaration(this, visitor);
   }

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -42,7 +42,7 @@ myList.forEach(foo().f); // But this one invokes foo() just once.
 
 ''';
 
-class PreferForeach extends LintRule implements NodeLintRule {
+class PreferForeach extends LintRule implements NodeLintRuleWithContext {
   PreferForeach()
       : super(
             name: 'prefer_foreach',
@@ -52,7 +52,8 @@ class PreferForeach extends LintRule implements NodeLintRule {
             maturity: Maturity.experimental);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addForEachStatement(this, visitor);
   }

--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -36,7 +36,7 @@ void main() {
 ''';
 
 class PreferFunctionDeclarationsOverVariables extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferFunctionDeclarationsOverVariables()
       : super(
             name: 'prefer_function_declarations_over_variables',
@@ -45,7 +45,8 @@ class PreferFunctionDeclarationsOverVariables extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addVariableDeclaration(this, visitor);
   }

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -33,7 +33,7 @@ typedef F = void Function();
 ''';
 
 class PreferGenericFunctionTypeAliases extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferGenericFunctionTypeAliases()
       : super(
             name: 'prefer_generic_function_type_aliases',
@@ -42,7 +42,8 @@ class PreferGenericFunctionTypeAliases extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionTypeAlias(this, visitor);
   }

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -67,7 +67,8 @@ Element _getRightElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElementFromIdentifier(
         assignment.rightHandSide);
 
-class PreferInitializingFormals extends LintRule implements NodeLintRule {
+class PreferInitializingFormals extends LintRule
+    implements NodeLintRuleWithContext {
   PreferInitializingFormals()
       : super(
             name: 'prefer_initializing_formals',
@@ -76,7 +77,8 @@ class PreferInitializingFormals extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -32,7 +32,7 @@ main() {
 
 ''';
 
-class PreferIntLiterals extends LintRule implements NodeLintRule {
+class PreferIntLiterals extends LintRule implements NodeLintRuleWithContext {
   PreferIntLiterals()
       : super(
             name: 'prefer_int_literals',
@@ -41,7 +41,8 @@ class PreferIntLiterals extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     registry.addDoubleLiteral(this, new _Visitor(this));
   }
 }

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -30,7 +30,7 @@ and read than concatenation.
 ''';
 
 class PreferInterpolationToComposeStrings extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferInterpolationToComposeStrings()
       : super(
             name: 'prefer_interpolation_to_compose_strings',
@@ -39,7 +39,8 @@ class PreferInterpolationToComposeStrings extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -41,7 +41,7 @@ if (words.length != 0) return words.join(' ');
 
 ''';
 
-class PreferIsEmpty extends LintRule implements NodeLintRule {
+class PreferIsEmpty extends LintRule implements NodeLintRuleWithContext {
   PreferIsEmpty()
       : super(
             name: 'prefer_is_empty',
@@ -50,8 +50,9 @@ class PreferIsEmpty extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addSimpleIdentifier(this, visitor);
   }
 
@@ -74,7 +75,9 @@ class _LintCode extends LintCode {
 class _Visitor extends SimpleAstVisitor<void> {
   final PreferIsEmpty rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitSimpleIdentifier(SimpleIdentifier identifier) {
@@ -106,7 +109,6 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // Should be subtype of Iterable, Map or String.
-    AnalysisContext context = propertyElement.context;
     TypeProvider typeProvider = context.typeProvider;
     TypeSystem typeSystem = context.typeSystem;
 

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -40,7 +40,7 @@ if (!sources.isEmpty) {
 
 ''';
 
-class PreferIsNotEmpty extends LintRule implements NodeLintRule {
+class PreferIsNotEmpty extends LintRule implements NodeLintRuleWithContext {
   PreferIsNotEmpty()
       : super(
             name: 'prefer_is_not_empty',
@@ -49,7 +49,8 @@ class PreferIsNotEmpty extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addSimpleIdentifier(this, visitor);
   }

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -25,7 +25,8 @@ iterable.whereType<MyClass>()
 
 ''';
 
-class PreferIterableWhereType extends LintRule implements NodeLintRule {
+class PreferIterableWhereType extends LintRule
+    implements NodeLintRuleWithContext {
   PreferIterableWhereType()
       : super(
             name: 'prefer_iterable_whereType',
@@ -34,7 +35,8 @@ class PreferIterableWhereType extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }

--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -30,7 +30,7 @@ class C with M {}
 
 ''';
 
-class PreferMixin extends LintRule implements NodeLintRule {
+class PreferMixin extends LintRule implements NodeLintRuleWithContext {
   PreferMixin()
       : super(
             name: 'prefer_mixin',
@@ -39,7 +39,8 @@ class PreferMixin extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addWithClause(this, visitor);
   }

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -43,7 +43,7 @@ useStrings(
 
 ''';
 
-class PreferSingleQuotes extends LintRule implements NodeLintRule {
+class PreferSingleQuotes extends LintRule implements NodeLintRuleWithContext {
   PreferSingleQuotes()
       : super(
             name: 'prefer_single_quotes',
@@ -52,7 +52,8 @@ class PreferSingleQuotes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -56,7 +56,7 @@ class GoodClass {
 ''';
 
 class PreferTypingUninitializedVariables extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   PreferTypingUninitializedVariables()
       : super(
             name: 'prefer_typing_uninitialized_variables',
@@ -65,7 +65,8 @@ class PreferTypingUninitializedVariables extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addVariableDeclarationList(this, visitor);
   }

--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -45,7 +45,7 @@ for any type of map or list:
 ```
 ''';
 
-class PreferVoidToNull extends LintRule implements NodeLintRule {
+class PreferVoidToNull extends LintRule implements NodeLintRuleWithContext {
   PreferVoidToNull()
       : super(
             name: 'prefer_void_to_null',
@@ -55,7 +55,8 @@ class PreferVoidToNull extends LintRule implements NodeLintRule {
             maturity: Maturity.experimental);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addSimpleIdentifier(this, visitor);
   }

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -67,7 +67,7 @@ setters inherit the docs from the getters.
 // of the actual API surface area of a package - including that defined by
 // exports - and linting against that.
 
-class PublicMemberApiDocs extends LintRule implements NodeLintRule {
+class PublicMemberApiDocs extends LintRule implements NodeLintRuleWithContext {
   PublicMemberApiDocs()
       : super(
             name: 'public_member_api_docs',
@@ -76,7 +76,8 @@ class PublicMemberApiDocs extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addClassTypeAlias(this, visitor);

--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -36,7 +36,7 @@ int get field => _field;
 
 ''';
 
-class RecursiveGetters extends LintRule implements NodeLintRule {
+class RecursiveGetters extends LintRule implements NodeLintRuleWithContext {
   RecursiveGetters()
       : super(
             name: 'recursive_getters',
@@ -45,7 +45,8 @@ class RecursiveGetters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -42,7 +42,7 @@ bool isJavaStyle(Comment comment) {
   return comment.tokens[0].lexeme.startsWith('/**');
 }
 
-class SlashForDocComments extends LintRule implements NodeLintRule {
+class SlashForDocComments extends LintRule implements NodeLintRuleWithContext {
   SlashForDocComments()
       : super(
             name: 'slash_for_doc_comments',
@@ -51,7 +51,8 @@ class SlashForDocComments extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addClassTypeAlias(this, visitor);

--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -32,7 +32,8 @@ abstract class Visitor {
 
 ''';
 
-class SortConstructorsFirst extends LintRule implements NodeLintRule {
+class SortConstructorsFirst extends LintRule
+    implements NodeLintRuleWithContext {
   SortConstructorsFirst()
       : super(
             name: 'sort_constructors_first',
@@ -41,7 +42,8 @@ class SortConstructorsFirst extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -32,7 +32,8 @@ class _PriorityItem {
 
 ''';
 
-class SortUnnamedConstructorsFirst extends LintRule implements NodeLintRule {
+class SortUnnamedConstructorsFirst extends LintRule
+    implements NodeLintRuleWithContext {
   SortUnnamedConstructorsFirst()
       : super(
             name: 'sort_unnamed_constructors_first',
@@ -41,7 +42,8 @@ class SortUnnamedConstructorsFirst extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -45,7 +45,7 @@ View(Style style, List children)
 
 ''';
 
-class SuperGoesLast extends LintRule implements NodeLintRule {
+class SuperGoesLast extends LintRule implements NodeLintRuleWithContext {
   SuperGoesLast()
       : super(
             name: 'super_goes_last',
@@ -54,7 +54,8 @@ class SuperGoesLast extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -69,7 +69,7 @@ class Bad {
 
 ''';
 
-class TestTypesInEquals extends LintRule implements NodeLintRule {
+class TestTypesInEquals extends LintRule implements NodeLintRuleWithContext {
   TestTypesInEquals()
       : super(
             name: 'test_types_in_equals',
@@ -78,7 +78,8 @@ class TestTypesInEquals extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addAsExpression(this, visitor);
   }

--- a/lib/src/rules/throw_in_finally.dart
+++ b/lib/src/rules/throw_in_finally.dart
@@ -48,7 +48,7 @@ class BadThrow {
 
 ''';
 
-class ThrowInFinally extends LintRule implements NodeLintRule {
+class ThrowInFinally extends LintRule implements NodeLintRuleWithContext {
   ThrowInFinally()
       : super(
             name: 'throw_in_finally',
@@ -57,7 +57,8 @@ class ThrowInFinally extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addThrowExpression(this, visitor);
   }

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -48,7 +48,8 @@ With types, all of this is clarified.
 
 ''';
 
-class TypeAnnotatePublicApis extends LintRule implements NodeLintRule {
+class TypeAnnotatePublicApis extends LintRule
+    implements NodeLintRuleWithContext {
   TypeAnnotatePublicApis()
       : super(
             name: 'type_annotate_public_apis',
@@ -57,7 +58,8 @@ class TypeAnnotatePublicApis extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addFunctionDeclaration(this, visitor);

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -35,7 +35,7 @@ class Point {
 
 ''';
 
-class TypeInitFormals extends LintRule implements NodeLintRule {
+class TypeInitFormals extends LintRule implements NodeLintRuleWithContext {
   TypeInitFormals()
       : super(
             name: 'type_init_formals',
@@ -44,7 +44,8 @@ class TypeInitFormals extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFieldFormalParameter(this, visitor);
   }

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -40,7 +40,7 @@ void main() async {
 
 ''';
 
-class UnawaitedFutures extends LintRule implements NodeLintRule {
+class UnawaitedFutures extends LintRule implements NodeLintRuleWithContext {
   UnawaitedFutures()
       : super(
             name: 'unawaited_futures',
@@ -49,7 +49,8 @@ class UnawaitedFutures extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addExpressionStatement(this, visitor);
     registry.addCascadeExpression(this, visitor);

--- a/lib/src/rules/unnecessary_brace_in_string_interps.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interps.dart
@@ -33,7 +33,8 @@ final RegExp identifierPart = new RegExp(r'^[a-zA-Z0-9_]');
 bool isIdentifierPart(Token token) =>
     token is StringToken && token.lexeme.startsWith(identifierPart);
 
-class UnnecessaryBraceInStringInterps extends LintRule implements NodeLintRule {
+class UnnecessaryBraceInStringInterps extends LintRule
+    implements NodeLintRuleWithContext {
   UnnecessaryBraceInStringInterps()
       : super(
             name: 'unnecessary_brace_in_string_interps',
@@ -42,7 +43,8 @@ class UnnecessaryBraceInStringInterps extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addStringInterpolation(this, visitor);
   }

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -34,7 +34,7 @@ m(){
 
 ''';
 
-class UnnecessaryConst extends LintRule implements NodeLintRule {
+class UnnecessaryConst extends LintRule implements NodeLintRuleWithContext {
   UnnecessaryConst()
       : super(
             name: 'unnecessary_const',
@@ -43,7 +43,8 @@ class UnnecessaryConst extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addListLiteral(this, visitor);

--- a/lib/src/rules/unnecessary_getters.dart
+++ b/lib/src/rules/unnecessary_getters.dart
@@ -39,7 +39,7 @@ class Box {
 
 ''';
 
-class UnnecessaryGetters extends LintRule implements NodeLintRule {
+class UnnecessaryGetters extends LintRule implements NodeLintRuleWithContext {
   UnnecessaryGetters()
       : super(
             name: 'unnecessary_getters',
@@ -48,7 +48,8 @@ class UnnecessaryGetters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -49,7 +49,8 @@ class Box {
 
 ''';
 
-class UnnecessaryGettersSetters extends LintRule implements NodeLintRule {
+class UnnecessaryGettersSetters extends LintRule
+    implements NodeLintRuleWithContext {
   UnnecessaryGettersSetters()
       : super(
             name: 'unnecessary_getters_setters',
@@ -58,7 +59,8 @@ class UnnecessaryGettersSetters extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -59,7 +59,7 @@ bool _isNonFinalField(AstNode node) =>
         (_isNonFinalElement(node.methodName.staticElement))) ||
     (node is SimpleIdentifier && _isNonFinalElement(node.staticElement));
 
-class UnnecessaryLambdas extends LintRule implements NodeLintRule {
+class UnnecessaryLambdas extends LintRule implements NodeLintRuleWithContext {
   UnnecessaryLambdas()
       : super(
             name: 'unnecessary_lambdas',
@@ -68,7 +68,8 @@ class UnnecessaryLambdas extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionExpression(this, visitor);
   }

--- a/lib/src/rules/unnecessary_new.dart
+++ b/lib/src/rules/unnecessary_new.dart
@@ -32,7 +32,7 @@ m(){
 
 ''';
 
-class UnnecessaryNew extends LintRule implements NodeLintRule {
+class UnnecessaryNew extends LintRule implements NodeLintRuleWithContext {
   UnnecessaryNew()
       : super(
             name: 'unnecessary_new',
@@ -41,7 +41,8 @@ class UnnecessaryNew extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -31,7 +31,8 @@ x ??= null;
 
 ''';
 
-class UnnecessaryNullAwareAssignments extends LintRule implements NodeLintRule {
+class UnnecessaryNullAwareAssignments extends LintRule
+    implements NodeLintRuleWithContext {
   UnnecessaryNullAwareAssignments()
       : super(
             name: 'unnecessary_null_aware_assignments',
@@ -40,7 +41,8 @@ class UnnecessaryNullAwareAssignments extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addAssignmentExpression(this, visitor);
   }

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -31,7 +31,7 @@ var y = null ?? 1;
 ''';
 
 class UnnecessaryNullInIfNullOperators extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   UnnecessaryNullInIfNullOperators()
       : super(
             name: 'unnecessary_null_in_if_null_operators',
@@ -40,7 +40,8 @@ class UnnecessaryNullInIfNullOperators extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -47,7 +47,7 @@ super method,
 
 ''';
 
-class UnnecessaryOverrides extends LintRule implements NodeLintRule {
+class UnnecessaryOverrides extends LintRule implements NodeLintRuleWithContext {
   UnnecessaryOverrides()
       : super(
             name: 'unnecessary_overrides',
@@ -56,7 +56,8 @@ class UnnecessaryOverrides extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -24,7 +24,8 @@ a = (b);
 
 ''';
 
-class UnnecessaryParenthesis extends LintRule implements NodeLintRule {
+class UnnecessaryParenthesis extends LintRule
+    implements NodeLintRuleWithContext {
   UnnecessaryParenthesis()
       : super(
             name: 'unnecessary_parenthesis',
@@ -33,7 +34,8 @@ class UnnecessaryParenthesis extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addParenthesizedExpression(this, visitor);
   }

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -45,7 +45,8 @@ return myvar;
 
 ''';
 
-class UnnecessaryStatements extends LintRule implements NodeLintRule {
+class UnnecessaryStatements extends LintRule
+    implements NodeLintRuleWithContext {
   UnnecessaryStatements()
       : super(
             name: 'unnecessary_statements',
@@ -54,7 +55,8 @@ class UnnecessaryStatements extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(new _ReportNoClearEffectVisitor(this));
     registry.addExpressionStatement(this, visitor);
     registry.addForStatement(this, visitor);

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -50,7 +50,7 @@ class Box {
 
 ''';
 
-class UnnecessaryThis extends LintRule implements NodeLintRule {
+class UnnecessaryThis extends LintRule implements NodeLintRuleWithContext {
   UnnecessaryThis()
       : super(
             name: 'unnecessary_this',
@@ -59,8 +59,9 @@ class UnnecessaryThis extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    var visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    var visitor = new _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
     registry.addConstructorFieldInitializer(this, visitor);
   }
@@ -69,12 +70,10 @@ class UnnecessaryThis extends LintRule implements NodeLintRule {
 class _UnnecessaryThisVisitor extends ScopedVisitor {
   final LintRule rule;
 
-  _UnnecessaryThisVisitor(this.rule, CompilationUnit node)
-      : super(
-            node.declaredElement.library,
-            rule.reporter.source,
-            node.declaredElement.library.context.typeProvider,
-            AnalysisErrorListener.NULL_LISTENER);
+  _UnnecessaryThisVisitor(
+      this.rule, LinterContext context, CompilationUnit node)
+      : super(node.declaredElement.library, rule.reporter.source,
+            context.typeProvider, AnalysisErrorListener.NULL_LISTENER);
 
   @override
   void visitConstructorFieldInitializer(ConstructorFieldInitializer node) {
@@ -115,10 +114,12 @@ class _UnnecessaryThisVisitor extends ScopedVisitor {
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  _Visitor(this.rule);
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    new _UnnecessaryThisVisitor(rule, node).visitCompilationUnit(node);
+    new _UnnecessaryThisVisitor(rule, context, node).visitCompilationUnit(node);
   }
 }

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -153,7 +153,8 @@ bool _hasNonComparableOperands(BinaryExpression node) {
       !(_isFixNumIntX(leftType) && _isCoreInt(rightType));
 }
 
-class UnrelatedTypeEqualityChecks extends LintRule implements NodeLintRule {
+class UnrelatedTypeEqualityChecks extends LintRule
+    implements NodeLintRuleWithContext {
   UnrelatedTypeEqualityChecks()
       : super(
             name: 'unrelated_type_equality_checks',
@@ -162,7 +163,8 @@ class UnrelatedTypeEqualityChecks extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -38,7 +38,8 @@ try {
 
 ''';
 
-class UseRethrowWhenPossible extends LintRule implements NodeLintRule {
+class UseRethrowWhenPossible extends LintRule
+    implements NodeLintRuleWithContext {
   UseRethrowWhenPossible()
       : super(
             name: 'use_rethrow_when_possible',
@@ -47,7 +48,8 @@ class UseRethrowWhenPossible extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addThrowExpression(this, visitor);
   }

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -32,7 +32,8 @@ button.visible = false;
 bool _hasInheritedMethod(MethodDeclaration node) =>
     DartTypeUtilities.lookUpInheritedMethod(node) != null;
 
-class UseSettersToChangeAProperty extends LintRule implements NodeLintRule {
+class UseSettersToChangeAProperty extends LintRule
+    implements NodeLintRuleWithContext {
   UseSettersToChangeAProperty()
       : super(
             name: 'use_setters_to_change_properties',
@@ -41,7 +42,8 @@ class UseSettersToChangeAProperty extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -56,7 +56,7 @@ bool _isEmptyInterpolationString(AstNode node) =>
 /// step it creates an auxiliary String that takes O(amount of chars) to be
 /// computed, in otherwise using a StringBuffer the order is reduced to O(~N)
 /// so the bad case is N times slower than the good case.
-class UseStringBuffers extends LintRule implements NodeLintRule {
+class UseStringBuffers extends LintRule implements NodeLintRuleWithContext {
   UseStringBuffers()
       : super(
             name: 'use_string_buffers',
@@ -65,7 +65,8 @@ class UseStringBuffers extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForEachStatement(this, visitor);

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -55,7 +55,8 @@ bool _beginsWithAsOrTo(String name) {
 bool _isVoid(TypeAnnotation returnType) =>
     returnType is TypeName && returnType.name.name == 'void';
 
-class UseToAndAsIfApplicable extends LintRule implements NodeLintRule {
+class UseToAndAsIfApplicable extends LintRule
+    implements NodeLintRuleWithContext {
   UseToAndAsIfApplicable()
       : super(
             name: 'use_to_and_as_if_applicable',
@@ -64,7 +65,8 @@ class UseToAndAsIfApplicable extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/valid_regexps.dart
+++ b/lib/src/rules/valid_regexps.dart
@@ -30,7 +30,7 @@ print(new RegExp('[(]').hasMatch('foo()'));
 
 ''';
 
-class ValidRegExps extends LintRule implements NodeLintRule {
+class ValidRegExps extends LintRule implements NodeLintRuleWithContext {
   ValidRegExps()
       : super(
             name: 'valid_regexps',
@@ -39,7 +39,8 @@ class ValidRegExps extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -29,7 +29,7 @@ void main() {
 ```
 ''';
 
-class VoidChecks extends LintRule implements NodeLintRule {
+class VoidChecks extends LintRule implements NodeLintRuleWithContext {
   VoidChecks()
       : super(
             name: 'void_checks',
@@ -38,8 +38,9 @@ class VoidChecks extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
-    final visitor = new _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
     registry.addMethodInvocation(this, visitor);
     registry.addInstanceCreationExpression(this, visitor);
@@ -51,10 +52,12 @@ class VoidChecks extends LintRule implements NodeLintRule {
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
+  final LinterContext context;
+
   InterfaceType _futureDynamicType;
   InterfaceType _futureOrDynamicType;
 
-  _Visitor(this.rule);
+  _Visitor(this.rule, this.context);
 
   bool isTypeAcceptableWhenExpectingVoid(DartType type) {
     if (type.isVoid) return true;
@@ -77,7 +80,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    final typeProvider = node.declaredElement.context.typeProvider;
+    final typeProvider = context.typeProvider;
     _futureDynamicType =
         typeProvider.futureType.instantiate([typeProvider.dynamicType]);
     _futureOrDynamicType =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.33.0
+  analyzer: ^0.33.2
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -95,7 +95,6 @@ void updateRuleRegistry(String ruleName) {
   print('  pub run test -N $ruleName');
 }
 
-/// TODO(scheglov) Update to implement NodeLintRule, _Visitor, etc.
 String _generateClass(String ruleName, String className) => """
 // Copyright (c) $_thisYear, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
@@ -124,7 +123,7 @@ const _details = r'''
 
 ''';
 
-class $className extends LintRule implements NodeLintRule {
+class $className extends LintRule implements NodeLintRuleWithContext {
   $className() : super(
           name: '$ruleName',
             description: _desc,
@@ -132,7 +131,7 @@ class $className extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry, [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addSimpleIdentifier(this, visitor);
   }


### PR DESCRIPTION
This allows us to stop using the Element.context and
Element.computeNode APIs, which will soon be removed.