### PR TITLE
extension-method test for always_declare_return_types

### DIFF
--- a/test/rules/experiments/always_declare_return_types/always_declare_return_types.dart
+++ b/test/rules/experiments/always_declare_return_types/always_declare_return_types.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class A { }
+
+extension Foo on A {
+  foo() { } // LINT
+}

--- a/test/rules/experiments/always_declare_return_types/analysis_options.yaml
+++ b/test/rules/experiments/always_declare_return_types/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  enable-experiment:
+    - extension-methods

--- a/test/rules/experiments/experiments.dart
+++ b/test/rules/experiments/experiments.dart
@@ -3,8 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/rules/always_declare_return_types.dart';
 
-final experiments = <LintRule>[];
+final experiments = <LintRule>[
+  AlwaysDeclareReturnTypes(),
+];
 
 void registerLintRuleExperiments() {
   experiments.forEach(Analyzer.facade.register);


### PR DESCRIPTION
First of a set of tests that validate behavior w/ extension-methods enabled.

/cc @bwilkerson 
