### PR TITLE
reduce false positive for sized_box_for_whitespace

### DIFF
--- a/test/rules/sized_box_for_whitespace.dart
+++ b/test/rules/sized_box_for_whitespace.dart
@@ -13,21 +13,21 @@ Widget containerWithChild() {
 }
 
 Widget containerWithChildAndWidth() {
-  return Container( // OK
+  return Container( // LINT
     width: 10,
     child: Row(),
   );
 }
 
 Widget containerWithChildAndHeight() {
-  return Container( // OK
+  return Container( // LINT
     height: 10,
     child: Column(),
   );
 }
 
 Widget containerWithChildWidthAndHeight() {
-  return Container( // OK
+  return Container( // LINT
     width: 10,
     height: 10,
     child: Row(),
@@ -40,19 +40,27 @@ Widget emptyContainer() {
 }
 
 Widget emptyContainerWithWidth() {
-  return Container( // LINT
+  return Container( // OK
     width: 10,
   );
 }
 
 Widget emptyContainerWithHeight() {
-  return Container( // LINT
+  return Container( // OK
     height:10,
   );
 }
 
 Widget emptyContainerWithWidthAndHeight() {
   return Container( // LINT
+    width: 10,
+    height: 10,
+  );
+}
+
+Widget emptyContainerWithKeyAndWidthAndHeight() {
+  return Container( // LINT
+    key: null,
     width: 10,
     height: 10,
   );


### PR DESCRIPTION
# Description

Following [my comment on the initial PR](https://github.com/dart-lang/linter/pull/2049#issuecomment-607491147) there are some cases with behaviour changes. For instance the following change doesn't display the same thing (you can try it in dartpad):

```diff
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      debugShowCheckedModeBanner: false,
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: Column(
        children: [
-          ColoredBox(color: Colors.red, child: Container(height: 80)),
+          ColoredBox(color: Colors.red, child: SizedBox(height: 80)),
          SizedBox(height: 80),
-          ColoredBox(color: Colors.blue, child: Container(height: 80)),
+          ColoredBox(color: Colors.blue, child: SizedBox(height: 80)),
        ],
      ),
    );
  }
}
```

Basically it works with a child or with both width and height.

