### PR TITLE
Revert "Use LinterContext.resolveNameInScope() for avoid_types_as_par…

### DIFF
--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 
@@ -37,7 +36,7 @@ class AvoidTypesAsParameterNames extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    final visitor = _Visitor(this);
     registry.addFormalParameterList(this, visitor);
     registry.addCatchClause(this, visitor);
   }
@@ -45,14 +44,21 @@ class AvoidTypesAsParameterNames extends LintRule implements NodeLintRule {
 
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
-  final LinterContext context;
 
-  _Visitor(this.rule, this.context);
+  _Visitor(this.rule);
+
+  bool isTypeName(String name) =>
+      // TODO(a14n) test that parameter name matches a existing type. No api to do
+      // that for now.
+      // todo (pq): consider adding a lookup method to LinterContext.
+      name != null &&
+      (name.startsWith(RegExp('[A-Z]')) ||
+          ['num', 'int', 'double', 'bool', 'dynamic'].contains(name));
 
   @override
   void visitCatchClause(CatchClause node) {
     final parameter = node.exceptionParameter;
-    if (parameter != null && _isTypeName(node, parameter)) {
+    if (parameter != null && isTypeName(parameter.name)) {
       rule.reportLint(parameter);
     }
   }
@@ -63,18 +69,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     for (final parameter in node.parameters) {
       if (parameter.declaredElement.hasImplicitType &&
-          _isTypeName(node, parameter.identifier)) {
+          isTypeName(parameter.identifier.name)) {
         rule.reportLint(parameter.identifier);
       }
     }
-  }
-
-  bool _isTypeName(AstNode scope, SimpleIdentifier node) {
-    final result = context.resolveNameInScope(node.name, false, scope);
-    if (result.isRequestedName) {
-      final element = result.element;
-      return element is ClassElement || element is FunctionTypeAliasElement;
-    }
-    return false;
   }
 }

--- a/test/rules/avoid_types_as_parameter_names.dart
+++ b/test/rules/avoid_types_as_parameter_names.dart
@@ -28,7 +28,7 @@ typedef void f5(
   bool, // LINT
 ]);
 typedef f6 = int Function(int); // OK
-typedef void f7(Undefined); // OK
+typedef void f7(Undefined); // LINT
 
 m1(f()) => null; // OK
 m2(f(int a)) => null; // OK
@@ -36,9 +36,6 @@ m3(f(int)) => null; // LINT
 m4(f(num a, {int})) => null; // LINT
 m5(f(double a, [bool])) => null; // LINT
 m6(int Function(int) f)=> null; // OK
-m7(f(Undefined)) => null; // OK
-m8(f6) => null; // LINT
-m9(f7) => null; // LINT
-m10(m1) => null; // OK
+m7(f(Undefined)) => null; // LINT
 
 final void Function(Object, [StackTrace]) onError = null; // OK


### PR DESCRIPTION
This reverts commit 7e67d966467eaa705f77e7ea120fa2c790b7beeb.

(In order to publish 0.1.115 as is before this change which is potentially breaking.  I'll reapply it in a moment.)

