### PR TITLE
0.1.117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.117
+
+* fixed `directives_ordering` to remove third party package special-casing
+* fixed `unnecessary_lambdas` to check for tearoff assignability
+* fixed `exhaustive_cases` to not flag missing cases that are defaulted 
+* fixed `prefer_is_empty` to special-case assert initializers and const contexts 
+* test utilities moved to:  `lib/src/test_utilities`
+* new lint: `do_not_use_environment`
+
 # 0.1.116
 
 * new lint: `no_default_cases` (experimental)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.116';
+const String version = '0.1.117';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.116
+version: 0.1.117
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.117

* fixed `directives_ordering` to remove third party package special-casing
* fixed `unnecessary_lambdas` to check for tearoff assignability
* fixed `exhaustive_cases` to not flag missing cases that are defaulted 
* fixed `prefer_is_empty` to special-case assert initializers and const contexts 
* test utilities moved to:  `lib/src/test_utilities`
* new lint: `do_not_use_environment`

/cc @bwilkerson 