### PR TITLE
Replace DartType.isMoreSpecificThan() with TypeSystem.isSubtypeOf().

### DIFF
--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -130,7 +130,7 @@ class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    final visitor = _Visitor(this, context.typeSystem);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -138,7 +138,7 @@ class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
 class _Visitor extends UnrelatedTypesProcessors {
   static final _DEFINITION = InterfaceTypeDefinition('Iterable', 'dart.core');
 
-  _Visitor(LintRule rule) : super(rule);
+  _Visitor(LintRule rule, TypeSystem typeSystem) : super(rule, typeSystem);
 
   @override
   InterfaceTypeDefinition get definition => _DEFINITION;

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -130,7 +130,7 @@ class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    final visitor = _Visitor(this, context.typeSystem);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -138,7 +138,7 @@ class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
 class _Visitor extends UnrelatedTypesProcessors {
   static final _DEFINITION = InterfaceTypeDefinition('List', 'dart.core');
 
-  _Visitor(LintRule rule) : super(rule);
+  _Visitor(LintRule rule, TypeSystem typeSystem) : super(rule, typeSystem);
 
   @override
   InterfaceTypeDefinition get definition => _DEFINITION;

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -132,7 +132,7 @@ class DerivedClass2 extends ClassBase with Mixin {}
 
 ''';
 
-bool _hasNonComparableOperands(BinaryExpression node) {
+bool _hasNonComparableOperands(TypeSystem typeSystem, BinaryExpression node) {
   var left = node.leftOperand;
   var leftType = left.staticType;
   var right = node.rightOperand;
@@ -142,7 +142,7 @@ bool _hasNonComparableOperands(BinaryExpression node) {
   }
   return !DartTypeUtilities.isNullLiteral(left) &&
       !DartTypeUtilities.isNullLiteral(right) &&
-      DartTypeUtilities.unrelatedTypes(leftType, rightType) &&
+      DartTypeUtilities.unrelatedTypes(typeSystem, leftType, rightType) &&
       !(_isFixNumIntX(leftType) && _isCoreInt(rightType));
 }
 
@@ -164,7 +164,7 @@ class UnrelatedTypeEqualityChecks extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    final visitor = _Visitor(this, context.typeSystem);
     registry.addBinaryExpression(this, visitor);
   }
 }
@@ -173,8 +173,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   static const String _boolClassName = 'bool';
 
   final LintRule rule;
+  final TypeSystem typeSystem;
 
-  _Visitor(this.rule);
+  _Visitor(this.rule, this.typeSystem);
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
@@ -188,7 +189,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    if (_hasNonComparableOperands(node)) {
+    if (_hasNonComparableOperands(typeSystem, node)) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -80,8 +80,9 @@ bool _isParameterizedMethodInvocation(
 /// define the target, i.e. implement only [definition] and [methodName].
 abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
   final LintRule rule;
+  final TypeSystem typeSystem;
 
-  UnrelatedTypesProcessors(this.rule);
+  UnrelatedTypesProcessors(this.rule, this.typeSystem);
 
   /// The type definition which this [UnrelatedTypesProcessors] is concerned
   /// with.
@@ -128,7 +129,7 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
     // Finally, determine whether the type of the argument is related to the
     // type of the method target.
     if (targetType is InterfaceType &&
-        DartTypeUtilities.unrelatedTypes(argument.staticType,
+        DartTypeUtilities.unrelatedTypes(typeSystem, argument.staticType,
             _findIterableTypeArgument(definition, targetType))) {
       rule.reportLint(node);
     }


### PR DESCRIPTION
All type operations in general should be done using `TypeSystem`.
We want to remove duplicate, older implementations in `DartTypeImp`.