### PR TITLE
Use TypeSystem class from API.

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -28,7 +28,8 @@ export 'package:analyzer/src/dart/error/lint_codes.dart';
 export 'package:analyzer/src/generated/engine.dart'
     show AnalysisContext, AnalysisErrorInfo;
 export 'package:analyzer/src/generated/resolver.dart'
-    show ExitDetector, TypeProvider, TypeSystem;
+    show ExitDetector, TypeProvider;
+export 'package:analyzer/dart/element/type_system.dart' show TypeSystem;
 export 'package:analyzer/src/generated/source.dart' show LineInfo, Source;
 export 'package:analyzer/src/lint/linter.dart'
     show


### PR DESCRIPTION
We would like to remove switch all clients to the API version, and remove `TypeSystem` declared in `analyzer/lib/src/generated/type_system.dart`. This change works with both version of analyzer, `0.39.1` and with my pending changes to update `LinterContext` to return the API version of `TypeSystem`.