### PR TITLE
bump deps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.39.14
+  analyzer: '>=0.39.14 <0.41.0'
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3
@@ -26,7 +26,6 @@ dev_dependencies:
   async: any # referenced in tests
   benchmark_harness: ^1.0.0
   cli_util: '>=0.1.2 <0.3.0'
-  dart_style: ^1.3.3
   fixnum:
     path: test/mock_packages/fixnum
   github: '>=6.0.5 <8.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.39.14 <0.41.0'
+  analyzer: ^0.40.0
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3

--- a/tool/baseline/pana.json
+++ b/tool/baseline/pana.json
@@ -1,5 +1,5 @@
 {
   "scores": {
-    "grantedPoints": 80
+    "grantedPoints": 70
   }
 }


### PR DESCRIPTION
Broadens `analyzer` package dependency.
Removes (unneeded 🤞 ) `dart_style` dependency.