### PR TITLE
export a version string

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,6 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// Package version.  Synchronized w/ pubspec.yaml.
 const String version = '0.1.82';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,2 @@
+/// Package version.  Synchronized w/ pubspec.yaml.
+const String version = '0.1.82';

--- a/test/all.dart
+++ b/test/all.dart
@@ -13,6 +13,7 @@ import 'rule_test.dart' as rule_test;
 import 'utils_test.dart' as utils_test;
 import 'validate_format_test.dart' as validate_format;
 import 'validate_headers_test.dart' as validate_headers;
+import 'version_test.dart' as version_test;
 
 main() {
   // Redirect output.
@@ -26,4 +27,5 @@ main() {
   utils_test.main();
   validate_format.main();
   validate_headers.main();
+  version_test.main();
 }

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:linter/src/version.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart' as yaml;
+
+main() {
+  group('package version', () {
+    test('version file up to date', () {
+      expect(readPackageVersion(), version,
+          reason: 'lib/src/version.dart should match pubspec.yaml');
+    });
+  });
+}
+
+String readPackageVersion() {
+  var pubspec = new File('pubspec.yaml');
+  var yamlDoc = yaml.loadYaml(pubspec.readAsStringSync());
+  if (yamlDoc == null) {
+    fail('Cannot find pubspec.yaml in ${Directory.current}');
+  }
+  var version = yamlDoc['version'];
+  return version;
+}


### PR DESCRIPTION
Stores version number in a string for pushing to analyzer for caching w/ summary cache signatures.

See: #1440 


/cc @scheglov 

