### PR TITLE
fix collection literals false positive for expression bodies

### DIFF
--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -87,6 +87,14 @@ class _Visitor extends SimpleAstVisitor<void> {
           }
         }
       }
+      // Skip: <int, LinkedHashSet<String>>{}.putIfAbsent(3, () => LinkedHashSet<String>());
+      if (parent is ExpressionFunctionBody) {
+        var expressionType = parent.expression.staticType;
+        if (expressionType != null &&
+            !DartTypeUtilities.isClass(expressionType, 'Set', 'dart.core')) {
+          return;
+        }
+      }
 
       if (constructorName == null) {
         rule.reportLint(node);

--- a/test/rules/prefer_collection_literals.dart
+++ b/test/rules/prefer_collection_literals.dart
@@ -56,4 +56,6 @@ void main() {
 
   Iterable iter = Iterable.empty(); // OK
   var sss = Set.from(iter); // OK
+
+  LinkedHashSet<String> sss1 = <int, LinkedHashSet<String>>{}.putIfAbsent(3, () => LinkedHashSet<String>()); // OK
 }


### PR DESCRIPTION
Fixes a false-positive identified while trying to migrate flutter.

![image](https://user-images.githubusercontent.com/67586/52600863-e4d50c00-2e11-11e9-89ba-dcb81b66a063.png)

/cc @bwilkerson 
