### PR TITLE
bump SDK lower bound to 2.2.0 (for Set literals)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ description: >-
 homepage: https://github.com/dart-lang/linter
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
   analyzer: ^0.35.1


### PR DESCRIPTION
Update to reflect the fact that we're flagging on Set literals.