### PR TITLE
nnbd test harness

### DIFF
--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -60,16 +60,20 @@ defineRuleTests() {
 
       for (var entry in Directory(p.join(ruleDir, 'experiments')).listSync()) {
         if (entry is! Directory) continue;
-        var analysisOptionsFile =
-            File(p.join(entry.path, 'analysis_options.yaml'));
-        var analysisOptions = analysisOptionsFile.readAsStringSync();
-        var ruleName = p.basename(entry.path);
-        var testFile = File(p.join(entry.path, '$ruleName.dart'));
-        if (!testFile.existsSync()) {
-          testFile = File(p.join(entry.path, 'lib', '$ruleName.dart'));
-        }
-        testRule(p.basename(ruleName), testFile,
-            analysisOptions: analysisOptions, debug: true);
+
+        group(p.basename(entry.path), () {
+          final analysisOptionsFile =
+              File(p.join(entry.path, 'analysis_options.yaml'));
+          final analysisOptions = analysisOptionsFile.readAsStringSync();
+          final ruleTestDir = Directory(p.join(entry.path, 'rules'));
+          for (var test in ruleTestDir.listSync()) {
+            if (test is! File) continue;
+            File testFile = test as File;
+            final ruleName = p.basenameWithoutExtension(test.path);
+            testRule(ruleName, testFile,
+                analysisOptions: analysisOptions, debug: true);
+          }
+        });
       }
     });
 

--- a/test/rules/experiments/nnbd/analysis_options.yaml
+++ b/test/rules/experiments/nnbd/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  enable-experiment:
+    - non-nullable

--- a/test/rules/experiments/nnbd/rules/avoid_init_to_null.dart
+++ b/test/rules/experiments/nnbd/rules/avoid_init_to_null.dart
@@ -15,7 +15,10 @@ foo({p: null}) {} //LINT
 class X {
   static const nil = null; //OK
   final nil2 = null; //OK
-  int x = null; //LINT
+
+  // TODO(pq): ints are not nullable so we'll want to update the lint here
+  // since it will produce a compilation error.
+  // int x = null; //LINT
   int y; //OK
   int z;
 

--- a/test/rules/experiments/nnbd/rules/avoid_init_to_null.dart
+++ b/test/rules/experiments/nnbd/rules/avoid_init_to_null.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_init_to_null`
+
+var x = null; //LINT
+var y; //OK
+var z = 1; //OK
+const nil = null; //OK
+final nil2 = null; //OK
+foo({p: null}) {} //LINT
+
+
+class X {
+  static const nil = null; //OK
+  final nil2 = null; //OK
+  int x = null; //LINT
+  int y; //OK
+  int z;
+
+  X({int a: null}); //LINT
+  X.b({this.z: null}); //LINT
+
+  fooNamed({
+    p: null, //LINT
+    p1 = null, //LINT
+    var p2 = null, //LINT
+    p3 = 1, //OK
+    p4, //OK
+  }) {}
+
+  fooOptional([
+    p = null, //LINT
+    p1 = null, //LINT
+    var p2 = null, //LINT
+    p3 = 1, //OK
+    p4, //OK
+  ]) {}
+}

--- a/test/rules/experiments/nnbd/rules/null_closures.dart
+++ b/test/rules/experiments/nnbd/rules/null_closures.dart
@@ -39,6 +39,7 @@ void future_wait() {
 }
 
 void list_generate() {
+  // todo (pq): look at migrated SDK and see if generators can be null.
   // List.generate is a _constructor_ with a _positional_ argument.
   new List.generate(3, null); // LINT
   new List.generate(3, (_) => null); // OK

--- a/test/rules/experiments/nnbd/rules/null_closures.dart
+++ b/test/rules/experiments/nnbd/rules/null_closures.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N null_closures`
+
+import 'dart:async';
+import 'dart:core';
+
+class A extends B {
+  A(int x);
+}
+class B extends A {}
+
+//https://github.com/dart-lang/linter/issues/1414
+void test_cycle() {
+  new A(null);
+}
+
+void list_firstWhere() {
+  // firstWhere has a _named_ closure argument.
+  <int>[2, 4, 6].firstWhere((e) => e.isEven, orElse: null); // LINT
+  <int>[2, 4, 6].firstWhere((e) => e.isEven, orElse: () => null); // OK
+  <int>[2, 4, 6].where(null); // LINT
+  <int>[2, 4, 6].where((e) => e.isEven); // OK
+}
+
+void map_putIfAbsent() {
+  // putIfAbsent has a _required_ closure argument.
+  var map = <int, int>{};
+  map.putIfAbsent(7, null); // LINT
+  map.putIfAbsent(7, () => null); // OK
+}
+
+void future_wait() {
+  // Future.wait is a _static_ function with a _named_ argument.
+  Future.wait([], cleanUp: null); // LINT
+  Future.wait([], cleanUp: (_) => print('clean')); // OK
+}
+
+void list_generate() {
+  // List.generate is a _constructor_ with a _positional_ argument.
+  new List.generate(3, null); // LINT
+  new List.generate(3, (_) => null); // OK
+}
+
+void map_otherMethods() {
+  // These methods have nothing we are concerned with.
+  new Map().keys; // OK
+  new Map().addAll({}); // OK
+}

--- a/test/rules/experiments/nnbd/rules/unnecessary_null_in_if_null_operators.dart
+++ b/test/rules/experiments/nnbd/rules/unnecessary_null_in_if_null_operators.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N unnecessary_null_in_if_null_operators`
+
+var x = 1 ?? null; //LINT
+var y = 1 ?? 1; //OK
+var z = null ?? 1; //LINT
+
+class X {
+  m1() {
+    var x = 1 ?? null; //LINT
+    var y = 1 ?? 1; //OK
+    var z = null ?? 1; //LINT
+  }
+}


### PR DESCRIPTION
Adds a test harness that runs rule tests with the `non-nullable` experiment enabled.

To start, I ported a few tests from the `pedantic` ruleset.  These tests are currently identical to those being tested w/o nnbd.

My intention is to evolve them to include nnb-migrated code so we can get early feedback on possible issues.

/cc @scheglov @srawlins 