### PR TITLE
add null_check_on_nullable_type_parameter

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -84,6 +84,7 @@ linter:
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names
+    - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types
     - one_member_abstracts

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -85,6 +85,7 @@ import 'rules/no_duplicate_case_values.dart';
 import 'rules/no_logic_in_create_state.dart';
 import 'rules/no_runtimeType_toString.dart';
 import 'rules/non_constant_identifier_names.dart';
+import 'rules/null_check_on_nullable_type_parameter.dart';
 import 'rules/null_closures.dart';
 import 'rules/omit_local_variable_types.dart';
 import 'rules/one_member_abstracts.dart';
@@ -267,6 +268,7 @@ void registerLintRules() {
     ..register(NonConstantIdentifierNames())
     ..register(NoLogicInCreateState())
     ..register(NoRuntimeTypeToString())
+    ..register(NullCheckOnNullableTypeParameter())
     ..register(NullClosures())
     ..register(OmitLocalVariableTypes())
     ..register(OneMemberAbstracts())

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import 'unnecessary_null_checks.dart';
+
+const _desc = r"Don't use null check on a potentially nullable type parameter.";
+
+const _details = r'''
+
+Don't use null check on a potentially nullable type parameter.
+
+Given a generic type parameter `T` which has a nullable bound (e.g. the default
+bound of `Object?`), it is very easy to introduce erroneous null checks when
+working with a variable of type `T?`. Specifically, it is not uncommon to have
+`T? x;` and want to assert that `x` has been set to a valid value of type `T`.
+A common mistake is to do so using `x!`. This is almost always incorrect, since
+if `T` is a nullable type, `x` may validly hold `null` as a value of type `T`.
+
+**BAD:**
+```
+T run<T>(T callback()) {
+  T? result;
+   (() { result = callback(); })();
+  return result!;
+}
+```
+
+**GOOD:**
+```
+T run<T>(T callback()) {
+  T? result;
+   (() { result = callback(); })();
+  return result as T;
+}
+```
+
+''';
+
+class NullCheckOnNullableTypeParameter extends LintRule
+    implements NodeLintRule {
+  NullCheckOnNullableTypeParameter()
+      : super(
+          name: 'null_check_on_nullable_type_parameter',
+          description: _desc,
+          details: _details,
+          maturity: Maturity.experimental,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry,
+      [LinterContext context]) {
+    final visitor = _Visitor(this, context);
+    registry.addCompilationUnit(this, visitor);
+    registry.addPostfixExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final LintRule rule;
+  final LinterContext context;
+
+  bool _isNonNullableEnabled;
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    _isNonNullableEnabled = node.featureSet.isEnabled(Feature.non_nullable);
+  }
+
+  @override
+  void visitPostfixExpression(PostfixExpression node) {
+    if (!_isNonNullableEnabled) return;
+    if (node.operator.type != TokenType.BANG) return;
+
+    final expectedType = getExpectedType(node);
+    if (context.typeSystem.isPotentiallyNullable(node.operand.staticType) &&
+        expectedType != null &&
+        context.typeSystem.isPotentiallyNullable(expectedType)) {
+      rule.reportLintForToken(node.operator);
+    }
+  }
+}

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -83,11 +83,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.operator.type != TokenType.BANG) return;
 
     final expectedType = getExpectedType(node);
-    if (node.operand.staticType is TypeParameterType &&
-        context.typeSystem.isNullable(node.operand.staticType) &&
+    final type = node.operand.staticType;
+    if (type is TypeParameterType &&
+        context.typeSystem.isNullable(type) &&
         expectedType != null &&
         context.typeSystem.isPotentiallyNullable(expectedType) &&
-        context.typeSystem.promoteToNonNull(node.operand.staticType) ==
+        context.typeSystem.promoteToNonNull(type) ==
             context.typeSystem.promoteToNonNull(expectedType)) {
       rule.reportLintForToken(node.operator);
     }

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 import 'unnecessary_null_checks.dart';
@@ -82,9 +83,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.operator.type != TokenType.BANG) return;
 
     final expectedType = getExpectedType(node);
-    if (context.typeSystem.isPotentiallyNullable(node.operand.staticType) &&
+    if (node.operand.staticType is TypeParameterType &&
+        context.typeSystem.isNullable(node.operand.staticType) &&
         expectedType != null &&
-        context.typeSystem.isPotentiallyNullable(expectedType)) {
+        context.typeSystem.isPotentiallyNullable(expectedType) &&
+        context.typeSystem.promoteToNonNull(node.operand.staticType) ==
+            context.typeSystem.promoteToNonNull(expectedType)) {
       rule.reportLintForToken(node.operator);
     }
   }

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -63,29 +63,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitPostfixExpression(PostfixExpression node) {
     if (node.operator.type != TokenType.BANG) return;
 
-    var realNode = node
-        .thisOrAncestorMatching((e) => e.parent is! ParenthesizedExpression);
-    var parent = realNode.parent;
-
-    // in variable declaration
-    if (parent is VariableDeclaration) {
-      reportIfNullable(node, parent.declaredElement.type);
-      return;
-    }
-    // as right member of binary operator
-    if (parent is BinaryExpression && parent.rightOperand == realNode) {
-      reportIfNullable(node, parent.staticElement.parameters.first.type);
-      return;
-    }
-    // as parameter of function
-    if (parent is NamedExpression) {
-      realNode = parent;
-      parent = parent.parent;
-    }
-    if (parent is ArgumentList) {
-      reportIfNullable(
-          node, (realNode as Expression).staticParameterElement.type);
-      return;
+    final expectedType = getExpectedType(node);
+    if (expectedType != null && context.typeSystem.isNullable(expectedType)) {
+      rule.reportLintForToken(node.operator);
     }
   }
 
@@ -94,4 +74,34 @@ class _Visitor extends SimpleAstVisitor<void> {
       rule.reportLintForToken(node.operator);
     }
   }
+}
+
+DartType getExpectedType(PostfixExpression node) {
+  var realNode =
+      node.thisOrAncestorMatching((e) => e.parent is! ParenthesizedExpression);
+  var parent = realNode.parent;
+
+  // in return value
+  if (parent is ReturnStatement || parent is ExpressionFunctionBody) {
+    return (parent.thisOrAncestorOfType<FunctionExpression>().staticType
+            as FunctionType)
+        .returnType;
+  }
+  // in variable declaration
+  if (parent is VariableDeclaration) {
+    return parent.declaredElement.type;
+  }
+  // as right member of binary operator
+  if (parent is BinaryExpression && parent.rightOperand == realNode) {
+    return parent.staticElement.parameters.first.type;
+  }
+  // as parameter of function
+  if (parent is NamedExpression) {
+    realNode = parent;
+    parent = parent.parent;
+  }
+  if (parent is ArgumentList) {
+    return (realNode as Expression).staticParameterElement.type;
+  }
+  return null;
 }

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -87,6 +87,10 @@ DartType getExpectedType(PostfixExpression node) {
             as FunctionType)
         .returnType;
   }
+  // assignment
+  if (parent is AssignmentExpression) {
+    return parent.leftHandSide.staticType;
+  }
   // in variable declaration
   if (parent is VariableDeclaration) {
     return parent.declaredElement.type;

--- a/test/rules/experiments/nnbd/rules/null_check_on_nullable_type_parameter.dart
+++ b/test/rules/experiments/nnbd/rules/null_check_on_nullable_type_parameter.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N null_check_on_nullable_type_parameter`
+
+m1<T>(T p) => p!; // LINT
+m2<T>(T? p) => p!; // LINT
+m3<T extends Object>(T p) => p!; // OK
+m4<T extends Object?>(T p) => p!; // LINT
+m5<T extends dynamic>(T p) => p!; // LINT
+m6<T extends dynamic>(T p) => p!.a; // OK
+m7<T extends dynamic>(T p) => p!.m(); // OK
+
+m10<T>(T p) { return p!; } // LINT
+m20<T>(T? p) { T t = p!; } // LINT

--- a/test/rules/experiments/nnbd/rules/null_check_on_nullable_type_parameter.dart
+++ b/test/rules/experiments/nnbd/rules/null_check_on_nullable_type_parameter.dart
@@ -4,13 +4,16 @@
 
 // test w/ `pub run test -N null_check_on_nullable_type_parameter`
 
-m1<T>(T p) => p!; // LINT
-m2<T>(T? p) => p!; // LINT
-m3<T extends Object>(T p) => p!; // OK
-m4<T extends Object?>(T p) => p!; // LINT
-m5<T extends dynamic>(T p) => p!; // LINT
-m6<T extends dynamic>(T p) => p!.a; // OK
-m7<T extends dynamic>(T p) => p!.m(); // OK
+T m1<T>(T p) => p!; // OK
+T m2a<T>(T? p) => p!; // LINT
+dynamic m2b<T>(T? p) => p!; // OK
+T m3<T extends Object>(T? p) => p!; // OK
+T m4<T extends Object?>(T? p) => p!; // LINT
+T m5<T extends dynamic>(T? p) => p!; // LINT
+T m6<T>(T p) => p!.a; // OK
+T m7<T>(T p) => p!.m(); // OK
 
-m10<T>(T p) { return p!; } // LINT
-m20<T>(T? p) { T t = p!; } // LINT
+T m10<T>(T? p) { return p!; } // LINT
+T m20<T>(T? p) { T t = p!; } // LINT
+
+R m<P, R>(P? p) => p!; // OK

--- a/test/rules/experiments/nnbd/rules/null_check_on_nullable_type_parameter.dart
+++ b/test/rules/experiments/nnbd/rules/null_check_on_nullable_type_parameter.dart
@@ -10,10 +10,21 @@ dynamic m2b<T>(T? p) => p!; // OK
 T m3<T extends Object>(T? p) => p!; // OK
 T m4<T extends Object?>(T? p) => p!; // LINT
 T m5<T extends dynamic>(T? p) => p!; // LINT
-T m6<T>(T p) => p!.a; // OK
-T m7<T>(T p) => p!.m(); // OK
+T m6<T>(T? p) => p!.a; // OK
+T m7<T>(T? p) => p!.m(); // OK
+T m8<T>(T? p) => p!..m(); // OK
 
 T m10<T>(T? p) { return p!; } // LINT
 T m20<T>(T? p) { T t = p!; } // LINT
+T m30<T>(T? p) {
+  T t;
+  t = p!; // LINT
+}
+class C<T> {
+  T t;
+  m(T? p) {
+    t = p!; // LINT
+  }
+}
 
 R m<P, R>(P? p) => p!; // OK

--- a/test/rules/experiments/nnbd/rules/unnecessary_null_checks.dart
+++ b/test/rules/experiments/nnbd/rules/unnecessary_null_checks.dart
@@ -33,3 +33,8 @@ class A {
 
 int? f1(int? i) => i!; // LINT
 int? f2(int? i) { return i!; } // LINT
+
+f3(int? i) {
+  int? v;
+  v = i!; // LINT
+}

--- a/test/rules/experiments/nnbd/rules/unnecessary_null_checks.dart
+++ b/test/rules/experiments/nnbd/rules/unnecessary_null_checks.dart
@@ -30,3 +30,6 @@ class A {
   operator +(int? p) => A() + i!; // LINT
   operator -(int? p) => A() + (i!); // LINT
 }
+
+int? f1(int? i) => i!; // LINT
+int? f2(int? i) { return i!; } // LINT


### PR DESCRIPTION
# Description

Don't use null check on a potentially nullable type parameter.
**BAD:**
```dart
T run<T>(T callback()) {
  T? result;
   (() { result = callback(); })();
  return result!;
}
```
**GOOD:**
```dart
T run<T>(T callback()) {
  T? result;
   (() { result = callback(); })();
  return result as T;
}
```

Fixes #2243

In this PR I also extended `unnecessary_null_checks` to return cases.
