### PR TITLE
0.1.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.76
+
+* `unnecessary_parenthesis` updated to allow wrapping a `!` argument
+* miscellaneous documentation grammar and spelling fixes
+* improved error messages for `always_declare_return_types`
+* fix `prefer_final_fields ` to work with classes that have generic type arrguments
+* (internal): deprecated code cleanup
+* fixed false positives in `unrelated_type_equality_checks`
+
 # 0.1.75
 
 * analyzer package dependency bumped to `^0.34.0` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * `unnecessary_parenthesis` updated to allow wrapping a `!` argument
 * miscellaneous documentation grammar and spelling fixes
 * improved error messages for `always_declare_return_types`
-* fix `prefer_final_fields ` to work with classes that have generic type arrguments
+* fix `prefer_final_fields ` to work with classes that have generic type arguments
 * (internal): deprecated code cleanup
 * fixed false positives in `unrelated_type_equality_checks`
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.75
+version: 0.1.76
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.76

* `unnecessary_parenthesis` updated to allow wrapping a `!` argument
* miscellaneous documentation grammar and spelling fixes
* improved error messages for `always_declare_return_types`
* fix `prefer_final_fields ` to work with classes that have generic type arguments
* (internal): deprecated code cleanup
* fixed false positives in `unrelated_type_equality_checks`

/cc @srawlins @bwilkerson @a14n 