### PR TITLE
add sort_child_properties_last

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -115,6 +115,7 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - slash_for_doc_comments
+    - sort_child_properties_last
     - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -118,6 +118,7 @@ import 'package:linter/src/rules/pub/sort_pub_dependencies.dart';
 import 'package:linter/src/rules/public_member_api_docs.dart';
 import 'package:linter/src/rules/recursive_getters.dart';
 import 'package:linter/src/rules/slash_for_doc_comments.dart';
+import 'package:linter/src/rules/sort_child_properties_last.dart';
 import 'package:linter/src/rules/sort_constructors_first.dart';
 import 'package:linter/src/rules/sort_unnamed_constructors_first.dart';
 import 'package:linter/src/rules/super_goes_last.dart';
@@ -265,6 +266,7 @@ void registerLintRules() {
     ..register(new PubPackageNames())
     ..register(new RecursiveGetters())
     ..register(new SlashForDocComments())
+    ..register(new SortChildPropertiesLast())
     ..register(new SortConstructorsFirst())
     ..register(new SortPubDependencies())
     ..register(new SortUnnamedConstructorsFirst())

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/ast.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
+import 'package:linter/src/util/flutter_utils.dart';
 
 const _desc = r'DO reference all public properties in debug methods.';
 
@@ -216,26 +217,6 @@ class _Visitor extends SimpleAstVisitor {
       properties.removeWhere(
           (property) => property.name == debugName || property.name == name);
     });
-  }
-
-  var collectionInterfaces = <InterfaceTypeDefinition>[
-    new InterfaceTypeDefinition('List', 'dart.core'),
-    new InterfaceTypeDefinition('Map', 'dart.core'),
-    new InterfaceTypeDefinition('LinkedHashMap', 'dart.collection'),
-    new InterfaceTypeDefinition('Set', 'dart.core'),
-    new InterfaceTypeDefinition('LinkedHashSet', 'dart.collection'),
-  ];
-
-  bool isWidgetProperty(DartType type) {
-    if (DartTypeUtilities.implementsInterface(type, 'Widget', '')) {
-      return true;
-    }
-    if (type is ParameterizedType &&
-        DartTypeUtilities.implementsAnyInterface(type, collectionInterfaces)) {
-      return type.typeParameters.length == 1 &&
-          isWidgetProperty(type.typeArguments.first);
-    }
-    return false;
   }
 
   bool skipForDiagnostic(

--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -101,19 +101,23 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     var arguments = node.argumentList.arguments;
-    if (arguments.length < 2) {
+    if (arguments.length < 2 || isChildArg(arguments.last)) {
       return;
     }
 
     for (int i = 0; i < arguments.length - 1; ++i) {
-      var arg = arguments[i];
-      if (arg is NamedExpression) {
-        var name = arg.name.label.name;
-        if ((name == 'child' || name == 'children') &&
-            isWidgetProperty(arg.staticType)) {
-          rule.reportLint(arg);
-        }
+      if (isChildArg(arguments[i])) {
+        rule.reportLint(arguments[i]);
       }
     }
+  }
+
+  static bool isChildArg(Expression e) {
+    if (e is NamedExpression) {
+      var name = e.name.label.name;
+      return (name == 'child' || name == 'children') &&
+          isWidgetProperty(e.staticType);
+    }
+    return false;
   }
 }

--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/util/flutter_utils.dart';
+
+const _desc = r'Sort child properties last in widget instance creations.';
+
+const _details = r'''
+Sort child properties last in widget instance creations.  This improves
+readability and plays nicest with UI as Code visualization in IDEs with UI as
+Code Guides in editors (such as IntelliJ) where Properties in the correct order 
+appear clearly associated with the constructor call and separated from the 
+children.
+
+**BAD:**
+```
+return Scaffold(
+  appBar: AppBar(
+    title: Text(widget.title),
+  ),
+  body: Center(
+    child: Column(
+      children: <Widget>[
+        Text(
+          'You have pushed the button this many times:',
+         ),
+        Text(
+          '$_counter',
+          style: Theme.of(context).textTheme.display1,
+         ),
+      ],
+      mainAxisAlignment: MainAxisAlignment.center,
+    ),
+    floatingActionButton: FloatingActionButton(
+      child: Icon(Icons.add),
+      onPressed: _incrementCounter,
+      tooltip: 'Increment',
+    ),
+  ),
+);
+```
+
+**GOOD:**
+```
+return Scaffold(
+  appBar: AppBar(
+    title: Text(widget.title),
+  ),
+  body: Center(
+    mainAxisAlignment: MainAxisAlignment.center,
+    child: Column(
+      children: <Widget>[
+        Text(
+          'You have pushed the button this many times:',
+         ),
+        Text(
+          '$_counter',
+          style: Theme.of(context).textTheme.display1,
+         ),
+      ],
+    ),
+    floatingActionButton: FloatingActionButton(
+      onPressed: _incrementCounter,
+      tooltip: 'Increment',
+      child: Icon(Icons.add),
+    ),
+  ),
+);
+```
+''';
+
+class SortChildPropertiesLast extends LintRule implements NodeLintRule {
+  SortChildPropertiesLast()
+      : super(
+            name: 'sort_child_properties_last',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this);
+    registry.addInstanceCreationExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if (!isWidgetType(node.staticType)) {
+      return;
+    }
+
+    var arguments = node.argumentList.arguments;
+    if (arguments.length < 2) {
+      return;
+    }
+
+    for (int i = 0; i < arguments.length - 1; ++i) {
+      var arg = arguments[i];
+      if (arg is NamedExpression) {
+        var name = arg.name.label.name;
+        if ((name == 'child' || name == 'children') &&
+            isWidgetProperty(arg.staticType)) {
+          rule.reportLint(arg);
+        }
+      }
+    }
+  }
+}

--- a/lib/src/util/flutter_utils.dart
+++ b/lib/src/util/flutter_utils.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/type.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
+
+var _collectionInterfaces = <InterfaceTypeDefinition>[
+  new InterfaceTypeDefinition('List', 'dart.core'),
+  new InterfaceTypeDefinition('Map', 'dart.core'),
+  new InterfaceTypeDefinition('LinkedHashMap', 'dart.collection'),
+  new InterfaceTypeDefinition('Set', 'dart.core'),
+  new InterfaceTypeDefinition('LinkedHashSet', 'dart.collection'),
+];
+
+// todo (pq): consider caching lookups
+bool isWidgetType(DartType type) =>
+    DartTypeUtilities.implementsInterface(type, 'Widget', '');
+
+bool isWidgetProperty(DartType type) {
+  if (isWidgetType(type)) {
+    return true;
+  }
+  if (type is ParameterizedType &&
+      DartTypeUtilities.implementsAnyInterface(type, _collectionInterfaces)) {
+    return type.typeParameters.length == 1 &&
+        isWidgetProperty(type.typeArguments.first);
+  }
+  return false;
+}

--- a/test/rules/sort_child_properties_last.dart
+++ b/test/rules/sort_child_properties_last.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N sort_child_properties_last`
+
+// ignore_for_file: prefer_expression_function_bodies
+
+class W0 extends Widget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Center(), // OK
+      ),
+    );
+  }
+}
+
+class W1 extends Widget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Center(), // LINT
+        key: 0,
+      ),
+    );
+  }
+}
+
+class W2 extends Widget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        key: 0,
+        child: Center(), // OK
+      ),
+    );
+  }
+}
+
+class W3 extends Widget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        key: 0,
+        child: Center(
+          child: Column(
+            key: 0,
+            children: [], // OK
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class W4 extends Widget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        key: 0,
+        child: Center(
+          child: Column(
+            children: [], // LINT
+            key: 0,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+class BuildContext {}
+
+abstract class Widget {
+  const Widget();
+  Widget build(BuildContext context) => null;
+}
+
+class Scaffold extends Widget {
+  const Scaffold({
+    int key,
+    Widget body,
+    // ...
+  });
+}
+
+class Center extends Widget {
+  const Center(
+      {int key, double widthFactor, double heightFactor, Widget child});
+}
+
+class Column extends Widget {
+  Column({
+    int key,
+    List<Widget> children = const <Widget>[],
+  });
+}
+


### PR DESCRIPTION
Adds new lint `sort_child_properties_last`.

Currently limited to `child` and `children` properties but after some analysis we could consider broadening.

Fixes #1542


/cc @jacob314 @a14n @bwilkerson 