### PR TITLE
Switch unsafe_html to be a SecurityLintCode

### DIFF
--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -64,11 +64,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   // single-quotes to match the convention in the analyzer and linter packages.
   // This requires some coordination within Google, as various allow-lists are
   // keyed on the exact text of the LintCode message.
-  static const unsafeAttributeCode =
-      LintCode('unsafe_html', '$_descPrefix (assigning "{0}" attribute).');
-  static const unsafeMethodCode = LintCode(
+  static const unsafeAttributeCode = SecurityLintCode(
+      'unsafe_html', '$_descPrefix (assigning "{0}" attribute).');
+  static const unsafeMethodCode = SecurityLintCode(
       'unsafe_html', "$_descPrefix (calling the '{0}' method of {1}).");
-  static const unsafeConstructorCode = LintCode(
+  static const unsafeConstructorCode = SecurityLintCode(
       'unsafe_html', "$_descPrefix (calling the '{0}' constructor of {1}).");
 
   final LintRule rule;

--- a/test/rules/unsafe_html.dart
+++ b/test/rules/unsafe_html.dart
@@ -58,6 +58,10 @@ void main() {
   d.setInnerHtml('<script>'); // LINT
   (script as dynamic).src = 'foo.js'; // LINT
   (C() as dynamic).src = 'foo.js'; // LINT
+
+  // As a SecurityLintCode, unsafe_html reports cannot be ignored.
+  // ignore: unsafe_html
+  IFrameElement()..srcdoc = 'foo'; // LINT
 }
 
 class C {


### PR DESCRIPTION
# Description

Lint rules which report on security-related issues should not be ignorable via comments like `// ignore:` or `// ignore_for_file:`. Upgrading unsafe_html from LintCode to SecurityLintCode prevents exactly this. If a developer writes:

```dart
// ignore: unsafe_html
IFrameElement()..srcdoc = 'foo';
```

then the analyzer will still report the unsafe_html violation.