### PR TITLE
Improve unrelated type logic

### DIFF
--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -411,8 +411,12 @@ class DartTypeUtilities {
         // Otherwise, they might be related.
         return false;
       } else {
-        return leftElement.supertype?.isObject == true ||
-            leftElement.supertype != rightElement.supertype;
+        return [leftElement, rightElement].every((element) {
+          var eqClass = element
+              .lookUpConcreteMethod('==', element.library)
+              .enclosingElement;
+          return eqClass is ClassElement && eqClass.isDartCoreObject;
+        });
       }
     } else if (leftType is TypeParameterType &&
         rightType is TypeParameterType) {

--- a/test/rules/iterable_contains_unrelated_type.dart
+++ b/test/rules/iterable_contains_unrelated_type.dart
@@ -68,7 +68,7 @@ void someFunction7_1() {
 void someFunction8() {
   List<DerivedClass2> list = <DerivedClass2>[];
   DerivedClass3 instance;
-  if (list.contains(instance)) print('someFunction8'); // OK
+  if (list.contains(instance)) print('someFunction8'); // LINT
 }
 
 void someFunction9() {
@@ -182,4 +182,30 @@ abstract class MyIterableMixedClass extends Object
     implements Iterable<int> {
   bool myConcreteBadMethod(String thing) => this.contains(thing); // LINT
   bool myConcreteBadMethod1(String thing) => contains(thing); // LINT
+}
+
+abstract class MixinEq {
+  @override
+  operator ==(Object o) => false;
+}
+
+class DerivedClass6 extends ClassBase with MixinEq {}
+
+class DerivedClass7 extends ClassBase implements MixinEq {}
+
+class DerivedClass8 extends ClassBase {
+  @override
+  operator ==(Object o) => false;
+}
+
+void removeEqMixin(Iterable<DerivedClass2> list, DerivedClass6 o) {
+  list.contains(o); // OK
+}
+
+void removeEqImplements(Iterable<DerivedClass2> list, DerivedClass7 o) {
+  list.contains(o); // LINT
+}
+
+void removeEq(Iterable<DerivedClass8> list, ClassBase o) {
+  list.contains(o); // OK
 }

--- a/test/rules/list_remove_unrelated_type.dart
+++ b/test/rules/list_remove_unrelated_type.dart
@@ -68,7 +68,7 @@ void someFunction7_1() {
 void someFunction8() {
   List<DerivedClass2> list = <DerivedClass2>[];
   DerivedClass3 instance;
-  if (list.remove(instance)) print('someFunction8'); // OK
+  if (list.remove(instance)) print('someFunction8'); // LINT
 }
 
 void someFunction9() {
@@ -171,4 +171,30 @@ abstract class MyListMixedClass extends Object
     implements List<int> {
   bool myConcreteBadMethod(String thing) => this.remove(thing); // LINT
   bool myConcreteBadMethod1(String thing) => remove(thing); // LINT
+}
+
+abstract class MixinEq {
+  @override
+  operator ==(Object o) => false;
+}
+
+class DerivedClass6 extends ClassBase with MixinEq {}
+
+class DerivedClass7 extends ClassBase implements MixinEq {}
+
+class DerivedClass8 extends ClassBase {
+  @override
+  operator ==(Object o) => false;
+}
+
+void removeEqMixin(List<DerivedClass2> list, DerivedClass6 o) {
+  list.remove(o); // OK
+}
+
+void removeEqImplements(List<DerivedClass2> list, DerivedClass7 o) {
+  list.remove(o); // LINT
+}
+
+void removeEq(List<DerivedClass8> list, ClassBase o) {
+  list.remove(o); // OK
 }

--- a/test/rules/unrelated_type_equality_checks.dart
+++ b/test/rules/unrelated_type_equality_checks.dart
@@ -89,7 +89,7 @@ void someFunction12(Mixin instance) {
 void someFunction13(DerivedClass2 instance) {
   var other = new DerivedClass3();
 
-  if (other == instance) print('someFunction13'); // OK
+  if (other == instance) print('someFunction13'); // LINT
 }
 
 void someFunction14(DerivedClass4 instance) {


### PR DESCRIPTION
If two types are compared where the two types inherit `==` from `Object`, it will trigger unrelated type lints unrelated_type_equality_checks, iterable_contains_unrelated_type and list_remove_unrelated_type.

Fixes #1899 (partially - the rule description could still use improvement)