### PR TITLE
Avoid prefer_initializing_formals when parameter is named and the name is different from the field

### DIFF
--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -35,6 +35,41 @@ class Point {
 }
 ```
 
+**BAD:**
+```
+class Point {
+  num x, y;
+  Point({num x, num y}) {
+    this.x = x;
+    this.y = y;
+  }
+}
+```
+
+**GOOD:**
+```
+class Point {
+  num x, y;
+  Point({this.x, this.y});
+}
+```
+
+**NOTE**
+Named parameters must match with the field name in order to be consider by the
+lint to avoid having to update either the field or the named argument and to
+allow for the API to accomodate for different guidelines for named arguments
+and fields currently proposed in https://dart.dev/guides/language/effective-dart
+thus the following example won't trigger the lint:
+
+```
+class Point {
+  bool isEnabled;
+  Point({bool enabled}) {
+    this.isEnabled = enable; // OK
+  }
+}
+```
+
 ''';
 
 Iterable<AssignmentExpression> _getAssignmentExpressionsInConstructorBody(

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -103,7 +103,7 @@ class _Visitor extends SimpleAstVisitor<void> {
               node.declaredElement.enclosingElement &&
           parameters.contains(rightElement) &&
           (!parametersUsedMoreThanOnce.contains(rightElement) &&
-              !(rightElement as ParameterElement).isNamed ||
+                  !(rightElement as ParameterElement).isNamed ||
               leftElement.name == rightElement.name);
     }
 
@@ -115,7 +115,7 @@ class _Visitor extends SimpleAstVisitor<void> {
           expression is SimpleIdentifier &&
           parameters.contains(expression.staticElement) &&
           (!parametersUsedMoreThanOnce.contains(expression.staticElement) &&
-              !(expression.staticElement as ParameterElement).isNamed ||
+                  !(expression.staticElement as ParameterElement).isNamed ||
               (constructorFieldInitializer.fieldName.staticElement?.name ==
                   expression.staticElement.name));
     }

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -55,11 +55,11 @@ class Point {
 ```
 
 **NOTE**
-Named parameters must match with the field name in order to be considered by the
-lint to avoid having to update either the field or the named argument and to
-allow for the API to accommodate for different guidelines for named arguments
-and fields currently proposed in https://dart.dev/guides/language/effective-dart
-thus the following example won't trigger the lint:
+This rule will not generate a lint for named parameters unless the parameter
+name and the field name are the same. The reason for this is that resolving
+such a lint would require either renaming the field or renaming the parameter,
+and both of those actions would potentially be a breaking change. For example,
+the following will not generate a lint:
 
 ```
 class Point {

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -102,7 +102,8 @@ class _Visitor extends SimpleAstVisitor<void> {
           leftElement.enclosingElement ==
               node.declaredElement.enclosingElement &&
           parameters.contains(rightElement) &&
-          (!parametersUsedMoreThanOnce.contains(rightElement) ||
+          (!parametersUsedMoreThanOnce.contains(rightElement) &&
+              !(rightElement as ParameterElement).isNamed ||
               leftElement.name == rightElement.name);
     }
 
@@ -113,9 +114,10 @@ class _Visitor extends SimpleAstVisitor<void> {
               true) &&
           expression is SimpleIdentifier &&
           parameters.contains(expression.staticElement) &&
-          (!parametersUsedMoreThanOnce.contains(expression.staticElement) ||
-              constructorFieldInitializer.fieldName.staticElement?.name ==
-                  expression.staticElement.name);
+          (!parametersUsedMoreThanOnce.contains(expression.staticElement) &&
+              !(expression.staticElement as ParameterElement).isNamed ||
+              (constructorFieldInitializer.fieldName.staticElement?.name ==
+                  expression.staticElement.name));
     }
 
     void processElement(Element element) {

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -55,9 +55,9 @@ class Point {
 ```
 
 **NOTE**
-Named parameters must match with the field name in order to be consider by the
+Named parameters must match with the field name in order to be considered by the
 lint to avoid having to update either the field or the named argument and to
-allow for the API to accomodate for different guidelines for named arguments
+allow for the API to accommodate for different guidelines for named arguments
 and fields currently proposed in https://dart.dev/guides/language/effective-dart
 thus the following example won't trigger the lint:
 

--- a/test/rules/prefer_initializing_formals.dart
+++ b/test/rules/prefer_initializing_formals.dart
@@ -218,13 +218,13 @@ class GoodCaseWithDifferentNamedArgs {
 class BadCaseWithNamedArgsInitializer {
   num x, y;
   BadCaseWithNamedArgsInitializer({num x, num y = 1})
-    : this.x = x, // LINT
-      this.y = y; // LINT
+      : this.x = x, // LINT
+        this.y = y; // LINT
 }
 
 class GoodCaseWithDifferentNamedArgsInitializer {
   num x, y;
   GoodCaseWithDifferentNamedArgsInitializer({num a, num b = 1})
-    : this.x = a, // OK
-      this.y = b; // OK
+      : this.x = a, // OK
+        this.y = b; // OK
 }

--- a/test/rules/prefer_initializing_formals.dart
+++ b/test/rules/prefer_initializing_formals.dart
@@ -198,3 +198,33 @@ class GoodCaseWithOneParameterToTwoFieldsBecauseTheyHaveDifferentNames {
       : a = c, // OK
         b = c; // OK
 }
+
+class BadCaseWithNamedArgs {
+  num x, y;
+  BadCaseWithNamedArgs({num x, num y = 1}) {
+    this.x = x; // LINT
+    this.y = y; // LINT
+  }
+}
+
+class GoodCaseWithDifferentNamedArgs {
+  num x, y;
+  GoodCaseWithDifferentNamedArgs({num a, num b = 1}) {
+    this.x = a; // OK
+    this.y = b; // OK
+  }
+}
+
+class BadCaseWithNamedArgsInitializer {
+  num x, y;
+  BadCaseWithNamedArgsInitializer({num x, num y = 1})
+    : this.x = x, // LINT
+      this.y = y; // LINT
+}
+
+class GoodCaseWithDifferentNamedArgsInitializer {
+  num x, y;
+  GoodCaseWithDifferentNamedArgsInitializer({num a, num b = 1})
+    : this.x = a, // OK
+      this.y = b; // OK
+}


### PR DESCRIPTION
If the argument is a named argument only lint if the name is the same as to avoid changes to the API to either fix the field or the name arguments for more details see the issue provided below.

Fixes # http://go/gh/dart-lang/linter/issues/1587
