### PR TITLE
fix `hash_and_equals` to respect hashCode fields

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -112,9 +112,22 @@ bool isEquals(ClassMember element) =>
 bool isFinalOrConst(Token token) =>
     isKeyword(token, Keyword.FINAL) || isKeyword(token, Keyword.CONST);
 
-/// Returns `true` if this element is the `hashCode` method declaration.
+/// Returns `true` if this element is a `hashCode` method or field declaration.
 bool isHashCode(ClassMember element) =>
-    element is MethodDeclaration && element.name?.name == 'hashCode';
+    (element is MethodDeclaration && element.name?.name == 'hashCode') ||
+    (element is FieldDeclaration &&
+        getFieldIdentifier(element, 'hashCode') != null);
+
+/// Returns a field identifier with the given [name] in the given [decl]'s
+/// variable declaration list or `null` if none is found.
+SimpleIdentifier getFieldIdentifier(FieldDeclaration decl, String name) {
+  for (var v in decl.fields.variables) {
+    if (v.name?.name == name) {
+      return v.name;
+    }
+  }
+  return null;
+}
 
 /// Returns `true` if the keyword associated with the given [token] matches
 /// [keyword].

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -68,7 +68,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
-    MethodDeclaration eq, hash;
+    MethodDeclaration eq;
+    ClassMember hash;
     for (ClassMember member in node.members) {
       if (isEquals(member)) {
         eq = member;
@@ -81,7 +82,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       rule.reportLint(eq.name);
     }
     if (hash != null && eq == null) {
-      rule.reportLint(hash.name);
+      if (hash is MethodDeclaration) {
+        rule.reportLint(hash.name);
+      } else if (hash is FieldDeclaration) {
+        rule.reportLint(getFieldIdentifier(hash, 'hashCode'));
+      }
     }
   }
 }

--- a/test/rules/hash_and_equals.dart
+++ b/test/rules/hash_and_equals.dart
@@ -33,3 +33,18 @@ class Better //OK!
 }
 
 class OK {}
+
+class AlsoOk {
+  @override
+  final int hashCode;
+  AlsoOk(this.hashCode);
+
+  @override
+  bool operator ==(Object other) => other is AlsoOk && other.hashCode == hashCode; //OK
+}
+
+class NotOk {
+  @override
+  final int hashCode; //LINT
+  NotOk(this.hashCode);
+}


### PR DESCRIPTION
Fixes: #1356.

/cc @bwilkerson 