### PR TITLE
0.1.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.88
+
+* fixed `prefer_asserts_in_initializer_lists` false positives
+* fixed `curly_braces_in_flow_control_structures` to handle more cases
+* new lint: `prefer_double_quotes`
+* new lint: `sort_child_properties_last`
+* fixed `type_annotate_public_apis` false positive for `static const` initializers
+
 # 0.1.87
 
 * change: `prefer_const_constructors_in_immutables` is currently overly permissive, pending analyzer changes (#1537)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.87';
+const String version = '0.1.88';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.87
+version: 0.1.88
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.88

* fixed `prefer_asserts_in_initializer_lists` false positives
* fixed `curly_braces_in_flow_control_structures` to handle more cases
* new lint: `prefer_double_quotes`
* new lint: `sort_child_properties_last`
* fixed `type_annotate_public_apis` false positive for `static const` initializers

/cc @bwilkerson @stereotype441 @a14n 
