### PR TITLE
Recommend using runtimeType in hash_and_equals

### DIFF
--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -39,7 +39,10 @@ class Better {
   Better(this.value);
 
   @override
-  bool operator ==(Object other) => other is Better && other.value == value;
+  bool operator ==(Object other) =>
+      other is Better &&
+      other.runtimeType == runtimeType &&
+      other.value == value;
 
   @override
   int get hashCode => value.hashCode;


### PR DESCRIPTION
### Description
> Using `is` in `operator ==` is usually wrong as it makes the `==` operator asymmetric.
https://github.com/dart-lang/sdk/issues/36004#issuecomment-557958476

I based my early `==` overrides on the `hash_and_equals` docs, so I'm sure others have done the same