### PR TITLE
Fix unrelated type checks of generic types

### DIFF
--- a/test/rules/unrelated_type_equality_checks.dart
+++ b/test/rules/unrelated_type_equality_checks.dart
@@ -122,6 +122,50 @@ void someFunction18() {
   if (0 == x) print('someFunction18'); // LINT
 }
 
+void someFunction19<A, B>(A a, B b) {
+  if (a == b) print('someFunction19'); // OK
+  if (<A>[a] == <B>[b]) print('someFunction19'); // OK
+  if (<String, A>{'a': a} == <String, B>{'b': b}) // OK
+    print('someFunction19');
+  if (<A, String>{a: 'a'} == <B, String>{b: 'b'}) // OK
+    print('someFunction19');
+}
+
+void someFunction20<A, B extends A>(A a, B b) {
+  if (a == b) print('someFunction19'); // OK
+  if (<A>[a] == <B>[b]) print('someFunction19'); // OK
+  if (<String, A>{'a': a} == <String, B>{'b': b}) // OK
+    print('someFunction20');
+  if (<A, String>{a: 'a'} == <B, String>{b: 'b'}) // OK
+    print('someFunction20');
+}
+
+void someFunction21<A extends num, B extends List>(A a, B b) {
+  if (a == b) print('someFunction19'); // LINT
+  if (<A>[a] == <B>[b]) print('someFunction19'); // LINT
+  if (<String, A>{'a': a} == <String, B>{'b': b}) // LINT
+    print('someFunction21');
+  if (<A, String>{a: 'a'} == <B, String>{b: 'b'}) // LINT
+    print('someFunction21');
+}
+
+void someFunction22<A extends num, B extends num>(A a, B b) {
+  if (a == b) print('someFunction19'); // OK
+  if (<A>[a] == <B>[b]) print('someFunction19'); // OK
+  if (<String, A>{'a': a} == <String, B>{'b': b}) // OK
+    print('someFunction22');
+  if (<A, String>{a: 'a'} == <B, String>{b: 'b'}) // OK
+    print('someFunction22');
+}
+
+void function23() {
+  Future getFuture() => new Future.value();
+  Future<void> aVoidFuture;
+
+  var aFuture = getFuture();
+  if (aFuture == aVoidFuture) print('someFunction23'); // OK
+}
+
 class ClassBase {}
 
 class DerivedClass1 extends ClassBase {}


### PR DESCRIPTION
Fixes #1085 and https://github.com/dart-lang/sdk/issues/32522

The `unrelated_type_equality_checks` lint, to avoid false positives, treats types that _might_ be related as good enough, such as `fn<A, B>(A a, B b) => a == b`; no lint. This rule was not applied to generics, so the following types on either side of `==` were reported:

* `List<dynamic>` and `List<String>`
* `Future<dynamic>` and `Future<T>`
* `List<A>` and `List<B>` for unbound `A` and `B`.