### PR TITLE
0.1.105+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.105+1
+
+* fixed regressions in `always_require_non_null_named_parameters`
+* (internal) pedantic lint clean-up
+
 # 0.1.105
 
 * hardened check for lib dir location (fixing crashes in `avoid_renaming_method_parameters`,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.105';
+const String version = '0.1.105+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.105
+version: 0.1.105+1
 
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
# 0.1.105+1

* fixed regressions in `always_require_non_null_named_parameters`
* (internal) pedantic lint clean-up

/cc @bwilkerson 
