### PR TITLE
Fix sort_child_properties_last example

### DIFF
--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -36,6 +36,7 @@ return Scaffold(
       ],
       mainAxisAlignment: MainAxisAlignment.center,
     ),
+    widthFactor: 0.5,
   ),
   floatingActionButton: FloatingActionButton(
     child: Icon(Icons.add),
@@ -52,6 +53,7 @@ return Scaffold(
     title: Text(widget.title),
   ),
   body: Center(
+    widthFactor: 0.5,
     child: Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[

--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -36,11 +36,11 @@ return Scaffold(
       ],
       mainAxisAlignment: MainAxisAlignment.center,
     ),
-    floatingActionButton: FloatingActionButton(
-      child: Icon(Icons.add),
-      onPressed: _incrementCounter,
-      tooltip: 'Increment',
-    ),
+  ),
+  floatingActionButton: FloatingActionButton(
+    child: Icon(Icons.add),
+    onPressed: _incrementCounter,
+    tooltip: 'Increment',
   ),
 );
 ```
@@ -52,11 +52,6 @@ return Scaffold(
     title: Text(widget.title),
   ),
   body: Center(
-    floatingActionButton: FloatingActionButton(
-      onPressed: _incrementCounter,
-      tooltip: 'Increment',
-      child: Icon(Icons.add),
-    ),
     child: Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
@@ -69,6 +64,11 @@ return Scaffold(
          ),
       ],
     ),
+  ),
+  floatingActionButton: FloatingActionButton(
+    onPressed: _incrementCounter,
+    tooltip: 'Increment',
+    child: Icon(Icons.add),
   ),
 );
 ```

--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -52,8 +52,13 @@ return Scaffold(
     title: Text(widget.title),
   ),
   body: Center(
-    mainAxisAlignment: MainAxisAlignment.center,
+    floatingActionButton: FloatingActionButton(
+      onPressed: _incrementCounter,
+      tooltip: 'Increment',
+      child: Icon(Icons.add),
+    ),
     child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         Text(
           'You have pushed the button this many times:',
@@ -63,11 +68,6 @@ return Scaffold(
           style: Theme.of(context).textTheme.display1,
          ),
       ],
-    ),
-    floatingActionButton: FloatingActionButton(
-      onPressed: _incrementCounter,
-      tooltip: 'Increment',
-      child: Icon(Icons.add),
     ),
   ),
 );


### PR DESCRIPTION
The GOOD example both violated the lint and did not correspond to the same layout as the BAD example. This makes the GOOD example match the existing BAD example, and moves the floatingActionButton above child so that it passes the lint.
