### PR TITLE
Remove references to ListLiteral2 so that it can be removed from analyzer

### DIFF
--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -56,7 +56,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.methodName.name != 'toSet') {
       return;
     }
-    if (node.target is ListLiteral || node.target is ListLiteral2) {
+    if (node.target is ListLiteral) {
       rule.reportLint(node);
     }
   }
@@ -103,8 +103,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         if (args.length != 1) {
           return;
         }
-        var arg = args.first;
-        if (arg is ListLiteral || arg is ListLiteral2) {
+        if (args.first is ListLiteral) {
           rule.reportLint(node);
         }
       }


### PR DESCRIPTION
The class ListLiteral2 is being removed in favor of changes that will allow existing code to continue to use ListLiteral after converting to use a new getter to get the contents. But we can't remove it until linter no longer references it.

After this PR is merged we'll need to pull in a new version (or commit) of linter.