### PR TITLE
remove (stale) appveyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ analysis server and the `dartanalyzer` commandline tool.
 
 [![Lint Count](https://dart-lang.github.io/linter/lints/count-badge.svg)](https://dart-lang.github.io/linter/lints/)
 [![Build Status](https://travis-ci.org/dart-lang/linter.svg)](https://travis-ci.org/dart-lang/linter)
-[![Build status](https://ci.appveyor.com/api/projects/status/3a2437l58uhmvckm/branch/master?svg=true)](https://ci.appveyor.com/project/pq/linter/branch/master)
 [![Coverage Status](https://coveralls.io/repos/dart-lang/linter/badge.svg)](https://coveralls.io/r/dart-lang/linter)
 [![Pub](https://img.shields.io/pub/v/linter.svg)](https://pub.dev/packages/linter)
 


### PR DESCRIPTION
See: https://github.com/dart-lang/linter/issues/1833.

/cc @bwilkerson 