### PR TITLE
0.1.119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.119
+
+* fix `close_sinks` to handle `this`-prefixed property accesses
+* new lint: `unnecessary_null_checks`
+* fix `unawaited_futures` to handle `Future` subtypes
+* new lint: `avoid_type_to_string`
+
 # 0.1.118
 
 * new lint: `unnecessary_nullable_for_final_variable_declarations`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.118';
+const String version = '0.1.119';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.118
+version: 0.1.119
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.119

* fix `close_sinks` to handle `this`-prefixed property accesses
* new lint: `unnecessary_null_checks`
* fix `unawaited_futures` to handle `Future` subtypes
* new lint: `avoid_type_to_string`

/cc @bwilkerson 
