### PR TITLE
Fix null_closures bug with Iterable.singleWhere

### DIFF
--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -60,7 +60,8 @@ in the following locations:
     parameter `orElse`
   * `Iterable.map` at the 0th positional parameter
   * `Iterable.reduce` at the 0th positional parameter
-  * `Iterable.singleWhere` at the 0th positional parameter
+  * `Iterable.singleWhere` at the 0th positional parameter, and the named
+    parameter `orElse`
   * `Iterable.skipWhile` at the 0th positional parameter
   * `Iterable.takeWhile` at the 0th positional parameter
   * `Iterable.where` at the 0th positional parameter
@@ -152,7 +153,7 @@ final Map<String, Set<NonNullableFunction>>
   },
   'singleWhere': {
     NonNullableFunction('dart.core', 'Iterable', 'singleWhere',
-        positional: [0]),
+        positional: [0], named: ['orElse']),
   },
   'skipWhile': {
     NonNullableFunction('dart.core', 'Iterable', 'skipWhile', positional: [0]),

--- a/test/rules/null_closures.dart
+++ b/test/rules/null_closures.dart
@@ -25,6 +25,12 @@ void list_firstWhere() {
   <int>[2, 4, 6].where((e) => e.isEven); // OK
 }
 
+void iterable_singleWhere() {
+  // singleWhere has a _named_ closure argument.
+  {2, 4, 6}.singleWhere((e) => e.isEven, orElse: null); // LINT
+  [2, 4, 6].singleWhere((e) => e.isEven, orElse: () => null); // OK
+}
+
 void map_putIfAbsent() {
   // putIfAbsent has a _required_ closure argument.
   var map = <int, int>{};

--- a/test/rules/null_closures.dart
+++ b/test/rules/null_closures.dart
@@ -27,8 +27,8 @@ void list_firstWhere() {
 
 void iterable_singleWhere() {
   // singleWhere has a _named_ closure argument.
-  {2, 4, 6}.singleWhere((e) => e.isEven, orElse: null); // LINT
-  [2, 4, 6].singleWhere((e) => e.isEven, orElse: () => null); // OK
+  <int>{2, 4, 6}.singleWhere((e) => e.isEven, orElse: null); // LINT
+  <int>[2, 4, 6].singleWhere((e) => e.isEven, orElse: () => null); // OK
 }
 
 void map_putIfAbsent() {


### PR DESCRIPTION
null_closures erroneously did not flag the `orElse` named parameter of [Iterable.singleWhere](https://api.dartlang.org/stable/2.7.0/dart-core/Iterable/singleWhere.html).