### PR TITLE
Check for `Diagnosticable`s (over `DiagnosticableMixin`s)

### DIFF
--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -125,7 +125,7 @@ class _Visitor extends SimpleAstVisitor {
     // We only care about Diagnosticables.
     final type = node.declaredElement.thisType;
     if (!DartTypeUtilities.implementsInterface(
-        type, 'DiagnosticableMixin', '')) {
+        type, 'Diagnosticable', '')) {
       return;
     }
 

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -17,7 +17,7 @@ const _desc = r'DO reference all public properties in debug methods.';
 const _details = r'''
 **DO** reference all public properties in `debug` method implementations.
 
-Implementers of `DiagnosticableMixin` should reference all public properties in
+Implementers of `Diagnosticable` should reference all public properties in
 a `debugFillProperties(...)` or `debugDescribeChildren(...)` method
 implementation to improve debuggability at runtime.
 

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -124,8 +124,7 @@ class _Visitor extends SimpleAstVisitor {
   void visitClassDeclaration(ClassDeclaration node) {
     // We only care about Diagnosticables.
     final type = node.declaredElement.thisType;
-    if (!DartTypeUtilities.implementsInterface(
-        type, 'Diagnosticable', '')) {
+    if (!DartTypeUtilities.implementsInterface(type, 'Diagnosticable', '')) {
       return;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.9
+  analyzer: ^0.39.13
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.13
+  analyzer: ^0.39.9
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3

--- a/test/rules/diagnostic_describe_all_properties.dart
+++ b/test/rules/diagnostic_describe_all_properties.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-class MyWidget with DiagnosticableMixin {
+class MyWidget with Diagnosticable {
   Widget p0; //Skipped
   List<Widget> p00; //Skipped
   Widget get p000 => null; //Skipped
@@ -41,6 +41,6 @@ class MyWidget with DiagnosticableMixin {
   }
 }
 
-class MyWidget2 with DiagnosticableMixin {
+class MyWidget2 with Diagnosticable {
   bool property; //LINT
 }


### PR DESCRIPTION
Essentially a revert of https://github.com/dart-lang/linter/pull/2003 as `Diagnosticable` is here to stay.

/fyi @gspencergoog 

/cc @bwilkerson 
