### PR TITLE
migration from dart_coveralls

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -56,15 +56,19 @@ else
 
   echo ""
 
+  OBS_PORT=9292
+
   # Run the tests.
-  dart --enable-asserts test/all.dart
-  
+  dart --disable-service-auth-codes \
+    --enable-vm-service=$OBS_PORT \
+    --pause-isolates-on-exit \
+    test/all.dart &
+
   # Install dart_coveralls; gather and send coverage data.
   if [ "$COVERALLS_TOKEN" ]; then
 
     pub global activate coverage
 
-    OBS_PORT=9292
     echo "Collecting coverage on port $OBS_PORT..."
 
     # Run the coverage collector to generate the JSON coverage report.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -68,14 +68,14 @@ else
     echo "Collecting coverage on port $OBS_PORT..."
 
     # Run the coverage collector to generate the JSON coverage report.
-    dart collect_coverage \
+    collect_coverage \
       --port=$OBS_PORT \
       --out=var/coverage.json \
       --wait-paused \
       --resume-isolates
 
     echo "Generating LCOV report..."
-    dart format_coverage \
+    format_coverage \
       --lcov \
       --in=var/coverage.json \
       --out=var/lcov.info \

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -62,18 +62,20 @@ else
   # Install dart_coveralls; gather and send coverage data.
   if [ "$COVERALLS_TOKEN" ]; then
 
+    pub global activate coverage
+
     OBS_PORT=9292
     echo "Collecting coverage on port $OBS_PORT..."
 
     # Run the coverage collector to generate the JSON coverage report.
-    dart bin/collect_coverage.dart \
+    dart collect_coverage \
       --port=$OBS_PORT \
       --out=var/coverage.json \
       --wait-paused \
       --resume-isolates
 
     echo "Generating LCOV report..."
-    dart bin/format_coverage.dart \
+    dart format_coverage \
       --lcov \
       --in=var/coverage.json \
       --out=var/lcov.info \


### PR DESCRIPTION
Modernize coverage reporting to mimic how `dart-lang/coverage` self-reports.

/cc @bwilkerson 

/fyi @grouma 
