### PR TITLE
fixes for const typed literals

### DIFF
--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
@@ -80,6 +81,10 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (!node.isFinal) return;
     if (node.variables.every((declaration) =>
         declaration.initializer != null &&
+        (declaration.initializer is! TypedLiteral ||
+            (declaration.initializer is TypedLiteral &&
+                declaration.initializer.beginToken?.keyword ==
+                    Keyword.CONST)) &&
         !hasErrorWithConstantVisitor(context, declaration.initializer))) {
       rule.reportLint(node);
     }

--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -79,13 +79,13 @@ class _Visitor extends SimpleAstVisitor<void> {
   _visitVariableDeclarationList(VariableDeclarationList node) {
     if (node.isConst) return;
     if (!node.isFinal) return;
-    if (node.variables.every((declaration) =>
-        declaration.initializer != null &&
-        (declaration.initializer is! TypedLiteral ||
-            (declaration.initializer is TypedLiteral &&
-                declaration.initializer.beginToken?.keyword ==
-                    Keyword.CONST)) &&
-        !hasErrorWithConstantVisitor(context, declaration.initializer))) {
+    if (node.variables.every((declaration) {
+      var initializer = declaration.initializer;
+      return initializer != null &&
+          (initializer is! TypedLiteral ||
+              (initializer.beginToken?.keyword == Keyword.CONST)) &&
+          !hasErrorWithConstantVisitor(context, initializer);
+    })) {
       rule.reportLint(node);
     }
   }

--- a/test/rules/prefer_const_declarations.dart
+++ b/test/rules/prefer_const_declarations.dart
@@ -64,12 +64,15 @@ m() {
   // https://github.com/dart-lang/sdk/issues/32745
   final b, c = 1; // OK
 
-  var s = {}; // OK
+  final s = {}; // OK
   final Set<int> ids = {}; // OK
   final Set<int> ids2 = <int>{}; // OK
 
-  var m = <int,int>{}; // OK
+  final m = <int,int>{}; // OK
   final Map<int,int> m2 = {}; // OK
   final Map<int,int> m3 = <int,int>{}; // OK
 
+  final l = <int>[]; // OK
+  final List<int> l2 = []; // OK
+  final List<int> l3 = <int>[]; // OK
 }

--- a/test/rules/prefer_const_declarations.dart
+++ b/test/rules/prefer_const_declarations.dart
@@ -4,6 +4,8 @@
 
 // test w/ `pub run test -N prefer_const_declarations`
 
+//ignore_for_file: unused_local_variable
+
 const o1 = const []; // OK
 final o2 = []; // OK
 final o3 = const []; // LINT
@@ -61,4 +63,13 @@ m() {
 
   // https://github.com/dart-lang/sdk/issues/32745
   final b, c = 1; // OK
+
+  var s = {}; // OK
+  final Set<int> ids = {}; // OK
+  final Set<int> ids2 = <int>{}; // OK
+
+  var m = <int,int>{}; // OK
+  final Map<int,int> m2 = {}; // OK
+  final Map<int,int> m3 = <int,int>{}; // OK
+
 }


### PR DESCRIPTION
Work-in-progress fixes for #1427.

Note that these tests are not expected to pass on travis until a new `analyzer` package is published w/ set-literals support on by default (https://github.com/dart-lang/sdk/issues/35905).

/cc @bwilkerson 