### PR TITLE
check for null packages in "isInLibDir" check

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -124,6 +124,7 @@ bool isHashCode(ClassMember element) =>
 /// Return true if this compilation unit [node] is declared within the given
 /// [package]'s `lib/` directory tree.
 bool isInLibDir(CompilationUnit node, WorkspacePackage package) {
+  if (package == null) return false;
   final cuPath = node.declaredElement.library?.source?.fullName;
   if (cuPath == null) return false;
   final libDir = path.join(package.root, 'lib');


### PR DESCRIPTION
Fixes: #1862 #1863 .

Looking closer at call sites, it's possible for `package` to be null so we need to guard against that.

/cc @bwilkerson 

/fyi @scheglov 