### PR TITLE
Get the type of a FormalParameter from the declared element.

### DIFF
--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -100,9 +100,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _isFormalParameterToLint(FormalParameter node) =>
-      DartTypeUtilities.implementsInterface(
-          node.identifier.staticType, 'bool', 'dart.core') &&
-      !node.isNamed;
+      !node.isNamed &&
+      DartTypeUtilities.isClass(node.declaredElement.type, 'bool', 'dart.core');
 
   bool _isOverridingMember(Element member) {
     if (member == null) {


### PR DESCRIPTION
We want to stop setting `staticType` for Identifier(s) that are used not as expressions, e.g. names of types, names of declarations (classes, functions, parameters).