### PR TITLE
allow underscores for constructor names

### DIFF
--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -71,7 +71,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
-    checkIdentifier(node.name);
+    // For rationale on accepting underscores, see:
+    // https://github.com/dart-lang/linter/issues/1854
+    checkIdentifier(node.name, underscoresOk: true);
   }
 
   @override

--- a/test/rules/non_constant_identifier_names.dart
+++ b/test/rules/non_constant_identifier_names.dart
@@ -25,13 +25,16 @@ abstract class A {
   A(this.bar_bar); //OK
   A.N(this.bar_bar); //OK
   A.Named(this.bar_bar); //LINT
-  factory A.Named2(a) = A; //LINT
+  factory A.Named2(String a) = A; //LINT
   A._Named(this.bar_bar); //LINT
   A.named_bar(this.bar_bar); //LINT
   A.namedBar(this.bar_bar); //OK
   A._N(this.bar_bar); //LINT
   A._named(this.bar_bar); //OK
   A.$Named(this.bar_bar); //OK
+  A._(this.bar_bar); //OK
+  A.__(this.bar_bar); //OK
+  A.___(this.bar_bar); //OK
 
   String foo_bar(); //LINT
 


### PR DESCRIPTION
Fixes: #1854 

/cc @bwilkerson 