### PR TITLE
Check the variable type in prefer_typing_uninitialized_variables to account for type inference

### DIFF
--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -85,7 +85,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     node.variables.forEach((v) {
-      if (v.initializer == null) {
+      if (v.initializer == null && v.declaredElement.type.isDynamic) {
         rule.reportLint(v);
       }
     });


### PR DESCRIPTION
Under null safety it will sometimes be possible for local variables without a type annotation to have a type inferred for them even if they don't have an initializer. This updates the rule to not flag such variables. I believe that this is consistent with the intent of the rule, which is to prevent variables whose type is `dynamic`.