### PR TITLE
widen application of prefer_null_aware_operators

### DIFF
--- a/lib/src/rules/prefer_null_aware_operators.dart
+++ b/lib/src/rules/prefer_null_aware_operators.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
 const _desc = r'Prefer using null aware operators.';
@@ -71,28 +70,26 @@ class _Visitor extends SimpleAstVisitor {
         expression = condition.rightOperand;
       } else if (condition.rightOperand is NullLiteral) {
         expression = condition.leftOperand;
+      } else {
+        return;
       }
 
-      // lint only if local variable is the subject to avoid side effects
-      if (expression is SimpleIdentifier &&
-          expression.staticElement is LocalVariableElement) {
-        Expression exp = condition.operator.type == TokenType.EQ_EQ
-            ? node.elseExpression
-            : node.thenExpression;
-        while (exp is PrefixedIdentifier ||
-            exp is MethodInvocation ||
-            exp is PropertyAccess) {
-          if (exp is PrefixedIdentifier) {
-            exp = (exp as PrefixedIdentifier).prefix;
-          } else if (exp is MethodInvocation) {
-            exp = (exp as MethodInvocation).target;
-          } else if (exp is PropertyAccess) {
-            exp = (exp as PropertyAccess).target;
-          }
+      Expression exp = condition.operator.type == TokenType.EQ_EQ
+          ? node.elseExpression
+          : node.thenExpression;
+      while (exp is PrefixedIdentifier ||
+          exp is MethodInvocation ||
+          exp is PropertyAccess) {
+        if (exp is PrefixedIdentifier) {
+          exp = (exp as PrefixedIdentifier).prefix;
+        } else if (exp is MethodInvocation) {
+          exp = (exp as MethodInvocation).target;
+        } else if (exp is PropertyAccess) {
+          exp = (exp as PropertyAccess).target;
         }
-        if (exp is SimpleIdentifier &&
-            exp.staticElement == expression.staticElement) {
+        if (exp.toString() == expression.toString()) {
           rule.reportLint(node);
+          return;
         }
       }
     }

--- a/test/rules/prefer_null_aware_operators.dart
+++ b/test/rules/prefer_null_aware_operators.dart
@@ -6,28 +6,44 @@
 
 var v;
 
-m() {
+m(p) {
   var a, b;
   a == null ? null : a.b; // LINT
   a == null ? null : a.b(); // LINT
   a == null ? null : a.b.c; // LINT
   a == null ? null : a.b.c(); // LINT
+  a.b == null ? null : a.b.c; // LINT
+  a.b == null ? null : a.b.c(); // LINT
+  p == null ? null : p.b; // LINT
+  v == null ? null : v.b; // LINT
   null == a ? null : a.b; // LINT
   null == a ? null : a.b(); // LINT
   null == a ? null : a.b.c; // LINT
   null == a ? null : a.b.c(); // LINT
+  null == a.b ? null : a.b.c; // LINT
+  null == a.b ? null : a.b.c(); // LINT
+  null == p ? null : p.b; // LINT
+  null == v ? null : v.b; // LINT
   a != null ? a.b : null; // LINT
   a != null ? a.b() : null; // LINT
   a != null ? a.b.c : null; // LINT
   a != null ? a.b.c() : null; // LINT
+  a.b != null ? a.b.c : null; // LINT
+  a.b != null ? a.b.c() : null; // LINT
+  p != null ? p.b : null; // LINT
+  v != null ? v.b : null; // LINT
   null != a ? a.b : null; // LINT
   null != a ? a.b() : null; // LINT
   null != a ? a.b.c : null; // LINT
   null != a ? a.b.c() : null; // LINT
+  null != a.b ? a.b.c : null; // LINT
+  null != a.b ? a.b.c() : null; // LINT
+  null != p ? p.b : null; // LINT
+  null != v ? v.b : null; // LINT
+
   a == null ? b : a; // OK
   a == null ? b.c : null; // OK
   a.b != null ? a.b : null; // OK
 
-  // lint only for local vars
-  v == null ? null : v.b; // OK
+  a == null ? null : a.b + 10; // OK
 }


### PR DESCRIPTION
Remove restriction on `prefer_null_aware_operators` (was only applied for local variables).