### PR TITLE
fix test parse error

### DIFF
--- a/test/rules/type_annotate_public_apis.dart
+++ b/test/rules/type_annotate_public_apis.dart
@@ -75,7 +75,7 @@ typedef void _PrivateMethod2(value); //OK
 
 extension Ext on A {
   set x(x) { }  // LINT
-  set _x(x); // OK
+  set _x(x) { } // OK
   get x => 0; // LINT
 
   f() {} // LINT


### PR DESCRIPTION
Abstract methods are disallowed in extensions.

/cc @MichaelRFairhurst @bwilkerson 
