### PR TITLE
emphasize non-stable lints in docs

### DIFF
--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -31,7 +31,8 @@ void main([List<String> args]) async {
 const ruleFootMatter = '''
 In addition, rules can be further distinguished by *maturity*.  Unqualified
 rules are considered stable, while others may be marked **experimental**
-to indicate that they are under review.
+to indicate that they are under review.  Lints that are marked as **deprecated**
+should not be used and are subject to removal in future Linter releases.
 
 Rules can be selectively enabled in the analyzer using
 [analysis options](https://pub.dartlang.org/packages/analyzer)
@@ -147,6 +148,17 @@ class Generator {
     }
   }
 
+  String get maturityString {
+    switch (rule.maturity) {
+      case Maturity.deprecated:
+        return '<span style="color:orangered;font-weight:bold;" >$maturity</span>';
+      case Maturity.experimental:
+        return '<span style="color:hotpink;font-weight:bold;" >$maturity</span>';
+      default:
+        return maturity;
+    }
+  }
+
   String _generate() => '''
 <!doctype html>
 <html>
@@ -167,7 +179,7 @@ class Generator {
          <header>
             <h1>$humanReadableName</h1>
             <p>Group: $group</p>
-            <p>Maturity: $maturity</p>
+            <p>Maturity: $maturityString</p>
             <p class="view"><a href="https://github.com/dart-lang/linter">View the Project on GitHub <small>dart-lang/linter</small></a></p>
             <ul>
                <li><a href="https://www.dartlang.org/articles/style-guide/">See the <strong>Style Guide</strong></a></li>


### PR DESCRIPTION
Emphasize non-stable lints in their generated docs

* adds doc styling to emphasize deprecated and experimental lints
* adds blurb about deprecated lints to lint index description

![image](https://user-images.githubusercontent.com/67586/49019192-3ab6e380-f142-11e8-8f10-c50ea31b5ea2.png)


Red and pink may be a subtle distinction but I do want them to pop.

![image](https://user-images.githubusercontent.com/67586/49019107-03483700-f142-11e8-9772-68c726742327.png)

![image](https://user-images.githubusercontent.com/67586/49019125-0fcc8f80-f142-11e8-94e7-28167b866ba5.png)


/cc @bwilkerson @srawlins @a14n 