### PR TITLE
`exhaustive_cases`: don’t flag missing cases that are defaulted

### DIFF
--- a/lib/src/rules/exhaustive_cases.dart
+++ b/lib/src/rules/exhaustive_cases.dart
@@ -128,6 +128,9 @@ class _Visitor extends SimpleAstVisitor {
             enumConstantNames.remove(expression.propertyName.name);
           }
         }
+        if (member is SwitchDefault) {
+          return;
+        }
       }
 
       for (var constantName in enumConstantNames) {

--- a/test/rules/exhaustive_cases.dart
+++ b/test/rules/exhaustive_cases.dart
@@ -40,6 +40,17 @@ void ok(E e) {
   }
 }
 
+void okDefault(E e) {
+  // Missing cases w/ default is OK.
+  switch(e) { // OK
+    case E.e :
+      print('e');
+      break;
+    default :
+      print('default');
+      break;
+  }
+}
 
 // Not Enum-like
 class Subclassed {


### PR DESCRIPTION
Fixes: #2128.

/cc @bwilkerson 