### PR TITLE
Lints that warn about compile-time errors of invalid FFI usage

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -56,6 +56,7 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
+    - ffi
     - file_names
     - flutter_style_todos
     - hash_and_equals

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -57,6 +57,7 @@ import 'package:linter/src/rules/directives_ordering.dart';
 import 'package:linter/src/rules/empty_catches.dart';
 import 'package:linter/src/rules/empty_constructor_bodies.dart';
 import 'package:linter/src/rules/empty_statements.dart';
+import 'package:linter/src/rules/ffi.dart';
 import 'package:linter/src/rules/file_names.dart';
 import 'package:linter/src/rules/flutter_style_todos.dart';
 import 'package:linter/src/rules/hash_and_equals.dart';
@@ -212,6 +213,7 @@ void registerLintRules() {
     ..register(EmptyCatches())
     ..register(EmptyConstructorBodies())
     ..register(EmptyStatements())
+    ..register(Ffi())
     ..register(FileNames())
     ..register(FlutterStyleTodos())
     ..register(HashAndEquals())

--- a/lib/src/rules/ffi.dart
+++ b/lib/src/rules/ffi.dart
@@ -1,0 +1,90 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Static checks on "dart:ffi".';
+
+const _details = r'''
+Applies static rules of the "dart:ffi" package.
+See the "dart:ffi" API documentation for details.
+''';
+
+class Ffi extends LintRule implements NodeLintRule {
+  Ffi()
+      : super(
+            name: 'ffi',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    final visitor = _Visitor(this, context);
+    registry.addCompilationUnit(this, visitor);
+    registry.addClassDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  static const LintCode invalidSuperclass = LintCode(
+      'ffi', //
+      '{0} may not be extended.',
+      correction: 'Considering extending dart:ffi.Struct instead.');
+
+  static const LintCode invalidSupertype = LintCode(
+      'ffi', //
+      '{0} may not be implemented.',
+      correction: 'Considering extending dart:ffi.Struct instead.');
+
+  static const LintCode genericStruct = LintCode(
+      'ffi', //
+      'Subclasses of Struct may not be generic.');
+
+  final LintRule rule;
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
+
+  bool _isFfiCoreClass(TypeName cls) {
+    final Element target = cls.name.staticElement;
+    if (target is ClassElement) {
+      return target.library.name == 'dart.ffi';
+    }
+    return false;
+  }
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    bool isStruct = false;
+
+    // Only the Struct class may be extended.
+    if (node.extendsClause != null) {
+      final TypeName superclass = node.extendsClause.superclass;
+      if (_isFfiCoreClass(superclass) && !isStruct) {
+        if (superclass.name.staticElement.name == 'Struct') {
+          isStruct = true;
+        } else {
+          rule.reportLint(superclass.name,
+              errorCode: invalidSuperclass, arguments: [superclass.name]);
+        }
+      }
+    }
+
+    // No classes from the FFI may be explicitly implemented.
+    void checkSupertype(TypeName typename) {
+      if (_isFfiCoreClass(typename)) {
+        rule.reportLint(typename.name,
+            errorCode: invalidSupertype, arguments: [typename.name]);
+      }
+    }
+
+    node.implementsClause?.interfaces?.forEach(checkSupertype);
+    node.withClause?.mixinTypes?.forEach(checkSupertype);
+
+    if (isStruct && node.declaredElement.typeParameters?.isNotEmpty == true) {
+      rule.reportLint(node.name, errorCode: genericStruct);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.97+1
+version: 0.1.98
 
 author: Dart Team <misc@dartlang.org>
 

--- a/test/mock_sdk.dart
+++ b/test/mock_sdk.dart
@@ -22,6 +22,7 @@ const Map<String, LibraryInfo> libraries = const {
   "collection": const LibraryInfo("collection/collection.dart"),
   "convert": const LibraryInfo("convert/convert.dart"),
   "core": const LibraryInfo("core/core.dart"),
+  "ffi": const LibraryInfo("ffi/ffi.dart"),
   "io": const LibraryInfo("io/io.dart'"),
   "html": const LibraryInfo(
     "html/dartium/html_dartium.dart",
@@ -147,7 +148,7 @@ abstract class Map<K, V> extends Object {
   factory Map.fromIterable(Iterable iterable,
       {K key(element), V value(element)}) = LinkedHashMap<K, V>.fromIterable;
   factory Map.fromIterables(Iterable<K> keys, Iterable<V> values) =
-      LinkedHashMap<K, V>.fromIterables;    
+      LinkedHashMap<K, V>.fromIterables;
   factory Map.of(Map<K, V> other) = LinkedHashMap<K, V>.of;
   factory Map.identity() = LinkedHashMap<K, V>.identity;
   /* external */ factory Map.unmodifiable(Map other);
@@ -204,6 +205,25 @@ part of dart.async;
 ''')
   ]);
 
+  static _MockSdkLibrary LIB_FFI =
+      _MockSdkLibrary('dart:ffi', '/lib/ffi/ffi.dart', '''
+library dart.ffi;
+class NativeType {}
+class Void extends NativeType {}
+class Int8 extends NativeType {}
+class Uint8 extends NativeType {}
+class Int16 extends NativeType {}
+class Uint16 extends NativeType {}
+class Int32 extends NativeType {}
+class Uint32 extends NativeType {}
+class Int64 extends NativeType {}
+class Uint64 extends NativeType {}
+class Float extends NativeType {}
+class Double extends NativeType {}
+class Pointer<T extends NativeType> extends NativeType {}
+class Struct<S extends NativeType> extends NativeType {}
+    ''');
+
   static _MockSdkLibrary LIB_COLLECTION =
       _MockSdkLibrary('dart:collection', '/lib/collection/collection.dart', '''
 library dart.collection;
@@ -218,7 +238,7 @@ abstract class LinkedHashMap<K, V> implements Map<K, V> {
   factory LinkedHashMap.from(Map other);
   factory LinkedHashMap.fromIterable(Iterable iterable,
       {K key(element), V value(element)});
-  factory LinkedHashMap.fromIterables(Iterable<K> keys, Iterable<V> values);    
+  factory LinkedHashMap.fromIterables(Iterable<K> keys, Iterable<V> values);
   factory LinkedHashMap.of(Map<K, V> other) =>
     new LinkedHashMap<K, V>()..addAll(other);
 }
@@ -229,7 +249,7 @@ class LinkedHashSet<E> implements Set<E> {
       bool isValidKey(potentialKey)});
   /* external factory */ LinkedHashSet.identity();
   factory LinkedHashSet.from(Iterable elements);
-  
+
   factory LinkedHashSet.of(Iterable<E> elements) =>
       new LinkedHashSet<E>()..addAll(elements);
 }
@@ -339,6 +359,7 @@ class  ScriptElement {
     LIB_ASYNC,
     LIB_COLLECTION,
     LIB_CONVERT,
+    LIB_FFI,
     LIB_IO,
     LIB_MATH,
     LIB_HTML,
@@ -460,6 +481,7 @@ class  ScriptElement {
       'dart:async/stream.dart': '/lib/async/stream.dart',
       'dart:collection': '/lib/collection/collection.dart',
       'dart:convert': '/lib/convert/convert.dart',
+      'dart:ffi': '/lib/ffi/ffi.dart',
       'dart:io': '/lib/io/io.dart',
       'dart:math': '/lib/math/math.dart'
     };

--- a/test/rules/ffi.dart
+++ b/test/rules/ffi.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N ffi`
+
+import 'dart:ffi';
+
+// No FFI types except Struct may be extended.
+class X extends Void  {}  //LINT
+class X extends Int8  {}  //LINT
+class X extends Uint8  {}  //LINT
+class X extends Int16  {}  //LINT
+class X extends Uint16  {}  //LINT
+class X extends Int32  {}  //LINT
+class X extends Uint32  {}  //LINT
+class X extends Int64  {}  //LINT
+class X extends Uint64  {}  //LINT
+class X extends Float  {}  //LINT
+class X extends Double  {}  //LINT
+class X extends Pointer {}  //LINT
+class X extends Struct<X> {}  //OK
+
+// No FFI types may be implemented.
+class X implements Void  {}  //LINT
+class X implements Int8  {}  //LINT
+class X implements Uint8  {}  //LINT
+class X implements Int16  {}  //LINT
+class X implements Uint16  {}  //LINT
+class X implements Int32  {}  //LINT
+class X implements Uint32  {}  //LINT
+class X implements Int64  {}  //LINT
+class X implements Uint64  {}  //LINT
+class X implements Float  {}  //LINT
+class X implements Double  {}  //LINT
+class X implements Pointer {}  //LINT
+class X implements Struct<X> {}  //LINT
+
+// Structs may not be generic.
+class X<T> extends Struct<X<T>> {}  //LINT

--- a/tool/since/linter.yaml
+++ b/tool/since/linter.yaml
@@ -52,6 +52,7 @@ directives_ordering: 0.1.30
 empty_catches: 0.1.22
 empty_constructor_bodies: 0.1.1
 empty_statements: 0.1.21
+ffi: 0.1.98
 file_names: 0.1.54
 flutter_style_todos: 0.1.61
 hash_and_equals: 0.1.11


### PR DESCRIPTION
We have a number of custom compile-time errors implemented in the CFE's VM target which halt compilation if the FFI is used incorrectly.

We would like to surface these errors earlier through an Analyzer lint.

This PR replicates some of the FFI checks. I ran into some issues:

1. How can we make this lint on-by-default? It should be on-by-default because the custom compile-time errors that it warns about cannot be disabled by the user.
2. How can I check whether an Expression in the source is constant?
3. To reproduce some of the type tests in the CFE, I need to construct a DartType which is parallel to a DartType containing FFI phantom types. How can I access the ClassElements which are known to be declared in the core (or FFI) libraries?

/cc @mkustermann @dcharkes @mraleph 