### PR TITLE
New lint: prefer_is_not_operator

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -111,6 +111,7 @@ linter:
     - prefer_interpolation_to_compose_strings
     - prefer_is_empty
     - prefer_is_not_empty
+    - prefer_is_not_operator
     - prefer_iterable_whereType
     - prefer_mixin
     - prefer_null_aware_operators

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -112,6 +112,7 @@ import 'rules/prefer_int_literals.dart';
 import 'rules/prefer_interpolation_to_compose_strings.dart';
 import 'rules/prefer_is_empty.dart';
 import 'rules/prefer_is_not_empty.dart';
+import 'rules/prefer_is_not_operator.dart';
 import 'rules/prefer_iterable_whereType.dart';
 import 'rules/prefer_mixin.dart';
 import 'rules/prefer_null_aware_operators.dart';
@@ -270,6 +271,7 @@ void registerLintRules() {
     ..register(PreferIntLiterals())
     ..register(PreferIsEmpty())
     ..register(PreferIsNotEmpty())
+    ..register(PreferIsNotOperator())
     ..register(PreferIterableWhereType())
     ..register(PreferMixin())
     ..register(PreferNullAwareOperators())

--- a/lib/src/rules/prefer_is_not_operator.dart
+++ b/lib/src/rules/prefer_is_not_operator.dart
@@ -51,13 +51,19 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitIsExpression(IsExpression node) {
+    // Return if it is `is!` expression
+    if (node.notOperator != null) {
+      return;
+    }
+
     // Check whether is expression is inside parenthesis
     if (node.parent is ParenthesizedExpression) {
-      final isExpressionInsideParenthesis = node.parent;
+      final parenthesizedExpression = node.parent;
+      final prefixExpression = parenthesizedExpression.parent;
       // Check for NOT (!) operator
-      if (isExpressionInsideParenthesis.parent.beginToken.type ==
-          TokenType.BANG) {
-        rule.reportLint(isExpressionInsideParenthesis.parent);
+      if (prefixExpression is PrefixExpression &&
+          prefixExpression.operator.type == TokenType.BANG) {
+        rule.reportLint(parenthesizedExpression.parent);
       }
     }
   }

--- a/lib/src/rules/prefer_is_not_operator.dart
+++ b/lib/src/rules/prefer_is_not_operator.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:linter/src/analyzer.dart';
+
+const _desc = r'Prefer is! operator.';
+
+const _details = r'''
+When checking if the object has not specified type, it is preferable to use 'is!' operator.
+
+**BAD:**
+```
+if (!(foo is Foo)) {
+  ...
+}
+```
+
+**GOOD:**
+```
+if (foo is! Foo) {
+  ...
+}
+''';
+
+class PreferIsNotOperator extends LintRule implements NodeLintRule {
+  PreferIsNotOperator()
+      : super(
+            name: 'prefer_is_not_operator',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    final visitor = _Visitor(this);
+    registry.addIsExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitIsExpression(IsExpression node) {
+    // Check whether is expression is inside parenthesis
+    if (node.parent is ParenthesizedExpression) {
+      final isExpressionInsideParenthesis = node.parent;
+      // Check for NOT (!) operator
+      if (isExpressionInsideParenthesis.parent.beginToken.type ==
+          TokenType.BANG) {
+        rule.reportLint(isExpressionInsideParenthesis.parent);
+      }
+    }
+  }
+}

--- a/lib/src/rules/prefer_is_not_operator.dart
+++ b/lib/src/rules/prefer_is_not_operator.dart
@@ -24,6 +24,8 @@ if (!(foo is Foo)) {
 if (foo is! Foo) {
   ...
 }
+```
+
 ''';
 
 class PreferIsNotOperator extends LintRule implements NodeLintRule {

--- a/test/rules/prefer_is_not_operator.dart
+++ b/test/rules/prefer_is_not_operator.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_is_not_operator`
+
+class Foo {}
+var _a;
+
+foo() {
+  if (!(_a is Foo)) {} // LINT
+  var _exp = !(_a is Foo); // LINT
+
+  if (_a is! Foo) {} // OK
+  var _exp1 = _a is! Foo; // OK
+}


### PR DESCRIPTION
Fixed #1522 

When checking if the object has not specified type, it is preferable to use 'is!' operator.


**BAD:**
```
if (!(foo is Foo)) {
  ...
}
```

**GOOD:**
```
if (foo is! Foo) {
  ...
}
```