### PR TITLE
0.1.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.78
+
+* restored `prefer_final_locals` to ignore loop variables, and
+* introduced a new `prefer_final_in_for_each` lint to handle the `for each` case
+
 # 0.1.77
 
 * updated `prefer_final_locals` to check to for loop variables

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.77
+version: 0.1.78
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.78

* restored `prefer_final_locals` to ignore loop variables, and
* introduced a new `prefer_final_in_for_each` lint to handle the `for each` case

---

Fixes: #1342

/cc @bwilkerson @srawlins 