### PR TITLE
0.1.115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.115
+
+* updated `avoid_types_as_parameter_names` to check catch-clauses
+* fixed `unsafe_html` to check attributes and methods on extensions
+* extended `unsafe_html` to include `Window.open`, `Element.html` and `DocumentFragment.html` in unsafe API checks
+* improved docs for `sort_child_properties_last`
+* (internal) `package:analyzer` API updates
+* new lint: `sized_box_for_whitespace`
+
 # 0.1.114
 
 * fixed `avoid_shadowing_type_parameters` to support extensions and mixins

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.114';
+const String version = '0.1.115';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.114
+version: 0.1.115
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.115

* updated `avoid_types_as_parameter_names` to check catch-clauses
* fixed `unsafe_html` to check attributes and methods on extensions
* extended `unsafe_html` to include `Window.open`, `Element.html` and `DocumentFragment.html` in unsafe API checks
* improved docs for `sort_child_properties_last`
* (internal) `package:analyzer` API updates
* new lint: `sized_box_for_whitespace`

/cc @bwilkerson 

/fyi @srawlins @a14n 