### PR TITLE
0.1.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# 0.1.80
+# 0.1.81
 
 * updated `prefer_collection_literals` to support Set literals
+
+# 0.1.80
+
 * deprecated `super_goes_last`
 * (internal) migrations to analyzer's preferred `InheritanceManager2` API
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.80
+version: 0.1.81
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
It looks like I targeted the wrong commit when I published `0.1.80` and it does not include the set literals fixes.

I think publishing a quick 0.1.81 is the easiest fix.

/cc @bwilkerson @scheglov 
