### PR TITLE
Add effective_dart to linter page

### DIFF
--- a/tool/crawl.dart
+++ b/tool/crawl.dart
@@ -19,11 +19,15 @@ const _rulePathPrefix = 'https://raw.githubusercontent.com/dart-lang/linter';
 
 const _flutterOptionsUrl =
     'https://raw.githubusercontent.com/flutter/flutter/master/packages/flutter/lib/analysis_options_user.yaml';
-const _flutterRepoOptionsUrl = 'https://raw.githubusercontent.com/flutter/flutter/master/analysis_options.yaml';
-const _pedanticOptionsRootUrl = 'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib';
+const _flutterRepoOptionsUrl =
+    'https://raw.githubusercontent.com/flutter/flutter/master/analysis_options.yaml';
+const _pedanticOptionsRootUrl =
+    'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib';
 const _pedanticOptionsUrl = '$_pedanticOptionsRootUrl/analysis_options.yaml';
-const _effectiveDartOptionsRootUrl = 'https://raw.githubusercontent.com/tenhobi/effective_dart/master/lib';
-const _effectiveDartOptionsUrl = '$_effectiveDartOptionsRootUrl/analysis_options.yaml';
+const _effectiveDartOptionsRootUrl =
+    'https://raw.githubusercontent.com/tenhobi/effective_dart/master/lib';
+const _effectiveDartOptionsUrl =
+    '$_effectiveDartOptionsRootUrl/analysis_options.yaml';
 const _stagehandOptionsUrl =
     'https://raw.githubusercontent.com/dart-lang/stagehand/master/templates/analysis_options.yaml';
 
@@ -37,11 +41,14 @@ List<String> _pedanticRules;
 List<String> _effectiveDartRules;
 List<String> _stagehandRules;
 
-Future<List<String>> get flutterRules async => _flutterRules ??= await _fetchRules(_flutterOptionsUrl);
+Future<List<String>> get flutterRules async =>
+    _flutterRules ??= await _fetchRules(_flutterOptionsUrl);
 
-Future<List<String>> get flutterRepoRules async => _flutterRepoRules ??= await _fetchRules(_flutterRepoOptionsUrl);
+Future<List<String>> get flutterRepoRules async =>
+    _flutterRepoRules ??= await _fetchRules(_flutterRepoOptionsUrl);
 
-Future<List<String>> get pedanticRules async => _pedanticRules ??= await _fetchPedanticRules();
+Future<List<String>> get pedanticRules async =>
+    _pedanticRules ??= await _fetchPedanticRules();
 
 Future<List<String>> _fetchPedanticRules() async {
   var client = http.Client();
@@ -50,18 +57,22 @@ Future<List<String>> _fetchPedanticRules() async {
   return _fetchRules('$_pedanticOptionsRootUrl/$includedOptions');
 }
 
-Future<List<String>> get effectiveDartRules async => _effectiveDartRules ??= await _fetchEffectiveDartRules();
+Future<List<String>> get effectiveDartRules async =>
+    _effectiveDartRules ??= await _fetchEffectiveDartRules();
 
 Future<List<String>> _fetchEffectiveDartRules() async {
   var client = http.Client();
   var req = await client.get(_effectiveDartOptionsUrl);
-  var includedOptions = req.body.split('include: package:effective_dart/')[1].trim();
+  var includedOptions =
+      req.body.split('include: package:effective_dart/')[1].trim();
   return _fetchRules('$_effectiveDartOptionsRootUrl/$includedOptions');
 }
 
-Future<List<String>> get stagehandRules async => _stagehandRules ??= await _fetchRules(_stagehandOptionsUrl);
+Future<List<String>> get stagehandRules async =>
+    _stagehandRules ??= await _fetchRules(_stagehandOptionsUrl);
 
-Future<int> get latestMinor async => _latestMinor ??= await _readLatestMinorVersion();
+Future<int> get latestMinor async =>
+    _latestMinor ??= await _readLatestMinorVersion();
 
 List<String> _sdkTags;
 
@@ -100,7 +111,8 @@ Iterable<LintRule> get registeredLints {
   return _registeredLints;
 }
 
-Future<String> findSinceDartSdk(String linterVersion) async => await dartSdkForLinter(linterVersion);
+Future<String> findSinceDartSdk(String linterVersion) async =>
+    await dartSdkForLinter(linterVersion);
 
 Future<String> dartSdkForLinter(String version) async {
   var sdkVersions = <String>[];
@@ -143,14 +155,21 @@ Future<int> _readLatestMinorVersion() async {
   var contents = await File('pubspec.yaml').readAsString();
   YamlMap pubspec = loadYamlNode(contents) as YamlMap;
   // 0.1.79 or 0.1.79-dev or 0.1.97+1
-  return int.parse((pubspec['version'] as String).split('.').last.split('-').first.split('+').first);
+  return int.parse((pubspec['version'] as String)
+      .split('.')
+      .last
+      .split('-')
+      .first
+      .split('+')
+      .first);
 }
 
 Future<String> _crawlForVersion(String lint) async {
   var client = http.Client();
   for (int minor = 1; minor < 31; ++minor) {
     var version = '0.1.$minor';
-    var req = await client.get('$_rulePathPrefix/$version/lib/src/rules/$lint.dart');
+    var req =
+        await client.get('$_rulePathPrefix/$version/lib/src/rules/$lint.dart');
     if (req.statusCode == 200) {
       return version;
     }
@@ -161,14 +180,16 @@ Future<String> _crawlForVersion(String lint) async {
 Future<List<String>> rulesForVersion(int minor) async {
   var version = '0.1.$minor';
   if (minor >= 31) {
-    return _sinceMap[version] ??= await _fetchRules('$_repoPathPrefix$version$_allPathSuffix');
+    return _sinceMap[version] ??=
+        await _fetchRules('$_repoPathPrefix$version$_allPathSuffix');
   }
   return null;
 }
 
 Map<String, String> _dartSdkToLinterMap = <String, String>{};
 
-Future<String> linterForDartSdk(String sdk) async => _dartSdkToLinterMap[sdk] ??= await _fetchLinterForVersion(sdk);
+Future<String> linterForDartSdk(String sdk) async =>
+    _dartSdkToLinterMap[sdk] ??= await _fetchLinterForVersion(sdk);
 
 Future<String> _fetchLinterForVersion(String version) async {
   var deps = await _fetchDEPSforVersion(version);
@@ -190,7 +211,8 @@ Future<String> _fetchLinterForVersion(String version) async {
 Future<String> _fetchDEPSforVersion(String version) async {
   var client = http.Client();
   //https://raw.githubusercontent.com/dart-lang/sdk/2.1.0-dev.1.0/DEPS
-  var req = await client.get('https://raw.githubusercontent.com/dart-lang/sdk/$version/DEPS');
+  var req = await client
+      .get('https://raw.githubusercontent.com/dart-lang/sdk/$version/DEPS');
   return req.body;
 }
 

--- a/tool/crawl.dart
+++ b/tool/crawl.dart
@@ -19,11 +19,11 @@ const _rulePathPrefix = 'https://raw.githubusercontent.com/dart-lang/linter';
 
 const _flutterOptionsUrl =
     'https://raw.githubusercontent.com/flutter/flutter/master/packages/flutter/lib/analysis_options_user.yaml';
-const _flutterRepoOptionsUrl =
-    'https://raw.githubusercontent.com/flutter/flutter/master/analysis_options.yaml';
-const _pedanticOptionsRootUrl =
-    'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib';
+const _flutterRepoOptionsUrl = 'https://raw.githubusercontent.com/flutter/flutter/master/analysis_options.yaml';
+const _pedanticOptionsRootUrl = 'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib';
 const _pedanticOptionsUrl = '$_pedanticOptionsRootUrl/analysis_options.yaml';
+const _effectiveDartOptionsRootUrl = 'https://raw.githubusercontent.com/tenhobi/effective_dart/master/lib';
+const _effectiveDartOptionsUrl = '$_effectiveDartOptionsRootUrl/analysis_options.yaml';
 const _stagehandOptionsUrl =
     'https://raw.githubusercontent.com/dart-lang/stagehand/master/templates/analysis_options.yaml';
 
@@ -34,16 +34,14 @@ Map<String, List<String>> _sinceMap = <String, List<String>>{};
 List<String> _flutterRules;
 List<String> _flutterRepoRules;
 List<String> _pedanticRules;
+List<String> _effectiveDartRules;
 List<String> _stagehandRules;
 
-Future<List<String>> get flutterRules async =>
-    _flutterRules ??= await _fetchRules(_flutterOptionsUrl);
+Future<List<String>> get flutterRules async => _flutterRules ??= await _fetchRules(_flutterOptionsUrl);
 
-Future<List<String>> get flutterRepoRules async =>
-    _flutterRepoRules ??= await _fetchRules(_flutterRepoOptionsUrl);
+Future<List<String>> get flutterRepoRules async => _flutterRepoRules ??= await _fetchRules(_flutterRepoOptionsUrl);
 
-Future<List<String>> get pedanticRules async =>
-    _pedanticRules ??= await _fetchPedanticRules();
+Future<List<String>> get pedanticRules async => _pedanticRules ??= await _fetchPedanticRules();
 
 Future<List<String>> _fetchPedanticRules() async {
   var client = http.Client();
@@ -52,11 +50,18 @@ Future<List<String>> _fetchPedanticRules() async {
   return _fetchRules('$_pedanticOptionsRootUrl/$includedOptions');
 }
 
-Future<List<String>> get stagehandRules async =>
-    _stagehandRules ??= await _fetchRules(_stagehandOptionsUrl);
+Future<List<String>> get effectiveDartRules async => _effectiveDartRules ??= await _fetchEffectiveDartRules();
 
-Future<int> get latestMinor async =>
-    _latestMinor ??= await _readLatestMinorVersion();
+Future<List<String>> _fetchEffectiveDartRules() async {
+  var client = http.Client();
+  var req = await client.get(_effectiveDartOptionsUrl);
+  var includedOptions = req.body.split('include: package:effective_dart/')[1].trim();
+  return _fetchRules('$_effectiveDartOptionsRootUrl/$includedOptions');
+}
+
+Future<List<String>> get stagehandRules async => _stagehandRules ??= await _fetchRules(_stagehandOptionsUrl);
+
+Future<int> get latestMinor async => _latestMinor ??= await _readLatestMinorVersion();
 
 List<String> _sdkTags;
 
@@ -95,8 +100,7 @@ Iterable<LintRule> get registeredLints {
   return _registeredLints;
 }
 
-Future<String> findSinceDartSdk(String linterVersion) async =>
-    await dartSdkForLinter(linterVersion);
+Future<String> findSinceDartSdk(String linterVersion) async => await dartSdkForLinter(linterVersion);
 
 Future<String> dartSdkForLinter(String version) async {
   var sdkVersions = <String>[];
@@ -139,21 +143,14 @@ Future<int> _readLatestMinorVersion() async {
   var contents = await File('pubspec.yaml').readAsString();
   YamlMap pubspec = loadYamlNode(contents) as YamlMap;
   // 0.1.79 or 0.1.79-dev or 0.1.97+1
-  return int.parse((pubspec['version'] as String)
-      .split('.')
-      .last
-      .split('-')
-      .first
-      .split('+')
-      .first);
+  return int.parse((pubspec['version'] as String).split('.').last.split('-').first.split('+').first);
 }
 
 Future<String> _crawlForVersion(String lint) async {
   var client = http.Client();
   for (int minor = 1; minor < 31; ++minor) {
     var version = '0.1.$minor';
-    var req =
-        await client.get('$_rulePathPrefix/$version/lib/src/rules/$lint.dart');
+    var req = await client.get('$_rulePathPrefix/$version/lib/src/rules/$lint.dart');
     if (req.statusCode == 200) {
       return version;
     }
@@ -164,16 +161,14 @@ Future<String> _crawlForVersion(String lint) async {
 Future<List<String>> rulesForVersion(int minor) async {
   var version = '0.1.$minor';
   if (minor >= 31) {
-    return _sinceMap[version] ??=
-        await _fetchRules('$_repoPathPrefix$version$_allPathSuffix');
+    return _sinceMap[version] ??= await _fetchRules('$_repoPathPrefix$version$_allPathSuffix');
   }
   return null;
 }
 
 Map<String, String> _dartSdkToLinterMap = <String, String>{};
 
-Future<String> linterForDartSdk(String sdk) async =>
-    _dartSdkToLinterMap[sdk] ??= await _fetchLinterForVersion(sdk);
+Future<String> linterForDartSdk(String sdk) async => _dartSdkToLinterMap[sdk] ??= await _fetchLinterForVersion(sdk);
 
 Future<String> _fetchLinterForVersion(String version) async {
   var deps = await _fetchDEPSforVersion(version);
@@ -195,8 +190,7 @@ Future<String> _fetchLinterForVersion(String version) async {
 Future<String> _fetchDEPSforVersion(String version) async {
   var client = http.Client();
   //https://raw.githubusercontent.com/dart-lang/sdk/2.1.0-dev.1.0/DEPS
-  var req = await client
-      .get('https://raw.githubusercontent.com/dart-lang/sdk/$version/DEPS');
+  var req = await client.get('https://raw.githubusercontent.com/dart-lang/sdk/$version/DEPS');
   return req.body;
 }
 

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -16,7 +16,8 @@ import 'since.dart';
 
 /// Generates lint rule docs for publishing to https://dart-lang.github.io/
 void main([List<String> args]) async {
-  var parser = ArgParser(allowTrailingOptions: true)..addOption('out', abbr: 'o', help: 'Specifies output directory.');
+  var parser = ArgParser(allowTrailingOptions: true)
+    ..addOption('out', abbr: 'o', help: 'Specifies output directory.');
 
   var options;
   try {
@@ -58,21 +59,32 @@ final pedanticRules = <String>[];
 final effectiveDartRules = <String>[];
 
 /// Sorted list of contributed lint rules.
-final List<LintRule> rules = List<LintRule>.from(Registry.ruleRegistry, growable: false)..sort();
+final List<LintRule> rules =
+    List<LintRule>.from(Registry.ruleRegistry, growable: false)..sort();
 
-String get enumerateErrorRules =>
-    rules.where((r) => r.group == Group.errors).map((r) => '${toDescription(r)}').join('\n\n');
+String get enumerateErrorRules => rules
+    .where((r) => r.group == Group.errors)
+    .map((r) => '${toDescription(r)}')
+    .join('\n\n');
 
-String get enumerateGroups =>
-    Group.builtin.map((Group g) => '<li><strong>${g.name}</strong> - ${markdownToHtml(g.description)}</li>').join('\n');
+String get enumerateGroups => Group.builtin
+    .map((Group g) =>
+        '<li><strong>${g.name}</strong> - ${markdownToHtml(g.description)}</li>')
+    .join('\n');
 
-String get enumeratePubRules => rules.where((r) => r.group == Group.pub).map((r) => '${toDescription(r)}').join('\n\n');
+String get enumeratePubRules => rules
+    .where((r) => r.group == Group.pub)
+    .map((r) => '${toDescription(r)}')
+    .join('\n\n');
 
-String get enumerateStyleRules =>
-    rules.where((r) => r.group == Group.style).map((r) => '${toDescription(r)}').join('\n\n');
+String get enumerateStyleRules => rules
+    .where((r) => r.group == Group.style)
+    .map((r) => '${toDescription(r)}')
+    .join('\n\n');
 
 Future<String> get pedanticLatestVersion async {
-  var url = 'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib/analysis_options.yaml';
+  var url =
+      'https://raw.githubusercontent.com/dart-lang/pedantic/master/lib/analysis_options.yaml';
   var client = http.Client();
   var req = await client.get(url);
   var parts = req.body.split('package:pedantic/analysis_options.');
@@ -80,7 +92,8 @@ Future<String> get pedanticLatestVersion async {
 }
 
 Future<String> get effectiveDartLatestVersion async {
-  var url = 'https://raw.githubusercontent.com/tenhobi/effective_dart/master/lib/analysis_options.yaml';
+  var url =
+      'https://raw.githubusercontent.com/tenhobi/effective_dart/master/lib/analysis_options.yaml';
   var client = http.Client();
   var req = await client.get(url);
   var parts = req.body.split('package:effective_dart/analysis_options.');
@@ -190,7 +203,8 @@ ${parser.usage}
 
 String qualify(LintRule r) => r.name.toString() + describeMaturity(r);
 
-String describeMaturity(LintRule r) => r.maturity == Maturity.stable ? '' : ' (${r.maturity.name})';
+String describeMaturity(LintRule r) =>
+    r.maturity == Maturity.stable ? '' : ' (${r.maturity.name})';
 
 String toDescription(LintRule r) =>
     '<!--suppress HtmlUnknownTarget --><strong><a href = "${r.name}.html">${qualify(r)}</a></strong><br/> ${getBadges(r.name)} ${markdownToHtml(r.description)}';
@@ -203,7 +217,8 @@ class CountBadger {
     var lintCount = rules.length;
 
     var client = http.Client();
-    var req = await client.get(Uri.parse('https://img.shields.io/badge/lints-$lintCount-blue.svg'));
+    var req = await client.get(
+        Uri.parse('https://img.shields.io/badge/lints-$lintCount-blue.svg'));
     var bytes = req.bodyBytes;
     await File('$dirPath/count-badge.svg').writeAsBytes(bytes);
   }
@@ -232,7 +247,9 @@ class Generator {
 
   String get since {
     var info = sinceInfo[name];
-    var version = info.sinceDartSdk != null ? '>= ${info.sinceDartSdk}' : '<strong>unreleased</strong>';
+    var version = info.sinceDartSdk != null
+        ? '>= ${info.sinceDartSdk}'
+        : '<strong>unreleased</strong>';
     // todo (pq): consider a footnote explaining that since info is static and "unreleased" tags may be stale.
     return 'Dart SDK: $version • <small>(Linter v${info.sinceLinter})</small>';
   }
@@ -409,7 +426,11 @@ linter:
   rules:
 ''');
 
-    var sortedRules = rules.where((r) => r.maturity != Maturity.deprecated).map((r) => r.name).toList()..sort();
+    var sortedRules = rules
+        .where((r) => r.maturity != Maturity.deprecated)
+        .map((r) => r.name)
+        .toList()
+          ..sort();
     for (String rule in sortedRules) {
       sb.write('    - $rule\n');
     }

--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -25,7 +25,8 @@ Iterable<LintRule> _registeredLints;
 Iterable<LintRule> get registeredLints {
   if (_registeredLints == null) {
     registerLintRules();
-    _registeredLints = Registry.ruleRegistry.toList()..sort((l1, l2) => l1.name.compareTo(l2.name));
+    _registeredLints = Registry.ruleRegistry.toList()
+      ..sort((l1, l2) => l1.name.compareTo(l2.name));
   }
   return _registeredLints;
 }
@@ -138,7 +139,8 @@ class _AssistCollector extends GeneralizingAstVisitor<void> {
     if (node.name.toString() == 'associatedErrorCodes:') {
       ListLiteral list = node.expression as ListLiteral;
       for (var element in list.elements) {
-        var name = element.toString().substring(1, element.toString().length - 1);
+        var name =
+            element.toString().substring(1, element.toString().length - 1);
         lintNames.add(name);
         if (!registeredLintNames.contains(name)) {
           print('WARNING: unrecognized lint in assists: $name');
@@ -196,7 +198,8 @@ class ScoreCard {
 
     var parser = CompilationUnitParser();
     var cu = parser.parse(contents: req.body, name: 'lint_names.dart');
-    var lintNamesClass = cu.declarations.firstWhere((m) => m is ClassDeclaration && m.name.name == 'LintNames');
+    var lintNamesClass = cu.declarations
+        .firstWhere((m) => m is ClassDeclaration && m.name.name == 'LintNames');
 
     var collector = _FixCollector();
     lintNamesClass.accept(collector);
@@ -209,7 +212,8 @@ class ScoreCard {
         'https://raw.githubusercontent.com/dart-lang/sdk/master/pkg/analysis_server/lib/src/services/correction/assist.dart');
     var parser = CompilationUnitParser();
     var cu = parser.parse(contents: req.body, name: 'assist.dart');
-    var assistKindClass = cu.declarations.firstWhere((m) => m is ClassDeclaration && m.name.name == 'DartAssistKind');
+    var assistKindClass = cu.declarations.firstWhere(
+        (m) => m is ClassDeclaration && m.name.name == 'DartAssistKind');
 
     var collector = _AssistCollector();
     assistKindClass.accept(collector);
@@ -258,7 +262,8 @@ class ScoreCard {
 
       scorecard.add(LintScore(
           name: lint.name,
-          hasFix: lintsWithFixes.contains(lint.name) || lintsWithAssists.contains(lint.name),
+          hasFix: lintsWithFixes.contains(lint.name) ||
+              lintsWithAssists.contains(lint.name),
           maturity: lint.maturity.name,
           ruleSets: ruleSets,
           since: sinceInfo[lint.name],
@@ -284,7 +289,13 @@ class LintScore {
   List<String> ruleSets;
   List<String> bugReferences;
 
-  LintScore({this.name, this.hasFix, this.maturity, this.ruleSets, this.bugReferences, this.since});
+  LintScore(
+      {this.name,
+      this.hasFix,
+      this.maturity,
+      this.ruleSets,
+      this.bugReferences,
+      this.since});
 
   String get _ruleSets => ruleSets.isNotEmpty ? ' ${ruleSets.toString()}' : '';
 
@@ -296,7 +307,8 @@ class LintScore {
     for (var detail in details) {
       switch (detail) {
         case Detail.rule:
-          sb.write(' [$name](https://dart-lang.github.io/linter/lints/$name.html) |');
+          sb.write(
+              ' [$name](https://dart-lang.github.io/linter/lints/$name.html) |');
           break;
         case Detail.linter:
           sb.write(' ${since.sinceLinter} |');
@@ -311,13 +323,15 @@ class LintScore {
           sb.write('${ruleSets.contains('pedantic') ? " $checkMark" : ""} |');
           break;
         case Detail.effectiveDart:
-          sb.write('${ruleSets.contains('effective_dart') ? " $checkMark" : ""} |');
+          sb.write(
+              '${ruleSets.contains('effective_dart') ? " $checkMark" : ""} |');
           break;
         case Detail.flutterUser:
           sb.write('${ruleSets.contains('flutter') ? " $checkMark" : ""} |');
           break;
         case Detail.flutterRepo:
-          sb.write('${ruleSets.contains('flutter_repo') ? " $checkMark" : ""} |');
+          sb.write(
+              '${ruleSets.contains('flutter_repo') ? " $checkMark" : ""} |');
           break;
         case Detail.status:
           sb.write('${maturity != 'stable' ? ' **$maturity** ' : ""} |');


### PR DESCRIPTION
# Description

This PR adds effective dart badge to lints, similarly to pedantic and flutter. (Discussed in https://github.com/dart-lang/linter/pull/1781)

I tested to build pages on local, and everything works as expected (except I don't have styles and images – mentioned bellow).

# Issues

I do not know where to save the badge for the effective dart. In `tools/doc.dart:174` there is mentioned `<img alt="effective_dart" src="style-effective_dart.svg">`, which is just a copy from pedantic, but I do not know where it is stored.

I would like to use this [badge](https://github.com/tenhobi/effective_dart/#badge) (https://img.shields.io/badge/style-effective_dart-40c4ff.svg).

cc @pq 