### PR TITLE
bail on first non-assert in `always_require_non_null_named_parameters`

### DIFF
--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -120,6 +120,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       for (final statement in body.block.statements) {
         if (statement is AssertStatement) {
           _checkAssert(statement.condition, params);
+        } else {
+          // Bail on first non-assert.
+          return;
         }
       }
     }

--- a/test/rules/always_require_non_null_named_parameters.dart
+++ b/test/rules/always_require_non_null_named_parameters.dart
@@ -6,6 +6,17 @@
 
 import 'package:meta/meta.dart';
 
+var condition = true;
+
+m0({
+  Object a, // OK
+}) {
+  if (condition) {
+    return;
+  }
+  assert(a != null);
+}
+
 m1(
   a,
   b,


### PR DESCRIPTION
Fixes #1872

/cc @bwilkerson 
