### PR TITLE
Stop using deprecated analyzer API left over from "UI as code" migration.

### DIFF
--- a/lib/src/rules/curly_braces_in_flow_control_structures.dart
+++ b/lib/src/rules/curly_braces_in_flow_control_structures.dart
@@ -80,7 +80,7 @@ class _Visitor extends SimpleAstVisitor {
   }
 
   @override
-  void visitForStatement2(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     _check(node.body);
   }
 

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -130,7 +130,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   @override
-  void visitForStatement2(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     final loopParts = node.forLoopParts;
     if (loopParts is ForParts) {
       if (_onlyLiterals(loopParts.condition)) {

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -66,7 +66,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   _Visitor(this.rule);
 
   @override
-  void visitForStatement2(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     final loopParts = node.forLoopParts;
     if (loopParts is ForPartsWithDeclarations) {
       _visitVariableDeclarationList(loopParts.variables);

--- a/lib/src/rules/prefer_final_in_for_each.dart
+++ b/lib/src/rules/prefer_final_in_for_each.dart
@@ -64,7 +64,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   _Visitor(this.rule);
 
   @override
-  void visitForStatement2(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     var forLoopParts = node.forLoopParts;
     // If the following `if` test fails, then either the statement is not a
     // for-each loop, or it is something like `for(a in b) { ... }`.  In the

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -79,7 +79,7 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
   }
 
   @override
-  visitForStatement2(ForStatement node) {
+  visitForStatement(ForStatement node) {
     final loopParts = node.forLoopParts;
     if (loopParts is ForEachPartsWithDeclaration) {
       final element = loopParts.loopVariable?.declaredElement;
@@ -128,7 +128,7 @@ class _Visitor extends SimpleAstVisitor {
   _Visitor(this.rule);
 
   @override
-  visitForStatement2(ForStatement node) {
+  visitForStatement(ForStatement node) {
     final loopParts = node.forLoopParts;
     if (loopParts is ForEachParts) {
       final visitor = new _PreferForEachVisitor(rule);

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -214,7 +214,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   @override
-  void visitForStatement2(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     final loopParts = node.forLoopParts;
     if (loopParts is ForPartsWithExpression) {
       loopParts.initialization?.accept(reportNoClearEffect);

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -175,7 +175,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   @override
-  void visitForStatement2(ForStatement node) {
+  void visitForStatement(ForStatement node) {
     final visitor = new _UseStringBufferVisitor(rule);
     node.body.accept(visitor);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.91-dev
+version: 0.1.90
 
 author: Dart Team <misc@dartlang.org>
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.90
+version: 0.1.91-dev
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
Since analyzer version 0.36.0, we no longer need to override
visitForStatement2.  visitForStatement is equivalent.