### PR TITLE
Fix #1473 by looking at constructor field initializers

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -108,7 +108,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _containsFunctionExpression(ParenthesizedExpression node) {
-    final containsFunctionExpressionVisitor = _ContainsFunctionExpressionVisitor();
+    final containsFunctionExpressionVisitor =
+        _ContainsFunctionExpressionVisitor();
     node.accept(containsFunctionExpressionVisitor);
     return containsFunctionExpressionVisitor.hasFunctionExpression;
   }

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -68,9 +68,10 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // Constructor field initializers are rather unguarded by delimiting
-    // tokens, which can get confused with a function literal. See test cases
-    // for issues #1395 and #1473.
-    if (parent is ConstructorFieldInitializer) {
+    // tokens, which can get confused with a function expression. See test
+    // cases for issues #1395 and #1473.
+    if (parent is ConstructorFieldInitializer &&
+        _containsFunctionExpression(node)) {
       return;
     }
 
@@ -106,6 +107,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
+  bool _containsFunctionExpression(ParenthesizedExpression node) {
+    final containsFunctionExpressionVisitor = _ContainsFunctionExpressionVisitor();
+    node.accept(containsFunctionExpressionVisitor);
+    return containsFunctionExpressionVisitor.hasFunctionExpression;
+  }
+
   /// Returns whether [node] "starts" with whitespace.
   ///
   /// That is, is there definitely whitespace after the first token in [node]?
@@ -125,4 +132,20 @@ class _Visitor extends SimpleAstVisitor<void> {
       // As in, `-(new List(3).length)`, and chains like
       // `-(new List(3).length.bitLength.bitLength)`.
       (node is PropertyAccess && _expressionStartsWithWhitespace(node.target));
+}
+
+class _ContainsFunctionExpressionVisitor extends UnifyingAstVisitor<void> {
+  bool hasFunctionExpression = false;
+
+  @override
+  void visitFunctionExpression(FunctionExpression node) {
+    hasFunctionExpression = true;
+  }
+
+  @override
+  void visitNode(AstNode node) {
+    if (!hasFunctionExpression) {
+      node.visitChildren(this);
+    }
+  }
 }

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -67,6 +67,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
+    // Constructor field initializers are rather unguarded by delimiting
+    // tokens, which can get confused with a function literal. See test cases
+    // for issues #1395 and #1473.
+    if (parent is ConstructorFieldInitializer) {
+      return;
+    }
+
     if (parent is Expression) {
       if (parent is BinaryExpression) return;
       if (parent is ConditionalExpression) return;

--- a/test/rules/unnecessary_parenthesis.dart
+++ b/test/rules/unnecessary_parenthesis.dart
@@ -27,7 +27,8 @@ main() async {
   // than the cascade.
   (true ? [] : [])..add(''); // OK
   (a ?? true) ? true : true; // OK
-  true ? [] : []..add(''); // OK
+  true ? [] : []
+    ..add(''); // OK
   m(p: (1 + 3)); // LINT
 
   // OK because it is unobvious where cascades fall in precedence.
@@ -55,13 +56,24 @@ bool Function(dynamic) get fn => (x) => x is bool ? x : false;
 
 class ClassWithFunction {
   Function f;
+  int number;
+
+  ClassWithFunction.named(int a) : this.number = (a + 2); // LINT
+  // https://github.com/dart-lang/linter/issues/1473
+  ClassWithFunction.named2(Function value) : this.f = (value ?? (_) => 42); // OK
+}
+
+class ClassWithClassWithFunction {
+  ClassWithFunction c;
+
+  // https://github.com/dart-lang/linter/issues/1395
+  ClassWithClassWithFunction() : c = (ClassWithFunction()..f = () => 42); // OK
 }
 
 class UnnecessaryParenthesis {
-  final value;
-  // https://github.com/dart-lang/linter/issues/1395
-  UnnecessaryParenthesis() : value = (ClassWithFunction()..f = () => 42); // OK
-  // https://github.com/dart-lang/linter/issues/1473
-  UnnecessaryParenthesis.named(Function value)
-      : this.value = (value ?? (_) => 42); // OK
+  ClassWithClassWithFunction c;
+
+  UnnecessaryParenthesis()
+      : c = (ClassWithClassWithFunction()
+          ..c = ClassWithFunction().f = () => 42); // OK
 }

--- a/test/rules/unnecessary_parenthesis.dart
+++ b/test/rules/unnecessary_parenthesis.dart
@@ -6,7 +6,7 @@
 
 import 'dart:async';
 
-var a,b,c,d;
+var a, b, c, d;
 
 main() async {
   1; // OK
@@ -59,6 +59,9 @@ class ClassWithFunction {
 
 class UnnecessaryParenthesis {
   final value;
-  //https://github.com/dart-lang/linter/issues/1395
+  // https://github.com/dart-lang/linter/issues/1395
   UnnecessaryParenthesis() : value = (ClassWithFunction()..f = () => 42); // OK
+  // https://github.com/dart-lang/linter/issues/1473
+  UnnecessaryParenthesis.named(Function value)
+      : this.value = (value ?? (_) => 42); // OK
 }


### PR DESCRIPTION
Fixes #1473. This is a rather broad fix 🙁 For example the unnecessary_parenthesis rule would no longer complain about:

```dart
class C {
  C(int a) : a = (1 + 2);
}
```

in which the parens are definitely unnecessary and kind of silly. But taking a look at our two real world examples:


```dart
 class UnnecessaryParenthesis {
  final value;
  // https://github.com/dart-lang/linter/issues/1395
  UnnecessaryParenthesis() : value = (ClassWithFunction()..f = () => 42); // OK
  // https://github.com/dart-lang/linter/issues/1473
  UnnecessaryParenthesis.named(Function value)
      : this.value = (value ?? (_) => 42); // OK
}
```

The offending  arrow which leaps downwards (I think) in precedence is not easy to find... The cascade there is a hint that users could totally put that thing deep.