### PR TITLE
Fix an NPE in prefer_asserts_in_initializer_lists

### DIFF
--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -72,7 +72,7 @@ class _AssertVisitor extends RecursiveAstVisitor {
             _hasAccessor(element) &&
             !constructorElement.parameters
                 .whereType<FieldFormalParameterElement>()
-                .any((p) => p.field.getter == element);
+                .any((p) => p.field?.getter == element);
   }
 
   @override


### PR DESCRIPTION
This is to fix the bug reported in #2198.

There isn't a test for it, though I suspect it happens when there's code of the form
```dart
class C {
  C(this.x);
}
```
(a field initializer for a non-existent field).

I'm happy to add a test, but I'm not sure of the best approach.