### PR TITLE
New lint avoid_async_from_sync

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -10,6 +10,7 @@ linter:
     - annotate_overrides
     - avoid_annotating_with_dynamic
     - avoid_as
+    - avoid_async_from_sync
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
@@ -129,7 +130,6 @@ linter:
     - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures
-    - avoid_async_from_sync
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -129,6 +129,7 @@ linter:
     - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures
+    - avoid_async_from_sync
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -11,6 +11,7 @@ import 'package:linter/src/rules/always_specify_types.dart';
 import 'package:linter/src/rules/annotate_overrides.dart';
 import 'package:linter/src/rules/avoid_annotating_with_dynamic.dart';
 import 'package:linter/src/rules/avoid_as.dart';
+import 'package:linter/src/rules/avoid_async_from_sync.dart';
 import 'package:linter/src/rules/avoid_bool_literals_in_conditional_expressions.dart';
 import 'package:linter/src/rules/avoid_catches_without_on_clauses.dart';
 import 'package:linter/src/rules/avoid_catching_errors.dart';
@@ -287,6 +288,7 @@ void registerLintRules() {
     ..register(TypeAnnotatePublicApis())
     ..register(TypeInitFormals())
     ..register(UnawaitedFutures())
+    ..register(AvoidAsyncFromSync())
     ..register(UnnecessaryAwaitInReturn())
     ..register(UnnecessaryBraceInStringInterps())
     ..register(UnnecessaryConst())

--- a/lib/src/rules/avoid_async_from_sync.dart
+++ b/lib/src/rules/avoid_async_from_sync.dart
@@ -66,7 +66,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (final expr in node.cascadeSections) {
       if (expr.staticType?.isDartAsyncFuture == true &&
           _isEnclosedInSyncFunctionBody(expr) &&
-          !(expr is AssignmentExpression)) {
+          expr is! AssignmentExpression) {
         rule.reportLint(expr);
       }
     }

--- a/lib/src/rules/avoid_async_from_sync.dart
+++ b/lib/src/rules/avoid_async_from_sync.dart
@@ -41,10 +41,15 @@ void main() {
 
 class AvoidAsyncFromSync extends LintRule implements NodeLintRule {
   AvoidAsyncFromSync()
-      : super(name: 'avoid_async_from_sync', description: _desc, details: _details, group: Group.style);
+      : super(
+            name: 'avoid_async_from_sync',
+            description: _desc,
+            details: _details,
+            group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry, LinterContext context) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addExpressionStatement(this, visitor);
     registry.addCascadeExpression(this, visitor);
@@ -75,7 +80,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     var type = expr?.staticType;
     if (type?.isDartAsyncFuture == true) {
       // Ignore a couple of special known cases.
-      if (_isFutureDelayedInstanceCreationWithComputation(expr) || _isMapPutIfAbsentInvocation(expr)) {
+      if (_isFutureDelayedInstanceCreationWithComputation(expr) ||
+          _isMapPutIfAbsentInvocation(expr)) {
         return;
       }
 
@@ -100,7 +106,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       expr.constructorName?.name?.name == 'delayed' &&
       expr.argumentList.arguments.length == 2;
 
-  bool _isMapClass(Element e) => e is ClassElement && e.name == 'Map' && e.library?.name == 'dart.core';
+  bool _isMapClass(Element e) =>
+      e is ClassElement && e.name == 'Map' && e.library?.name == 'dart.core';
 
   /// Detects Map.putIfAbsent invocations.
   bool _isMapPutIfAbsentInvocation(Expression expr) =>

--- a/lib/src/rules/avoid_async_from_sync.dart
+++ b/lib/src/rules/avoid_async_from_sync.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'`Future` results in `sync` function bodies must be '
+    'avoided or marked `unawaited` using `package:pedantic`.';
+
+const _details = r'''
+
+**DO** avoid functions that return a `Future` inside of an sync function body.
+Convert function to async or mark function call with unawaited.
+
+When you really _do_ want to start a fire-and-forget `Future`, the recommended
+way is to use `unawaited` from `package:pedantic`. The `// ignore` and
+`// ignore_for_file` comments also work.
+
+**GOOD:**
+```
+Future doSomething() => ...;
+
+void main() async {
+  await doSomething();
+
+  unawaited(doSomething()); // Explicitly-ignored fire-and-forget.
+}
+```
+
+**BAD:**
+```
+void main() {
+  doSomething(); // Likely a bug.
+}
+```
+
+''';
+
+class AvoidAsyncFromSync extends LintRule implements NodeLintRule {
+  AvoidAsyncFromSync()
+      : super(name: 'avoid_async_from_sync', description: _desc, details: _details, group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry, LinterContext context) {
+    final visitor = _Visitor(this);
+    registry.addExpressionStatement(this, visitor);
+    registry.addCascadeExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitCascadeExpression(CascadeExpression node) {
+    for (final expr in node.cascadeSections) {
+      if (expr.staticType?.isDartAsyncFuture == true &&
+          _isEnclosedInSyncFunctionBody(expr) &&
+          !(expr is AssignmentExpression)) {
+        rule.reportLint(expr);
+      }
+    }
+  }
+
+  @override
+  void visitExpressionStatement(ExpressionStatement node) {
+    var expr = node?.expression;
+    if (expr is AssignmentExpression) return;
+
+    var type = expr?.staticType;
+    if (type?.isDartAsyncFuture == true) {
+      // Ignore a couple of special known cases.
+      if (_isFutureDelayedInstanceCreationWithComputation(expr) || _isMapPutIfAbsentInvocation(expr)) {
+        return;
+      }
+
+      if (_isEnclosedInSyncFunctionBody(node)) {
+        // Future expression statement that isn't awaited in an sync function:
+        // while this is legal, it's a very frequent sign of an error.
+        rule.reportLint(node);
+      }
+    }
+  }
+
+  bool _isEnclosedInSyncFunctionBody(AstNode node) {
+    final enclosingFunctionBody = node.thisOrAncestorOfType<FunctionBody>();
+    return enclosingFunctionBody?.isSynchronous == true;
+  }
+
+  /// Detects `new Future.delayed(duration, [computation])` creations with a
+  /// computation.
+  bool _isFutureDelayedInstanceCreationWithComputation(Expression expr) =>
+      expr is InstanceCreationExpression &&
+      expr.staticType?.isDartAsyncFuture == true &&
+      expr.constructorName?.name?.name == 'delayed' &&
+      expr.argumentList.arguments.length == 2;
+
+  bool _isMapClass(Element e) => e is ClassElement && e.name == 'Map' && e.library?.name == 'dart.core';
+
+  /// Detects Map.putIfAbsent invocations.
+  bool _isMapPutIfAbsentInvocation(Expression expr) =>
+      expr is MethodInvocation &&
+      expr.methodName.name == 'putIfAbsent' &&
+      _isMapClass(expr.methodName.staticElement?.enclosingElement);
+}

--- a/test/rules/avoid_async_from_sync.dart
+++ b/test/rules/avoid_async_from_sync.dart
@@ -66,6 +66,11 @@ foo12() async {
   x..[0] = fut();
 }
 
+foo13() {
+  _Foo foo = _Foo();
+  var x = foo.asyncProperty;
+}
+
 class _Bar {
   Future<void> futureField;
 }

--- a/test/rules/avoid_async_from_sync.dart
+++ b/test/rules/avoid_async_from_sync.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_async_from_sync`
+
+
+import 'dart:async';
+
+Future fut() => null;
+
+foo1() {
+  fut(); //LINT
+}
+
+foo2() async {
+  fut();
+
+  // ignore: unawaited_futures
+  fut();
+}
+
+foo3() async {
+  await fut();
+}
+
+foo4() async {
+  var x = fut();
+}
+
+foo5() async {
+  new Future.delayed(d);
+  new Future.delayed(d, bar);
+}
+
+foo6() async {
+  var map = <String, Future>{};
+  map.putIfAbsent('foo', fut());
+}
+
+foo7() async {
+  _Foo()
+    ..doAsync()
+    ..doSync();
+}
+
+foo8() {
+  _Foo()
+    ..doAsync() //LINT
+    ..doSync();
+}
+
+foo9() async {
+  _Foo()
+    ..futureField = fut();
+}
+
+foo10() async {
+  _Foo()
+    ..futureListField[0] = fut();
+}
+
+foo11() async {
+  _Foo()
+    ..bar.futureField = fut();
+}
+
+foo12() async {
+  final x = [fut()];
+  x..[0] = fut();
+}
+
+class _Bar {
+  Future<void> futureField;
+}
+
+class _Foo {
+  Future<void> futureField;
+  List<Future<void>> futureListField;
+  _Bar bar;
+  Future<void> doAsync() async {}
+  void doSync() => null;
+  Future<void> get asyncProperty => doAsync();
+  List<Future<void>> get futures => [doAsync()];
+}

--- a/test/rules/avoid_async_from_sync.dart
+++ b/test/rules/avoid_async_from_sync.dart
@@ -4,7 +4,6 @@
 
 // test w/ `pub run test -N avoid_async_from_sync`
 
-
 import 'dart:async';
 
 Future fut() => null;
@@ -51,18 +50,15 @@ foo8() {
 }
 
 foo9() async {
-  _Foo()
-    ..futureField = fut();
+  _Foo()..futureField = fut();
 }
 
 foo10() async {
-  _Foo()
-    ..futureListField[0] = fut();
+  _Foo()..futureListField[0] = fut();
 }
 
 foo11() async {
-  _Foo()
-    ..bar.futureField = fut();
+  _Foo()..bar.futureField = fut();
 }
 
 foo12() async {


### PR DESCRIPTION
# Description

This lint is necessary when we want to know places where we call async functions from non-async functions. This can be a lurking bug. In my case, I never actually want to do this. I want to make the enclosing function async, await the call, and repeat as necessary.

Fixes #836 