### PR TITLE
0.1.112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.112
+
+* marked `prefer_typing_uninitialized_variables` and `omit_local_variable_types` as compatible
+
 # 0.1.111+1
 
 * new lint: `use_raw_strings`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.111+1';
+const String version = '0.1.112';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.111+1
+version: 0.1.112
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.112

* marked `prefer_typing_uninitialized_variables` and `omit_local_variable_types` as compatible

/cc @bwilkerson 
