### PR TITLE
remove extension-methods test config

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
-  analyzer: ^0.38.4
+  analyzer: ^0.38.5
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2

--- a/test/configs/extension_methods/analysis_options.yaml
+++ b/test/configs/extension_methods/analysis_options.yaml
@@ -1,3 +1,0 @@
-analyzer:
-  enable-experiment:
-    - extension-methods


### PR DESCRIPTION
As of `0.38.5` enabled by default in analyzer so no need for an extra run of tests.

/cc  @bwilkerson @stereotype441 