### PR TITLE
Do not report parens around set-or-map literal as method target

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -106,15 +106,19 @@ class _Visitor extends SimpleAstVisitor<void> {
       // PrefixExpression.
       if (parent is MethodInvocation) {
         Expression target = parent.target;
-
-        // Something like `({1, 2, 3}).forEach(print);`.
-        // The parens cannot be removed because then the curly brackets are not
-        // interpreted as a set-or-map literal.
-        if (target == node && node.expression is SetOrMapLiteral) return;
-
         if (parent.parent is PrefixExpression &&
             target == node &&
             _expressionStartsWithWhitespace(node.expression)) return;
+      }
+
+      // Something like `({1, 2, 3}).forEach(print);`.
+      // The parens cannot be removed because then the curly brackets are not
+      // interpreted as a set-or-map literal.
+      if (parent is PropertyAccess || parent is MethodInvocation) {
+        Expression target = (parent as dynamic).target;
+        if (target == node &&
+            node.expression is SetOrMapLiteral &&
+            parent.parent is ExpressionStatement) return;
       }
 
       if (parent.precedence < node.expression.precedence) {

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -106,6 +106,12 @@ class _Visitor extends SimpleAstVisitor<void> {
       // PrefixExpression.
       if (parent is MethodInvocation) {
         Expression target = parent.target;
+
+        // Something like `({1, 2, 3}).forEach(print);`.
+        // The parens cannot be removed because then the curly brackets are not
+        // interpreted as a set-or-map literal.
+        if (target == node && node.expression is SetOrMapLiteral) return;
+
         if (parent.parent is PrefixExpression &&
             target == node &&
             _expressionStartsWithWhitespace(node.expression)) return;

--- a/test/rules/unnecessary_parenthesis.dart
+++ b/test/rules/unnecessary_parenthesis.dart
@@ -58,6 +58,8 @@ main() async {
 
   ({false: 'false', true: 'true'}).forEach((k, v) => print('$k: $v'));
   ({false, true}).forEach(print);
+  ({false, true}).length;
+  print(({1, 2, 3}).length); // LINT
   ([false, true]).forEach(print); // LINT
 }
 

--- a/test/rules/unnecessary_parenthesis.dart
+++ b/test/rules/unnecessary_parenthesis.dart
@@ -55,6 +55,10 @@ main() async {
   (int).runtimeType;
   (bool).noSuchMethod();
   (double).toString();
+
+  ({false: 'false', true: 'true'}).forEach((k, v) => print('$k: $v'));
+  ({false, true}).forEach(print);
+  ([false, true]).forEach(print); // LINT
 }
 
 m({p}) => null;


### PR DESCRIPTION
Currently the unnecessary_parenthesis rule reports the following statement:

```dart
({1, 2, 3}).forEach(print);
```

But Dart cannot parse the statement if the parens are removed; it thinks an anonymous block is being declared, and fails to parse.

This PR stops reporting that case.