### PR TITLE
Upgrade to analyzer 0.38.3 and fix deprecation warnings.

### DIFF
--- a/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
+++ b/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
@@ -58,7 +58,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitInstanceCreationExpression(InstanceCreationExpression creation) {
     ConstructorElement element = creation.staticElement;
     if (element?.name != 'fromIterable' ||
-        element.enclosingElement != context.typeProvider.mapType.element) {
+        element.enclosingElement != context.typeProvider.mapElement) {
       return;
     }
 

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/util/dart_type_utilities.dart';
 
 const alwaysFalse = 'Always false because length is always greater or equal 0.';
 
@@ -111,13 +112,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // Should be subtype of Iterable, Map or String.
-    TypeProvider typeProvider = context.typeProvider;
-    TypeSystem typeSystem = context.typeSystem;
-
-    if (typeSystem.mostSpecificTypeArgument(type, typeProvider.iterableType) ==
-            null &&
-        typeSystem.mostSpecificTypeArgument(type, typeProvider.mapType) ==
-            null &&
+    if (!DartTypeUtilities.implementsInterface(type, 'Iterable', 'dart.core') &&
+        !DartTypeUtilities.implementsInterface(type, 'Map', 'dart.core') &&
         !type.isDartCoreString) {
       return;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
-  analyzer: ^0.38.0
+  analyzer: ^0.38.3
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2


### PR DESCRIPTION
https://github.com/dart-lang/linter/pull/1725 is in a strange state where it is blocked, because Travis runs it with analyzer `0.38.3`, but the PR decided to not upgrade to `0.38.3` because it itself does not have to. So, here is a separate PR to upgrade and fix deprecations.