### PR TITLE
 Adjust the 'prefer_final_fields' lint to cover more cases

### DIFF
--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -163,11 +163,9 @@ class _Visitor extends SimpleAstVisitor<void> {
                 .any((formal) => _containedInFormal(element, formal));
 
         final classDeclaration = node.parent;
-        final constructors = (classDeclaration is ClassDeclaration
-            ? classDeclaration.members
-                .whereType<ConstructorDeclaration>()
-                .toSet()
-            : <ConstructorDeclaration>{});
+        final Iterable constructors = (classDeclaration is ClassDeclaration
+            ? classDeclaration.members.whereType<ConstructorDeclaration>()
+            : []);
         final isFieldInConstructors = constructors.any(fieldInConstructor);
         final isFieldInAllConstructors = constructors.every(fieldInConstructor);
 
@@ -190,6 +188,8 @@ bool _containedInInitializer(
             initializer.fieldName) ==
         element;
 
-bool _containedInFormal(Element element, FormalParameter formal) =>
-    formal is FieldFormalParameter &&
-    formal.declaredElement.toString() == element.toString();
+bool _containedInFormal(Element element, FormalParameter formal) {
+  final formalField = formal.identifier.staticElement;
+  return formalField is FieldFormalParameterElement &&
+      formalField.field == element;
+}

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -87,10 +87,10 @@ class NotAssignedInAllConstructors {
 class PreferFinalFields extends LintRule implements NodeLintRule {
   PreferFinalFields()
       : super(
-      name: 'prefer_final_fields',
-      description: _desc,
-      details: _details,
-      group: Group.style);
+            name: 'prefer_final_fields',
+            description: _desc,
+            details: _details,
+            group: Group.style);
 
   @override
   void registerNodeProcessors(NodeLintRegistry registry,
@@ -126,7 +126,7 @@ class _MutatedFieldsCollector extends RecursiveAstVisitor<void> {
 
   void _addMutatedFieldElement(Expression expression) {
     final element =
-    DartTypeUtilities.getCanonicalElementFromIdentifier(expression);
+        DartTypeUtilities.getCanonicalElementFromIdentifier(expression);
     if (element is FieldElement) {
       _mutatedFields.add(element);
     }
@@ -159,14 +159,14 @@ class _Visitor extends SimpleAstVisitor<void> {
         bool fieldInConstructor(constructor) =>
             constructor.initializers.any((initializer) =>
                 _containedInInitializer(element, initializer)) ||
-                constructor.parameters.parameters
-                    .any((formal) => _containedInFormal(element, formal));
+            constructor.parameters.parameters
+                .any((formal) => _containedInFormal(element, formal));
 
         final classDeclaration = node.parent;
         final constructors = (classDeclaration is ClassDeclaration
             ? classDeclaration.members
-            .whereType<ConstructorDeclaration>()
-            .toSet()
+                .whereType<ConstructorDeclaration>()
+                .toSet()
             : <ConstructorDeclaration>{});
         final isFieldInConstructors = constructors.any(fieldInConstructor);
         final isFieldInAllConstructors = constructors.every(fieldInConstructor);
@@ -184,12 +184,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 }
 
 bool _containedInInitializer(
-    Element element, ConstructorInitializer initializer) =>
+        Element element, ConstructorInitializer initializer) =>
     initializer is ConstructorFieldInitializer &&
-        DartTypeUtilities.getCanonicalElementFromIdentifier(
+    DartTypeUtilities.getCanonicalElementFromIdentifier(
             initializer.fieldName) ==
-            element;
+        element;
 
 bool _containedInFormal(Element element, FormalParameter formal) =>
     formal is FieldFormalParameter &&
-        formal.declaredElement.toString() == element.toString();
+    formal.declaredElement.toString() == element.toString();

--- a/test/rules/prefer_final_fields.dart
+++ b/test/rules/prefer_final_fields.dart
@@ -4,6 +4,7 @@
 
 // test w/ `pub run test -N prefer_final_fields`
 
+//ignore_for_file: unused_field, unused_local_variable
 class FalsePositiveWhenReturn {
   int _value = 0;
   int getValue() {
@@ -45,6 +46,41 @@ class MultipleMutable {
   void changeLabel() {
     _label = 'hello world! GoodMutable';
   }
+}
+
+class BadMultipleFormals {
+  var _label; // LINT
+  BadMultipleFormals(this._label);
+  BadMultipleFormals.withDefault(this._label);
+}
+
+class BadInitializer {
+  var _label; // LINT
+  BadInitializer() : _label = 'Hello';
+}
+
+class BadMultipleInitializer {
+  var _label; // LINT
+  BadMultipleInitializer() : _label = 'Hello';
+  BadMultipleInitializer.withDefault() : _label = 'Default';
+}
+
+class BadMultipleMixConstructors {
+  var _label; // LINT
+  BadMultipleMixConstructors(this._label);
+  BadMultipleMixConstructors.withDefault() : _label = 'Hello';
+}
+
+class GoodFormals {
+  var _label; // OK
+  GoodFormals(this._label);
+  GoodFormals.empty();
+}
+
+class GoodInitializer {
+  var _label; // OK
+  GoodInitializer() : _label = 'Hello';
+  GoodInitializer.empty();
 }
 
 class C {


### PR DESCRIPTION
The current lint only covers fields which have a default value set to them which excludes cases like:

```dart
class AssignedInAllConstructors {
  var _label; // Currently OK
  AssignedInAllConstructors(this._label);
  AssignedInAllConstructors.withDefault() : _label = 'Hello';
}
```
These change tries to aim for linting fields assigned only once (either by default or in all the constructors)"

Fixes #1606

@pq @bwilkerson 
