### PR TITLE
Make await_only_futures mention the incorrectly-awaited type.

### DIFF
--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -47,6 +47,9 @@ class AwaitOnlyFutures extends LintRule implements NodeLintRule {
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
+  static const LintCode _errorCode = LintCode('await_only_futures',
+      "'await' applied to '{0}', which is not a 'Future'.");
+
   final LintRule rule;
 
   _Visitor(this.rule);
@@ -63,8 +66,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         DartTypeUtilities.implementsInterface(type, 'Future', 'dart.async') ||
         DartTypeUtilities.isClass(type, 'FutureOr', 'dart.async'))) {
       rule.reportLintForToken(node.awaitKeyword,
-          errorCode: LintCode('await_only_futures',
-              'Await applied to $type, which is not a Future'));
+          errorCode: _errorCode, arguments: [type]);
     }
   }
 }

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -62,7 +62,9 @@ class _Visitor extends SimpleAstVisitor<void> {
         DartTypeUtilities.extendsClass(type, 'Future', 'dart.async') ||
         DartTypeUtilities.implementsInterface(type, 'Future', 'dart.async') ||
         DartTypeUtilities.isClass(type, 'FutureOr', 'dart.async'))) {
-      rule.reportLintForToken(node.awaitKeyword);
+      rule.reportLintForToken(node.awaitKeyword,
+          errorCode: LintCode('await_only_futures',
+              'Await applied to $type, which is not a Future'));
     }
   }
 }


### PR DESCRIPTION
On behalf of a googler without a github account :)

The more detailed message is useful for us in cleaning up google3 because we need to fix awaiting a method that returns `void` differently from everything else. That can actually have an effect, and we then need to check if it was intended that the method return `Future<void>`.

What do you think, please?