### PR TITLE
Use LinterContext.resolveNameInScope() for avoid_types_as_parameter_n…

### DIFF
--- a/test/rules/avoid_types_as_parameter_names.dart
+++ b/test/rules/avoid_types_as_parameter_names.dart
@@ -28,7 +28,7 @@ typedef void f5(
   bool, // LINT
 ]);
 typedef f6 = int Function(int); // OK
-typedef void f7(Undefined); // LINT
+typedef void f7(Undefined); // OK
 
 m1(f()) => null; // OK
 m2(f(int a)) => null; // OK
@@ -36,6 +36,9 @@ m3(f(int)) => null; // LINT
 m4(f(num a, {int})) => null; // LINT
 m5(f(double a, [bool])) => null; // LINT
 m6(int Function(int) f)=> null; // OK
-m7(f(Undefined)) => null; // LINT
+m7(f(Undefined)) => null; // OK
+m8(f6) => null; // LINT
+m9(f7) => null; // LINT
+m10(m1) => null; // OK
 
 final void Function(Object, [StackTrace]) onError = null; // OK


### PR DESCRIPTION
Follow-up from #2063; reapply change to use `LinterContext`. 
