### PR TITLE
add prefer_inlined_adds; update prefer_spread_collections

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -99,6 +99,7 @@ linter:
     - prefer_generic_function_type_aliases
     - prefer_if_elements_to_conditional_expressions
     - prefer_initializing_formals
+    - prefer_inlined_adds
     - prefer_int_literals
     - prefer_interpolation_to_compose_strings
     - prefer_is_empty

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -100,6 +100,7 @@ import 'package:linter/src/rules/prefer_function_declarations_over_variables.dar
 import 'package:linter/src/rules/prefer_generic_function_type_aliases.dart';
 import 'package:linter/src/rules/prefer_if_elements_to_conditional_expressions.dart';
 import 'package:linter/src/rules/prefer_initializing_formals.dart';
+import 'package:linter/src/rules/prefer_inlined_adds.dart';
 import 'package:linter/src/rules/prefer_int_literals.dart';
 import 'package:linter/src/rules/prefer_interpolation_to_compose_strings.dart';
 import 'package:linter/src/rules/prefer_is_empty.dart';
@@ -247,6 +248,7 @@ void registerLintRules() {
     ..register(new PreferGenericFunctionTypeAliases())
     ..register(new PreferIfElementsToConditionalExpressions())
     ..register(new PreferInitializingFormals())
+    ..register(new PreferInlinedAdds())
     ..register(new PreferIntLiterals())
     ..register(new PreferInterpolationToComposeStrings())
     ..register(new PreferIterableWhereType())

--- a/lib/src/rules/prefer_inlined_adds.dart
+++ b/lib/src/rules/prefer_inlined_adds.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+
+const _desc = r'Inline list item declarations where possible.';
+
+const _details = r'''
+Declare elements in list literals inline, rather than using `add` and 
+`addAll` methods where possible.
+
+
+**BAD:**
+```
+var l = ['a']..add('b')..add('c');
+var l2 = ['a']..addAll(['b', 'c'])
+```
+
+**GOOD:**
+```
+var l = ['a', 'b', 'c'];
+var 2 = ['a', 'b', 'c'];
+```
+''';
+
+class PreferInlinedAdds extends LintRule implements NodeLintRule {
+  PreferInlinedAdds()
+      : super(
+            name: 'prefer_inlined_adds',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this);
+    registry.addMethodInvocation(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation invocation) {
+    bool addAll = invocation.methodName.name == 'addAll';
+    if ((invocation.methodName.name != 'add' && !addAll) ||
+        !invocation.isCascaded ||
+        invocation.argumentList.arguments.length != 1) {
+      return;
+    }
+
+    CascadeExpression cascade = invocation.thisOrAncestorOfType();
+    NodeList<Expression> sections = cascade.cascadeSections;
+    Expression target = cascade.target;
+    if (target is! ListLiteral || sections[0] != invocation) {
+      // todo (pq): consider extending to handle set literals.
+      return;
+    }
+
+    if (addAll && invocation.argumentList.arguments[0] is! ListLiteral) {
+      // Handled by: prefer_spread_collections
+      return;
+    }
+
+    rule.reportLint(invocation.methodName);
+  }
+}

--- a/lib/src/rules/prefer_inlined_adds.dart
+++ b/lib/src/rules/prefer_inlined_adds.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:linter/src/analyzer.dart';
-import 'package:linter/src/util/dart_type_utilities.dart';
 
 const _desc = r'Inline list item declarations where possible.';
 

--- a/lib/src/rules/prefer_spread_collections.dart
+++ b/lib/src/rules/prefer_spread_collections.dart
@@ -103,6 +103,12 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
+    Expression argument = invocation.argumentList.arguments[0];
+    if (argument is ListLiteral) {
+      // Handled by: prefer_inlined_adds
+      return;
+    }
+
     rule.reportLint(invocation.methodName);
   }
 }

--- a/test/mock_sdk.dart
+++ b/test/mock_sdk.dart
@@ -130,6 +130,7 @@ abstract class List<E> implements Iterable<E> {
   /* external */ factory List([int length]);
   /* external */ factory List.filled(int length, E fill, {bool growable: false});
   void add(E value);
+  void addAll(Iterable<E> iterable);
   E operator [](int index);
   void operator []=(int index, E value);
   Iterator<E> get iterator => null;

--- a/test/rules/prefer_inlined_adds.dart
+++ b/test/rules/prefer_inlined_adds.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_inlined_adds`
+
+
+var l = ['a']..add('b'); // LINT
+var l2 = ['a']..add('b')..add('c'); // LINT
+
+var l3 = ['a']..addAll(['b', 'c']); // LINT
+
+var things;
+var l4 = ['a']..addAll(things ?? const []); // OK

--- a/test/rules/prefer_spread_collections.dart
+++ b/test/rules/prefer_spread_collections.dart
@@ -2,13 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-
 f() {
   var ints = [1, 2, 3];
   print(['a']..addAll(ints.map((i) => i.toString()))..addAll(['c'])); // LINT
 }
 
-var l = ['a']..addAll(['b']); // LINT
+var l = ['a']..addAll(['b']); // OK -- prefer_inlined_adds
 
 var l1 = [];
 var l2 = l1..addAll(['b']); //OK


### PR DESCRIPTION
Introduces `prefer_inlined_adds` and updates `prefer_spread_collections` to no longer flag `addAll` calls that can be inlined.

See also: https://dart-review.googlesource.com/c/sdk/+/99040

/cc @bwilkerson 
