### PR TITLE
Allow ! arg to be wrapped in parens, even if not required by precedence

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -72,6 +72,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (parent is ConditionalExpression) return;
       if (parent is CascadeExpression) return;
       if (parent is FunctionExpressionInvocation) return;
+      if (parent is PrefixExpression) return;
       if (parent.precedence < node.expression.precedence) {
         rule.reportLint(node);
         return;

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -72,7 +72,12 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (parent is ConditionalExpression) return;
       if (parent is CascadeExpression) return;
       if (parent is FunctionExpressionInvocation) return;
-      if (parent is PrefixExpression) return;
+
+      // A prefix expression (! or -) can have an argument wrapped in
+      // "unnecessary" parens if that argument has potentially confusing
+      // whitespace after its first token.
+      if (parent is PrefixExpression &&
+          _expressionStartsWithWhitespace(node.expression)) return;
       if (parent.precedence < node.expression.precedence) {
         rule.reportLint(node);
         return;
@@ -82,4 +87,24 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
   }
+
+  /// Returns whether [node] "starts" with whitespace.
+  ///
+  /// That is, is there definitely whitespace after the first token in [node]?
+  bool _expressionStartsWithWhitespace(Expression node) =>
+      // As in, `!(await foo)`.
+      node is AwaitExpression ||
+      // As in, `!(new Foo())`.
+      (node is InstanceCreationExpression && node.keyword != null) ||
+      // No TypedLiteral (ListLiteral, MapLiteral, SetLiteral) accepts `-` or
+      // `!` as a prefix operator, but this method can be called recursively,
+      // so this catches things like `!(const [].contains(42))`.
+      (node is TypedLiteral && node.constKeyword != null) ||
+      // As in, `!(const List(3).contains(7))`, and chains like
+      // `-(new List(3).skip(1).take(3).skip(1).length)`.
+      (node is MethodInvocation &&
+          _expressionStartsWithWhitespace(node.target)) ||
+      // As in, `-(new List(3).length)`, and chains like
+      // `-(new List(3).length.bitLength.bitLength)`.
+      (node is PropertyAccess && _expressionStartsWithWhitespace(node.target));
 }

--- a/test/rules/unnecessary_parenthesis.dart
+++ b/test/rules/unnecessary_parenthesis.dart
@@ -30,7 +30,12 @@ main() async {
   ((x) => x is bool ? x : false)(a); // OK
   (fn)(a); // LINT
   !(const [7].contains(42)); // OK
+  !(new List(3).contains(42)); // OK
   !(await Future.value(false)); // OK
+  -(new List(3).length); // OK
+  !(new List(3).length.isEven); // OK
+  -(new List(3).length.abs().abs().abs()); // OK
+  -(new List(3).length.sign.sign.sign); // OK
 }
 
 m({p}) => null;

--- a/test/rules/unnecessary_parenthesis.dart
+++ b/test/rules/unnecessary_parenthesis.dart
@@ -29,6 +29,8 @@ main() async {
   a..b = (c..d); // OK
   ((x) => x is bool ? x : false)(a); // OK
   (fn)(a); // LINT
+  !(const [7].contains(42)); // OK
+  !(await Future.value(false)); // OK
 }
 
 m({p}) => null;


### PR DESCRIPTION
Fixes #1283 