### PR TITLE
update rule to use `NodeLintRuleWithContext`

### DIFF
--- a/lib/src/rules/use_function_type_syntax_for_parameters.dart
+++ b/lib/src/rules/use_function_type_syntax_for_parameters.dart
@@ -25,7 +25,7 @@ Iterable<T> where(bool Function(T) predicate) {}
 ''';
 
 class UseFunctionTypeSyntaxForParameters extends LintRule
-    implements NodeLintRule {
+    implements NodeLintRuleWithContext {
   UseFunctionTypeSyntaxForParameters()
       : super(
             name: 'use_function_type_syntax_for_parameters',
@@ -34,7 +34,8 @@ class UseFunctionTypeSyntaxForParameters extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry) {
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
     final visitor = new _Visitor(this);
     registry.addFunctionTypedFormalParameter(this, visitor);
   }


### PR DESCRIPTION
fixes build:

![image](https://user-images.githubusercontent.com/67586/48026106-08ddce80-e0fa-11e8-8d2b-09e95aef05eb.png)

https://travis-ci.org/dart-lang/linter/jobs/451058523

/cc @stereotype441 