### PR TITLE
make type utils extension-safe

### DIFF
--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -189,10 +189,9 @@ class DartTypeUtilities {
       expression?.unParenthesized is NullLiteral;
 
   static PropertyAccessorElement lookUpGetter(MethodDeclaration node) {
-    final parent = node.parent;
-    if (parent is ClassOrMixinDeclaration) {
-      return parent.declaredElement
-          .lookUpGetter(node.name.name, node.declaredElement.library);
+    final parent = node.declaredElement.enclosingElement;
+    if (parent is ClassElement) {
+      return parent.lookUpGetter(node.name.name, node.declaredElement.library);
     }
     // todo (pq): consider extensions
     return null;
@@ -200,9 +199,9 @@ class DartTypeUtilities {
 
   static PropertyAccessorElement lookUpInheritedConcreteGetter(
       MethodDeclaration node) {
-    final parent = node.parent;
-    if (parent is ClassOrMixinDeclaration) {
-      return parent.declaredElement.lookUpInheritedConcreteGetter(
+    final parent = node.declaredElement.enclosingElement;
+    if (parent is ClassElement) {
+      return parent.lookUpInheritedConcreteGetter(
           node.name.name, node.declaredElement.library);
     }
     // todo (pq): consider extensions
@@ -210,9 +209,9 @@ class DartTypeUtilities {
   }
 
   static MethodElement lookUpInheritedConcreteMethod(MethodDeclaration node) {
-    final parent = node.parent;
-    if (parent is ClassOrMixinDeclaration) {
-      return parent.declaredElement.lookUpInheritedConcreteMethod(
+    final parent = node.declaredElement.enclosingElement;
+    if (parent is ClassElement) {
+      return parent.lookUpInheritedConcreteMethod(
           node.name.name, node.declaredElement.library);
     }
     // todo (pq): consider extensions
@@ -221,9 +220,9 @@ class DartTypeUtilities {
 
   static PropertyAccessorElement lookUpInheritedConcreteSetter(
       MethodDeclaration node) {
-    final parent = node.parent;
-    if (parent is ClassOrMixinDeclaration) {
-      return parent.declaredElement.lookUpInheritedConcreteSetter(
+    final parent = node.declaredElement.enclosingElement;
+    if (parent is ClassElement) {
+      return parent.lookUpInheritedConcreteSetter(
           node.name.name, node.declaredElement.library);
     }
     // todo (pq): consider extensions
@@ -231,18 +230,17 @@ class DartTypeUtilities {
   }
 
   static MethodElement lookUpInheritedMethod(MethodDeclaration node) {
-    final parent = node.parent;
-    return parent is ClassOrMixinDeclaration
-        ? parent.declaredElement
-            .lookUpInheritedMethod(node.name.name, node.declaredElement.library)
+    final parent = node.declaredElement.enclosingElement;
+    return parent is ClassElement
+        ? parent.lookUpInheritedMethod(
+            node.name.name, node.declaredElement.library)
         : null;
   }
 
   static PropertyAccessorElement lookUpSetter(MethodDeclaration node) {
-    final parent = node.parent;
-    if (parent is ClassOrMixinDeclaration) {
-      return parent.declaredElement
-          .lookUpSetter(node.name.name, node.declaredElement.library);
+    final parent = node.declaredElement.enclosingElement;
+    if (parent is ClassElement) {
+      return parent.lookUpSetter(node.name.name, node.declaredElement.library);
     }
     // todo (pq): consider extensions
     return null;

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -188,30 +188,47 @@ class DartTypeUtilities {
   static bool isNullLiteral(Expression expression) =>
       expression?.unParenthesized is NullLiteral;
 
-  static PropertyAccessorElement lookUpGetter(MethodDeclaration node) =>
-      (node.parent as ClassOrMixinDeclaration)
-          .declaredElement
+  static PropertyAccessorElement lookUpGetter(MethodDeclaration node) {
+    final parent = node.parent;
+    if (parent is ClassOrMixinDeclaration) {
+      return parent.declaredElement
           .lookUpGetter(node.name.name, node.declaredElement.library);
+    }
+    // todo (pq): consider extensions
+    return null;
+  }
 
   static PropertyAccessorElement lookUpInheritedConcreteGetter(
-          MethodDeclaration node) =>
-      (node.parent as ClassOrMixinDeclaration)
-          .declaredElement
-          .lookUpInheritedConcreteGetter(
-              node.name.name, node.declaredElement.library);
+      MethodDeclaration node) {
+    final parent = node.parent;
+    if (parent is ClassOrMixinDeclaration) {
+      return parent.declaredElement.lookUpInheritedConcreteGetter(
+          node.name.name, node.declaredElement.library);
+    }
+    // todo (pq): consider extensions
+    return null;
+  }
 
-  static MethodElement lookUpInheritedConcreteMethod(MethodDeclaration node) =>
-      (node.parent as ClassOrMixinDeclaration)
-          .declaredElement
-          .lookUpInheritedConcreteMethod(
-              node.name.name, node.declaredElement.library);
+  static MethodElement lookUpInheritedConcreteMethod(MethodDeclaration node) {
+    final parent = node.parent;
+    if (parent is ClassOrMixinDeclaration) {
+      return parent.declaredElement.lookUpInheritedConcreteMethod(
+          node.name.name, node.declaredElement.library);
+    }
+    // todo (pq): consider extensions
+    return null;
+  }
 
   static PropertyAccessorElement lookUpInheritedConcreteSetter(
-          MethodDeclaration node) =>
-      (node.parent as ClassOrMixinDeclaration)
-          .declaredElement
-          .lookUpInheritedConcreteSetter(
-              node.name.name, node.declaredElement.library);
+      MethodDeclaration node) {
+    final parent = node.parent;
+    if (parent is ClassOrMixinDeclaration) {
+      return parent.declaredElement.lookUpInheritedConcreteSetter(
+          node.name.name, node.declaredElement.library);
+    }
+    // todo (pq): consider extensions
+    return null;
+  }
 
   static MethodElement lookUpInheritedMethod(MethodDeclaration node) {
     final parent = node.parent;
@@ -221,10 +238,15 @@ class DartTypeUtilities {
         : null;
   }
 
-  static PropertyAccessorElement lookUpSetter(MethodDeclaration node) =>
-      (node.parent as ClassOrMixinDeclaration)
-          .declaredElement
+  static PropertyAccessorElement lookUpSetter(MethodDeclaration node) {
+    final parent = node.parent;
+    if (parent is ClassOrMixinDeclaration) {
+      return parent.declaredElement
           .lookUpSetter(node.name.name, node.declaredElement.library);
+    }
+    // todo (pq): consider extensions
+    return null;
+  }
 
   static bool matchesArgumentsWithParameters(
       NodeList<Expression> arguments, NodeList<FormalParameter> parameters) {


### PR DESCRIPTION
Protects utilities from calls against methods defined on extensions.

See: #1683 

/cc @bwilkerson @scheglov 
