### PR TITLE
Improve prefer_single_quotes message.

### DIFF
--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -8,8 +8,7 @@ import 'package:meta/meta.dart';
 
 import '../analyzer.dart';
 
-const _desc =
-    r"Only use double quotes for strings containing single quotes.";
+const _desc = r'Only use double quotes for strings containing single quotes.';
 
 const _details = '''
 

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 import '../analyzer.dart';
 
 const _desc =
-    r"Prefer single quotes where they won't require escape sequences.";
+    r"Only use double quotes for strings containing single quotes.";
 
 const _details = '''
 


### PR DESCRIPTION
Fixes #1954 

Changed slightly from the text on the issue, which was

`Only use double quotes if the string contains single quotes.`

in this PR I use

`Only use double quotes for strings containing single quotes.`

but, happy to tweak it either way :)

Thanks.