### PR TITLE
0.1.111+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 0.1.111
+# 0.1.111+1
 
+* new lint: `use_raw_strings`
 * new lint: `unnecessary_raw_strings`
 * new lint: `avoid_escaping_inner_quotes`
 * new lint: `unnecessary_string_escapes`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.111';
+const String version = '0.1.111+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.111
+version: 0.1.111+1
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.111+1

* new lint: `use_raw_strings`
* new lint: `unnecessary_raw_strings`
* new lint: `avoid_escaping_inner_quotes`
* new lint: `unnecessary_string_escapes`
* incompatible rule documentation improvements

---

(sorry: missed doc of `use_raw_strings`)

/cc @bwilkerson 