### PR TITLE
0.1.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.92
+
+* improved `prefer_collection_literals` to better handle `LinkedHashSet`s and `LinkedHashMap`s
+* updates to the Effective Dart rule set
+* updated `prefer_final_fields` to be more inclusive
+* miscellaneous documentation fixes
+
 # 0.1.91
 
 * fixed missed cases in `prefer_const_constructors`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.91';
+const String version = '0.1.92';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.91
+version: 0.1.92
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.92

* improved `prefer_collection_literals` to better handle `LinkedHashSet`s and `LinkedHashMap`s
* updates to the Effective Dart rule set
* updated `prefer_final_fields` to be more inclusive
* miscellaneous documentation fixes

/cc @bwilkerson 

/fyi @dramos07 