### PR TITLE
Stop referencing ParameterizedType.

### DIFF
--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -66,7 +66,7 @@ String _META_LIB_NAME = 'meta';
 /// type args.
 String _OPTIONAL_TYPE_ARGS_VAR_NAME = 'optionalTypeArgs';
 
-bool _isOptionallyParameterized(ParameterizedType type) {
+bool _isOptionallyParameterized(InterfaceType type) {
   List<ElementAnnotation> metadata = type.element?.metadata;
   if (metadata != null) {
     return metadata
@@ -126,7 +126,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   visitNamedType(NamedType namedType) {
     DartType type = namedType.type;
-    if (type is ParameterizedType) {
+    if (type is InterfaceType) {
       if (type.typeParameters.isNotEmpty &&
           namedType.typeArguments == null &&
           namedType.parent is! IsExpression &&

--- a/lib/src/rules/avoid_returning_null_for_void.dart
+++ b/lib/src/rules/avoid_returning_null_for_void.dart
@@ -102,7 +102,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       rule.reportLint(node);
     } else if (isAsync &&
         type.isDartAsyncFuture &&
-        (type as ParameterizedType).typeArguments.first.isVoid) {
+        (type as InterfaceType).typeArguments.first.isVoid) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -64,7 +64,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (type.isVoid) return true;
     if (type.isDartCoreNull) return true;
     if (type.isDartAsyncFuture &&
-        type is ParameterizedType &&
+        type is InterfaceType &&
         (type.typeArguments.first.isVoid ||
             type.typeArguments.first.isDartCoreNull)) {
       return true;

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -375,17 +375,17 @@ class DartTypeUtilities {
         typeSystem.isSubtypeOf(rightType, leftType)) {
       return false;
     }
-    Element leftElement = leftType.element;
-    Element rightElement = rightType.element;
-    if (leftElement is ClassElement && rightElement is ClassElement) {
-      // In this case, [leftElement] and [rightElement] each represent a class,
-      // like `int` or `List` or `Future<T>` or `Iterable<String>`.
-      if (isClass(leftType, rightElement.name, rightElement.library.name)) {
+    if (leftType is InterfaceType && rightType is InterfaceType) {
+      // In this case, [leftElement] and [rightElement] each represent
+      // the same class, like `int`, or `Iterable<String>`.
+      var leftElement = leftType.element;
+      var rightElement = rightType.element;
+      if (leftElement == rightElement) {
         // In this case, [leftElement] and [rightElement] represent the same
         // class, modulo generics, e.g. `List<int>` and `List<dynamic>`. Now we
         // need to check type arguments.
-        var leftTypeArguments = (leftType as ParameterizedType).typeArguments;
-        var rightTypeArguments = (rightType as ParameterizedType).typeArguments;
+        var leftTypeArguments = leftType.typeArguments;
+        var rightTypeArguments = rightType.typeArguments;
         if (leftTypeArguments.length != rightTypeArguments.length) {
           // I cannot think of how we would enter this block, but it guards
           // against RangeError below.
@@ -405,9 +405,10 @@ class DartTypeUtilities {
         return leftElement.supertype?.isObject == true ||
             leftElement.supertype != rightElement.supertype;
       }
-    } else if (leftElement is TypeParameterElement &&
-        rightElement is TypeParameterElement) {
-      return unrelatedTypes(typeSystem, leftElement.bound, rightElement.bound);
+    } else if (leftType is TypeParameterType &&
+        rightType is TypeParameterType) {
+      return unrelatedTypes(
+          typeSystem, leftType.element.bound, rightType.element.bound);
     } else if (leftType is FunctionType) {
       if (_isFunctionTypeUnrelatedToType(leftType, rightType)) {
         return true;

--- a/lib/src/util/flutter_utils.dart
+++ b/lib/src/util/flutter_utils.dart
@@ -26,7 +26,7 @@ bool isWidgetProperty(DartType type) {
   if (isWidgetType(type)) {
     return true;
   }
-  if (type is ParameterizedType &&
+  if (type is InterfaceType &&
       DartTypeUtilities.implementsAnyInterface(type, _collectionInterfaces)) {
     return type.typeParameters.length == 1 &&
         isWidgetProperty(type.typeArguments.first);


### PR DESCRIPTION
I'd like to remove it, and ask clients to use `InterfaceType` and `FunctionType` directly.