### PR TITLE
0.1.102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.102
+
+* `avoid_web_libraries_in_flutter` updated to disallow access from all but Flutter web plugin packages
+* updated `avoid_returning_null_for_void` to check only `null` literals (and not expressions having `Null` types)
+* fixed `prefer_final_fields` to respect non-mutating prefix operators
+* new lint: `prefer_is_not_operator`
+* new lint: `avoid_unnecessary_containers`
+* added basic nnbd-awareness to `avoid_init_to_null`
+
 # 0.1.101
 
 * fixed `diagnostic_describe_all_properties` to flag properties in `Diagnosticable`s with no debug methods defined

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.101';
+const String version = '0.1.102';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.101
+version: 0.1.102
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.102

* `avoid_web_libraries_in_flutter` updated to disallow access from all but Flutter web plugin packages
* updated `avoid_returning_null_for_void` to check only `null` literals (and not expressions having `Null` types)
* fixed `prefer_final_fields` to respect non-mutating prefix operators
* new lint: `prefer_is_not_operator`
* new lint: `avoid_unnecessary_containers`
* added basic nnbd-awareness to `avoid_init_to_null`

/cc @bwilkerson @a14n 
