### PR TITLE
Split the unsafe_html errorCodes

### DIFF
--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -8,7 +8,8 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
-const _desc = r'Avoid unsafe HTML APIs.';
+const _descPrefix = r'Avoid unsafe HTML APIs';
+const _desc = r'$_descPrefix.';
 
 const _details = r'''
 
@@ -40,6 +41,11 @@ class UnsafeHtml extends LintRule implements NodeLintRule {
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
+  static const hrefAttributeCode =
+      LintCode('unsafe_html', '$_descPrefix (assigning "href" attribute).');
+  static const srcAttributeCode =
+      LintCode('unsafe_html', '$_descPrefix (assigning "src" attribute).');
+
   final LintRule rule;
 
   _Visitor(this.rule);
@@ -71,14 +77,14 @@ class _Visitor extends SimpleAstVisitor<void> {
               type, 'ImageElement', 'dart.dom.html') ||
           DartTypeUtilities.extendsClass(
               type, 'ScriptElement', 'dart.dom.html')) {
-        rule.reportLint(assignment);
+        rule.reportLint(assignment, errorCode: srcAttributeCode);
       }
     } else if (property.name == 'href') {
       DartType type = target.staticType;
       if (type.isDynamic ||
           DartTypeUtilities.extendsClass(
               type, 'AnchorElement', 'dart.dom.html')) {
-        rule.reportLint(assignment);
+        rule.reportLint(assignment, errorCode: hrefAttributeCode);
       }
     }
   }

--- a/test/mock_sdk.dart
+++ b/test/mock_sdk.dart
@@ -306,8 +306,21 @@ class HtmlElement {}
   static _MockSdkLibrary LIB_DOM_HTML = _MockSdkLibrary(
       'dart:_dom_html', '/lib/html/dartium/dom_html_dartium.dart', '''
 library dart.dom.html;
+class AnchorElement extends HtmlElement {
+  String href;
+}
+class EmbedElement extends HtmlEment {
+  String src;
+}
+class IFrameElement extends HtmlEment {
+  String src;
+}
+class ImageElement extends HtmlEment {
+  String src;
+}
 class  ScriptElement {
   String src;
+  String type;
 }
 ''');
 


### PR DESCRIPTION
The unsafe_html error message currently does not state what about a given statement is "unsafe." This makes it clearer, per HTML field, and allows tools to filter violations per error code.

Also fix missing classes etc in the mock_sdk.