### PR TITLE
Fix example/all.yaml ordering to make Travis happy

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -151,9 +151,9 @@ linter:
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_new
-    - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_raw_strings


### PR DESCRIPTION
# Description

Travis is unhappy with the ordering of `example/all.yaml` from #2208.