### PR TITLE
move annotation_matcher to test_utilities

### DIFF
--- a/lib/src/test_utilities/annotation_matcher.dart
+++ b/lib/src/test_utilities/annotation_matcher.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/error/error.dart';
+import 'package:test/test.dart';
+
+import 'annotation.dart';
+
+AnnotationMatcher matchesAnnotation(
+        String message, ErrorType type, int lineNumber) =>
+    AnnotationMatcher(Annotation(message, type, lineNumber));
+
+class AnnotationMatcher extends Matcher {
+  final Annotation _expected;
+
+  AnnotationMatcher(this._expected);
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+
+  @override
+  bool matches(item, Map matchState) => item is Annotation && _matches(item);
+
+  bool _matches(Annotation other) {
+    // Only test messages if they're specified in the expectation
+    if (_expected.message != null) {
+      if (_expected.message != other.message) {
+        return false;
+      }
+    }
+    // Similarly for highlighting
+    if (_expected.column != null) {
+      if (_expected.column != other.column ||
+          _expected.length != other.length) {
+        return false;
+      }
+    }
+    return _expected.type == other.type &&
+        _expected.lineNumber == other.lineNumber;
+  }
+}

--- a/lib/src/test_utilities/annotation_matcher.dart
+++ b/lib/src/test_utilities/annotation_matcher.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/error/error.dart';
-import 'package:test/test.dart';
+import 'package:matcher/matcher.dart';
 
 import 'annotation.dart';
 

--- a/test/util/annotation_matcher.dart
+++ b/test/util/annotation_matcher.dart
@@ -2,41 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/error/error.dart';
-import 'package:linter/src/test_utilities/annotation.dart';
-import 'package:test/test.dart';
-
-AnnotationMatcher matchesAnnotation(
-        String message, ErrorType type, int lineNumber) =>
-    AnnotationMatcher(Annotation(message, type, lineNumber));
-
-class AnnotationMatcher extends Matcher {
-  final Annotation _expected;
-
-  AnnotationMatcher(this._expected);
-
-  @override
-  Description describe(Description description) =>
-      description.addDescriptionOf(_expected);
-
-  @override
-  bool matches(item, Map matchState) => item is Annotation && _matches(item);
-
-  bool _matches(Annotation other) {
-    // Only test messages if they're specified in the expectation
-    if (_expected.message != null) {
-      if (_expected.message != other.message) {
-        return false;
-      }
-    }
-    // Similarly for highlighting
-    if (_expected.column != null) {
-      if (_expected.column != other.column ||
-          _expected.length != other.length) {
-        return false;
-      }
-    }
-    return _expected.type == other.type &&
-        _expected.lineNumber == other.lineNumber;
-  }
-}
+@Deprecated(
+    'Prefer importing `package:linter/src/test_utilities/annotation_matcher.dart` directly')
+export 'package:linter/src/test_utilities/annotation_matcher.dart';


### PR DESCRIPTION
Follow-on from https://github.com/dart-lang/linter/issues/2104

/cc @davidmorgan @bwilkerson 
