### PR TITLE
0.1.90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.90
+
+* fixed null-reference in `unrelated_type_equality_checks`
+* new lint: `unsafe_html`
+
 # 0.1.89
 
 * broadened `prefer_null_aware_operators` to work beyond local variables

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.89';
+const String version = '0.1.90';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.89
+version: 0.1.90
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.90

* fixed null-reference in `unrelated_type_equality_checks`
* new lint: `unsafe_html`

/cc @bwilkerson @srawlins 