### PR TITLE
Don’t lint as expressions.

### DIFF
--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -58,6 +58,7 @@ class UnnecessaryStatements extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(_ReportNoClearEffectVisitor(this));
+    registry.addAsExpression(this, visitor);
     registry.addExpressionStatement(this, visitor);
     registry.addForStatement(this, visitor);
     registry.addCascadeExpression(this, visitor);
@@ -68,6 +69,11 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
   final LintRule rule;
 
   _ReportNoClearEffectVisitor(this.rule);
+
+  @override
+  void visitAsExpression(AsExpression node) {
+    //  https://github.com/dart-lang/linter/issues/2163
+  }
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {

--- a/test/rules/unnecessary_statements.dart
+++ b/test/rules/unnecessary_statements.dart
@@ -4,6 +4,12 @@
 
 // test w/ `pub run test -N unnecessary_statements`
 
+String f(Object o) {
+  // See: https://github.com/dart-lang/linter/issues/2163
+  o as int; // OK
+  return /* o.toRadixString(16); */ null;
+}
+
 notReturned() {
   1; // LINT
   1 + 1; // LINT
@@ -82,11 +88,11 @@ expressionBranching() {
   null ?? new MyClass().foo; // LINT
   false || 1 + 1 == 2; // LINT
   false || foo == true; // LINT
-  false || new MyClass() as bool; // LINT
+  false || new MyClass() as bool; // OK
   false || new MyClass().foo == true; // LINT
   true && 1 + 1 == 2; // LINT
   true && foo == true; // LINT
-  true && new MyClass() as bool; // LINT
+  true && new MyClass() as bool; // OK
   true && new MyClass().foo == true; // LINT
 
   // ternaries can detect either/both sides
@@ -108,7 +114,7 @@ expressionBranching() {
 
   // not unnecessary condition, but unnecessary branching
   foo() ?? 1 + 1; // LINT
-  foo() || new MyClass() as bool; // LINT
+  foo() || new MyClass() as bool; // OK
   foo() && foo == true; // LINT
   foo() ? 1 + 1 : foo(); // LINT
   foo() ? foo() : foo; // LINT

--- a/test/rules/unnecessary_statements.dart
+++ b/test/rules/unnecessary_statements.dart
@@ -7,7 +7,7 @@
 String f(Object o) {
   // See: https://github.com/dart-lang/linter/issues/2163
   o as int; // OK
-  return /* o.toRadixString(16); */ null;
+  return null;
 }
 
 notReturned() {


### PR DESCRIPTION
Fixes #2163

I considered some fancy  footwork to  check for really side-effecting expressions but opted instead for the simpler  implementation which I think will ultimately serve us better in the long run (esp. post  NNBD migration).

/cc @bwilkerson @MichaelRFairhurst 