### PR TITLE
Consider nested TypeNames when counting uses.

### DIFF
--- a/lib/src/rules/avoid_private_typedef_functions.dart
+++ b/lib/src/rules/avoid_private_typedef_functions.dart
@@ -52,6 +52,7 @@ class _CountVisitor extends RecursiveAstVisitor {
   @override
   visitTypeName(TypeName node) {
     if (node.name.name == type) count++;
+    super.visitTypeName(node);
   }
 }
 

--- a/test/rules/avoid_private_typedef_functions.dart
+++ b/test/rules/avoid_private_typedef_functions.dart
@@ -24,3 +24,11 @@ _F5 v5b;
 typedef void _F6(); // OK
 _F6 f6a() => null;
 _F6 f6b() => null;
+
+typedef _F7 = void Function(); // OK
+m7(_F7 f) => null;
+List<_F7> l7 = [];
+
+typedef void _F8(); // OK
+m8(_F8 f) => null;
+List<_F8> l8 = [];


### PR DESCRIPTION
# Description

Nested `TypeName`s in the AST were being ignored due to a missing call to super. This results in false positives for `avoid_private_typedef_functions` in cases such as type parameters on generic types.

Fixes https://github.com/dart-lang/linter/issues/1856
