### PR TITLE
add rule doc links to scores

### DIFF
--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -274,7 +274,8 @@ class LintScore {
     for (var detail in details) {
       switch (detail) {
         case Detail.rule:
-          sb.write(' $name |');
+          sb.write(
+              ' [$name](https://dart-lang.github.io/linter/lints/$name.html) |');
           break;
         case Detail.linter:
           sb.write(' ${since.sinceLinter} |');


### PR DESCRIPTION
Adds doc links to rule names in the scorecard.

| name | linter | dart sdk | fix | pedantic | flutter user | flutter repo | status | bug refs |
| :--- | :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---  |
|  [always_declare_return_types](https://dart-lang.github.io/linter/lints/always_declare_return_types.html) | 0.1.4 | 2.0.0 | | | | ✅ | |  |
|  [always_put_control_body_on_new_line](https://dart-lang.github.io/linter/lints/always_put_control_body_on_new_line.html) | 0.1.31 | 2.0.0 | | | | ✅ | |  |
|  [always_put_required_named_parameters_first](https://dart-lang.github.io/linter/lints/always_put_required_named_parameters_first.html) | 0.1.33 | 2.0.0 | | | | | |  |
|  [always_require_non_null_named_parameters](https://dart-lang.github.io/linter/lints/always_require_non_null_named_parameters.html) | 0.1.31 | 2.0.0 | 💡 | | | ✅ | |  |
|  [always_specify_types](https://dart-lang.github.io/linter/lints/always_specify_types.html) | 0.1.4 | 2.0.0 | 💡 | | | ✅ | |  |
|  [annotate_overrides](https://dart-lang.github.io/linter/lints/annotate_overrides.html) | 0.1.11 | 2.0.0 | 💡 | | | ✅ | |  |
|  [avoid_annotating_with_dynamic](https://dart-lang.github.io/linter/lints/avoid_annotating_with_dynamic.html) | 0.1.31 | 2.0.0 | 💡 | | | | | #1162 |
|  [avoid_as](https://dart-lang.github.io/linter/lints/avoid_as.html) | 0.1.5 | 2.0.0 | | | | ✅ | |  |
|  [avoid_bool_literals_in_conditional_expressions](https://dart-lang.github.io/linter/lints/avoid_bool_literals_in_conditional_expressions.html) | 0.1.46 | 2.0.0 | | | | | |  |
|  [avoid_catches_without_on_clauses](https://dart-lang.github.io/linter/lints/avoid_catches_without_on_clauses.html) | 0.1.31 | 2.0.0 | | | | | |  |
|  [avoid_catching_errors](https://dart-lang.github.io/linter/lints/avoid_catching_errors.html) | 0.1.31 | 2.0.0 | | | | | |  |
|  [avoid_classes_with_only_static_members](https://dart-lang.github.io/linter/lints/avoid_classes_with_only_static_members.html) | 0.1.31 | 2.0.0 | | | | ✅ | |  |
|  [avoid_double_and_int_checks](https://dart-lang.github.io/linter/lints/avoid_double_and_int_checks.html) | 0.1.47 | 2.0.0 | | | | | |  |
|  [avoid_empty_else](https://dart-lang.github.io/linter/lints/avoid_empty_else.html) | 0.1.8 | 2.0.0 | 💡 | ✅ | ✅ | ✅ | |  |
|  [avoid_field_initializers_in_const_classes](https://dart-lang.github.io/linter/lints/avoid_field_initializers_in_const_classes.html) | 0.1.48 | 2.0.0 | | | | ✅ | |  |

...

Full run here: https://github.com/dart-lang/linter/issues/1449

/cc @bwilkerson 