### PR TITLE
Scorecard (work in progress).

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,11 @@ dependencies:
 dev_dependencies:
   cli_util: ^0.1.2
   dart_style: ^1.1.0
+  github:
+    git:
+      # todo(pq): update when 4.0.1 is released (https://github.com/DirectMyFile/github.dart/issues/128)
+      url: git://github.com/DirectMyFile/github.dart.git
+      ref: 0a04ae19e06f95b8afe018d666eea96585869492
   grinder: ^0.8.0
   markdown: ^2.0.0
   matcher: ^0.12.0

--- a/tool/crawl.dart
+++ b/tool/crawl.dart
@@ -7,10 +7,8 @@ import 'package:http/http.dart' as http;
 
 const _flutterOptionsUrl =
     'https://raw.githubusercontent.com/flutter/flutter/master/packages/flutter/lib/analysis_options_user.yaml';
-
 const _flutterRepoOptionsUrl =
-'https://raw.githubusercontent.com/flutter/flutter/master/analysis_options.yaml';
-
+    'https://raw.githubusercontent.com/flutter/flutter/master/analysis_options.yaml';
 const _pedanticOptionsUrl =
     'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib/analysis_options.yaml';
 const _stagehandOptionsUrl =

--- a/tool/crawl.dart
+++ b/tool/crawl.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/tool/crawl.dart
+++ b/tool/crawl.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/src/lint/config.dart';
+import 'package:http/http.dart' as http;
+
+const _flutterOptionsUrl =
+    'https://raw.githubusercontent.com/flutter/flutter/master/packages/flutter/lib/analysis_options_user.yaml';
+
+const _flutterRepoOptionsUrl =
+'https://raw.githubusercontent.com/flutter/flutter/master/analysis_options.yaml';
+
+const _pedanticOptionsUrl =
+    'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib/analysis_options.yaml';
+const _stagehandOptionsUrl =
+    'https://raw.githubusercontent.com/dart-lang/stagehand/master/templates/analysis_options.yaml';
+
+List<String> _flutterRules;
+List<String> _flutterRepoRules;
+List<String> _pedanticRules;
+List<String> _stagehandRules;
+
+Future<List<String>> get flutterRules async =>
+    _flutterRules ??= await _fetchRules(_flutterOptionsUrl);
+
+Future<List<String>> get flutterRepoRules async =>
+    _flutterRepoRules ??= await _fetchRules(_flutterRepoOptionsUrl);
+
+Future<List<String>> get pedanticRules async =>
+    _pedanticRules ??= await _fetchRules(_pedanticOptionsUrl);
+
+Future<List<String>> get stagehandRules async =>
+    _stagehandRules ??= await _fetchRules(_stagehandOptionsUrl);
+
+Future<LintConfig> _fetchConfig(String url) async {
+  var client = new http.Client();
+  var req = await client.get(url);
+  return processAnalysisOptionsFile(req.body);
+}
+
+Future<List<String>> _fetchRules(String optionsUrl) async {
+  var config = await _fetchConfig(optionsUrl);
+  var rules = <String>[];
+  for (var ruleConfig in config.ruleConfigs) {
+    rules.add(ruleConfig.name);
+  }
+  return rules;
+}

--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -1,0 +1,159 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:analyzer/src/lint/registry.dart';
+import 'package:github/server.dart';
+import 'package:http/http.dart' as http;
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/rules.dart';
+
+import 'crawl.dart';
+
+const bulb = '💡';
+const checkMark = '✅';
+
+Iterable<LintRule> _registeredLints;
+
+Iterable<LintRule> get registeredLints {
+  if (_registeredLints == null) {
+    registerLintRules();
+    _registeredLints = Registry.ruleRegistry;
+  }
+  return _registeredLints;
+}
+
+main() async {
+  var scorecard = await ScoreCard.calculate();
+
+  //printAll(scorecard);
+  printMarkdownTable(scorecard);
+}
+
+void printAll(ScoreCard scorecard) {
+  print('-- ALL -----------------------------------------');
+  scorecard.forEach(print);
+}
+
+void printMarkdownTable(ScoreCard scorecard) {
+  print(
+      '| name | fix | flutter user | flutter repo | pedantic | stagehand | status | bug refs |');
+  print('| :--- | :---: | :---:| :---: | :---: | :---: | :---: | :--- |');
+  scorecard.forEach((lint) {
+    var sb = StringBuffer('| `${lint.name}` |');
+    sb.write('${lint.hasFix ? " $bulb" : ""} |');
+    sb.write('${lint.ruleSets.contains('flutter') ? " $checkMark" : ""} |');
+    sb.write(
+        '${lint.ruleSets.contains('flutter_repo') ? " $checkMark" : ""} |');
+    sb.write('${lint.ruleSets.contains('pedantic') ? " $checkMark" : ""} |');
+    sb.write('${lint.ruleSets.contains('stagehand') ? " $checkMark" : ""} |');
+    sb.write('${lint.maturity != 'stable' ? ' **${lint.maturity}** ' : ""} |');
+    sb.write(' ${lint.bugReferences.join(", ")} |');
+    print(sb.toString());
+  });
+}
+
+class ScoreCard {
+  int get lintCount => registeredLints.length;
+
+  List<LintScore> scores = <LintScore>[];
+
+  void add(LintScore score) {
+    scores.add(score);
+  }
+
+  void forEach(void f(LintScore element)) {
+    scores.forEach(f);
+  }
+
+  static Future<List<String>> _getLintsWithFixes() async {
+    var client = http.Client();
+    var req = await client.get(
+        'https://raw.githubusercontent.com/dart-lang/sdk/master/pkg/analysis_server/lib/src/services/correction/fix_internal.dart');
+    var lintsWithFixes = <String>[];
+    for (var word in req.body.split(RegExp('\\s+'))) {
+      if (word.startsWith('LintNames.')) {
+        var lintName = word.substring(10);
+        if (lintName.endsWith(')')) {
+          lintName = lintName.substring(0, lintName.length - 1);
+        }
+        lintsWithFixes.add(lintName);
+      }
+    }
+    return lintsWithFixes;
+  }
+
+  static Future<List<Issue>> _getIssues() async {
+    var github = createGitHubClient();
+    var slug = RepositorySlug('dart-lang', 'linter');
+    return github.issues.listByRepo(slug).toList();
+  }
+
+  static Future<ScoreCard> calculate() async {
+    var lintsWithFixes = await _getLintsWithFixes();
+    var flutterRuleset = await flutterRules;
+    var flutterRepoRuleset = await flutterRepoRules;
+    var pedanticRuleset = await pedanticRules;
+    var stagehandRuleset = await stagehandRules;
+
+    var issues = await _getIssues();
+    var bugs = issues.where(_isBug).toList();
+
+    var scorecard = ScoreCard();
+    for (var lint in registeredLints) {
+      var ruleSets = <String>[];
+      if (flutterRuleset.contains(lint.name)) {
+        ruleSets.add('flutter');
+      }
+      if (flutterRepoRuleset.contains(lint.name)) {
+        ruleSets.add('flutter_repo');
+      }
+      if (pedanticRuleset.contains(lint.name)) {
+        ruleSets.add('pedantic');
+      }
+      if (stagehandRuleset.contains(lint.name)) {
+        ruleSets.add('stagehand');
+      }
+      var bugReferences = <String>[];
+      for (var bug in bugs) {
+        if (bug.title.contains(lint.name)) {
+          bugReferences.add('#${bug.number.toString()}');
+        }
+      }
+
+      scorecard.add(LintScore(
+          name: lint.name,
+          hasFix: lintsWithFixes.contains(lint.name),
+          maturity: lint.maturity.name,
+          ruleSets: ruleSets,
+          bugReferences: bugReferences));
+    }
+
+    return scorecard;
+  }
+}
+
+bool _isBug(Issue issue) => issue.labels.map((l) => l.name).contains('bug');
+
+class LintScore {
+  String name;
+  bool hasFix;
+  String maturity;
+
+  List<String> ruleSets;
+  List<String> bugReferences;
+
+  LintScore(
+      {this.name,
+      this.hasFix,
+      this.maturity,
+      this.ruleSets,
+      this.bugReferences});
+
+  String get _ruleSets => ruleSets.isNotEmpty ? ' ${ruleSets.toString()}' : '';
+
+  @override
+  String toString() => '$name$_ruleSets${hasFix ? " 💡" : ""}';
+}

--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 


### PR DESCRIPTION
WIP but at a reasonable checkpoint.  Ultimately this may generate a publishable report (or inform badging) but for now it dumps a table that can be used for informal scoring.

/cc @bwilkerson @srawlins 

fyi @devoncarew 

---

### Sample run:


| name | fix | flutter user | flutter repo | pedantic | stagehand | status | bug refs |
| :--- | :---: | :---:| :---: | :---: | :---: | :---: | :--- |
| `always_declare_return_types` | | | ✅ | | | |  |
| `always_put_control_body_on_new_line` | | | ✅ | | | |  |
| `always_put_required_named_parameters_first` | | | | | | |  |
| `always_require_non_null_named_parameters` | 💡 | | ✅ | | | |  |
| `always_specify_types` | | | ✅ | | | |  |
| `annotate_overrides` | 💡 | | ✅ | | | |  |
| `avoid_annotating_with_dynamic` | 💡 | | | | | | #1162 |
| `avoid_bool_literals_in_conditional_expressions` | | | | | | |  |
| `avoid_types_on_closure_parameters` | 💡 | | | | | | #1099 |
| `avoid_as` | | | ✅ | | | |  |
| `avoid_catching_errors` | | | | | | |  |
| `avoid_catches_without_on_clauses` | | | | | | |  |
| `avoid_classes_with_only_static_members` | | | ✅ | | | |  |
| `avoid_double_and_int_checks` | | | | | | |  |
| `avoid_empty_else` | 💡 | ✅ | ✅ | ✅ | | |  |
| `avoid_field_initializers_in_const_classes` | | | ✅ | | | |  |
| `avoid_function_literals_in_foreach_calls` | | | ✅ | | | |  |
| `avoid_implementing_value_types` | | | | | | |  |
| `avoid_init_to_null` | 💡 | ✅ | ✅ | ✅ | | |  |
| `avoid_js_rounded_ints` | | | | | | |  |
| `avoid_null_checks_in_equality_operators` | | | ✅ | | | |  |
| `avoid_positional_boolean_parameters` | | | | | | |  |
| `avoid_private_typedef_functions` | | | | | | |  |
| `avoid_relative_lib_imports` | | | ✅ | ✅ | | |  |
| `avoid_renaming_method_parameters` | | | ✅ | | | |  |
| `avoid_returning_null` | | | | | | |  |
| `avoid_returning_null_for_future` | | | | | | |  |
| `avoid_returning_null_for_void` | | | ✅ | | | |  |
| `avoid_return_types_on_setters` | 💡 | ✅ | ✅ | ✅ | | |  |
| `avoid_returning_this` | | | | | | |  |
| `avoid_setters_without_getters` | | | | | | |  |
| `avoid_shadowing_type_parameters` | | | | | | |  |
| `avoid_single_cascade_in_expression_statements` | | | | | | |  |
| `avoid_slow_async_io` | | | ✅ | | | |  |
| `avoid_types_as_parameter_names` | | | ✅ | ✅ | | |  |
| `avoid_unused_constructor_parameters` | | | ✅ | | | |  |
| `avoid_void_async` | | | ✅ | | | |  |
| `await_only_futures` | 💡 | ✅ | ✅ | | | |  |
| `camel_case_types` | | ✅ | ✅ | | | |  |
| `cancel_subscriptions` | | ✅ | ✅ | | ✅ | |  |
| `cascade_invocations` | | | | | | | #1023, #806, #787 |
| `close_sinks` | | ✅ | | | | |  |
| `comment_references` | | | | | | |  |
| `control_flow_in_finally` | | ✅ | ✅ | | | |  |
| `constant_identifier_names` | | | | | | |  |
| `curly_braces_in_flow_control_structures` | | | | | | |  |
| `directives_ordering` | | | ✅ | | | |  |
| `empty_catches` | 💡 | | ✅ | | | |  |
| `empty_constructor_bodies` | 💡 | ✅ | ✅ | | | |  |
| `empty_statements` | 💡 | ✅ | ✅ | | | |  |
| `file_names` | | | | | | |  |
| `flutter_style_todos` | | | ✅ | | | |  |
| `hash_and_equals` | | ✅ | ✅ | | ✅ | |  |
| `implementation_imports` | | ✅ | ✅ | | | | #1175 |
| `invariant_booleans` | | | | | | **experimental**  | #1321, #914, #811, #720, #674 |
| `iterable_contains_unrelated_type` | | | ✅ | | ✅ | | #1003 |
| `join_return_with_assignment` | | | | | | |  |
| `library_names` | | ✅ | ✅ | | | |  |
| `library_prefixes` | | | ✅ | | | |  |
| `lines_longer_than_80_chars` | | | | | | |  |
| `list_remove_unrelated_type` | | | ✅ | | ✅ | |  |
| `literal_only_boolean_expressions` | | | | | | |  |
| `no_adjacent_strings_in_list` | | | ✅ | | | |  |
| `no_duplicate_case_values` | | | ✅ | ✅ | | |  |
| `non_constant_identifier_names` | 💡 | ✅ | ✅ | | | |  |
| `null_closures` | | | | ✅ | | |  |
| `one_member_abstracts` | | | | | | | #990 |
| `omit_local_variable_types` | | | | | | | #1006 |
| `only_throw_errors` | | | | | | |  |
| `overridden_fields` | | | ✅ | | | |  |
| `package_api_docs` | | ✅ | ✅ | | | | #213 |
| `package_prefixed_library_names` | | ✅ | ✅ | | | |  |
| `parameter_assignments` | | | | | | |  |
| `prefer_adjacent_string_concatenation` | | | ✅ | | | | #1191 |
| `prefer_bool_in_asserts` | | | | | | **deprecated**  |  |
| `prefer_collection_literals` | 💡 | | ✅ | | | |  |
| `prefer_conditional_assignment` | 💡 | | ✅ | | | |  |
| `prefer_const_constructors` | | | ✅ | | | |  |
| `prefer_const_constructors_in_immutables` | | | ✅ | | | |  |
| `prefer_const_declarations` | 💡 | | ✅ | | | |  |
| `prefer_const_literals_to_create_immutables` | | | ✅ | | | |  |
| `prefer_asserts_in_initializer_lists` | | | ✅ | | | |  |
| `prefer_constructors_over_static_methods` | | | | | | |  |
| `prefer_contains` | | | ✅ | ✅ | | |  |
| `prefer_equal_for_default_values` | | | ✅ | ✅ | | |  |
| `prefer_expression_function_bodies` | | | | | | |  |
| `prefer_final_fields` | 💡 | | ✅ | | | |  |
| `prefer_final_locals` | 💡 | | ✅ | | | | #1342 |
| `prefer_foreach` | | | ✅ | | | |  |
| `prefer_function_declarations_over_variables` | | | | | | |  |
| `prefer_generic_function_type_aliases` | | | ✅ | | | |  |
| `prefer_initializing_formals` | | | ✅ | | | |  |
| `prefer_int_literals` | | | | | | |  |
| `prefer_interpolation_to_compose_strings` | | | | | | |  |
| `prefer_iterable_whereType` | | | ✅ | | | |  |
| `prefer_is_empty` | | | ✅ | ✅ | | |  |
| `prefer_is_not_empty` | 💡 | ✅ | ✅ | ✅ | | | #1232 |
| `prefer_mixin` | | | | | | |  |
| `prefer_single_quotes` | | | ✅ | | | |  |
| `prefer_typing_uninitialized_variables` | | | ✅ | | | |  |
| `prefer_void_to_null` | | | ✅ | | | |  |
| `public_member_api_docs` | | | | | | |  |
| `package_names` | | ✅ | ✅ | | | |  |
| `recursive_getters` | | | ✅ | ✅ | | |  |
| `slash_for_doc_comments` | | ✅ | ✅ | | | |  |
| `sort_constructors_first` | | | ✅ | | | |  |
| `sort_pub_dependencies` | | | ✅ | | | |  |
| `sort_unnamed_constructors_first` | | | ✅ | | | |  |
| `super_goes_last` | | ✅ | ✅ | | | |  |
| `test_types_in_equals` | | ✅ | ✅ | | ✅ | | #443 |
| `throw_in_finally` | | ✅ | ✅ | | | |  |
| `type_annotate_public_apis` | | | | | | | #1121 |
| `type_init_formals` | 💡 | ✅ | ✅ | | | |  |
| `unawaited_futures` | | | | ✅ | | | #1007, #836, #534, #419 |
| `unnecessary_await_in_return` | | | | | | |  |
| `unnecessary_brace_in_string_interps` | | ✅ | ✅ | | | |  |
| `unnecessary_const` | | | ✅ | | | |  |
| `unnecessary_new` | | | ✅ | | | |  |
| `unnecessary_null_aware_assignments` | | | ✅ | | | |  |
| `unnecessary_null_in_if_null_operators` | | | ✅ | | | |  |
| `unnecessary_getters_setters` | | ✅ | ✅ | | | | #275 |
| `unnecessary_lambdas` | 💡 | | | | | |  |
| `unnecessary_overrides` | | | ✅ | | | |  |
| `unnecessary_parenthesis` | | | ✅ | | | |  |
| `unnecessary_statements` | | ✅ | ✅ | | | |  |
| `unnecessary_this` | 💡 | | ✅ | | | |  |
| `unrelated_type_equality_checks` | | ✅ | ✅ | ✅ | ✅ | |  |
| `use_function_type_syntax_for_parameters` | | | | | | |  |
| `use_rethrow_when_possible` | | | ✅ | ✅ | | |  |
| `use_setters_to_change_properties` | | | | | | |  |
| `use_string_buffers` | | | | | | | #777 |
| `use_to_and_as_if_applicable` | | | | | | |  |
| `valid_regexps` | | ✅ | ✅ | ✅ | ✅ | |  |
| `void_checks` | | | | | | |  |