### PR TITLE
async cleanup

### DIFF
--- a/bin/linter.dart
+++ b/bin/linter.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'package:linter/src/cli.dart' as cli;
 
 Future main(List<String> args) async {

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:analyzer/file_system/physical_file_system.dart';

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -26,7 +26,6 @@ much slower than their synchronous counterparts.
 
 **BAD:**
 ```
-import 'dart:async';
 import 'dart:io';
 
 Future<Null> someFunction() async {
@@ -38,7 +37,6 @@ Future<Null> someFunction() async {
 
 **GOOD:**
 ```
-import 'dart:async';
 import 'dart:io';
 
 Future<Null> someFunction() async {

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/rules/await_only_futures.dart
+++ b/test/rules/await_only_futures.dart
@@ -29,10 +29,6 @@ class CancellableFuture<T> implements Future<T> {
     throw new Exception('Not supported.');
   }
 
-  @override
-  Future then(onValue(T value), {Function onError}) {
-    throw new Exception('Not supported.');
-  }
 
   @override
   Future<T> timeout(Duration timeLimit, {onTimeout()}) {
@@ -41,6 +37,11 @@ class CancellableFuture<T> implements Future<T> {
 
   @override
   Future<T> whenComplete(action()) {
+    throw new Exception('Not supported.');
+  }
+
+  @override
+  Future<R> then<R>(FutureOr<R> Function(T value) onValue, {Function onError}) {
     throw new Exception('Not supported.');
   }
 }

--- a/test/validate_headers_test.dart
+++ b/test/validate_headers_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:analyzer/src/lint/registry.dart';


### PR DESCRIPTION
* fixed override in `await_only_futures.dart`
* removed unneeded `dart:async` imports

/cc @bwilkerson @a14n 