### PR TITLE
rename unnecessary_escapes_in_string to unnecessary_string_escapes

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -140,7 +140,6 @@ linter:
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
-    - unnecessary_escapes_in_string
     - unnecessary_final
     - unnecessary_getters_setters
     - unnecessary_lambdas
@@ -150,6 +149,7 @@ linter:
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_statements
+    - unnecessary_string_escapes
     - unnecessary_string_interpolations
     - unnecessary_this
     - unrelated_type_equality_checks

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -143,7 +143,6 @@ import 'rules/unawaited_futures.dart';
 import 'rules/unnecessary_await_in_return.dart';
 import 'rules/unnecessary_brace_in_string_interps.dart';
 import 'rules/unnecessary_const.dart';
-import 'rules/unnecessary_escapes_in_string.dart';
 import 'rules/unnecessary_final.dart';
 import 'rules/unnecessary_getters_setters.dart';
 import 'rules/unnecessary_lambdas.dart';
@@ -153,6 +152,7 @@ import 'rules/unnecessary_null_in_if_null_operators.dart';
 import 'rules/unnecessary_overrides.dart';
 import 'rules/unnecessary_parenthesis.dart';
 import 'rules/unnecessary_statements.dart';
+import 'rules/unnecessary_string_escapes.dart';
 import 'rules/unnecessary_string_interpolations.dart';
 import 'rules/unnecessary_this.dart';
 import 'rules/unrelated_type_equality_checks.dart';
@@ -311,7 +311,6 @@ void registerLintRules() {
     ..register(UnnecessaryAwaitInReturn())
     ..register(UnnecessaryBraceInStringInterps())
     ..register(UnnecessaryConst())
-    ..register(UnnecessaryEscapesInString())
     ..register(UnnecessaryFinal())
     ..register(UnnecessaryNew())
     ..register(UnnecessaryNullAwareAssignments())
@@ -323,6 +322,7 @@ void registerLintRules() {
     ..register(UnnecessaryOverrides())
     ..register(UnnecessaryParenthesis())
     ..register(UnnecessaryStatements())
+    ..register(UnnecessaryStringEscapes())
     ..register(UnnecessaryStringInterpolations())
     ..register(UnnecessaryThis())
     ..register(UnrelatedTypeEqualityChecks())

--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -29,10 +29,10 @@ Remove unnecessary backslashes in strings.
 
 ''';
 
-class UnnecessaryEscapesInString extends LintRule implements NodeLintRule {
-  UnnecessaryEscapesInString()
+class UnnecessaryStringEscapes extends LintRule implements NodeLintRule {
+  UnnecessaryStringEscapes()
       : super(
-            name: 'unnecessary_escapes_in_string',
+            name: 'unnecessary_string_escapes',
             description: _desc,
             details: _details,
             group: Group.style);

--- a/test/rules/unnecessary_string_escapes.dart
+++ b/test/rules/unnecessary_string_escapes.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// test w/ `pub run test -N unnecessary_escapes_in_string`
+// test w/ `pub run test -N unnecessary_string_escapes`
 
 f(o){
   f("\'");// LINT


### PR DESCRIPTION
According to https://github.com/dart-lang/linter/issues/2002#issuecomment-588253987 this PR rename `unnecessary_escapes_in_string` to `unnecessary_string_escapes`.