### PR TITLE
👟👟👟 `prefer_relative_imports`: stop parsing pubspecs (query ws package for self-references)

### DIFF
--- a/lib/src/rules/prefer_relative_imports.dart
+++ b/lib/src/rules/prefer_relative_imports.dart
@@ -75,7 +75,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return false;
     }
 
-    final source = node.uriElement.library?.source;
+    final source = node.uriElement?.library?.source;
     if (source == null) return false;
     // todo (pq): should context.package.contains(source)work?
     return path.isWithin(context.package.root, source.fullName);

--- a/lib/src/rules/prefer_relative_imports.dart
+++ b/lib/src/rules/prefer_relative_imports.dart
@@ -8,7 +8,6 @@ import 'package:path/path.dart' as path;
 
 import '../analyzer.dart';
 import '../ast.dart';
-import '../rules/implementation_imports.dart';
 
 const _desc = r'Prefer relative imports for files in `lib/`.';
 
@@ -63,21 +62,13 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (!isInLibFolder) return false;
 
     // Is it a package: import?
-    String importUri = node?.uri?.stringValue;
-    if (importUri == null) return false;
+    final importUri = node.uriContent;
+    if (importUri?.startsWith('package:') != true) return false;
 
-    // todo (pq): is there a better way to do this?
-    Uri uri;
-    try {
-      uri = Uri.parse(importUri);
-      if (!isPackage(uri)) return false;
-    } on FormatException catch (_) {
-      return false;
-    }
-
-    final source = node.uriElement?.library?.source;
+    final source = node.uriSource;
     if (source == null) return false;
-    // todo (pq): should context.package.contains(source)work?
+
+    // todo (pq): context.package.contains(source) should work (but does not)
     return path.isWithin(context.package.root, source.fullName);
   }
 

--- a/test/_data/prefer_relative_imports/_packages
+++ b/test/_data/prefer_relative_imports/_packages
@@ -1,1 +1,2 @@
 sample_project:lib/
+p6:../p6/lib/

--- a/test/_data/prefer_relative_imports/bin/bin.dart
+++ b/test/_data/prefer_relative_imports/bin/bin.dart
@@ -1,0 +1,1 @@
+import 'package:sample_project/dummy.dart'; // OK

--- a/test/_data/prefer_relative_imports/lib/main.dart
+++ b/test/_data/prefer_relative_imports/lib/main.dart
@@ -1,3 +1,5 @@
 import 'package:sample_project/dummy.dart'; //LINT
 
+import 'package:p6/p6_lib.dart'; //OK
+
 import 'dummy.dart'; //OK

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -686,8 +686,12 @@ defineTests() {
           '--packages',
           'test/_data/prefer_relative_imports/_packages'
         ], LinterOptions());
-        expect(collectingOut.trim(),
-            contains('4 files analyzed, 1 issue found, in'));
+        expect(
+            collectingOut.trim(),
+            stringContainsInOrder([
+              'main.dart 1:8',
+              '4 files analyzed, 1 issue found, in',
+            ]));
         expect(exitCode, 1);
       });
     });

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -687,7 +687,7 @@ defineTests() {
           'test/_data/prefer_relative_imports/_packages'
         ], LinterOptions());
         expect(collectingOut.trim(),
-            contains('3 files analyzed, 1 issue found, in'));
+            contains('4 files analyzed, 1 issue found, in'));
         expect(exitCode, 1);
       });
     });


### PR DESCRIPTION
Speed up `prefer_relative_imports` and make it google3-friendly by querying the workspace package (and forgoing any pubspec parsing).

Before:

![image](https://user-images.githubusercontent.com/67586/67990810-37e72d00-fbf4-11e9-883a-ef3d0517c802.png)

After:

![image](https://user-images.githubusercontent.com/67586/67991544-d4123380-fbf6-11e9-9fc1-178bdb2ea7fd.png)

Definitely **_faster_**...  Still need to convince myself that it's correct.  (A few TODOs to consider.)

See also: #1810.

/cc @devoncarew @bwilkerson 