### PR TITLE
0.1.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.106
+
+* improved docs for `comment_references`
+* fixed `null_closures` to properly handle `Iterable.singleWhere`
+* (internal) migrated to latest analyzer APIs
+* new lint: `no_logic_in_create_state`
+
 # 0.1.105+1
 
 * fixed regressions in `always_require_non_null_named_parameters`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.105+1';
+const String version = '0.1.106';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.105+1
+version: 0.1.106
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.106

* improved docs for `comment_references`
* fixed `null_closures` to properly handle `Iterable.singleWhere`
* (internal) migrated to latest analyzer APIs
* new lint: `no_logic_in_create_state`

/cc @bwilkerson 
