### PR TITLE
unnecessary_raw_strings

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -149,6 +149,7 @@ linter:
     - unnecessary_null_in_if_null_operators
     - unnecessary_overrides
     - unnecessary_parenthesis
+    - unnecessary_raw_strings
     - unnecessary_statements
     - unnecessary_string_interpolations
     - unnecessary_this

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -152,6 +152,7 @@ import 'rules/unnecessary_null_aware_assignments.dart';
 import 'rules/unnecessary_null_in_if_null_operators.dart';
 import 'rules/unnecessary_overrides.dart';
 import 'rules/unnecessary_parenthesis.dart';
+import 'rules/unnecessary_raw_strings.dart';
 import 'rules/unnecessary_statements.dart';
 import 'rules/unnecessary_string_interpolations.dart';
 import 'rules/unnecessary_this.dart';
@@ -322,6 +323,7 @@ void registerLintRules() {
     ..register(UnnecessaryLambdas())
     ..register(UnnecessaryOverrides())
     ..register(UnnecessaryParenthesis())
+    ..register(UnnecessaryRawStrings())
     ..register(UnnecessaryStatements())
     ..register(UnnecessaryStringInterpolations())
     ..register(UnnecessaryThis())

--- a/lib/src/rules/unnecessary_raw_strings.dart
+++ b/lib/src/rules/unnecessary_raw_strings.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Unnecessary raw string.';
+
+const _details = r'''
+
+Use raw string only when needed.
+
+**BAD:**
+```
+var s1 = r'a';
+```
+
+**GOOD:**
+```
+var s1 = 'a';
+var s2 = r'$a';
+var s3 = r'\a';
+```
+
+''';
+
+class UnnecessaryRawStrings extends LintRule implements NodeLintRule {
+  UnnecessaryRawStrings()
+      : super(
+            name: 'unnecessary_raw_strings',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = _Visitor(this);
+    registry.addSimpleStringLiteral(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitSimpleStringLiteral(SimpleStringLiteral node) {
+    if (node.isRaw && ![r'\', r'$'].any(node.literal.lexeme.contains)) {
+      rule.reportLint(node);
+    }
+  }
+}

--- a/test/rules/unnecessary_raw_strings.dart
+++ b/test/rules/unnecessary_raw_strings.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N unnecessary_raw_strings`
+
+f(o) {
+  f(r'a b c d');// LINT
+  f(r"a b c d");// LINT
+  f(r'''a b c d''');// LINT
+  f(r"""a b c d""");// LINT
+  // with \
+  f(r'a b c\d');// OK
+  f(r"a b c\d");// OK
+  f(r'''a b c\d''');// OK
+  f(r"""a b c\d""");// OK
+  // with $
+  f(r'a b c$d');// OK
+  f(r"a b c$d");// OK
+  f(r'''a b c$d''');// OK
+  f(r"""a b c$d""");// OK
+}


### PR DESCRIPTION
# Description

Use raw string only when needed.

**BAD:**
```
var s1 = r'a';
```

**GOOD:**
```
var s1 = 'a';
var s2 = r'$a';
var s3 = r'\a';
```
