### PR TITLE
Fixed - avoid_print rule fails to catch tear-off usage

### DIFF
--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -46,8 +46,8 @@ class _Visitor extends SimpleAstVisitor {
     if (expression is SimpleIdentifier) {
       final Element element = expression.staticElement;
       if (element is FunctionElement &&
-          element?.name == 'print' &&
-          element?.library?.name == 'dart.core') {
+          element.name == 'print' &&
+          element.library.isDartCore) {
         rule.reportLint(expression);
       }
     }

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -61,7 +61,7 @@ class _Visitor extends SimpleAstVisitor {
     if (node.methodName.name == 'print' && isDartCore(node)) {
       rule.reportLint(node.methodName);
     }
-    
+
     node.argumentList.arguments.forEach(_validateArgument);
   }
 }

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:linter/src/analyzer.dart';
 
 const _desc = r'Avoid `print` calls in production code.';
@@ -41,6 +42,17 @@ class _Visitor extends SimpleAstVisitor {
 
   _Visitor(this.rule);
 
+  _validateArgument(Expression expression) {
+    if (expression is SimpleIdentifier) {
+      final Element element = expression.staticElement;
+      if (element is FunctionElement &&
+          element?.name == 'print' &&
+          element?.library?.name == 'dart.core') {
+        rule.reportLint(expression);
+      }
+    }
+  }
+
   @override
   visitMethodInvocation(MethodInvocation node) {
     bool isDartCore(MethodInvocation node) =>
@@ -49,5 +61,7 @@ class _Visitor extends SimpleAstVisitor {
     if (node.methodName.name == 'print' && isDartCore(node)) {
       rule.reportLint(node.methodName);
     }
+    
+    node.argumentList.arguments.forEach(_validateArgument);
   }
 }

--- a/test/rules/avoid_print.dart
+++ b/test/rules/avoid_print.dart
@@ -6,12 +6,17 @@
 
 void main() {
   print('ha'); // LINT
+  [1,2,3].forEach(print); // LINT
+  Future.value('hello').then(print); // LINT
 }
+
 
 var x = print; // OK
 
 void f() {
   x('ha'); // OK?
+  [1,2,3].forEach(x); // OK
+  Future.value('hello').then(x); // OK
 }
 
 class A {


### PR DESCRIPTION
The lint rule `avoid_print` is not catching the scenario when `print` function passed as an argument. This PR includes code that added additional check to validate function arguments for `print`.

Fixes #1696 
