### PR TITLE
Linter: add 'avoid_relative_imports'

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -24,6 +24,7 @@ linter:
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_private_typedef_functions
+    - avoid_relative_imports
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -26,6 +26,7 @@ import 'package:linter/src/rules/avoid_null_checks_in_equality_operators.dart';
 import 'package:linter/src/rules/avoid_positional_boolean_parameters.dart';
 import 'package:linter/src/rules/avoid_private_typedef_functions.dart';
 import 'package:linter/src/rules/avoid_relative_lib_imports.dart';
+import 'package:linter/src/rules/avoid_relative_imports.dart';
 import 'package:linter/src/rules/avoid_renaming_method_parameters.dart';
 import 'package:linter/src/rules/avoid_return_types_on_setters.dart';
 import 'package:linter/src/rules/avoid_returning_null.dart';
@@ -179,6 +180,7 @@ void registerLintRules() {
     ..register(new AvoidPositionalBooleanParameters())
     ..register(new AvoidPrivateTypedefFunctions())
     ..register(new AvoidRelativeLibImports())
+    ..register(new AvoidRelativeImports())
     ..register(new AvoidRenamingMethodParameters())
     ..register(new AvoidReturningNull())
     ..register(new AvoidReturningNullForFuture())

--- a/lib/src/rules/avoid_relative_imports.dart
+++ b/lib/src/rules/avoid_relative_imports.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Avoid relative imports for all files`.';
+
+const _details = r'''*DO* avoid relative imports for files in `lib/`.
+
+Mixing relative and absolute imports makes it complicated to refactor across
+multiple packages.
+
+This is a more strict version of 'avoid_relative_lib_imports'.
+
+**GOOD:**
+
+```
+import 'package:foo/bar.dart';
+
+import 'package:foo/baz.dart';
+
+import 'package:foo/src/baz.dart';
+...
+```
+
+**BAD:**
+
+```
+import 'baz.dart';
+
+import 'src/bag.dart'
+
+import '../lib/baz.dart';
+
+...
+```
+
+''';
+
+class AvoidRelativeImports extends LintRule implements NodeLintRule {
+  AvoidRelativeImports()
+      : super(
+            name: 'avoid_relative_imports',
+            description: _desc,
+            details: _details,
+            group: Group.errors);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this);
+    registry.addImportDirective(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  bool isRelativeImport(ImportDirective node) {
+    try {
+      Uri uri = Uri.parse(node.uriContent);
+      return uri.scheme.isEmpty;
+      // ignore: avoid_catches_without_on_clauses
+    } catch (e) {
+      // Ignore.
+    }
+    return false;
+  }
+
+  @override
+  void visitImportDirective(ImportDirective node) {
+    if (isRelativeImport(node)) {
+      rule.reportLint(node.uri);
+    }
+  }
+}

--- a/test/rules/avoid_relative_imports.dart
+++ b/test/rules/avoid_relative_imports.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_relative_imports`
+
+import '../_data/avoid_relative_lib_imports/lib/dummy.dart'; //LINT
+import 'avoid_catching_errors.dart'; //LINT
+import 'package:linter/linter.dart'; //OK
+import 'package:linter/rules/src/avoid_relative_imports.dart'; //OK
+


### PR DESCRIPTION
This lint is necessary on codebases where there are often files being
moved around. The lack of consistent
'package:my.project.folder/mypackage.dart' makes it very painful to
detect when files are imported since not even intellij tells you that.

This lint is not supposed to be used for everyone since there are a lot
of valid cases for relative imports but I would prefer to have it as
warning or lints, not errors.

This is the opposite of #1101 since we prefer to have fully qualified types.

# Description

Please include a summary of the change and a reference to any corresponding issues.
If this is a fix to an existing lint rule or a proposed new one, please include
the name of the rule in the pull request.

If this is a new lint or feature and there is not an existing tracking bug, please
consider opening one to better facilitate conversation.

Fixes #1601
