### PR TITLE
0.1.113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.113
+
+* updated documentation links
+* `one_member_abstracts` updated to not lint classes with mixins or implementing interfaces
+* `unnecessary_getters_setters` fixed to ignore cases where a getter/setter is deprecated
+* new lint: `leading_newlines_in_multiline_strings`
+* improved highlight ranges for `avoid_private_typedef_functions` and `avoid_returning_null_for_future`
+
 # 0.1.112
 
 * marked `prefer_typing_uninitialized_variables` and `omit_local_variable_types` as compatible

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.112';
+const String version = '0.1.113';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.112
+version: 0.1.113
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.113

* updated documentation links
* `one_member_abstracts` updated to not lint classes with mixins or implementing interfaces
* `unnecessary_getters_setters` fixed to ignore cases where a getter/setter is deprecated
* new lint: `leading_newlines_in_multiline_strings`
* improved highlight ranges for `avoid_private_typedef_functions` and `avoid_returning_null_for_future`

/cc @bwilkerson 
