### PR TITLE
avoid_print

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -23,6 +23,7 @@ linter:
     - avoid_js_rounded_ints
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
+    - avoid_print
     - avoid_private_typedef_functions
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -24,6 +24,7 @@ import 'package:linter/src/rules/avoid_init_to_null.dart';
 import 'package:linter/src/rules/avoid_js_rounded_ints.dart';
 import 'package:linter/src/rules/avoid_null_checks_in_equality_operators.dart';
 import 'package:linter/src/rules/avoid_positional_boolean_parameters.dart';
+import 'package:linter/src/rules/avoid_print.dart';
 import 'package:linter/src/rules/avoid_private_typedef_functions.dart';
 import 'package:linter/src/rules/avoid_relative_lib_imports.dart';
 import 'package:linter/src/rules/avoid_renaming_method_parameters.dart';
@@ -177,6 +178,7 @@ void registerLintRules() {
     ..register(new AvoidJsRoundedInts())
     ..register(new AvoidNullChecksInEqualityOperators())
     ..register(new AvoidPositionalBooleanParameters())
+    ..register(new AvoidPrint())
     ..register(new AvoidPrivateTypedefFunctions())
     ..register(new AvoidRelativeLibImports())
     ..register(new AvoidRenamingMethodParameters())

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -44,7 +44,7 @@ class _Visitor extends SimpleAstVisitor {
   @override
   visitMethodInvocation(MethodInvocation node) {
     bool isDartCore(MethodInvocation node) =>
-        node.staticInvokeType?.element?.library?.name == 'dart.core';
+        node.methodName.staticElement?.library?.name == 'dart.core';
 
     if (node.methodName.name == 'print' && isDartCore(node)) {
       rule.reportLint(node.methodName);

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Avoid `print` calls in production code.';
+
+const _details = r'''
+**DO** avoid `print` calls in production code.
+
+**BAD:**
+```
+void f(int x) {
+  print('debug: $x');
+  ...
+}
+```
+''';
+
+class AvoidPrint extends LintRule implements NodeLintRule {
+  AvoidPrint()
+      : super(
+            name: 'avoid_print',
+            description: _desc,
+            details: _details,
+            group: Group.errors);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = new _Visitor(this);
+    registry.addMethodInvocation(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  visitMethodInvocation(MethodInvocation node) {
+    bool isDartCore(MethodInvocation node) =>
+        node.staticInvokeType?.element?.library?.name == 'dart.core';
+
+    if (node.methodName.name == 'print' && isDartCore(node)) {
+      rule.reportLint(node.methodName);
+    }
+  }
+}

--- a/test/rules/avoid_print.dart
+++ b/test/rules/avoid_print.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_print`
+
+void main() {
+  print('ha'); // LINT
+}
+
+var x = print; // OK
+
+void f() {
+  x('ha'); // OK?
+}
+
+class A {
+  print() {
+  }
+}
+
+void g() {
+  A().print(); // OK
+}


### PR DESCRIPTION
(Nearly) the simplest possible lint for `print`s.

Refinements welcome.

(In particular, do we want to allow calls in `Logger`s?)

Fixes #88

/cc @bwilkerson 