### PR TITLE
use workspace package to locate `lib/`

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -122,7 +122,7 @@ bool isHashCode(ClassMember element) =>
         getFieldIdentifier(element, 'hashCode') != null);
 
 /// Return true if this compilation unit [node] is declared within the given
-/// [package]'s `lib/` directory.
+/// [package]'s `lib/` directory tree.
 bool isInLibDir(CompilationUnit node, WorkspacePackage package) {
   final cuPath = node.declaredElement.library?.source?.fullName;
   if (cuPath == null) return false;

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -124,9 +124,10 @@ bool isHashCode(ClassMember element) =>
 /// Return true if this compilation unit [node] is declared within the given
 /// [package]'s `lib/` directory.
 bool isInLibDir(CompilationUnit node, WorkspacePackage package) {
-  final libDir = path.join(package.root, 'lib');
   final cuPath = node.declaredElement.library?.source?.fullName;
-  return cuPath?.startsWith(libDir) == true;
+  if (cuPath == null) return false;
+  final libDir = path.join(package.root, 'lib');
+  return path.isWithin(libDir, cuPath);
 }
 
 /// Returns `true` if the keyword associated with the given [token] matches

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -121,8 +121,8 @@ bool isHashCode(ClassMember element) =>
     (element is FieldDeclaration &&
         getFieldIdentifier(element, 'hashCode') != null);
 
-/// Return true if the given compilation unit is declared in the given [package]'s
-/// `lib/` directory.
+/// Return true if this compilation unit [node] is declared within the given
+/// [package]'s `lib/` directory.
 bool isInLibDir(CompilationUnit node, WorkspacePackage package) {
   final libDir = path.join(package.root, 'lib');
   final cuPath = node.declaredElement.library?.source?.fullName;

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -65,6 +65,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
   final LinterContext context;
 
+  /// Tracks if we are in a compilation unit within a `lib/` dir so we can
+  /// short-circuit needless checking of method declarations.
   bool isInLib;
 
   _Visitor(this.rule, this.context);

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -55,18 +55,29 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    final visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
+    registry.addCompilationUnit(this, visitor);
   }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+  final LinterContext context;
 
-  _Visitor(this.rule);
+  bool isInLib;
+
+  _Visitor(this.rule, this.context);
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    isInLib = isInLibDir(node, context.package);
+  }
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
+    if (!isInLib) return;
+
     if (node.isStatic) return;
     if (node.documentationComment != null) return;
 
@@ -80,7 +91,6 @@ class _Visitor extends SimpleAstVisitor<void> {
     final classElement = parentElement as ClassElement;
 
     if (classElement.isPrivate) return;
-    if (!isDefinedInLib(getCompilationUnit(node))) return;
 
     final parentMethod = classElement.lookUpInheritedMethod(
         node.name.name, classElement.library);

--- a/lib/src/rules/prefer_relative_imports.dart
+++ b/lib/src/rules/prefer_relative_imports.dart
@@ -61,7 +61,7 @@ class PreferRelativeImports extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    final visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
     registry.addImportDirective(this, visitor);
   }
@@ -69,12 +69,13 @@ class PreferRelativeImports extends LintRule implements NodeLintRule {
 
 class _Visitor extends SimpleAstVisitor<void> {
   final PreferRelativeImports rule;
+  final LinterContext context;
 
   bool isInLibFolder;
   File pubspecFile;
   YamlMap parsedPubspec;
 
-  _Visitor(this.rule);
+  _Visitor(this.rule, this.context);
 
   bool isPackageSelfReference(ImportDirective node) {
     // Ignore this compilation unit if it's not in the lib/ folder.
@@ -110,7 +111,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    isInLibFolder = isDefinedInLib(node);
+    isInLibFolder = isInLibDir(node, context.package);
 
     pubspecFile = locatePubspecFile(node);
     parsedPubspec = null;

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -203,7 +203,7 @@ class _Visitor extends SimpleAstVisitor {
   @override
   visitCompilationUnit(CompilationUnit node) {
     // Ignore this compilation unit if it's not in the lib/ folder.
-    isInLibFolder = isDefinedInLib(node);
+    isInLibFolder = isInLibDir(node, context.package);
     if (!isInLibFolder) return;
 
     Map<String, FunctionDeclaration> getters = <String, FunctionDeclaration>{};


### PR DESCRIPTION
Fixes: #1786

Should also make `prefer_relative_imports` and `public_member_api_docs` google3-friendly.

Bonus: makes `avoid_renaming_method_parameters` way more performant.

Before:

![image](https://user-images.githubusercontent.com/67586/67974980-94385580-fbd0-11e9-9bf3-280433bef30d.png)

After:

![image](https://user-images.githubusercontent.com/67586/67975006-9b5f6380-fbd0-11e9-90a5-b49aeddc6039.png)

🏅 🏅 🏅 

/cc @bwilkerson @scheglov 

/fyi @a14n 