### PR TITLE
re-enable sort_pub_dependencies test

### DIFF
--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -802,8 +802,7 @@ defineTests() {
               '1 file analyzed, 3 issues found',
             ]));
         expect(exitCode, 1);
-        // TODO(pq): re-enable w/ analyzer >=0.33.1 https://github.com/dart-lang/linter/issues/1195
-      }, skip: true);
+      });
     });
 
     group('examples', () {

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -69,8 +69,7 @@ defineTests() {
         await cli.run(['test/_data/p3', 'test/_data/p3/_pubpspec.yaml']);
         expect(collectingOut.trim(),
             startsWith('1 file analyzed, 0 issues found, in'));
-        // TODO(pq): re-enable w/ analyzer >=0.33.1 https://github.com/dart-lang/linter/issues/1195
-      }, skip: true);
+      });
     });
     group('p4', () {
       IOSink currentOut = outSink;


### PR DESCRIPTION
Noticed when scanning our test coverage:

![image](https://user-images.githubusercontent.com/67586/51483977-3a585480-1d4f-11e9-9e72-ab50529601c0.png)

Missed enabling this in: https://github.com/dart-lang/linter/pull/1249.

/cc @bwilkerson @srawlins @a14n 
