### PR TITLE
ignore unnec. getter/setter if deprecated

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -87,6 +87,10 @@ bool inPrivateMember(AstNode node) {
   return false;
 }
 
+/// Returns `true` if the given [declaration] is annotated `@deprecated`.
+bool isDeprecated(Declaration declaration) =>
+    declaration.declaredElement.hasDeprecated;
+
 /// Returns `true` if this element is the `==` method declaration.
 bool isEquals(ClassMember element) =>
     element is MethodDeclaration && element.name?.name == '==';
@@ -329,6 +333,7 @@ typedef ElementProcessor = bool Function(Element element);
 /// A [GeneralizingElementVisitor] adapter for [ElementProcessor].
 class _ElementVisitorAdapter extends GeneralizingElementVisitor {
   final ElementProcessor processor;
+
   _ElementVisitorAdapter(this.processor);
 
   @override

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -97,7 +97,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (isSimpleSetter(setter) &&
         isSimpleGetter(getter) &&
         !isProtected(getter) &&
-        !isProtected(setter)) {
+        !isProtected(setter) &&
+        !isDeprecated(getter) &&
+        !isDeprecated(setter)) {
       rule..reportLint(getter.name)..reportLint(setter.name);
     }
   }

--- a/test/rules/unnecessary_getters_setters.dart
+++ b/test/rules/unnecessary_getters_setters.dart
@@ -51,8 +51,16 @@ class Box5 {
   var _contents;
   @protected
   get contents => _contents; //OK (protected)
-  set contents(value)
-  {
+  set contents(value) {
+    _contents = value;
+  }
+}
+
+class Box6 {
+  var _contents;
+  @Deprecated('blah')
+  get contents => _contents; //OK (deprecated)
+  set contents(value) {
     _contents = value;
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/linter/issues/1992

/cc @bwilkerson 

/fyi @srawlins 
