### PR TITLE
update `file_names` to skip extension-prefixed .dart files

### DIFF
--- a/lib/src/rules/file_names.dart
+++ b/lib/src/rules/file_names.dart
@@ -30,6 +30,13 @@ symbolic imports.
 * `filesystem.dart`
 * `file-system.dart`
 
+Files without a strict `.dart` extension are ignored.  For example:
+
+**OK:**
+
+* `file-system.g.dart`
+* `SliderMenu.css.dart`
+
 The lint `library_names` can be used to enforce the same kind of naming on the
 library.
 
@@ -58,7 +65,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    if (!isLowerCaseUnderScoreWithDots(node.declaredElement.source.shortName)) {
+    var fileName = node.declaredElement.source.shortName;
+    if (isStrictDartFileName(fileName) &&
+        !isLowerCaseUnderScoreWithDots(fileName)) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,6 +4,8 @@
 
 import 'package:linter/src/ast.dart';
 
+const _dot = '\.';
+
 final _identifier = new RegExp(r'^([(_|$)a-zA-Z]+([_a-zA-Z0-9])*)$');
 
 final _lowerCamelCase = new RegExp(
@@ -47,6 +49,12 @@ bool isLowerCaseUnderScoreWithDots(String id) =>
 
 /// Returns `true` if this [fileName] is a Pubspec file.
 bool isPubspecFileName(String fileName) => _pubspec.hasMatch(fileName);
+
+/// Returns true if this is a non-prefixed `.dart extension file.
+/// * `foo.dart` => true
+/// * `foo.css.dart => false
+bool isStrictDartFileName(String fileName) =>
+    isDartFileName(fileName) && _dot.allMatches(fileName).length == 1;
 
 /// Returns `true` if the given code unit [c] is upper case.
 bool isUpperCase(int c) => c >= 0x40 && c <= 0x5A;

--- a/test/_data/file_names/non-strict.css.dart
+++ b/test/_data/file_names/non-strict.css.dart
@@ -1,0 +1,3 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -375,14 +375,22 @@ defineTests() {
         exitCode = 0;
       });
 
-      test('on bad file names', () async {
-        await cli.run(['test/_data/file_names', '--rules=file_names']);
+      test('bad', () async {
+        await cli.run(['test/_data/file_names/a-b.dart', '--rules=file_names']);
         expect(
             collectingOut.trim(),
             stringContainsInOrder([
               'a-b.dart 1:1 [lint] Name source files using `lowercase_with_underscores`.'
             ]));
         expect(exitCode, 1);
+      });
+
+      test('ok', () async {
+        await cli.run([
+          'test/_data/file_names/non-strict.css.dart',
+          '--rules=file_names'
+        ]);
+        expect(exitCode, 0);
       });
     });
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -17,6 +17,14 @@ main() {
     ], isDartFileName, isFalse);
   });
 
+  group('isStrictDartFileName', () {
+    testEach(['foo.dart', 'a-b.dart'], isStrictDartFileName, isTrue);
+    testEach([
+      'a-b.css.dart',
+      'foo',
+    ], isStrictDartFileName, isFalse);
+  });
+
   group('pubspec', () {
     testEach(['pubspec.yaml', '_pubspec.yaml'], isPubspecFileName, isTrue);
     testEach(['__pubspec.yaml', 'foo.yaml'], isPubspecFileName, isFalse);


### PR DESCRIPTION
Allow (`.css.dart`, `.g.dart`, etc.).

Fixes: #1486


/cc @kevmoo @bwilkerson @matanlurey @davidmorgan 