### PR TITLE
allow LINT to reference a relative line

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/dart-lang/linter
 documentation: https://dart-lang.github.io/linter/lints
 
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   analyzer: ^0.39.3

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -247,9 +247,8 @@ void testRule(String ruleName, File file,
 
     var lineNumber = 1;
     for (var line in file.readAsLinesSync()) {
-      var annotation = extractAnnotation(line);
+      var annotation = extractAnnotation(lineNumber, line);
       if (annotation != null) {
-        annotation.lineNumber = lineNumber;
         expected.add(AnnotationMatcher(annotation));
       }
       ++lineNumber;

--- a/test/util/annotation_test.dart
+++ b/test/util/annotation_test.dart
@@ -10,22 +10,37 @@ import 'annotation_matcher.dart';
 
 void main() {
   test('extraction', () {
-    expect(extractAnnotation('int x; // LINT [1:3]'), isNotNull);
-    expect(extractAnnotation('int x; //LINT'), isNotNull);
-    expect(extractAnnotation('int x; // OK'), isNull);
-    expect(extractAnnotation('int x;'), isNull);
-    expect(extractAnnotation('dynamic x; // LINT dynamic is bad').message,
+    expect(extractAnnotation(1, 'int x; // LINT [1:3]'), isNotNull);
+    expect(extractAnnotation(1, 'int x; //LINT'), isNotNull);
+    expect(extractAnnotation(1, 'int x; // OK'), isNull);
+    expect(extractAnnotation(1, 'int x;'), isNull);
+    expect(extractAnnotation(1, 'dynamic x; // LINT dynamic is bad').message,
         'dynamic is bad');
-    expect(extractAnnotation('dynamic x; // LINT [1:3] dynamic is bad').message,
+    expect(extractAnnotation(1, 'dynamic x; // LINT dynamic is bad').lineNumber,
+        1);
+    expect(
+        extractAnnotation(1, 'dynamic x; // LINT [1:3] dynamic is bad').message,
         'dynamic is bad');
     expect(
-        extractAnnotation('dynamic x; // LINT [1:3] dynamic is bad').column, 1);
+        extractAnnotation(1, 'dynamic x; // LINT [1:3] dynamic is bad').column,
+        1);
     expect(
-        extractAnnotation('dynamic x; // LINT [1:3] dynamic is bad').length, 3);
-    expect(extractAnnotation('dynamic x; //LINT').message, isNull);
-    expect(extractAnnotation('dynamic x; //LINT ').message, isNull);
+        extractAnnotation(1, 'dynamic x; // LINT [1:3] dynamic is bad').length,
+        3);
+    expect(extractAnnotation(1, 'dynamic x; //LINT').message, isNull);
+    expect(extractAnnotation(1, 'dynamic x; //LINT ').message, isNull);
     // Commented out lines shouldn't get linted.
-    expect(extractAnnotation('// dynamic x; //LINT '), isNull);
+    expect(extractAnnotation(1, '// dynamic x; //LINT '), isNull);
+    expect(extractAnnotation(1, 'int x; // LINT [2:3]').lineNumber, 1);
+    expect(extractAnnotation(1, 'int x; // LINT [2:3]').column, 2);
+    expect(extractAnnotation(1, 'int x; // LINT [2:3]').length, 3);
+    expect(extractAnnotation(1, 'int x; // LINT [+2]').lineNumber, 3);
+    expect(extractAnnotation(1, 'int x; // LINT [+2]').column, isNull);
+    expect(extractAnnotation(1, 'int x; // LINT [+2]').length, isNull);
+    expect(extractAnnotation(1, 'int x; // LINT [+2,4:5]').lineNumber, 3);
+    expect(extractAnnotation(1, 'int x; // LINT [+2,4:5]').column, 4);
+    expect(extractAnnotation(1, 'int x; // LINT [+2,4:5]').length, 5);
+    expect(extractAnnotation(10, 'int x; // LINT [-2]').lineNumber, 8);
   });
 
   test('equality', () {


### PR DESCRIPTION
This PR allow to mark lints in test file on another line:

```dart
// LINT [+1] lint on the following line
var x = y;
// LINT [+3] lint 3 lines after this line
var x = '''


''';

var x = y;
// LINT [-1] lint on the above line
```

The previous pattern `// LINT [column:length] message` still works and you can combine them with `// LINT [lineDelta,column:length] message`