### PR TITLE
update path dep

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,5 +23,5 @@ dev_dependencies:
   grinder: ^0.8.0
   markdown: ^2.0.0
   matcher: ^0.12.0
-  path: '>=0.9.0 <2.0.0'
+  path: ^1.2.0
   test: ^1.0.0


### PR DESCRIPTION
Package `test` requires at least `1.2.0` so this is our effective bottom (and has been for a while).  Version compatibility `0.9.0` hasn't been needed for quite a while.

/cc @bwilkerson @a14n 