### PR TITLE
0.1.111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.111
+
+* new lint: `unnecessary_raw_strings`
+* new lint: `avoid_escaping_inner_quotes`
+* new lint: `unecessary_string_escapes`
+* incompatible rule documentation improvements
+
 # 0.1.110
 
 * fixed flutter web plugin detection in `avoid_web_libraries_in_flutter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * new lint: `unnecessary_raw_strings`
 * new lint: `avoid_escaping_inner_quotes`
-* new lint: `unecessary_string_escapes`
+* new lint: `unnecessary_string_escapes`
 * incompatible rule documentation improvements
 
 # 0.1.110

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.110';
+const String version = '0.1.111';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.110
+version: 0.1.111
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.111

* new lint: `unnecessary_raw_strings`
* new lint: `avoid_escaping_inner_quotes`
* new lint: `unnecessary_string_escapes`
* incompatible rule documentation improvements


/cc @bwilkerson 
