### PR TITLE
add a pana baseline bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script: ./tool/travis.sh
 env:
   - LINTER_BOT=main
   - LINTER_BOT=benchmark
+  - LINTER_BOT=pana_baseline
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/tool/baseline/pana.json
+++ b/tool/baseline/pana.json
@@ -1,0 +1,6 @@
+{
+  "scores": {
+    "health": 98.0,
+    "maintenance": 90.0
+  }
+}

--- a/tool/pana_baseline.dart
+++ b/tool/pana_baseline.dart
@@ -8,17 +8,17 @@ import 'dart:io';
 const baseLinePath = 'tool/baseline/pana.json';
 
 main() async {
-  print('reading baseline...');
+  print('Reading baseline...');
   var contents = new File(baseLinePath).readAsStringSync();
   var baseline = jsonDecode(contents)['scores'];
   print(baseline);
 
-  print('installing pana...');
+  print('Installing pana...');
   var activate = await Process.run('pub', ['global', 'activate', 'pana']);
   expectOk(activate);
   print(activate.stdout);
 
-  print('running pana...');
+  print('Running pana...');
   var output = await Process.run('pub', [
     'global',
     'run',
@@ -33,7 +33,6 @@ main() async {
   print(output.stdout);
 
   var panaJson = jsonDecode(output.stdout);
-
   var health = panaJson['health'];
   print(health);
   var scores = panaJson['scores'];
@@ -55,10 +54,10 @@ main() async {
         'maintenance dropped from $baselineMaintenance to $currentMaintenance';
   }
   if (failureReport.isNotEmpty) {
-    print('baseline check failed: $failureReport');
+    print('Baseline check failed: $failureReport');
     exit(13);
   }
-  print('baseline check passed ✅');
+  print('Baseline check passed ✅');
 
   if (currentHealth != baselineHealth ||
       currentMaintenance != baselineMaintenance) {

--- a/tool/pana_baseline.dart
+++ b/tool/pana_baseline.dart
@@ -61,7 +61,8 @@ main() async {
 
   if (currentHealth != baselineHealth ||
       currentMaintenance != baselineMaintenance) {
-    print('... you have a new baseline! 🎉 Consider updating $baseLinePath');
+    print('... you have a new baseline! 🎉 Update $baseLinePath to match.');
+    exit(67);
   }
 }
 

--- a/tool/pana_baseline.dart
+++ b/tool/pana_baseline.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+const baseLinePath = 'tool/baseline/pana.json';
+
+main() async {
+  print('reading baseline...');
+  var contents = new File(baseLinePath).readAsStringSync();
+  var baseline = jsonDecode(contents)['scores'];
+  print(baseline);
+
+  print('installing pana...');
+  var activate = await Process.run('pub', ['global', 'activate', 'pana']);
+  expectOk(activate);
+  print(activate.stdout);
+
+  print('running pana...');
+  var output = await Process.run('pub', [
+    'global',
+    'run',
+    'pana',
+    '-s',
+    'path',
+    Directory.current.path,
+    '-j',
+    '--scores'
+  ]);
+  expectOk(output);
+  print(output.stdout);
+
+  var panaJson = jsonDecode(output.stdout);
+
+  var health = panaJson['health'];
+  print(health);
+  var scores = panaJson['scores'];
+  print(scores);
+
+  var failureReport = '';
+  var baselineHealth = baseline['health'];
+  var currentHealth = scores['health'];
+  var baselineMaintenance = baseline['maintenance'];
+  var currentMaintenance = scores['maintenance'];
+  if (currentHealth < baselineHealth) {
+    failureReport = 'health dropped from $baselineHealth to $currentHealth';
+  }
+  if (currentMaintenance < baselineMaintenance) {
+    if (failureReport.isNotEmpty) {
+      failureReport += ', ';
+    }
+    failureReport +=
+        'maintenance dropped from $baselineMaintenance to $currentMaintenance';
+  }
+  if (failureReport.isNotEmpty) {
+    print('baseline check failed: $failureReport');
+    exit(13);
+  }
+  print('baseline check passed ✅');
+
+  if (currentHealth != baselineHealth ||
+      currentMaintenance != baselineMaintenance) {
+    print('... you have a new baseline! 🎉 Consider updating $baseLinePath');
+  }
+}
+
+void expectOk(ProcessResult result) {
+  if (result.exitCode != 0) {
+    print(result.stdout);
+    print(result.stderr);
+    exit(result.exitCode);
+  }
+}

--- a/tool/pana_baseline.dart
+++ b/tool/pana_baseline.dart
@@ -61,8 +61,8 @@ main() async {
 
   if (currentHealth != baselineHealth ||
       currentMaintenance != baselineMaintenance) {
-    print('... you have a new baseline! 🎉 Update $baseLinePath to match.');
-    exit(67);
+    print(
+        '... you have a new baseline! 🎉 Consider updating $baseLinePath to match.');
   }
 }
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -30,6 +30,11 @@ if [ "$LINTER_BOT" = "benchmark" ]; then
     exit 1
   fi
 
+elif [ "$LINTER_BOT" = "pana_baseline" ]; then
+  echo "Checking the linter pana baseline..."
+
+  dart tool/pana_baseline.dart
+
 else
   echo "Running main linter bot"
 


### PR DESCRIPTION
The output is a little spammy but serviceable as a first cut.

Essentially, this:

* adds a new `pana_baseline` bot, that
* checks current pana scores against a
* baseline stored in `'tool/baseline/pana.json'`

![image](https://user-images.githubusercontent.com/67586/53824589-25afd480-3f29-11e9-99ee-734a0509ec32.png)

Sample run [here](https://travis-ci.org/dart-lang/linter/jobs/502145908).


Fixes #1463.

/cc @devoncarew @bwilkerson 

/fyi @isoos @jonasfj 
