### PR TITLE
0.1.103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.103
+
+* updated `prefer_relative_imports` to use a faster and more robust way to check for self-package references
+* updated our approach to checking for `lib` dir contents (speeding up `avoid_renaming_method_parameters` and 
+  making `prefer_relative_imports` and `public_member_api_docs` amenable to internal package formats -- w/o pubspecs)
+
 # 0.1.102
 
 * `avoid_web_libraries_in_flutter` updated to disallow access from all but Flutter web plugin packages

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.102';
+const String version = '0.1.103';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.102
+version: 0.1.103
 
 author: Dart Team <misc@dartlang.org>
 
@@ -14,7 +14,7 @@ environment:
   sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.0
+  analyzer: ^0.39.1
   args: '>=1.4.0 <2.0.0'
   glob: ^1.0.3
   meta: ^1.0.2


### PR DESCRIPTION
# 0.1.103

* updated `prefer_relative_imports` to use a faster and more robust way to check for self-package references
* updated our approach to checking for `lib` dir contents (speeding up `avoid_renaming_method_parameters` and 
  making `prefer_relative_imports` and `public_member_api_docs` amenable to internal package formats -- w/o pubspecs)

/cc @bwilkerson 
