### PR TITLE
fix false positive for unnecessary_await_in_return

### DIFF
--- a/test/rules/unnecessary_await_in_return.dart
+++ b/test/rules/unnecessary_await_in_return.dart
@@ -24,14 +24,12 @@ Future<int> f3b() async {
   return await futureFuture; // OK
 }
 
-Future<dynamic> f4a() async => await future; // OK
-Future<dynamic> f4b() async {
-  return await future; // OK
-}
-
-Future<Object> f5a() async => await future; // OK
-Future<Object> f5b() async {
-  return await future; // OK
+Future<dynamic> f4() async {
+  try {
+    return await future; // OK
+  } catch (e) {
+    return await future; // LINT
+  }
 }
 
 class A {
@@ -50,13 +48,11 @@ class A {
     return await futureFuture; // OK
   }
 
-  Future<dynamic> f4a() async => await future; // OK
-  Future<dynamic> f4b() async {
-    return await future; // OK
-  }
-
-  Future<Object> f5a() async => await future; // OK
-  Future<Object> f5b() async {
-    return await future; // OK
+  Future<dynamic> f4() async {
+    try {
+      return await future; // OK
+    } catch (e) {
+      return await future; // LINT
+    }
   }
 }


### PR DESCRIPTION
Contrary to what I thought [an issue in flutter](https://github.com/dart-lang/linter/pull/1252#issuecomment-436586241) was not due to `Future<dynamic>` but it was because it is not safe to replace `return await f` by `return f` when the return statement is in a try block. It completly changes the behaviour.