### PR TITLE
Fix RangeError in unnecessary_string_escapes

### DIFF
--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -71,13 +71,8 @@ class _Visitor extends SimpleAstVisitor<void> {
         element.contents,
         isSingleQuoted: node.isSingleQuoted,
         isMultiline: node.isMultiline,
-        // TODO(a14n): should be the following line but the values look buggy
-        // contentsOffset: element.contentsOffset,
-        // contentsEnd: element.contentsEnd,
-        contentsOffset: element.offset +
-            (element != node.elements.first ? 0 : node.isMultiline ? 3 : 1),
-        contentsEnd: element.end -
-            (element != node.elements.last ? 0 : node.isMultiline ? 3 : 1),
+        contentsOffset: element.contentsOffset,
+        contentsEnd: element.contentsEnd,
       );
     }
   }


### PR DESCRIPTION
Previous versions of pkg:analyzer didn't give the correct offsets for
even simple interpolation strings such as "$foo". This prompted the
workaround code here. However, the workaround code here doesn't handle
unclosed quotes:

```dart
  "foo$bar
```

The analyzer API has been fixed, and supports this error recovery, so we
can drop the workaround and that will fix the RangeError we've been
seeing.