### PR TITLE
0.1.110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.110
+
+* fixed flutter web plugin detection in `avoid_web_libraries_in_flutter`
+* new lint: `unnecessary_string_interpolations`
+* new lint: `missing_whitespace_between_adjacent_strings`
+* `avoid_unused_constructor_parameters` updated to ignore deprecated parameters
+* new lint: `no_runtimeType_toString`
+* miscellaneous doc fixes
+
 # 0.1.109
 
 * improved`prefer_single_quotes` lint message

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.109';
+const String version = '0.1.110';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.109
+version: 0.1.110
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.110

* fixed flutter web plugin detection in `avoid_web_libraries_in_flutter`
* new lint: `unnecessary_string_interpolations`
* new lint: `missing_whitespace_between_adjacent_strings`
* `avoid_unused_constructor_parameters` updated to ignore deprecated parameters
* new lint: `no_runtimeType_toString`
* miscellaneous doc fixes


/cc @bwilkerson 
