### PR TITLE
add http

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dev_dependencies:
   dart_style: ^1.2.5
   github: ^4.0.1
   grinder: ^0.8.0
+  http: ^0.12.0
   markdown: ^2.0.0
   matcher: ^0.12.0
   path: ^1.2.0


### PR DESCRIPTION
Add `http` dep explicitly.

Noted by `pub publish`:

```
* line 12, column 1 of tool/scorecard.dart: This package doesn't depend on http.
  import 'package:http/http.dart' as http;
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
* line 10, column 1 of tool/crawl.dart: This package doesn't depend on http.
  import 'package:http/http.dart' as http;
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
* line 10, column 1 of tool/doc.dart: This package doesn't depend on http.
  import 'package:http/http.dart' as http;
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

/cc @bwilkerson 