### PR TITLE
Report shadowed type parameters in generic typedefs

### DIFF
--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -40,8 +40,9 @@ class AvoidShadowingTypeParameters extends LintRule implements NodeLintRule {
   void registerNodeProcessors(NodeLintRegistry registry,
       [LinterContext context]) {
     final visitor = _Visitor(this);
-    registry.addMethodDeclaration(this, visitor);
     registry.addFunctionDeclarationStatement(this, visitor);
+    registry.addGenericTypeAlias(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
   }
 }
 
@@ -60,6 +61,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   @override
+  void visitGenericTypeAlias(GenericTypeAlias node) {
+    _checkForShadowing(node.functionType.typeParameters, node.typeParameters);
+  }
+
+  @override
   void visitMethodDeclaration(MethodDeclaration node) {
     if (node.typeParameters == null) {
       return;
@@ -72,7 +78,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   // Check the ancestors of [node] for type parameter shadowing.
-  _checkAncestorParameters(TypeParameterList typeParameters, AstNode node) {
+  void _checkAncestorParameters(
+      TypeParameterList typeParameters, AstNode node) {
     var parent = node.parent;
 
     while (parent != null) {
@@ -89,7 +96,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   // Check whether any of [typeParameters] shadow [ancestorTypeParameters].
-  _checkForShadowing(TypeParameterList typeParameters,
+  void _checkForShadowing(TypeParameterList typeParameters,
       TypeParameterList ancestorTypeParameters) {
     if (ancestorTypeParameters == null) {
       return;

--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -62,6 +62,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitGenericTypeAlias(GenericTypeAlias node) {
+    if (node.functionType.typeParameters == null) {
+      return;
+    }
     _checkForShadowing(node.functionType.typeParameters, node.typeParameters);
   }
 

--- a/test/rules/avoid_shadowing_type_parameters.dart
+++ b/test/rules/avoid_shadowing_type_parameters.dart
@@ -55,3 +55,5 @@ class E {
 typedef Fn1<T> = void Function<T>(T); // LINT
 typedef Fn2<T> = void Function<U>(T); // OK
 typedef Fn3<T> = void Function<U>(U); // OK
+typedef Fn4<T> = void Function(T); // OK
+typedef Fn5 = void Function<T>(T); // OK

--- a/test/rules/avoid_shadowing_type_parameters.dart
+++ b/test/rules/avoid_shadowing_type_parameters.dart
@@ -51,3 +51,7 @@ class E {
 
   void fn4<T>() {} // OK
 }
+
+typedef Fn1<T> = void Function<T>(T); // LINT
+typedef Fn2<T> = void Function<U>(T); // OK
+typedef Fn3<T> = void Function<U>(U); // OK


### PR DESCRIPTION
Partial fix for #1027 but I suspect not the whole story...