### PR TITLE
0.1.120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.120
+
+* new lint: `cast_nullable_to_non_nullable`
+* new lint: `null_check_on_nullable_type_parameter`
+* new lint: `tighten_type_of_initializing_formals`
+* update `public_member_apis` to check generic type aliases
+* (internal): update to new analyzer APIs
+
 # 0.1.119
 
 * fix `close_sinks` to handle `this`-prefixed property accesses

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.119';
+const String version = '0.1.120';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.119
+version: 0.1.120
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.120

* new lint: `cast_nullable_to_non_nullable`
* new lint: `null_check_on_nullable_type_parameter`
* new lint: `tighten_type_of_initializing_formals`
* update `public_member_apis` to check generic type aliases
* (internal): update to new analyzer APIs

/cc @bwilkerson 

/fyi @scheglov 