### PR TITLE
avoid_returning_null_for_void only checks null literal

### DIFF
--- a/lib/src/rules/avoid_returning_null_for_void.dart
+++ b/lib/src/rules/avoid_returning_null_for_void.dart
@@ -77,7 +77,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _visit(AstNode node, Expression expression) {
-    if (expression.staticType?.isDartCoreNull != true) {
+    if (expression is! NullLiteral) {
       return;
     }
 


### PR DESCRIPTION
# Description

Relax `avoid_returning_null_for_void` to check only `null` literal (and not expression having Null type)

Fixes #1787
