### PR TITLE
0.1.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.86
+
+* updated `prefer_spread_collections` to ignore calls to `addAll` that could be inlined
+* new lint: `prefer_inlined_adds`
+
 # 0.1.85
 
 * (**BREAKING**) renamed `spread_collections` to `prefer_spread_collections`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.85';
+const String version = '0.1.86';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.85
+version: 0.1.86
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.86

* updated `prefer_spread_collections` to ignore calls to `addAll` that could be inlined
* new lint: `prefer_inlined_adds`


/cc @bwilkerson 
