### PR TITLE
Lint proposal: avoid_type_to_string

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -40,6 +40,7 @@ linter:
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_slow_async_io
+    - avoid_type_to_string
     - avoid_types_as_parameter_names
     - avoid_types_on_closure_parameters
     - avoid_unnecessary_containers

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -41,6 +41,7 @@ import 'rules/avoid_setters_without_getters.dart';
 import 'rules/avoid_shadowing_type_parameters.dart';
 import 'rules/avoid_single_cascade_in_expression_statements.dart';
 import 'rules/avoid_slow_async_io.dart';
+import 'rules/avoid_type_to_string.dart';
 import 'rules/avoid_types_as_parameter_names.dart';
 import 'rules/avoid_types_on_closure_parameters.dart';
 import 'rules/avoid_unnecessary_containers.dart';
@@ -220,6 +221,7 @@ void registerLintRules() {
     ..register(AvoidShadowingTypeParameters())
     ..register(AvoidSingleCascadeInExpressionStatements())
     ..register(AvoidSlowAsyncIo())
+    ..register(AvoidTypeToString())
     ..register(AvoidTypesAsParameterNames())
     ..register(AvoidTypesOnClosureParameters())
     ..register(AvoidUnnecessaryContainers())

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -74,6 +74,8 @@ class AvoidTypeToString extends LintRule implements NodeLintRule {
 
     // These nodes delegate to general visitArgumentList,
     // since SimpleAstVisitor only calls visits for concrete node subtypes.
+    // TODO: replace these with addArgumentList(...) once it's added to the registry API.
+    // Context: https://github.com/dart-lang/linter/pull/2209#discussion_r465196745
     registry.addFunctionExpressionInvocation(this, visitor);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addRedirectingConstructorInvocation(this, visitor);

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -57,7 +57,7 @@ class AvoidTypeToString extends LintRule implements NodeLintRule {
             name: 'avoid_type_to_string',
             description: _desc,
             details: _details,
-            group: Group.style);
+            group: Group.errors);
 
   @override
   void registerNodeProcessors(NodeLintRegistry registry,

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -141,7 +141,7 @@ class _Visitor extends SimpleAstVisitor {
     final targetType = (node.realTarget?.staticType is InterfaceType)
         ? node.realTarget.staticType as InterfaceType
         : thisType;
-    _reportIfToStringOnCoreTypeClass(node, targetType, node.methodName);
+    _reportIfToStringOnCoreTypeClass(targetType, node.methodName);
   }
 
   @override
@@ -154,23 +154,21 @@ class _Visitor extends SimpleAstVisitor {
       final targetType = (expression.realTarget?.staticType is InterfaceType)
           ? expression.realTarget?.staticType as InterfaceType
           : thisType;
-      _reportIfToStringOnCoreTypeClass(
-          expression, targetType, expression.propertyName);
+      _reportIfToStringOnCoreTypeClass(targetType, expression.propertyName);
     } else if (expression is PrefixedIdentifier) {
       final prefixType = expression.prefix.staticType;
       if (prefixType is InterfaceType) {
-        _reportIfToStringOnCoreTypeClass(
-            expression, prefixType, expression.identifier);
+        _reportIfToStringOnCoreTypeClass(prefixType, expression.identifier);
       }
     } else if (expression is SimpleIdentifier) {
-      _reportIfToStringOnCoreTypeClass(expression, thisType, expression);
+      _reportIfToStringOnCoreTypeClass(thisType, expression);
     }
   }
 
-  void _reportIfToStringOnCoreTypeClass(AstNode offendingNode,
+  void _reportIfToStringOnCoreTypeClass(
       InterfaceType targetType, SimpleIdentifier methodIdentifier) {
     if (_isToStringOnCoreTypeClass(targetType, methodIdentifier)) {
-      rule.reportLint(offendingNode);
+      rule.reportLint(methodIdentifier);
     }
   }
 

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -9,7 +9,8 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid <Type>.toString() in production code since results may be minified.';
+const _desc =
+    r'Avoid <Type>.toString() in production code since results may be minified.';
 
 const _details = r'''
 
@@ -50,9 +51,8 @@ Object baz(Thing myThing) {
 
 ''';
 
-// TODO: handle local toString lambda declared in scope
 class AvoidTypeToString extends LintRule implements NodeLintRule {
-  AvoidTypeToString() 
+  AvoidTypeToString()
       : super(
             name: 'avoid_type_to_string',
             description: _desc,
@@ -60,94 +60,130 @@ class AvoidTypeToString extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry, [LinterContext context]) {
-    final visitor = _Visitor(this);
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    assert(context != null);
+    final visitor =
+        _Visitor(this, context.typeSystem, context.typeProvider.typeType);
+    // Gathering meta information at these nodes.
+    // Nodes visited in DFS, so this will be called before
+    // each visitMethodInvocation.
     registry.addClassDeclaration(this, visitor);
     registry.addMixinDeclaration(this, visitor);
     registry.addExtensionDeclaration(this, visitor);
+
+    // These nodes delegate to general visitArgumentList,
+    // since SimpleAstVisitor only calls visits for concrete node subtypes.
+    registry.addFunctionExpressionInvocation(this, visitor);
+    registry.addInstanceCreationExpression(this, visitor);
+    registry.addRedirectingConstructorInvocation(this, visitor);
+    registry.addSuperConstructorInvocation(this, visitor);
+
+    // Actually checking things at these nodes.
+    // Also delegates to visitArgumentList.
     registry.addMethodInvocation(this, visitor);
   }
 }
 
 class _Visitor extends SimpleAstVisitor {
   final LintRule rule;
+  final TypeSystem typeSystem;
+  final InterfaceType typeType;
 
+  // Null if there is no logical `this` in the given context.
   InterfaceType thisType;
 
-  _Visitor(this.rule);
+  _Visitor(this.rule, this.typeSystem, this.typeType);
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
-    // Nodes visited in DFS, so this will be set before each visitMethodInvocation.
     thisType = node.declaredElement.thisType;
   }
 
   @override
   void visitMixinDeclaration(MixinDeclaration node) {
-    // Nodes visited in DFS, so this will be set before each visitMethodInvocation.
     thisType = node.declaredElement.thisType;
   }
 
   @override
   void visitExtensionDeclaration(ExtensionDeclaration node) {
-    // Nodes visited in DFS, so this will be set before each visitMethodInvocation.
-    thisType = node.declaredElement.extendedType as InterfaceType;
+    // Might not be InterfaceType. Ex: visiting an extension on a dynamic type.
+    thisType = (node.declaredElement.extendedType is InterfaceType)
+        ? node.declaredElement.extendedType as InterfaceType
+        : null;
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    visitArgumentList(node.argumentList);
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    visitArgumentList(node.argumentList);
+  }
+
+  @override
+  void visitRedirectingConstructorInvocation(
+      RedirectingConstructorInvocation node) {
+    visitArgumentList(node.argumentList);
+  }
+
+  @override
+  void visitSuperConstructorInvocation(SuperConstructorInvocation node) {
+    visitArgumentList(node.argumentList);
   }
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    final methodName = node.methodName.name;
-    final targetType = (node.realTarget?.staticType is InterfaceType)
-        ?  node.realTarget.staticType as InterfaceType : thisType;
-    final library = node.methodName.staticElement?.library;
-    if (_isToStringOnCoreTypeClass(methodName, targetType, library)) {
-      rule.reportLint(node);
-    }
+    visitArgumentList(node.argumentList);
 
-    node.argumentList.arguments.forEach(_validateArgument);
+    final targetType = (node.realTarget?.staticType is InterfaceType)
+        ? node.realTarget.staticType as InterfaceType
+        : thisType;
+    _reportIfToStringOnCoreTypeClass(node, targetType, node.methodName);
+  }
+
+  @override
+  void visitArgumentList(ArgumentList node) {
+    node.arguments.forEach(_validateArgument);
   }
 
   void _validateArgument(Expression expression) {
-    String methodName;
-    InterfaceType targetType;
-    LibraryElement library;
     if (expression is PropertyAccess) {
-      methodName = expression.propertyName.name;
-      targetType = (expression.realTarget?.staticType is InterfaceType) 
-          ? expression.realTarget?.staticType as InterfaceType : thisType;
-      library = expression.propertyName.staticElement?.library;
-    }
-    else if (expression is SimpleIdentifier) {
-      methodName = expression.name;
-      targetType = thisType;
-      library = expression.staticElement?.library;
-    }
-    else {
-      return;
-    }
-    
-    if (_isToStringOnCoreTypeClass(methodName, targetType, library)) {
-      rule.reportLint(expression);
-    }
-  }
-
-  bool _isToStringOnCoreTypeClass(String methodName, InterfaceType targetType, LibraryElement library) =>
-      methodName == 'toString'
-      && _coreTypeClassInAncestors(targetType)
-      && _rootMethodIsCoreToString(targetType, library);
-
-  bool _coreTypeClassInAncestors(InterfaceType targetType) {
-    for (final iType in [targetType].followedBy(targetType.allSupertypes)) {
-      if (iType.element?.name == 'Type' && iType.element?.library?.isDartCore == true) {
-        return true;
+      final targetType = (expression.realTarget?.staticType is InterfaceType)
+          ? expression.realTarget?.staticType as InterfaceType
+          : thisType;
+      _reportIfToStringOnCoreTypeClass(
+          expression, targetType, expression.propertyName);
+    } else if (expression is PrefixedIdentifier) {
+      final prefixType = expression.prefix.staticType;
+      if (prefixType is InterfaceType) {
+        _reportIfToStringOnCoreTypeClass(
+            expression, prefixType, expression.identifier);
       }
+    } else if (expression is SimpleIdentifier) {
+      _reportIfToStringOnCoreTypeClass(expression, thisType, expression);
     }
-    return false;
   }
 
-  bool _rootMethodIsCoreToString(InterfaceType targetType, LibraryElement library) {
-    final rootMethod = targetType.lookUpMethod2('toString', library);
-    return rootMethod.library?.isDartCore == true
-        && rootMethod.enclosingElement?.name == 'Object';
+  void _reportIfToStringOnCoreTypeClass(AstNode offendingNode,
+      InterfaceType targetType, SimpleIdentifier methodIdentifier) {
+    if (_isToStringOnCoreTypeClass(targetType, methodIdentifier)) {
+      rule.reportLint(offendingNode);
+    }
+  }
+
+  // targetType is allowed to be null, because _isSimpleIdDeclByCoreObj will
+  // fail before NPE.
+  bool _isToStringOnCoreTypeClass(
+          InterfaceType targetType, SimpleIdentifier methodIdentifier) =>
+      methodIdentifier.name == 'toString' &&
+      _isSimpleIdDeclByCoreObj(methodIdentifier) &&
+      typeSystem.isSubtypeOf(targetType, typeType);
+
+  bool _isSimpleIdDeclByCoreObj(SimpleIdentifier simpleIdentifier) {
+    final encloser = simpleIdentifier?.staticElement?.enclosingElement;
+    return encloser is ClassElement && encloser.isDartCoreObject;
   }
 }

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Avoid <Type>.toString() in production code since results may be minified.';
+
+const _details = r'''
+
+**DO** avoid calls to <Type>.toString() in production code, since it does not
+contractually return the user-defined name of the Type (or underlying class).
+Development-mode compilers where code size is not a concern use the full name,
+but release-mode compilers often choose to minify these symbols.
+
+**BAD:**
+```
+void bar(Object other) {
+  if (other.runtimeType.toString() == 'Bar') {
+    doThing();
+  }
+}
+
+Object baz(Thing myThing) {
+  return getThingFromDatabase(key: myThing.runtimeType.toString());
+}
+```
+
+**GOOD:**
+```
+void bar(Object other) {
+  if (other is Bar) {
+    doThing();
+  }
+}
+
+class Thing {
+  String get thingTypeKey => ...
+}
+
+Object baz(Thing myThing) {
+  return getThingFromDatabase(key: myThing.thingTypeKey);
+}
+```
+
+''';
+
+// TODO: handle local toString lambda declared in scope
+class AvoidTypeToString extends LintRule implements NodeLintRule {
+  AvoidTypeToString() 
+      : super(
+            name: 'avoid_type_to_string',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry, [LinterContext context]) {
+    final visitor = _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+    registry.addMixinDeclaration(this, visitor);
+    registry.addExtensionDeclaration(this, visitor);
+    registry.addMethodInvocation(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  InterfaceType thisType;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    // Nodes visited in DFS, so this will be set before each visitMethodInvocation.
+    thisType = node.declaredElement.thisType;
+  }
+
+  @override
+  void visitMixinDeclaration(MixinDeclaration node) {
+    // Nodes visited in DFS, so this will be set before each visitMethodInvocation.
+    thisType = node.declaredElement.thisType;
+  }
+
+  @override
+  void visitExtensionDeclaration(ExtensionDeclaration node) {
+    // Nodes visited in DFS, so this will be set before each visitMethodInvocation.
+    thisType = node.declaredElement.extendedType as InterfaceType;
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final methodName = node.methodName.name;
+    final targetType = (node.realTarget?.staticType is InterfaceType)
+        ?  node.realTarget.staticType as InterfaceType : thisType;
+    final library = node.methodName.staticElement?.library;
+    if (_isToStringOnCoreTypeClass(methodName, targetType, library)) {
+      rule.reportLint(node);
+    }
+
+    node.argumentList.arguments.forEach(_validateArgument);
+  }
+
+  void _validateArgument(Expression expression) {
+    String methodName;
+    InterfaceType targetType;
+    LibraryElement library;
+    if (expression is PropertyAccess) {
+      methodName = expression.propertyName.name;
+      targetType = (expression.realTarget?.staticType is InterfaceType) 
+          ? expression.realTarget?.staticType as InterfaceType : thisType;
+      library = expression.propertyName.staticElement?.library;
+    }
+    else if (expression is SimpleIdentifier) {
+      methodName = expression.name;
+      targetType = thisType;
+      library = expression.staticElement?.library;
+    }
+    else {
+      return;
+    }
+    
+    if (_isToStringOnCoreTypeClass(methodName, targetType, library)) {
+      rule.reportLint(expression);
+    }
+  }
+
+  bool _isToStringOnCoreTypeClass(String methodName, InterfaceType targetType, LibraryElement library) =>
+      methodName == 'toString'
+      && _coreTypeClassInAncestors(targetType)
+      && _rootMethodIsCoreToString(targetType, library);
+
+  bool _coreTypeClassInAncestors(InterfaceType targetType) {
+    for (final iType in [targetType].followedBy(targetType.allSupertypes)) {
+      if (iType.element?.name == 'Type' && iType.element?.library?.isDartCore == true) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _rootMethodIsCoreToString(InterfaceType targetType, LibraryElement library) {
+    final rootMethod = targetType.lookUpMethod2('toString', library);
+    return rootMethod.library?.isDartCore == true
+        && rootMethod.enclosingElement?.name == 'Object';
+  }
+}

--- a/test/rules/avoid_type_to_string.dart
+++ b/test/rules/avoid_type_to_string.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_type_to_string`
+
+
+// SHARED
+
+class A {
+  String toString() {}
+}
+
+class TypeChildWithOverride extends Type {
+  @override
+  String toString() {}
+}
+class TypeGrandChildWithOverride extends TypeChildWithOverride {}
+
+class TypeChildNoOverride extends Type {}
+class TypeGrandChildNoOverride extends TypeChildNoOverride {}
+
+mixin ToStringMixin {
+  String toString() {}
+}
+
+
+// BAD
+
+class Bad {
+  void doBad() {
+    A().runtimeType.toString(); // LINT
+    TypeChildNoOverride().toString(); // LINT
+    TypeGrandChildNoOverride().toString(); // LINT
+  }
+}
+
+class BadWithType extends Type {
+  void doBad() {
+    toString(); // LINT
+    this.toString(); // LINT
+
+    Future.value('hello').whenComplete(toString); // LINT
+    Future.value('hello').whenComplete(this.toString); // LINT
+    Future.value('hello').whenComplete(BadWithType().toString); // LINT
+  }
+}
+
+mixin callToStringOnBadWithType on BadWithType {
+  void mixedBad() {
+    toString(); // LINT
+    this.toString(); // LINT
+  }
+}
+
+extension ExtensionOnBadWithType on BadWithType {
+  void extendedBad() {
+    toString(); // LINT
+    this.toString(); // LINT
+  }
+}
+
+
+// GOOD
+
+class Good {
+  void doGood() {
+    toString(); // OK
+    A().toString(); // OK
+    TypeChildWithOverride().toString(); // OK
+    TypeGrandChildWithOverride().toString(); // OK
+
+    final refToString = toString;
+    refToString(); // OK?
+    Future.value('hello').whenComplete(refToString); // OK
+  }
+}
+
+// TODO: this currently throws a false positive.
+// class GoodWithType extends Type {
+//   void good() {
+//     String toString() => null;
+//     toString(); // OK
+//   }
+// }
+
+class GoodWithTypeAndMixin extends Type with ToStringMixin {
+  void doGood() {
+    toString(); // OK
+    this.toString(); // OK
+
+    Future.value('hello').whenComplete(toString); // OK
+    Future.value('hello').whenComplete(this.toString); // OK
+    Future.value('hello').whenComplete(GoodWithTypeAndMixin().toString); // OK
+  }
+}
+
+mixin CallToStringOnGoodWithType on GoodWithTypeAndMixin {
+  void mixedGood() {
+    toString(); // OK
+    this.toString(); // OK
+  }
+}
+
+extension ExtensionOnGoodWithTypeAndMixin on GoodWithTypeAndMixin {
+  void extendedGood() {
+    toString(); // OK
+    this.toString(); // OK
+  }
+}


### PR DESCRIPTION
# Description

This rule would suggest users avoid calling `toString()` on objects of type `Type` (declared in `dart:core`), since the result may be minified by some compilers in release mode.

# Context

This was inspired by a recent post on an internal mailing list. No official verdict on whether this is a good idea has been reached at the time of writing, but it seemed useful so I decided to try implementing it for fun. If people want to move forward with this lint rule, then this PR could be a good starting point.

Credit for the idea and reasoning goes to @matanlurey 

**Should this be further discussed on this PR, a new issue, or the mailing list?**

# Reasoning

> \<Type\>.toString() does not contractually return the user-defined name of the Type (or underlying class ). What that means in practice is that development mode compilers (such as DDC, or Dart JIT) where code-size is not a concern use the full name, but release-mode compilers (such as Dart2JS or Dart AOT) often choose to minify these symbols.

# ~~Known issues~~

~~A false positive is thrown when attempting to call a local lambda function declared inside another function, if the outer class extends `Type`.~~

<details>

```dart
class GoodWithType extends Type {
  void good() {
    String toString() => null;
    toString(); // Should be OK, but the rule currently does not see the local toString lambda which hides Object.toString
  }
}
```

</details>

**Edit: this is now fixed.**