### PR TITLE
0.1.105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.105
+
+* hardened check for lib dir location (fixing crashes in `avoid_renaming_method_parameters`,
+  `prefer_relative_imports` and `public_member_api_docs`)
+* improved performance for `always_require_non_null_named_parameters`
+
 # 0.1.104
 
 * updated `unnecessary_overrides` to allow overrides when annotations (besides `@override` are specified)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.104';
+const String version = '0.1.105';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.104
+version: 0.1.105
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.105

* hardened check for lib dir location (fixing crashes in `avoid_renaming_method_parameters`,
  `prefer_relative_imports` and `public_member_api_docs`)
* improved performance for `always_require_non_null_named_parameters`

/cc @bwilkerson 
