### PR TITLE
Apply the same restrictions for LinkedHashMap as the ones for LinkedHashSet

### DIFF
--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -34,7 +34,7 @@ var coordinates = <int,int>{};
 
 **EXCEPTIONS:**
 
-There are cases with LinkedHasSet or LinkedHashMap where a literal constructor
+There are cases with `LinkedHashSet` or `LinkedHashMap` where a literal constructor
 will trigger a type error so those will be excluded from the lint.
 
 ```

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -32,6 +32,28 @@ var ids = <int>{};
 var coordinates = <int,int>{};
 ```
 
+**EXCEPTIONS:**
+
+There are cases with LinkedHasSet or LinkedHashMap where a literal constructor
+will trigger a type error so those will be excluded from the lint.
+
+```
+void main() {
+  LinkedHashSet<int> linkedHashSet =  LinkedHashSet.from([1, 2, 3]); // OK
+  LinkedHashMap linkedHashMap = LinkedHashMap(); // OK
+  
+  printSet(LinkedHashSet<int>()); // LINT
+  printHashSet(LinkedHashSet<int>()); // OK
+
+  printMap(LinkedHashMap<int, int>()); // LINT
+  printHashMap(LinkedHashMap<int, int>()); // OK
+}
+
+void printSet(Set<int> ids) => print('$ids!');
+void printHashSet(LinkedHashSet<int> ids) => printSet(ids);
+void printMap(Map map) => print('$map!');
+void printHashMap(LinkedHashMap map) => printMap(map);
+```
 ''';
 
 class PreferCollectionLiterals extends LintRule implements NodeLintRule {
@@ -72,6 +94,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Lists, Maps.
     if (_isList(node) || _isMap(node) || _isHashMap(node)) {
+      if (_shouldSkipLinkedHashLint(node, _isTypeMap)) {
+        return;
+      }
       if (constructorName == null && node.argumentList.arguments.isEmpty) {
         rule.reportLint(node);
       }
@@ -80,30 +105,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Sets.
     if (_isSet(node) || _isHashSet(node)) {
-      // Skip: LinkedHashSet<int> s =  ...;
-      var parent = node.parent;
-      if (parent is VariableDeclaration) {
-        var parent2 = parent.parent;
-        if (parent2 is VariableDeclarationList) {
-          var assignmentType = parent2.type?.type;
-          if (assignmentType != null && !_isTypeSet(assignmentType)) {
-            return;
-          }
-        }
-      }
-      // Skip: function(LinkedHashSet()); when function(LinkedHashSet mySet)
-      if (parent is ArgumentList) {
-        final paramType = parent.arguments.first.staticParameterElement.type;
-        if (paramType != null && !_isTypeSet(paramType)) {
-          return;
-        }
-      }
-      // Skip: <int, LinkedHashSet<String>>{}.putIfAbsent(3, () => LinkedHashSet<String>());
-      if (parent is ExpressionFunctionBody) {
-        var expressionType = parent.expression.staticType;
-        if (expressionType != null && !_isTypeSet(expressionType)) {
-          return;
-        }
+      if (_shouldSkipLinkedHashLint(node, _isTypeSet)) {
+        return;
       }
 
       var args = node.argumentList.arguments;
@@ -129,10 +132,45 @@ class _Visitor extends SimpleAstVisitor<void> {
       expression.staticType, 'LinkedHashSet', 'dart.collection');
   bool _isList(Expression expression) =>
       DartTypeUtilities.isClass(expression.staticType, 'List', 'dart.core');
-  bool _isMap(Expression expression) =>
-      DartTypeUtilities.isClass(expression.staticType, 'Map', 'dart.core');
+  bool _isMap(Expression expression) => _isTypeMap(expression.staticType);
   bool _isHashMap(Expression expression) => DartTypeUtilities.isClass(
       expression.staticType, 'LinkedHashMap', 'dart.collection');
   bool _isTypeSet(DartType type) =>
       DartTypeUtilities.isClass(type, 'Set', 'dart.core');
+  bool _isTypeMap(DartType type) =>
+      DartTypeUtilities.isClass(type, 'Map', 'dart.core');
+
+  bool _shouldSkipLinkedHashLint(
+      InstanceCreationExpression node, bool Function(DartType node) typeCheck) {
+    if (_isHashMap(node) || _isHashSet(node)) {
+      // Skip: LinkedHashSet<int> s =  ...; or LinkedHashMap<int> s =  ...;
+      var parent = node.parent;
+      if (parent is VariableDeclaration) {
+        var parent2 = parent.parent;
+        if (parent2 is VariableDeclarationList) {
+          var assignmentType = parent2.type?.type;
+          if (assignmentType != null && !typeCheck(assignmentType)) {
+            return true;
+          }
+        }
+      }
+      // Skip: function(LinkedHashSet()); when function(LinkedHashSet mySet) or
+      // function(LinkedHashMap()); when function(LinkedHashMap myMap)
+      if (parent is ArgumentList) {
+        final paramType = parent.arguments.first.staticParameterElement.type;
+        if (paramType != null && !typeCheck(paramType)) {
+          return true;
+        }
+      }
+      // Skip: <int, LinkedHashSet>{}.putIfAbsent(3, () => LinkedHashSet());
+      // or <int, LinkedHashMap>{}.putIfAbsent(3, () => LinkedHashMap());
+      if (parent is ExpressionFunctionBody) {
+        var expressionType = parent.expression.staticType;
+        if (expressionType != null && !typeCheck(expressionType)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/test/rules/prefer_collection_literals.dart
+++ b/test/rules/prefer_collection_literals.dart
@@ -65,7 +65,16 @@ void main() {
 
   var lhs = LinkedHashSet(equals: (a, b) => false, hashCode: (o) => 13)..addAll({}); // OK
 
+  LinkedHashMap hashMap = LinkedHashMap(); // OK
+
+  printMap(Map()); // LINT
+  printMap(LinkedHashMap<int, int>()); // LINT
+  printHashMap(LinkedHashMap<int, int>()); // OK
+
+  LinkedHashMap<String, String> lhm = <int, LinkedHashMap<String,String>>{}.putIfAbsent(3, () => LinkedHashMap<String, String>()); // OK
 }
 
 void printSet(Set<int> ids) => print('$ids!');
 void printHashSet(LinkedHashSet<int> ids) => printSet(ids);
+void printMap(Map map) => print('$map!');
+void printHashMap(LinkedHashMap map) => printMap(map);


### PR DESCRIPTION
Currently `LinkedHashSet` excludes the following cases for the lint:

```dart
void main() {
  LinkedHashSet<int> linkedHashSet =  LinkedHashSet.from([1, 2, 3]); // OK
  LinkedHashSet<String> sss1 = <int, LinkedHashSet<String>>{}.putIfAbsent(3, () => LinkedHashSet<String>()); // OK
 
  printSet(LinkedHashSet<int>()); // LINT
  printHashSet(LinkedHashSet<int>()); // OK
}
void printSet(Set<int> ids) => print('$ids!');
void printHashSet(LinkedHashSet<int> ids) => printSet(ids);
```
For consistency we want the same cases to be expected for `LinkedHashMap`:

```dart
void main() {
  LinkedHashMap linkedHashMap = LinkedHashMap(); // OK
  LinkedHashMap<String, String> lhm = <int, LinkedHashMap<String,String>>{}.putIfAbsent(3, () => LinkedHashMap<String, String>()); // OK

  printMap(LinkedHashMap<int, int>()); // LINT
  printHashMap(LinkedHashMap<int, int>()); // OK
}
void printMap(Map map) => print('$map!');
void printHashMap(LinkedHashMap map) => printMap(map);
```
@pq @bwilkerson 