### PR TITLE
0.1.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.72
+
+* new lint: `use_function_type_syntax_for_parameters`
+* internal changes to migrate towards analyzer's new `LinterContext` API
+* fix false positive in `use_setters_to_change_properties`
+* implementation improvements (and speed-ups) to `prefer_foreach` and `public_member_api_docs`
+* new lint: `avoid_returning_null_for_future`
+* new lint: `avoid_shadowing_type_parameters`
+
 # 0.1.71
 
 * new lint: `prefer_int_literals`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.71
+version: 0.1.72
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.72

* new lint: `use_function_type_syntax_for_parameters`
* internal changes to migrate towards analyzer's new `LinterContext` API
* fix false positive in `use_setters_to_change_properties`
* implementation improvements (and speed-ups) to `prefer_foreach` and `public_member_api_docs`
* new lint: `avoid_returning_null_for_future`
* new lint: `avoid_shadowing_type_parameters`

/cc @bwilkerson @a14n @stereotype441 