### PR TITLE
migrate to new SetOrMapLiteral API

### DIFF
--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -93,7 +93,7 @@ class AlwaysSpecifyTypes extends LintRule implements NodeLintRule {
     final visitor = new _Visitor(this);
     registry.addDeclaredIdentifier(this, visitor);
     registry.addListLiteral(this, visitor);
-    registry.addMapLiteral(this, visitor);
+    registry.addSetOrMapLiteral(this, visitor);
     registry.addSimpleFormalParameter(this, visitor);
     registry.addTypeName(this, visitor);
     registry.addVariableDeclarationList(this, visitor);
@@ -124,7 +124,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   @override
-  void visitMapLiteral(MapLiteral literal) {
+  void visitSetOrMapLiteral(SetOrMapLiteral literal) {
     checkLiteral(literal);
   }
 

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -63,7 +63,7 @@ class PreferConstLiteralsToCreateImmutables extends LintRule
       [LinterContext context]) {
     final visitor = new _Visitor(this, context);
     registry.addListLiteral(this, visitor);
-    registry.addMapLiteral(this, visitor);
+    registry.addSetOrMapLiteral(this, visitor);
   }
 }
 
@@ -78,7 +78,12 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitListLiteral(ListLiteral node) => _visitTypedLiteral(node);
 
   @override
-  void visitMapLiteral(MapLiteral node) => _visitTypedLiteral(node);
+  void visitSetOrMapLiteral(SetOrMapLiteral node) {
+    // todo (pq): should this apply to set literals as well?
+    if (node.isMap) {
+      _visitTypedLiteral(node);
+    }
+  }
 
   Iterable<InterfaceType> _getSelfAndInheritedTypes(InterfaceType type) sync* {
     InterfaceType current = type;
@@ -113,7 +118,8 @@ class _Visitor extends SimpleAstVisitor<void> {
         (node is ParenthesizedExpression ||
             node is ArgumentList ||
             node is ListLiteral ||
-            node is MapLiteral ||
+            node is SetOrMapLiteral ||
+            // todo (pq): check if this needs updating with the SetOrMapLiteral unification
             node is MapLiteralEntry ||
             node is NamedExpression)) {
       node = node.parent;

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -79,10 +79,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
-    // todo (pq): should this apply to set literals as well?
-    if (node.isMap) {
-      _visitTypedLiteral(node);
-    }
+    _visitTypedLiteral(node);
   }
 
   Iterable<InterfaceType> _getSelfAndInheritedTypes(InterfaceType type) sync* {
@@ -119,7 +116,6 @@ class _Visitor extends SimpleAstVisitor<void> {
             node is ArgumentList ||
             node is ListLiteral ||
             node is SetOrMapLiteral ||
-            // todo (pq): check if this needs updating with the SetOrMapLiteral unification
             node is MapLiteralEntry ||
             node is NamedExpression)) {
       node = node.parent;

--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -92,10 +92,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         final literal = parent.parent;
         if (literal is ListLiteral && literal.elements.isEmpty) {
           return;
-        } else if (literal is SetOrMapLiteral &&
-            // todo (pq): should this apply to set literals as well?
-            literal.isMap &&
-            literal.elements2.isEmpty) {
+        } else if (literal is SetOrMapLiteral && literal.elements2.isEmpty) {
           return;
         }
       }

--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -92,7 +92,10 @@ class _Visitor extends SimpleAstVisitor<void> {
         final literal = parent.parent;
         if (literal is ListLiteral && literal.elements.isEmpty) {
           return;
-        } else if (literal is MapLiteral && literal.entries.isEmpty) {
+        } else if (literal is SetOrMapLiteral &&
+            // todo (pq): should this apply to set literals as well?
+            literal.isMap &&
+            literal.elements2.isEmpty) {
           return;
         }
       }

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -75,10 +75,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
-    // todo (pq): should this apply to SetLiterals as well?
-    if (node.isMap) {
-      _visitTypedLiteral(node);
-    }
+    _visitTypedLiteral(node);
   }
 
   _visitTypedLiteral(TypedLiteral node) {

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -47,7 +47,7 @@ class UnnecessaryConst extends LintRule implements NodeLintRule {
     final visitor = new _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addListLiteral(this, visitor);
-    registry.addMapLiteral(this, visitor);
+    registry.addSetOrMapLiteral(this, visitor);
   }
 }
 
@@ -74,7 +74,12 @@ class _Visitor extends SimpleAstVisitor {
   visitListLiteral(ListLiteral node) => _visitTypedLiteral(node);
 
   @override
-  visitMapLiteral(MapLiteral node) => _visitTypedLiteral(node);
+  void visitSetOrMapLiteral(SetOrMapLiteral node) {
+    // todo (pq): should this apply to SetLiterals as well?
+    if (node.isMap) {
+      _visitTypedLiteral(node);
+    }
+  }
 
   _visitTypedLiteral(TypedLiteral node) {
     if (node.constKeyword == null) return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.35.2
+  analyzer: ^0.35.3
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/test/rules/always_specify_types.dart
+++ b/test/rules/always_specify_types.dart
@@ -19,6 +19,7 @@ const _OptionalTypeArgs optionalTypeArgs = const _OptionalTypeArgs();
 
 Map<String, String> map = {}; //LINT
 List<String> strings = []; //LINT
+Set<String> set = {}; //LINT
 
 List list; // LINT
 List<List> lists; //LINT


### PR DESCRIPTION
Migrates to new `SetOrMapLiteral` API.

A few notes on the unification:

* `always_specify_types` was missing the opportunity to flag set literals; this fixes that 👍 
* I added TODOs in places where existing logic was preserved but might better be widened to include Set literals too 🤔 
* I'm not sure what to do about the test for `node is MapLiteralEntry`:  will that interface go away too?

(A similar migration for `ForStatement2 ` to follow.)

/cc @stereotype441 @bwilkerson 
