### PR TITLE
Update always_put_required_parameters_first for nnbd

### DIFF
--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -51,7 +51,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitFormalParameterList(FormalParameterList node) {
     var nonRequiredSeen = false;
     for (var param in node.parameters.where((p) => p.isNamed)) {
-      if (param.declaredElement.hasRequired) {
+      var element = param.declaredElement;
+      if (element.hasRequired || element.isRequiredNamed) {
         if (nonRequiredSeen) {
           rule.reportLintForToken(param.identifier.token);
         }


### PR DESCRIPTION
I believe that this rule needs to be updated to recognize the to-be-added `required` keyword as a way of marking parameters as being required.