### PR TITLE
0.1.91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.91
+
+* fixed missed cases in `prefer_const_constructors`
+* fixed `prefer_initializing_formals` to no longer suggest API breaking changes
+* updated `omit_local_variable_types` to allow explicit `dynamic`s
+* (internal) migration from deprecated analyzer APIs
+
 # 0.1.90
 
 * fixed null-reference in `unrelated_type_equality_checks`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.90';
+const String version = '0.1.91';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.90
+version: 0.1.91
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.91

* fixed missed cases in `prefer_const_constructors`
* fixed `prefer_initializing_formals` to no longer suggest API breaking changes
* updated `omit_local_variable_types` to allow explicit `dynamic`s
* (internal) migration from deprecated analyzer APIs

/cc @bwilkerson @a14n @dramos07 
