### PR TITLE
widen github deps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   dart_style: ^1.3.3
   fixnum:
     path: test/mock_packages/fixnum
-  github: ^6.0.5
+  github: '>=6.0.5 <8.0.0'
   grinder: ^0.8.0
   markdown: ^2.0.0
   matcher: ^0.12.0


### PR DESCRIPTION
When there's a new analyzer that supports `cli_util` 0.2.0, after this our pana baseline should be fixed.

/cc @bwilkerson 