### PR TITLE
add lint use_function_type_syntax_for_parameters

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -128,6 +128,7 @@ linter:
     - unnecessary_statements
     - unnecessary_this
     - unrelated_type_equality_checks
+    - use_function_type_syntax_for_parameters
     - use_rethrow_when_possible
     - use_setters_to_change_properties
     - use_string_buffers

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -129,6 +129,7 @@ import 'package:linter/src/rules/unnecessary_parenthesis.dart';
 import 'package:linter/src/rules/unnecessary_statements.dart';
 import 'package:linter/src/rules/unnecessary_this.dart';
 import 'package:linter/src/rules/unrelated_type_equality_checks.dart';
+import 'package:linter/src/rules/use_function_type_syntax_for_parameters.dart';
 import 'package:linter/src/rules/use_rethrow_when_possible.dart';
 import 'package:linter/src/rules/use_setters_to_change_properties.dart';
 import 'package:linter/src/rules/use_string_buffers.dart';
@@ -266,6 +267,7 @@ void registerLintRules() {
     ..register(new UnnecessaryStatements())
     ..register(new UnnecessaryThis())
     ..register(new UnrelatedTypeEqualityChecks())
+    ..register(new UseFunctionTypeSyntaxForParameters())
     ..register(new UseRethrowWhenPossible())
     ..register(new UseSettersToChangeAProperty())
     ..register(new UseStringBuffers())

--- a/lib/src/rules/use_function_type_syntax_for_parameters.dart
+++ b/lib/src/rules/use_function_type_syntax_for_parameters.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Use function type syntax for parameters.';
+
+const _details = r'''
+
+**USE** function type syntax for parameters.
+
+**BAD:**
+```
+Iterable<T> where(bool predicate(T element)) {}
+```
+
+**GOOD:**
+```
+Iterable<T> where(bool Function(T) predicate) {}
+```
+
+''';
+
+class UseFunctionTypeSyntaxForParameters extends LintRule
+    implements NodeLintRule {
+  UseFunctionTypeSyntaxForParameters()
+      : super(
+            name: 'use_function_type_syntax_for_parameters',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry) {
+    final visitor = new _Visitor(this);
+    registry.addFunctionTypedFormalParameter(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitFunctionTypedFormalParameter(FunctionTypedFormalParameter node) {
+    rule.reportLint(node);
+  }
+}

--- a/lib/src/rules/use_function_type_syntax_for_parameters.dart
+++ b/lib/src/rules/use_function_type_syntax_for_parameters.dart
@@ -6,11 +6,11 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 
-const _desc = r'Use function type syntax for parameters.';
+const _desc = r'Use generic function type syntax for parameters.';
 
 const _details = r'''
 
-**USE** function type syntax for parameters.
+Use generic function type syntax for parameters.
 
 **BAD:**
 ```

--- a/test/rules/use_function_type_syntax_for_parameters.dart
+++ b/test/rules/use_function_type_syntax_for_parameters.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N use_function_type_syntax_for_parameters`
+
+void f1(bool f(int e)) {} // LINT
+void f2(bool Function(int e) f) {} // OK


### PR DESCRIPTION
Ensure effective dart rule: [CONSIDER using function type syntax for parameters.](https://www.dartlang.org/guides/language/effective-dart/design#consider-using-function-type-syntax-for-parameters)

Fixes #1204