### PR TITLE
Allow unused parameters when they are deprecated

### DIFF
--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -55,7 +55,9 @@ class _ConstructorVisitor extends RecursiveAstVisitor {
 
   _ConstructorVisitor(this.rule, this.element)
       : unusedParameters = element.parameters.parameters
-            .where((p) => p.declaredElement is! FieldFormalParameterElement)
+            .where((p) =>
+                p.declaredElement is! FieldFormalParameterElement &&
+                !p.declaredElement.hasDeprecated)
             .toSet();
 
   @override

--- a/test/rules/avoid_unused_constructor_parameters.dart
+++ b/test/rules/avoid_unused_constructor_parameters.dart
@@ -96,3 +96,7 @@ class N {
   external N(int n); // OK
   external factory N.named(int n); // OK
 }
+
+class O {
+  O(@Deprecated('') int x); // OK because the parameter is deprecated
+}


### PR DESCRIPTION
The rule `avoid_unused_constructor_parameters` should not produce a lint for parameters that are deprecated because it's appropriate that they are not referenced.