### PR TITLE
improve perf for `always_require_non_null_named_parameters`

### DIFF
--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -13,8 +13,8 @@ const _desc = r'Use @required.';
 
 const _details = r'''
 
-**DO** specify `@required` on named parameter without default value on which an
-assert(param != null) is done.
+**DO** specify `@required` on named parameters without a default value on which 
+an `assert(param != null)` is done.
 
 **GOOD:**
 ```
@@ -68,50 +68,64 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFormalParameterList(FormalParameterList node) {
-    final params = node.parameters
-        // only named parameters
-        .where((p) => p.isNamed)
-        .map((p) => p as DefaultFormalParameter)
-        // without default value
-        .where((p) => p.defaultValue == null)
-        // without @required
-        .where((p) => !p.declaredElement.hasRequired)
-        .toList();
+    List<DefaultFormalParameter> getParams() {
+      final params = <DefaultFormalParameter>[];
+      for (final p in node.parameters) {
+        // Only named parameters
+        if (p.isNamed) {
+          DefaultFormalParameter parameter = p as DefaultFormalParameter;
+          // Without a default value or marked @required
+          if (parameter.defaultValue == null &&
+              !parameter.declaredElement.hasRequired) {
+            params.add(parameter);
+          }
+        }
+      }
+      return params;
+    }
+
     final parent = node.parent;
     if (parent is FunctionExpression) {
-      _checkParams(params, parent.body);
+      _checkParams(getParams(), parent.body);
     } else if (parent is ConstructorDeclaration) {
-      _checkInitializerList(params, parent.initializers);
-      _checkParams(params, parent.body);
+      _checkInitializerList(getParams(), parent.initializers);
+      _checkParams(getParams(), parent.body);
     } else if (parent is MethodDeclaration) {
-      _checkParams(params, parent.body);
+      _checkParams(getParams(), parent.body);
+    }
+  }
+
+  void _checkAsserts(
+      List<Expression> asserts, List<DefaultFormalParameter> params) {
+    for (final expression in asserts) {
+      for (final param in params) {
+        if (_hasAssertNotNull(expression, param.identifier.name)) {
+          rule.reportLintForToken(param.identifier.beginToken);
+        }
+      }
     }
   }
 
   void _checkInitializerList(List<DefaultFormalParameter> params,
       NodeList<ConstructorInitializer> initializers) {
-    final asserts = initializers
-        .whereType<AssertInitializer>()
-        .map((e) => e.condition)
-        .toList();
-    for (final param in params) {
-      if (asserts.any((e) => _hasAssertNotNull(e, param.identifier.name))) {
-        rule.reportLintForToken(param.identifier.beginToken);
+    final asserts = <Expression>[];
+    for (final initializer in initializers) {
+      if (initializer is AssertInitializer) {
+        asserts.add(initializer.condition);
       }
     }
+    _checkAsserts(asserts, params);
   }
 
   void _checkParams(List<DefaultFormalParameter> params, FunctionBody body) {
     if (body is BlockFunctionBody) {
-      final asserts = body.block.statements
-          .takeWhile((e) => e is AssertStatement)
-          .map((e) => (e as AssertStatement).condition)
-          .toList();
-      for (final param in params) {
-        if (asserts.any((e) => _hasAssertNotNull(e, param.identifier.name))) {
-          rule.reportLintForToken(param.identifier.beginToken);
+      final asserts = <Expression>[];
+      for (final statement in body.block.statements) {
+        if (statement is AssertStatement) {
+          asserts.add(statement.condition);
         }
       }
+      _checkAsserts(asserts, params);
     }
   }
 

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -95,37 +95,31 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  void _checkAsserts(
-      List<Expression> asserts, List<DefaultFormalParameter> params) {
-    for (final expression in asserts) {
-      for (final param in params) {
-        if (_hasAssertNotNull(expression, param.identifier.name)) {
-          rule.reportLintForToken(param.identifier.beginToken);
-        }
+  void _checkAssert(
+      Expression assertExpression, List<DefaultFormalParameter> params) {
+    for (final param in params) {
+      if (_hasAssertNotNull(assertExpression, param.identifier.name)) {
+        rule.reportLintForToken(param.identifier.beginToken);
       }
     }
   }
 
   void _checkInitializerList(List<DefaultFormalParameter> params,
       NodeList<ConstructorInitializer> initializers) {
-    final asserts = <Expression>[];
     for (final initializer in initializers) {
       if (initializer is AssertInitializer) {
-        asserts.add(initializer.condition);
+        _checkAssert(initializer.condition, params);
       }
     }
-    _checkAsserts(asserts, params);
   }
 
   void _checkParams(List<DefaultFormalParameter> params, FunctionBody body) {
     if (body is BlockFunctionBody) {
-      final asserts = <Expression>[];
       for (final statement in body.block.statements) {
         if (statement is AssertStatement) {
-          asserts.add(statement.condition);
+          _checkAssert(statement.condition, params);
         }
       }
-      _checkAsserts(asserts, params);
     }
   }
 

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -100,6 +100,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (final param in params) {
       if (_hasAssertNotNull(assertExpression, param.identifier.name)) {
         rule.reportLintForToken(param.identifier.beginToken);
+        params.remove(param);
+        return;
       }
     }
   }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/67586/68880980-25272a80-06c1-11ea-8702-6c60c515225a.png)

After:

![image](https://user-images.githubusercontent.com/67586/68881325-c7dfa900-06c1-11ea-9f9c-b8f874ecf444.png)

/cc @bwilkerson 


See:  #1837.

