### PR TITLE
0.1.118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.1.118
+
+* new lint: `unnecessary_nullable_for_final_variable_declarations`
+* fixed NPE in `prefer_asserts_in_initializer_lists`
+* fixed range error in `unnecessary_string_escapes`
+* `unsafe_html` updated to support unique error codes
+* updates to `diagnostic_describe_all_properties` to check for `Diagnosticable`s (not `DiagnosticableMixin`s)
+* new lint: `use_late`
+* fixed `unnecessary_lambdas` to respect deferred imports
+* updated `public_member_api_docs` to check mixins
+* updated `unnecessary_statements` to skip `as` expressions
+* fixed `prefer_relative_imports` to work with path dependencies
+
 # 0.1.117
 
 * fixed `directives_ordering` to remove third party package special-casing

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.117';
+const String version = '0.1.118';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.117
+version: 0.1.118
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.118

* new lint: `unnecessary_nullable_for_final_variable_declarations`
* fixed NPE in `prefer_asserts_in_initializer_lists`
* fixed range error in `unnecessary_string_escapes`
* `unsafe_html` updated to support unique error codes
* updates to `diagnostic_describe_all_properties` to check for `Diagnosticable`s (not `DiagnosticableMixin`s)
* new lint: `use_late`
* fixed `unnecessary_lambdas` to respect deferred imports
* updated `public_member_api_docs` to check mixins
* updated `unnecessary_statements` to skip `as` expressions
* fixed `prefer_relative_imports` to work with path dependencies

/cc @bwilkerson @davidmorgan 