### PR TITLE
support for running tests w/ experiments enabled

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.35.0
+  analyzer: ^0.35.1
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/test/configs/control-flow-collections/analysis_options.yaml
+++ b/test/configs/control-flow-collections/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  enable-experiment:
+    - control-flow-collections


### PR DESCRIPTION
Plumbing for running test configurations.

Currently failing badly but that's unsurprising and so runs are disabled until control-flow-collections are further along.

See: https://github.com/dart-lang/linter/issues/1438

/cc @bwilkerson 