### PR TITLE
Migrate off deprecated precedence property

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -89,7 +89,7 @@ class _Visitor extends SimpleAstVisitor<void> {
             _expressionStartsWithWhitespace(node.expression)) return;
       }
 
-      if (parent.precedence < node.expression.precedence) {
+      if (parent.precedence2 < node.expression.precedence2) {
         rule.reportLint(node);
         return;
       }


### PR DESCRIPTION
This is safe since linter depends on analyzer `^0.35.3`, in which `precedence2` is introduced.