### PR TITLE
0.1.109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.109
+
+* improved`prefer_single_quotes` lint message
+* `unnecessary_finals` fixed to not flag fields
+* `unnecessary_lambdas` fixed to work with type arguments
+* (internal) migrated to use analyzer `LinterContext.resolveNameInScope()` API
+
 # 0.1.108
 
 * fixes to `avoid_redundant_argument_values`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.108';
+const String version = '0.1.109';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.108
+version: 0.1.109
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.109

* improved`prefer_single_quotes` lint message
* `unnecessary_finals` fixed to not flag fields
* `unnecessary_lambdas` fixed to work with type arguments
* (internal) migrated to use analyzer `LinterContext.resolveNameInScope()` API

/cc @bwilkerson 