### PR TITLE
support mixins and extensions in `avoid_shadowing_type_parameters`

### DIFF
--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -87,7 +87,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     var parent = node.parent;
 
     while (parent != null) {
-      if (parent is ClassDeclaration) {
+      if (parent is ClassOrMixinDeclaration) {
+        _checkForShadowing(typeParameters, parent.typeParameters);
+      } else if (parent is ExtensionDeclaration) {
         _checkForShadowing(typeParameters, parent.typeParameters);
       } else if (parent is MethodDeclaration) {
         _checkForShadowing(typeParameters, parent.typeParameters);

--- a/test/rules/avoid_shadowing_type_parameters.dart
+++ b/test/rules/avoid_shadowing_type_parameters.dart
@@ -18,6 +18,18 @@ class A<T> {
   static void fn1<T>() {} // OK
 }
 
+extension Ext<T> on A<T> {
+  void fn2<T>() {} // LINT
+  void fn3<U>() {} // OK
+  void fn4<V>() {} // OK
+}
+
+mixin M<T> {
+  void fn1<T>() {} // LINT
+  void fn2<U>() {} // OK
+  void fn3<V>() {} // OK
+}
+
 class B<T> {
   void fn1<T>() {} // LINT
   void fn2<U>() {} // OK


### PR DESCRIPTION
Fixes #2033

/cc @bwilkerson @srawlins 


