### PR TITLE
Loosen `avoid_function_literals_in_foreach_calls` to allow method chained calls

### DIFF
--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -54,6 +54,25 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
+    var exp = node.target;
+    var chainCount = 0;
+    while (exp is PrefixedIdentifier ||
+        exp is MethodInvocation ||
+        exp is PropertyAccess) {
+      if (exp is PrefixedIdentifier) {
+        chainCount++;
+        exp = (exp as PrefixedIdentifier).prefix;
+      } else if (exp is MethodInvocation) {
+        chainCount++;
+        exp = (exp as MethodInvocation).target;
+      } else if (exp is PropertyAccess) {
+        chainCount++;
+        exp = (exp as PropertyAccess).target;
+      }
+      if (chainCount > 1) {
+        return;
+      }
+    }
     if (node.target != null &&
         node.methodName.token.value() == 'forEach' &&
         node.argumentList.arguments.isNotEmpty &&

--- a/test/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/test/rules/avoid_function_literals_in_foreach_calls.dart
@@ -27,11 +27,18 @@ void main() {
       .map((person) => person.toUpperCase())
       .forEach((person) => print('$person!')); // OK
 
+  people
+      .where((person) => person != null)
+      .map((person) => person.toUpperCase())
+      .forEach(print); // OK
+
   Person()
       .children
       .firstWhere((person) => person != null)
       .children
       .forEach((person) => print('$person!')); // OK
+
+  Person().children.forEach(print); // OK
 
   Person()
       .children

--- a/test/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/test/rules/avoid_function_literals_in_foreach_calls.dart
@@ -12,26 +12,30 @@ void main() {
   Iterable<String> people;
 
   for (var person in people) { // OK
-    print(person);
+    print('$person!');
   }
   people.forEach((person) { // LINT
-    print(person);
+    print('$person!');
   });
 
-  people.forEach((person) => print(person)); // LINT
+  people.forEach((person) => print('$person!')); // LINT
 
   people.forEach(print); // OK
 
   people
       .where((person) => person != null)
-      .map((person) => '$person!')
-      .forEach((person) => print(person)); // OK
+      .map((person) => person.toUpperCase())
+      .forEach((person) => print('$person!')); // OK
 
   Person()
       .children
       .firstWhere((person) => person != null)
       .children
-      .forEach((person) => print(person)); // OK
+      .forEach((person) => print('$person!')); // OK
 
-  Person().children.first.children.forEach((person) => print(person)); // OK
+  Person()
+      .children
+      .first
+      .children
+      .forEach((person) => print('$person!')); // LINT
 }

--- a/test/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/test/rules/avoid_function_literals_in_foreach_calls.dart
@@ -4,6 +4,10 @@
 
 // test w/ `pub run test -N avoid_function_literals_in_foreach_calls`
 
+class Person {
+  Iterable<Person> children;
+}
+
 void main() {
   Iterable<String> people;
 
@@ -17,4 +21,17 @@ void main() {
   people.forEach((person) => print(person)); // LINT
 
   people.forEach(print); // OK
+
+  people
+      .where((person) => person != null)
+      .map((person) => '$person!')
+      .forEach((person) => print(person)); // OK
+
+  Person()
+      .children
+      .firstWhere((person) => person != null)
+      .children
+      .forEach((person) => print(person)); // OK
+
+  Person().children.first.children.forEach((person) => print(person)); // OK
 }


### PR DESCRIPTION
Loosens the lint to allow chained calls such as:
```dart
people
      .where((person) => person != null)
      .map((person) => '$person!')
      .forEach((person) => print(person)); // OK

Person()
    .children
    .firstWhere((person) => person != null)
    .children
    .forEach((person) => print(person)); // OK

Person().children.first.children.forEach((person) => print(person)); // OK
```
Fixes #365 
@pq @munificent 