### PR TITLE
0.1.116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.116
+
+* new lint: `no_default_cases`
+* new lint: `exhaustive_cases`
+* updated `type_annotate_public_apis.dart` to allow inferred types in final field assignments
+* updated `prefer_mixin.dart` to allow "legacy" SDK abstract class mixins
+* new lint: `use_is_even_rather_than_modulo`
+* update `unsafe_html` to use a `SecurityLintCode` (making it un-ignorable)
+* improved `sized_box_for_whitespace` to address false-positives
+
 # 0.1.115
 
 * updated `avoid_types_as_parameter_names` to check catch-clauses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * new lint: `no_default_cases`
 * new lint: `exhaustive_cases`
-* updated `type_annotate_public_apis.dart` to allow inferred types in final field assignments
+* updated `type_annotate_public_apis` to allow inferred types in final field assignments
 * updated `prefer_mixin.dart` to allow "legacy" SDK abstract class mixins
 * new lint: `use_is_even_rather_than_modulo`
 * update `unsafe_html` to use a `SecurityLintCode` (making it un-ignorable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * new lint: `no_default_cases`
 * new lint: `exhaustive_cases`
 * updated `type_annotate_public_apis` to allow inferred types in final field assignments
-* updated `prefer_mixin.dart` to allow "legacy" SDK abstract class mixins
+* updated `prefer_mixin` to allow "legacy" SDK abstract class mixins
 * new lint: `use_is_even_rather_than_modulo`
 * update `unsafe_html` to use a `SecurityLintCode` (making it un-ignorable)
 * improved `sized_box_for_whitespace` to address false-positives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.116
 
-* new lint: `no_default_cases`
+* new lint: `no_default_cases` (experimental)
 * new lint: `exhaustive_cases`
 * updated `type_annotate_public_apis` to allow inferred types in final field assignments
 * updated `prefer_mixin` to allow "legacy" SDK abstract class mixins

--- a/lib/src/rules/no_default_cases.dart
+++ b/lib/src/rules/no_default_cases.dart
@@ -53,7 +53,8 @@ class NoDefaultCases extends LintRule implements NodeLintRule {
             name: 'no_default_cases',
             description: _desc,
             details: _details,
-            group: Group.style);
+            group: Group.style,
+            maturity: Maturity.experimental);
 
   @override
   void registerNodeProcessors(NodeLintRegistry registry,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.115';
+const String version = '0.1.116';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.115
+version: 0.1.116
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.116

* new lint: `no_default_cases` (experimental)
* new lint: `exhaustive_cases`
* updated `type_annotate_public_apis` to allow inferred types in final field assignments
* updated `prefer_mixin` to allow "legacy" SDK abstract class mixins
* new lint: `use_is_even_rather_than_modulo`
* update `unsafe_html` to use a `SecurityLintCode` (making it un-ignorable)
* improved `sized_box_for_whitespace` to address false-positives

/cc @bwilkerson 

/fyi @srawlins 