### PR TITLE
In rule_test, fail on unregistered rule

### DIFF
--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -75,7 +75,7 @@ defineRuleTests() {
         if (entry is Directory) {
           for (var child in entry.listSync()) {
             if (child is File && isPubspecFile(child)) {
-              var ruleName = p.basename(child.path);
+              var ruleName = p.basename(entry.path);
               testRule(ruleName, child);
             }
           }
@@ -325,6 +325,10 @@ testRules(String ruleDir, {String analysisOptions}) {
   for (var entry in Directory(ruleDir).listSync()) {
     if (entry is! File || !isDartFile(entry)) continue;
     var ruleName = p.basenameWithoutExtension(entry.path);
+    if (ruleName == 'unnecessary_getters') {
+      // Disabled pending fix: https://github.com/dart-lang/linter/issues/23
+      continue;
+    }
     testRule(ruleName, entry as File,
         debug: true, analysisOptions: analysisOptions);
   }
@@ -353,8 +357,7 @@ testRule(String ruleName, File file,
 
     LintRule rule = Registry.ruleRegistry[ruleName];
     if (rule == null) {
-      print('WARNING: Test skipped -- rule `$ruleName` is not registered.');
-      return;
+      fail('rule `$ruleName` is not registered; unable to test.');
     }
 
     MemoryResourceProvider memoryResourceProvider = MemoryResourceProvider(


### PR DESCRIPTION
We should fail, not print, on an unregistered rule in the rule_test. This in fact uncovered a bug:

The package_names lint rule test was not being executed!, because the 'pub' group was misconfigured.

Additionally, since  `unnecessary_getters` is not registered in rules.dart, it cannot be tested, so I hard-coded a skip. If this is not super discovereable, we could rename the  file to something like `SKIP_unnecessary_getters.dart`, and check for file names beginning with `SKIP_`, or set the first line of the  file to, e.g. `SKIP SKIP SKIP`, and check for files starting with that. I'm open.