### PR TITLE
0.1.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.84
+
+* new lint: `spread_collections`
+* (internal) update to analyzer 0.36.0 APIs
+* new lint: `prefer_asserts_with_message`
+
 # 0.1.83
 
 * updated `file_names` to skip prefixed-extension Dart files (e.g., `.css.dart`, `.g.dart`)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.83';
+const String version = '0.1.84';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.83
+version: 0.1.84
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.84

* new lint: `spread_collections`
* (internal) update to analyzer 0.36.0 APIs
* new lint: `prefer_asserts_with_message`

/cc @bwilkerson 
