### PR TITLE
Add another corner relaxation for unnecessary_parenthesis

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -85,8 +85,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (parent is MethodInvocation) {
         Expression target = parent.target;
         if (parent.parent is PrefixExpression &&
-            target is ParenthesizedExpression &&
-            _expressionStartsWithWhitespace(target.expression)) return;
+            target == node &&
+            _expressionStartsWithWhitespace(node.expression)) return;
       }
 
       if (parent.precedence < node.expression.precedence) {

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -59,7 +59,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    // a..b=(c..d) is OK
+    // `a..b=(c..d)` is OK.
     if (node.expression is CascadeExpression ||
         node.thisOrAncestorMatching(
                 (n) => n is Statement || n is CascadeExpression)
@@ -78,6 +78,17 @@ class _Visitor extends SimpleAstVisitor<void> {
       // whitespace after its first token.
       if (parent is PrefixExpression &&
           _expressionStartsWithWhitespace(node.expression)) return;
+
+      // Another case of the above exception, something like
+      // `!(const [7]).contains(5);`, where the _parent's_ parent is the
+      // PrefixExpression.
+      if (parent is MethodInvocation) {
+        Expression target = parent.target;
+        if (parent.parent is PrefixExpression &&
+            target is ParenthesizedExpression &&
+            _expressionStartsWithWhitespace(target.expression)) return;
+      }
+
       if (parent.precedence < node.expression.precedence) {
         rule.reportLint(node);
         return;

--- a/test/rules/unnecessary_parenthesis.dart
+++ b/test/rules/unnecessary_parenthesis.dart
@@ -46,6 +46,7 @@ main() async {
   !(new List(3).length.isEven); // OK
   -(new List(3).length.abs().abs().abs()); // OK
   -(new List(3).length.sign.sign.sign); // OK
+  !(const [7]).contains(42); // OK
 }
 
 m({p}) => null;


### PR DESCRIPTION
The unnecessary_parenthesis rule has  some exceptions for unary operators next to whitespace-y keywords, but was still complaining about this:

```dart
!(const [7]).contains(42);
```

This fixes that.