### PR TITLE
unnecessary_string_interpolations

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -149,6 +149,7 @@ linter:
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_statements
+    - unnecessary_string_interpolations
     - unnecessary_this
     - unrelated_type_equality_checks
     - unsafe_html

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -152,6 +152,7 @@ import 'rules/unnecessary_null_in_if_null_operators.dart';
 import 'rules/unnecessary_overrides.dart';
 import 'rules/unnecessary_parenthesis.dart';
 import 'rules/unnecessary_statements.dart';
+import 'rules/unnecessary_string_interpolations.dart';
 import 'rules/unnecessary_this.dart';
 import 'rules/unrelated_type_equality_checks.dart';
 import 'rules/unsafe_html.dart';
@@ -319,6 +320,7 @@ void registerLintRules() {
     ..register(UnnecessaryOverrides())
     ..register(UnnecessaryParenthesis())
     ..register(UnnecessaryStatements())
+    ..register(UnnecessaryStringInterpolations())
     ..register(UnnecessaryThis())
     ..register(UnrelatedTypeEqualityChecks())
     ..register(UnsafeHtml())

--- a/lib/src/rules/unnecessary_string_interpolations.dart
+++ b/lib/src/rules/unnecessary_string_interpolations.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Unnecessary string interpolation.';
+
+const _details = r'''
+
+Don't use string interpolation if there's only a string expression in it.
+
+**BAD:**
+```
+String message;
+String o = '$message';
+```
+
+**GOOD:**
+```
+String message;
+String o = message;
+```
+
+''';
+
+class UnnecessaryStringInterpolations extends LintRule implements NodeLintRule {
+  UnnecessaryStringInterpolations()
+      : super(
+            name: 'unnecessary_string_interpolations',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = _Visitor(this);
+    registry.addStringInterpolation(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitStringInterpolation(StringInterpolation node) {
+    if (node.parent is AdjacentStrings) return;
+    if (node.elements.length == 3) {
+      final start = node.elements[0] as InterpolationString;
+      final interpolation = node.elements[1] as InterpolationExpression;
+      final end = node.elements[2] as InterpolationString;
+      if (start.value.isEmpty && end.value.isEmpty) {
+        if (interpolation.expression.staticType.isDartCoreString) {
+          rule.reportLint(node);
+        }
+      }
+    }
+  }
+}

--- a/test/rules/unnecessary_string_interpolations.dart
+++ b/test/rules/unnecessary_string_interpolations.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N unnecessary_string_interpolations`
+
+String o;
+
+f() {
+  o = '$o'; // LINT
+  o = '''$o'''; // LINT
+  o = '${o}'; // LINT
+  o = '${o.substring(1)}'; // LINT
+  o = '${o.length}'; // OK
+  o = 'a$o'; // OK
+  o = '''a$o'''; // OK
+  o = 'a' '$o'; // OK
+}


### PR DESCRIPTION
# Description

This lint catches `'$stringExpresion'` ; it can be replaced by `stringExpression` directly (modulo null handling)