### PR TITLE
Fix unnecessary_lambdas for coming MethodInvocation vs. FunctionExpressionInvocation changes.

### DIFF
--- a/test/rules/unnecessary_lambdas.dart
+++ b/test/rules/unnecessary_lambdas.dart
@@ -51,7 +51,7 @@ void main() {
   final x = new MyClass();
 
   // ignore: unused_local_variable
-  final notRelevantQuestionPeriod = (p) => array[x?.m1].m2(p); // LINT
+  final notRelevantQuestionPeriod = (p) => array[x?.m1].m2(p); // OK
   // ignore: unused_local_variable
   final correctNotRelevantQuestionPeriod = array[x?.m1].m2; // OK
 


### PR DESCRIPTION
 We used to represent all invocations like `foo()` as `MethodInvocation`(s). But this is not ideal, because if `foo` is not a `FunctionElement` or a `MethodElement`, but a `PropertyAccessorElement`, then it is not `foo` that is invoked, but the result returned from `foo` is invoked instead. This is what `FunctionExpressionInvocation` should represent.

This PR also changes `final notRelevantQuestionPeriod = (p) => array[x?.m1].m2(p);` from LINT to OK. The reason is that `IndexExpression` is basically a method invocation, so can return different values at different times.