### PR TITLE
0.1.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.93
+
+* new lint: `avoid_print`
+
 # 0.1.92
 
 * improved `prefer_collection_literals` to better handle `LinkedHashSet`s and `LinkedHashMap`s

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.92';
+const String version = '0.1.93';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.92
+version: 0.1.93
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.93

* new lint: `avoid_print`

/cc @bwilkerson 