### PR TITLE
0.1.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.89
+
+* broadened `prefer_null_aware_operators` to work beyond local variables
+* new lint: `prefer_if_null_operators`
+* fixed `prefer_contains` false positives
+* fixed `unnecessary_parenthesis` false positives
+
 # 0.1.88
 
 * fixed `prefer_asserts_in_initializer_lists` false positives

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.88';
+const String version = '0.1.89';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.88
+version: 0.1.89
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.89

* broadened `prefer_null_aware_operators` to work beyond local variables
* new lint: `prefer_if_null_operators`
* fixed `prefer_contains` false positives
* fixed `unnecessary_parenthesis` false positives

/cc @bwilkerson @a14n @srawlins 