### PR TITLE
Add support for reporting on parenthesized !isEmpty / !isNotEmpty

### DIFF
--- a/test/rules/prefer_is_not_empty.dart
+++ b/test/rules/prefer_is_not_empty.dart
@@ -4,11 +4,11 @@
 
 // test w/ `pub run test -N prefer_is_not_empty`
 
-bool lne = ![].isEmpty; // LINT [12:11]
-bool mne = !{}.isEmpty; // LINT
+bool lne = ![1].isEmpty; // LINT [12:12]
+bool mne = !{2: 'a'}.isEmpty; // LINT
 bool ine = !iterable.isEmpty; // LINT
-bool parens = !([].isEmpty); // LINT
-bool parens = !(([].isEmpty)); // LINT
+bool parens = !([3].isEmpty); // LINT
+bool parens2 = !(([4].isEmpty)); // LINT
 
 bool le = [].isEmpty;
 bool me = {}.isEmpty;

--- a/test/rules/prefer_is_not_empty.dart
+++ b/test/rules/prefer_is_not_empty.dart
@@ -4,9 +4,11 @@
 
 // test w/ `pub run test -N prefer_is_not_empty`
 
-bool lne = ![].isEmpty; //LINT [12:11]
-bool mne = !{}.isEmpty; //LINT
-bool ine = !iterable.isEmpty; //LINT
+bool lne = ![].isEmpty; // LINT [12:11]
+bool mne = !{}.isEmpty; // LINT
+bool ine = !iterable.isEmpty; // LINT
+bool parens = !([].isEmpty); // LINT
+bool parens = !(([].isEmpty)); // LINT
 
 bool le = [].isEmpty;
 bool me = {}.isEmpty;


### PR DESCRIPTION
While there is a lint rule for unnecessary parentheses, (a) we can't expect everyone has it enabled, and (b) it allows some exceptions. But that shouldn't allow these `!isEmpty` cases to hide!