### PR TITLE
Check doc comments for mixins in slash_for_doc_comments

### DIFF
--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -66,6 +66,7 @@ class SlashForDocComments extends LintRule implements NodeLintRule {
     registry.addFunctionTypeAlias(this, visitor);
     registry.addLibraryDirective(this, visitor);
     registry.addMethodDeclaration(this, visitor);
+    registry.addMixinDeclaration(this, visitor);
     registry.addTopLevelVariableDeclaration(this, visitor);
   }
 }
@@ -133,6 +134,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
+    checkComment(node.documentationComment);
+  }
+
+  @override
+  void visitMixinDeclaration(MixinDeclaration node) {
     checkComment(node.documentationComment);
   }
 

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -64,6 +64,7 @@ class SlashForDocComments extends LintRule implements NodeLintRule {
     registry.addFieldDeclaration(this, visitor);
     registry.addFunctionDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
+    registry.addGenericTypeAlias(this, visitor);
     registry.addLibraryDirective(this, visitor);
     registry.addMethodDeclaration(this, visitor);
     registry.addMixinDeclaration(this, visitor);
@@ -124,6 +125,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFunctionTypeAlias(FunctionTypeAlias node) {
+    checkComment(node.documentationComment);
+  }
+
+  @override
+  void visitGenericTypeAlias(GenericTypeAlias node) {
     checkComment(node.documentationComment);
   }
 

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
@@ -64,6 +65,7 @@ class SlashForDocComments extends LintRule implements NodeLintRule {
     registry.addExtensionDeclaration(this, visitor);
     registry.addFieldDeclaration(this, visitor);
     registry.addFunctionDeclaration(this, visitor);
+    registry.addFunctionDeclarationStatement(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
     registry.addGenericTypeAlias(this, visitor);
     registry.addMethodDeclaration(this, visitor);
@@ -129,6 +131,14 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
     checkComment(node.documentationComment);
+  }
+
+  @override
+  void visitFunctionDeclarationStatement(FunctionDeclarationStatement node) {
+    var comment = node.beginToken.precedingComments;
+    if (comment != null && comment.lexeme.startsWith('/**')) {
+      rule.reportLintForToken(comment);
+    }
   }
 
   @override

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -57,6 +57,7 @@ class SlashForDocComments extends LintRule implements NodeLintRule {
     final visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addClassTypeAlias(this, visitor);
+    registry.addCompilationUnit(this, visitor);
     registry.addConstructorDeclaration(this, visitor);
     registry.addEnumConstantDeclaration(this, visitor);
     registry.addEnumDeclaration(this, visitor);
@@ -65,7 +66,6 @@ class SlashForDocComments extends LintRule implements NodeLintRule {
     registry.addFunctionDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
     registry.addGenericTypeAlias(this, visitor);
-    registry.addLibraryDirective(this, visitor);
     registry.addMethodDeclaration(this, visitor);
     registry.addMixinDeclaration(this, visitor);
     registry.addTopLevelVariableDeclaration(this, visitor);
@@ -91,6 +91,14 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitClassTypeAlias(ClassTypeAlias node) {
     checkComment(node.documentationComment);
+  }
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    var directives = node.directives;
+    if (directives.isNotEmpty) {
+      checkComment(directives[0].documentationComment);
+    }
   }
 
   @override
@@ -130,11 +138,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitGenericTypeAlias(GenericTypeAlias node) {
-    checkComment(node.documentationComment);
-  }
-
-  @override
-  void visitLibraryDirective(LibraryDirective node) {
     checkComment(node.documentationComment);
   }
 

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';

--- a/test/rules/slash_for_doc_comments.dart
+++ b/test/rules/slash_for_doc_comments.dart
@@ -20,7 +20,10 @@ class B {
   var x;
 
   /** y */ //LINT
-  y() => null;
+  y() {
+    /** l */ //LINT
+    void l() {}
+  }
 }
 
 /** G */ //LINT

--- a/test/rules/slash_for_doc_comments.dart
+++ b/test/rules/slash_for_doc_comments.dart
@@ -45,6 +45,12 @@ var D = String;
 /** Z */ //LINT
 class Z = B with C;
 
+/** M1 */ //LINT
+mixin M1 {}
+
+/* meh */ //OK
+mixin M2 {}
+
 /** Ext */ //LINT
 extension Ext on Object {
   /** e */ // LINT

--- a/test/rules/slash_for_doc_comments.dart
+++ b/test/rules/slash_for_doc_comments.dart
@@ -33,6 +33,9 @@ enum G {
 /** f */ //LINT
 typedef bool F();
 
+/** f */ //LINT
+typedef F2 = bool Function();
+
 /** z */ //LINT
 z() => null;
 


### PR DESCRIPTION
This lint was not checking the doc comments on mixins. It was updated for extensions, but mixins were missed.

It seems unlikely that it will create problems when rolling into Flutter, but I haven't verified that. If you think we should hold off until that's been checked I'm happy to wait.