### PR TITLE
Add a cast that will be necessary as of the next published version of analyzer

### DIFF
--- a/lib/src/rules/avoid_implementing_value_types.dart
+++ b/lib/src/rules/avoid_implementing_value_types.dart
@@ -120,9 +120,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   static bool _overridesEquals(ClassElement element) =>
-      element
-          .lookUpConcreteMethod('==', element.library)
-          ?.enclosingElement
+      // ignore: unnecessary_cast
+      (element.lookUpConcreteMethod('==', element.library)?.enclosingElement
+              as ClassElement)
           ?.type
           ?.isObject ==
       false;


### PR DESCRIPTION
This will be needed in order to rework the element model, but I won't merge it until we know we need it.