### PR TITLE
Make LinkedHashSet method call behave the same as field assignment

### DIFF
--- a/test/rules/prefer_collection_literals.dart
+++ b/test/rules/prefer_collection_literals.dart
@@ -6,7 +6,7 @@
 
 import 'dart:collection';
 
-//ignore_for_file: unused_local_variable, prefer_collection_literals
+//ignore_for_file: unused_local_variable
 void main() {
   var listToLint = new List(); //LINT
   var mapToLint = new Map(); // LINT

--- a/test/rules/prefer_collection_literals.dart
+++ b/test/rules/prefer_collection_literals.dart
@@ -6,7 +6,7 @@
 
 import 'dart:collection';
 
-//ignore_for_file: unused_local_variable
+//ignore_for_file: unused_local_variable, prefer_collection_literals
 void main() {
   var listToLint = new List(); //LINT
   var mapToLint = new Map(); // LINT
@@ -51,6 +51,10 @@ void main() {
   Set<int> ss5 = LinkedHashSet<int>(); // LINT
   LinkedHashSet<int> ss6 = LinkedHashSet<int>(); // OK
 
+  printSet(Set()); // LINT
+  printSet(LinkedHashSet<int>()); // LINT
+  printHashSet(LinkedHashSet<int>()); // OK
+
   Set<int> ss7 = LinkedHashSet.from([1, 2, 3]); // LINT
   LinkedHashSet<int> ss8 =  LinkedHashSet.from([1, 2, 3]); // OK
 
@@ -62,3 +66,6 @@ void main() {
   var lhs = LinkedHashSet(equals: (a, b) => false, hashCode: (o) => 13)..addAll({}); // OK
 
 }
+
+void printSet(Set<int> ids) => print('$ids!');
+void printHashSet(LinkedHashSet<int> ids) => printSet(ids);


### PR DESCRIPTION
The current implementation of the lint handles LinkedHashSet as follows:

```dart
var ss5 = LinkedHashSet<int>(); // LINT
Set<int> ss5 = LinkedHashSet<int>(); // LINT
LinkedHashSet<int> ss6 = LinkedHashSet<int>(); // OK
```

The last one is precisely to avoid the type error but following the same this change includes function calls to follow the same:

```dart
printSet(Set()); // LINT
printSet(LinkedHashSet<int>()); // LINT
printHashSet(LinkedHashSet<int>()); // OK

void printSet(Set<int> ids) => ...
void printHashSet(LinkedHashSet<int> ids) => ...
```

@pq @bwilkerson 