### PR TITLE
Loosen prefer_initializing_formals to not include different params vs field types

### DIFF
--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -65,6 +65,23 @@ class GoodMutable {
 }
 ```
 
+**BAD:**
+```
+class AssignedInAllConstructors {
+  var _label; // LINT
+  AssignedInAllConstructors(this._label);
+  AssignedInAllConstructors.withDefault() : _label = 'Hello';
+}
+```
+
+**GOOD:**
+```
+class NotAssignedInAllConstructors {
+  var _label; // OK
+  NotAssignedInAllConstructors();
+  NotAssignedInAllConstructors.withDefault() : _label = 'Hello';
+}
+```
 ''';
 
 class PreferFinalFields extends LintRule implements NodeLintRule {
@@ -135,21 +152,44 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    fields.variables.forEach((VariableDeclaration variable) {
+    for (var variable in fields.variables) {
       final element = variable.declaredElement;
-      if (!element.isPrivate) {
-        return;
-      }
 
-      if (variable.initializer == null) {
-        return;
-      }
+      if (element.isPrivate && !_mutatedFields.contains(element)) {
+        bool fieldInConstructor(constructor) =>
+            constructor.initializers.any((initializer) =>
+                _containedInInitializer(element, initializer)) ||
+            constructor.parameters.parameters
+                .any((formal) => _containedInFormal(element, formal));
 
-      if (_mutatedFields.contains(element)) {
-        return;
-      }
+        final classDeclaration = node.parent;
+        final constructors = (classDeclaration is ClassDeclaration
+            ? classDeclaration.members
+                .whereType<ConstructorDeclaration>()
+                .toSet()
+            : <ConstructorDeclaration>{});
+        final isFieldInConstructors = constructors.any(fieldInConstructor);
+        final isFieldInAllConstructors = constructors.every(fieldInConstructor);
 
-      rule.reportLint(variable);
-    });
+        if (isFieldInConstructors) {
+          if (isFieldInAllConstructors) {
+            rule.reportLint(variable);
+          }
+        } else if (element.initializer != null) {
+          rule.reportLint(variable);
+        }
+      }
+    }
   }
 }
+
+bool _containedInInitializer(
+        Element element, ConstructorInitializer initializer) =>
+    initializer is ConstructorFieldInitializer &&
+    DartTypeUtilities.getCanonicalElementFromIdentifier(
+            initializer.fieldName) ==
+        element;
+
+bool _containedInFormal(Element element, FormalParameter formal) =>
+    formal is FieldFormalParameter &&
+    formal.declaredElement.toString() == element.toString();

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -88,14 +88,14 @@ Iterable<ConstructorFieldInitializer>
             ConstructorDeclaration node) =>
         node.initializers.whereType<ConstructorFieldInitializer>();
 
-Element _getLeftElement(AssignmentExpression assignment) =>
+FieldElement _getLeftElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElementFromIdentifier(
         assignment.leftHandSide);
 
 Iterable<Element> _getParameters(ConstructorDeclaration node) =>
     node.parameters.parameters.map((e) => e.identifier.staticElement);
 
-Element _getRightElement(AssignmentExpression assignment) =>
+VariableElement _getRightElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElementFromIdentifier(
         assignment.rightHandSide);
 
@@ -136,6 +136,7 @@ class _Visitor extends SimpleAstVisitor<void> {
           !leftElement.isSynthetic &&
           leftElement.enclosingElement ==
               node.declaredElement.enclosingElement &&
+          leftElement.type == rightElement.type &&
           parameters.contains(rightElement) &&
           (!parametersUsedMoreThanOnce.contains(rightElement) &&
                   !(rightElement as ParameterElement).isNamed ||
@@ -145,14 +146,15 @@ class _Visitor extends SimpleAstVisitor<void> {
     bool isConstructorFieldInitializerToLint(
         ConstructorFieldInitializer constructorFieldInitializer) {
       final expression = constructorFieldInitializer.expression;
-      return !(constructorFieldInitializer.fieldName.staticElement?.isPrivate ??
-              true) &&
+      final FieldElement fieldElement =
+          constructorFieldInitializer.fieldName.staticElement;
+      return !(fieldElement?.isPrivate ?? true) &&
           expression is SimpleIdentifier &&
+          fieldElement.type == expression.staticType &&
           parameters.contains(expression.staticElement) &&
           (!parametersUsedMoreThanOnce.contains(expression.staticElement) &&
                   !(expression.staticElement as ParameterElement).isNamed ||
-              (constructorFieldInitializer.fieldName.staticElement?.name ==
-                  expression.staticElement.name));
+              (fieldElement?.name == expression.staticElement.name));
     }
 
     void processElement(Element element) {

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -88,14 +88,14 @@ Iterable<ConstructorFieldInitializer>
             ConstructorDeclaration node) =>
         node.initializers.whereType<ConstructorFieldInitializer>();
 
-FieldElement _getLeftElement(AssignmentExpression assignment) =>
+Element _getLeftElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElementFromIdentifier(
         assignment.leftHandSide);
 
 Iterable<Element> _getParameters(ConstructorDeclaration node) =>
     node.parameters.parameters.map((e) => e.identifier.staticElement);
 
-VariableElement _getRightElement(AssignmentExpression assignment) =>
+Element _getRightElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElementFromIdentifier(
         assignment.rightHandSide);
 
@@ -131,6 +131,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       final rightElement = _getRightElement(assignment);
       return leftElement != null &&
           rightElement != null &&
+          rightElement is VariableElement &&
           !leftElement.isPrivate &&
           leftElement is FieldElement &&
           !leftElement.isSynthetic &&

--- a/test/rules/prefer_final_fields.dart
+++ b/test/rules/prefer_final_fields.dart
@@ -4,6 +4,7 @@
 
 // test w/ `pub run test -N prefer_final_fields`
 
+//ignore_for_file: unused_field, unused_local_variable
 class FalsePositiveWhenReturn {
   int _value = 0;
   int getValue() {
@@ -45,6 +46,41 @@ class MultipleMutable {
   void changeLabel() {
     _label = 'hello world! GoodMutable';
   }
+}
+
+class BadMultipleFormals {
+  var _label; // LINT
+  BadMultipleFormals(this._label);
+  BadMultipleFormals.withDefault(this._label);
+}
+
+class BadInitializer {
+  var _label; // LINT
+  BadInitializer() : _label = 'Hello';
+}
+
+class BadMultipleInitializer {
+  var _label; // LINT
+  BadMultipleInitializer() : _label = 'Hello';
+  BadMultipleInitializer.withDefault() : _label = 'Default';
+}
+
+class BadMultipleMixConstructors {
+  var _label; // LINT
+  BadMultipleMixConstructors(this._label);
+  BadMultipleMixConstructors.withDefault() : _label = 'Hello';
+}
+
+class GoodFormals {
+  var _label; // OK
+  GoodFormals(this._label);
+  GoodFormals.empty();
+}
+
+class GoodInitializer {
+  var _label; // OK
+  GoodInitializer() : _label = 'Hello';
+  GoodInitializer.empty();
 }
 
 class C {

--- a/test/rules/prefer_initializing_formals.dart
+++ b/test/rules/prefer_initializing_formals.dart
@@ -238,10 +238,9 @@ class GoodCaseWithDifferentType {
   }
 }
 
-class GoodCaseWithDifferentTypeNamed {
+class GoodCaseWithDifferentTypeNamedParam {
   Iterable<int> ids;
-
-  GoodCaseWithDifferentTypeNamed({List<int> ids}) {
+  GoodCaseWithDifferentTypeNamedParam({List<int> ids}) {
     this.ids = ids; // OK
     ids.add(12);
   }
@@ -249,17 +248,15 @@ class GoodCaseWithDifferentTypeNamed {
 
 class GoodCaseWithDifferentTypeInitializer {
   Iterable<int> ids;
-
   GoodCaseWithDifferentTypeInitializer(List<int> ids)
       : this.ids = ids { // OK
     ids.add(12);
   }
 }
 
-class GoodCaseWithDifferentTypeNamedInitializer {
+class GoodCaseWithDifferentTypeNamedParamInitializer {
   Iterable<int> ids;
-
-  GoodCaseWithDifferentTypeNamedInitializer({List<int> ids})
+  GoodCaseWithDifferentTypeNamedParamInitializer({List<int> ids})
       : this.ids = ids { // OK
     ids.add(12);
   }

--- a/test/rules/prefer_initializing_formals.dart
+++ b/test/rules/prefer_initializing_formals.dart
@@ -228,3 +228,39 @@ class GoodCaseWithDifferentNamedArgsInitializer {
       : this.x = a, // OK
         this.y = b; // OK
 }
+
+class GoodCaseWithDifferentType {
+  Iterable<int> ids;
+
+  GoodCaseWithDifferentType(List<int> ids) {
+    this.ids = ids; // OK
+    ids.add(12);
+  }
+}
+
+class GoodCaseWithDifferentTypeNamed {
+  Iterable<int> ids;
+
+  GoodCaseWithDifferentTypeNamed({List<int> ids}) {
+    this.ids = ids; // OK
+    ids.add(12);
+  }
+}
+
+class GoodCaseWithDifferentTypeInitializer {
+  Iterable<int> ids;
+
+  GoodCaseWithDifferentTypeInitializer(List<int> ids)
+      : this.ids = ids { // OK
+    ids.add(12);
+  }
+}
+
+class GoodCaseWithDifferentTypeNamedInitializer {
+  Iterable<int> ids;
+
+  GoodCaseWithDifferentTypeNamedInitializer({List<int> ids})
+      : this.ids = ids { // OK
+    ids.add(12);
+  }
+}

--- a/test/rules/prefer_initializing_formals.dart
+++ b/test/rules/prefer_initializing_formals.dart
@@ -231,7 +231,6 @@ class GoodCaseWithDifferentNamedArgsInitializer {
 
 class GoodCaseWithDifferentType {
   Iterable<int> ids;
-
   GoodCaseWithDifferentType(List<int> ids) {
     this.ids = ids; // OK
     ids.add(12);


### PR DESCRIPTION
The code below triggers the lint but they are using different field/param type and the actual fix will change the constructor argument to accept the same type as the field and thus will cause the "add" call to fail of course we could cast but it seems a bit odd
```dart
class CaseWithDifferentType {
  Iterable<int> ids;
  CaseWithDifferentType(List<int> ids){
    this.ids = ids; // LINT
    ids.add(1);
  }
}
```
The only current fix with casting:
```dart
class CaseWithDifferentType {
  Iterable<int> ids;
  CaseWithDifferentType(this.ids){
    (ids as List).add(1);
  }
}
```
This pull request will loosen this edge case to also match the type before linting so that this won't be an issue.

@pq @bwilkerson 