### PR TITLE
0.1.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.97
+
+* internal: migrated away from using analyzer `resolutionMap`
+* various fixes and improvements to anticipate support for extension-methods
+* new lint: `camel_case_extensions`
+* rule template generation improvements
+* new lint: `avoid_equals_and_hash_code_on_mutable_classes`
+* extended `avoid_slow_async_io` to flag async `Directory` methods
+
 # 0.1.96
 
 * fixed false positives in `unnecessary_parens`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.96';
+const String version = '0.1.97';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.96
+version: 0.1.97
 
 author: Dart Team <misc@dartlang.org>
 
@@ -32,3 +32,11 @@ dev_dependencies:
   pedantic: ^1.6.0
   pub_semver: ^1.4.2
   test: ^1.0.0
+
+dependency_overrides:
+  analyzer:
+    path: /Users/pquitslund/src/repos/dart/sdk/pkg/analyzer
+  front_end:
+    path: /Users/pquitslund/src/repos/dart/sdk/pkg/front_end
+  kernel:
+    path: /Users/pquitslund/src/repos/dart/sdk/pkg/kernel

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,11 +32,3 @@ dev_dependencies:
   pedantic: ^1.6.0
   pub_semver: ^1.4.2
   test: ^1.0.0
-
-dependency_overrides:
-  analyzer:
-    path: /Users/pquitslund/src/repos/dart/sdk/pkg/analyzer
-  front_end:
-    path: /Users/pquitslund/src/repos/dart/sdk/pkg/front_end
-  kernel:
-    path: /Users/pquitslund/src/repos/dart/sdk/pkg/kernel


### PR DESCRIPTION
# 0.1.97

* internal: migrated away from using analyzer `resolutionMap`
* various fixes and improvements to anticipate support for extension-methods
* new lint: `camel_case_extensions`
* rule template generation improvements
* new lint: `avoid_equals_and_hash_code_on_mutable_classes`
* extended `avoid_slow_async_io` to flag async `Directory` methods

/cc @bwilkerson 
