### PR TITLE
Bump analyzer

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -25,13 +25,10 @@ export 'package:analyzer/src/dart/constant/evaluation.dart'
 export 'package:analyzer/src/dart/constant/value.dart' show DartObjectImpl;
 export 'package:analyzer/src/dart/element/inheritance_manager3.dart'
     show InheritanceManager3, Name;
-export 'package:analyzer/src/dart/element/type_provider.dart'
-    show TypeProviderImpl;
 export 'package:analyzer/src/dart/error/lint_codes.dart';
+export 'package:analyzer/src/dart/resolver/exit_detector.dart';
 export 'package:analyzer/src/generated/engine.dart'
     show AnalysisContext, AnalysisErrorInfo;
-export 'package:analyzer/src/generated/resolver.dart'
-    show ExitDetector, TypeProvider;
 export 'package:analyzer/src/generated/source.dart' show LineInfo, Source;
 export 'package:analyzer/src/lint/linter.dart'
     show

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.9
+  analyzer: ^0.39.13
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.13
+  analyzer: ^0.39.14
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.13
+  analyzer: ^0.39.9
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3


### PR DESCRIPTION
Update to latest analyzer release.

Note the  failing tests: https://travis-ci.org/github/dart-lang/linter/jobs/708226853.

For context, integration tests live in `test/integration_test`.  For example here:

https://github.com/dart-lang/linter/blob/300531dce438c71e93cd447ed3acb2e69cf37299/test/integration_test.dart#L682-L693

With associated data files in `test/_data`, like:

https://github.com/dart-lang/linter/blob/300531dce438c71e93cd447ed3acb2e69cf37299/test/_data/prefer_relative_imports/lib/main.dart#L1

/cc @scheglov @bwilkerson 
