### PR TITLE
Stop using Element.type

### DIFF
--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -81,7 +81,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     Uri libraryUri = classElement.library.source.uri;
     return context.inheritanceManager.getInherited(
-      classElement.type,
+      classElement.thisType,
       Name(libraryUri, member.name),
     );
   }

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -112,9 +112,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       node.parent.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
-    final inheritedAndSelfTypes = clazz.allSupertypes..add(clazz.type);
-    final inheritedAndSelfAnnotations = inheritedAndSelfTypes
-        .map((type) => type.element)
+    final inheritedAndSelfElements = <ClassElement>[
+      ...clazz.allSupertypes.map((t) => t.element),
+      clazz,
+    ];
+    final inheritedAndSelfAnnotations = inheritedAndSelfElements
         .expand((c) => c.metadata)
         .map((m) => m.element);
     return inheritedAndSelfAnnotations.any(_isImmutable);

--- a/lib/src/rules/avoid_implementing_value_types.dart
+++ b/lib/src/rules/avoid_implementing_value_types.dart
@@ -119,11 +119,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  static bool _overridesEquals(ClassElement element) =>
-      // ignore: unnecessary_cast
-      (element.lookUpConcreteMethod('==', element.library)?.enclosingElement
-              as ClassElement)
-          ?.type
-          ?.isObject ==
-      false;
+  static bool _overridesEquals(ClassElement element) {
+    var method = element.lookUpConcreteMethod('==', element.library);
+    var enclosing = method?.enclosingElement;
+    return enclosing is ClassElement && !enclosing.isDartCoreObject;
+  }
 }

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -115,8 +115,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       return false;
     }
     Uri libraryUri = classElement.library.source.uri;
-    return context.inheritanceManager
-            .getInherited(classElement.type, Name(libraryUri, member.name)) !=
+    return context.inheritanceManager.getInherited(
+            classElement.thisType, Name(libraryUri, member.name)) !=
         null;
   }
 }

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/util/dart_type_utilities.dart';
 
@@ -76,8 +77,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     final parent = node.parent;
     if (parent is ClassOrMixinDeclaration) {
-      if (node.declaredElement.returnType != parent.declaredElement?.type ||
-          DartTypeUtilities.overridesMethod(node)) {
+      if (DartTypeUtilities.overridesMethod(node)) {
+        return;
+      }
+
+      var returnType = node.declaredElement.returnType;
+      if (returnType is InterfaceType &&
+          returnType.element == parent.declaredElement) {
+      } else {
         return;
       }
     } else {

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -117,8 +117,8 @@ class _Visitor extends SimpleAstVisitor {
       return false;
     }
     Uri libraryUri = classElement.library.source.uri;
-    return context.inheritanceManager
-            .getInherited(classElement.type, Name(libraryUri, member.name)) !=
+    return context.inheritanceManager.getInherited(
+            classElement.thisType, Name(libraryUri, member.name)) !=
         null;
   }
 
@@ -127,7 +127,7 @@ class _Visitor extends SimpleAstVisitor {
 //    ++totalClasses;
 
     // We only care about Diagnosticables.
-    var type = node.declaredElement.type;
+    var type = node.declaredElement.thisType;
     if (!DartTypeUtilities.implementsInterface(type, 'Diagnosticable', '')) {
       return;
     }

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -154,7 +154,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       interfaces = _findAllSupertypesInMixin(classElement);
     } else {
       interfaces =
-          _findAllSupertypesAndMixins(classElement.type, <InterfaceType>[]);
+          _findAllSupertypesAndMixins(classElement.thisType, <InterfaceType>[]);
     }
     InterfaceType interface =
         interfaces.firstWhere(containsOverriddenMember, orElse: () => null);

--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -68,6 +68,16 @@ class PreferConstConstructors extends LintRule implements NodeLintRule {
   }
 }
 
+class _Collector extends RecursiveAstVisitor<void> {
+  bool foundTypeParamElement = false;
+  @override
+  visitSimpleIdentifier(SimpleIdentifier node) {
+    if (node.staticElement is TypeParameterElement) {
+      foundTypeParamElement = true;
+    }
+  }
+}
+
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
@@ -85,9 +95,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         return;
       }
 
-      final typeProvider = context.typeProvider;
-
-      if (node.staticElement.enclosingElement.type == typeProvider.objectType) {
+      if (node.staticElement.enclosingElement.isDartCoreObject) {
         // Skip lint for `new Object()`, because it can be used for Id creation.
         return;
       }
@@ -101,16 +109,6 @@ class _Visitor extends SimpleAstVisitor<void> {
         }
         rule.reportLint(node);
       }
-    }
-  }
-}
-
-class _Collector extends RecursiveAstVisitor<void> {
-  bool foundTypeParamElement = false;
-  @override
-  visitSimpleIdentifier(SimpleIdentifier node) {
-    if (node.staticElement is TypeParameterElement) {
-      foundTypeParamElement = true;
     }
   }
 }

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -79,7 +79,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     final parent = node.parent;
     if (node.isStatic &&
         parent is ClassOrMixinDeclaration &&
-        returnType == parent.declaredElement.type &&
+        returnType is InterfaceType &&
+        returnType.element == parent.declaredElement &&
         _hasNewInvocation(returnType, node.body)) {
       rule.reportLint(node.name);
     }

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -120,7 +120,7 @@ class _Visitor extends SimpleAstVisitor {
     }
     Uri libraryUri = classElement.library.source.uri;
     return context.inheritanceManager.getInherited(
-      classElement.type,
+      classElement.thisType,
       Name(libraryUri, member.name),
     );
   }
@@ -172,7 +172,7 @@ class _Visitor extends SimpleAstVisitor {
         Uri libraryUri = node.declaredElement.library.source.uri;
         // Look for an inherited getter.
         Element getter = context.inheritanceManager.getMember(
-          node.declaredElement.type,
+          node.declaredElement.thisType,
           Name(libraryUri, setter.name.name),
         );
         if (getter is PropertyAccessorElement) {

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -104,7 +104,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   /// computation.
   bool _isFutureDelayedInstanceCreationWithComputation(Expression expr) =>
       expr is InstanceCreationExpression &&
-      expr.staticElement?.enclosingElement?.type?.isDartAsyncFuture == true &&
+      expr.staticType?.isDartAsyncFuture == true &&
       expr.constructorName?.name?.name == 'delayed' &&
       expr.argumentList.arguments.length == 2;
 

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -114,9 +114,9 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
       if (classDeclaration == null) {
         targetType = null;
       } else if (classDeclaration is ClassDeclaration) {
-        targetType = classDeclaration.declaredElement?.type;
+        targetType = classDeclaration.declaredElement?.thisType;
       } else if (classDeclaration is MixinDeclaration) {
-        targetType = classDeclaration.declaredElement?.type;
+        targetType = classDeclaration.declaredElement?.thisType;
       }
     }
     Expression argument = node.argumentList.arguments.first;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
-  analyzer: ^0.38.0
+  analyzer: ^0.38.3
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
-  analyzer: ^0.38.3
+  analyzer: ^0.38.0
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2


### PR DESCRIPTION
We are deprecating this getter, and want the clients to use more appropriate ways to access types. In case of the linter there is usually no reason to get the type from an element, instead already set types can be used.