### PR TITLE
ensure `prefer_constructors_over_static_methods` works with extensions

### DIFF
--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -76,9 +76,10 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
     final returnType = node.returnType?.type;
+    final parent = node.parent;
     if (node.isStatic &&
-        returnType ==
-            (node.parent as ClassOrMixinDeclaration).declaredElement.type &&
+        parent is ClassOrMixinDeclaration &&
+        returnType == parent.declaredElement.type &&
         _hasNewInvocation(returnType, node.body)) {
       rule.reportLint(node.name);
     }

--- a/test/rules/experiments/experiments.dart
+++ b/test/rules/experiments/experiments.dart
@@ -5,6 +5,7 @@
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules/always_declare_return_types.dart';
 import 'package:linter/src/rules/camel_case_extensions.dart';
+import 'package:linter/src/rules/prefer_constructors_over_static_methods.dart';
 import 'package:linter/src/rules/public_member_api_docs.dart';
 import 'package:linter/src/rules/slash_for_doc_comments.dart';
 import 'package:linter/src/rules/type_annotate_public_apis.dart';
@@ -12,6 +13,7 @@ import 'package:linter/src/rules/type_annotate_public_apis.dart';
 final experiments = <LintRule>[
   AlwaysDeclareReturnTypes(),
   CamelCaseExtensions(),
+  PreferConstructorsInsteadOfStaticMethods(),
   PublicMemberApiDocs(),
   SlashForDocComments(),
   TypeAnnotatePublicApis(),

--- a/test/rules/experiments/prefer_constructors_over_static_methods/analysis_options.yaml
+++ b/test/rules/experiments/prefer_constructors_over_static_methods/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  enable-experiment:
+    - extension-methods

--- a/test/rules/experiments/prefer_constructors_over_static_methods/prefer_constructors_over_static_methods.dart
+++ b/test/rules/experiments/prefer_constructors_over_static_methods/prefer_constructors_over_static_methods.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_constructors_over_static_methods`
+
+class A {
+  static final array = <A>[];
+
+  A.internal();
+
+  static A bad1() => // LINT
+  new A.internal();
+
+  static A get newA => // LINT
+  new A.internal();
+
+  static A bad2(){ // LINT
+    final a = new A.internal();
+    return a;
+  }
+
+  static A good1(int i) { // OK
+    return array[i];
+  }
+
+  factory A.good2(){ // OK
+    return new A.internal();
+  }
+
+  factory A.good3(){ // OK
+    return new A.internal();
+  }
+}
+
+extension E on A {
+  static A foo() => A(); // OK
+}


### PR DESCRIPTION
See #1683 .

/cc @bwilkerson 
