### PR TITLE
0.1.107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.107
+
+* miscellaneous doc cleanup (typos, etc)
+* new lint: `avoid_redundant_argument_values`
+* updated `slash_for_doc_comments` to check mixin declarations
+* (internal) updates to use new `LinterContext.evaluateConstant` API
+* improved docs for `always_require_non_null_named_parameters`
+
 # 0.1.106
 
 * improved docs for `comment_references`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.106';
+const String version = '0.1.107';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.106
+version: 0.1.107
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.107

* miscellaneous doc cleanup (typos, etc)
* new lint: `avoid_redundant_argument_values`
* updated `slash_for_doc_comments` to check mixin declarations
* (internal) updates to use new `LinterContext.evaluateConstant` API
* improved docs for `always_require_non_null_named_parameters`

/cc @bwilkerson 
