### PR TITLE
Stop using 'bestElement' name.

### DIFF
--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -134,8 +134,8 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
   visitPrefixedIdentifier(PrefixedIdentifier node) {
     // Allow getters; getters with side effects were the main cause of false
     // positives.
-    var bestElement = node.identifier.staticElement;
-    if (bestElement is PropertyAccessorElement && !bestElement.isSynthetic) {
+    var element = node.identifier.staticElement;
+    if (element is PropertyAccessorElement && !element.isSynthetic) {
       return;
     }
 
@@ -155,8 +155,8 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
   visitPropertyAccess(PropertyAccess node) {
     // Allow getters; getters with side effects were the main cause of false
     // positives.
-    var bestElement = node.propertyName.staticElement;
-    if (bestElement is PropertyAccessorElement && !bestElement.isSynthetic) {
+    var element = node.propertyName.staticElement;
+    if (element is PropertyAccessorElement && !element.isSynthetic) {
       return;
     }
 
@@ -172,9 +172,8 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
   visitSimpleIdentifier(SimpleIdentifier node) {
     // Allow getters; getters with side effects were the main cause of false
     // positives.
-    var bestElement = node.staticElement;
-    if (node.staticElement is PropertyAccessorElement &&
-        !bestElement.isSynthetic) {
+    var element = node.staticElement;
+    if (element is PropertyAccessorElement && !element.isSynthetic) {
       return;
     }
 


### PR DESCRIPTION
It does not access the corresponding deprecated 'bestElement' property from Analyzer, but just does not mean anything now, and I stumbled upon it while searching in google3.