### PR TITLE
0.1.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.87
+
+* fixed `unnecessary_await_in_return` false positive
+* fixed `unrelated_type_equality_checks` false negative with functions
+* fixed `prefer_spread_collections` to not lint in const contexts
+* fixed false positive in `prefer_iterable_whereType` for `is!`
+* fixed false positive in `prefer_collection_literals` for constructors with params
+
 # 0.1.86
 
 * updated `prefer_spread_collections` to ignore calls to `addAll` that could be inlined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.1.87
 
+* change: `prefer_const_constructors_in_immutables` is currently overly permissive, pending analyzer changes (#1537)
 * fixed `unnecessary_await_in_return` false positive
 * fixed `unrelated_type_equality_checks` false negative with functions
 * fixed `prefer_spread_collections` to not lint in const contexts

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.86';
+const String version = '0.1.87';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.86
+version: 0.1.87
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.87

* fixed `unnecessary_await_in_return` false positive
* fixed `unrelated_type_equality_checks` false negative with functions
* fixed `prefer_spread_collections` to not lint in const contexts
* fixed false positive in `prefer_iterable_whereType` for `is!`
* fixed false positive in `prefer_collection_literals` for constructors with params

/cc @bwilkerson @srawlins 
