### PR TITLE
Replace DartType.isSubtypeOf() with TypeSystem.isSubtypeOf().

### DIFF
--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -118,7 +118,7 @@ class _Visitor extends SimpleAstVisitor<void> {
             null &&
         typeSystem.mostSpecificTypeArgument(type, typeProvider.mapType) ==
             null &&
-        !type.element.type.isSubtypeOf(typeProvider.stringType)) {
+        !type.isDartCoreString) {
       return;
     }
 

--- a/lib/src/rules/unnecessary_await_in_return.dart
+++ b/lib/src/rules/unnecessary_await_in_return.dart
@@ -46,7 +46,7 @@ class UnnecessaryAwaitInReturn extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    final visitor = _Visitor(this, context.typeSystem);
     registry.addExpressionFunctionBody(this, visitor);
     registry.addReturnStatement(this, visitor);
   }
@@ -54,8 +54,9 @@ class UnnecessaryAwaitInReturn extends LintRule implements NodeLintRule {
 
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+  final TypeSystem typeSystem;
 
-  _Visitor(this.rule);
+  _Visitor(this.rule, this.typeSystem);
 
   @override
   void visitExpressionFunctionBody(ExpressionFunctionBody node) {
@@ -96,7 +97,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
     if (returnType != null &&
         returnType.isDartAsyncFuture &&
-        type.isSubtypeOf(returnType)) {
+        typeSystem.isSubtypeOf(type, returnType)) {
       rule.reportLintForToken((expression as AwaitExpression).awaitKeyword);
     }
   }

--- a/test/mock_sdk.dart
+++ b/test/mock_sdk.dart
@@ -193,7 +193,7 @@ abstract class StreamTransformer<S, T> {}
 
 class Future<T> {
   factory Future.delayed(Duration duration, [T computation()]) => null;
-  factory Future.value([value]) => null;
+  factory Future.value([FutureOr<T> value]) => null;
   static Future wait(List<Future> futures) => null;
 }
 


### PR DESCRIPTION
All type operations in general should be done using `TypeSystem`.
We want to remove duplicate, older implementations in `DartTypeImpl`.