### PR TITLE
remove experimental warning from prefer_asserts_in_initializer_lists

### DIFF
--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -10,10 +10,6 @@ import 'package:linter/src/analyzer.dart';
 const _desc = r'Prefer putting asserts in initializer list.';
 
 const _details = r'''
-
-**WARNING** Putting asserts in initializer lists is only possible using an
-experimental language feature that might be removed.
-
 **DO** put asserts in initializer list for constructors with only asserts in
 their body.
 


### PR DESCRIPTION
As this landed for real in Dart 2.0, I think we can safely remove the caveat?

Related to: https://github.com/dart-lang/linter/issues/1372

/cc @bwilkerson 
