### PR TITLE
0.1.114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.114
+
+* fixed `avoid_shadowing_type_parameters` to support extensions and mixins
+* updated `non_constant_identifier_names` to allow named constructors made up of only underscores (`_`)
+* updated `avoid_unused_constructor_parameters` to ignore unused params named in all underscores (`_`)
+
 # 0.1.113
 
 * updated documentation links

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.113';
+const String version = '0.1.114';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.113
+version: 0.1.114
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.114

* fixed `avoid_shadowing_type_parameters` to support extensions and mixins
* updated `non_constant_identifier_names` to allow named constructors made up of only underscores (`_`)
* updated `avoid_unused_constructor_parameters` to ignore unused params named in all underscores (`_`)

/cc @bwilkerson 
