### PR TITLE
fix overreporting on generic type aliases

### DIFF
--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -297,6 +297,8 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitGenericTypeAlias(GenericTypeAlias node) {
+    if (!isInLibFolder) return;
+
     if (!isPrivate(node.name)) {
       check(node);
     }

--- a/test/_data/public_member_api_docs/test/b.dart
+++ b/test/_data/public_member_api_docs/test/b.dart
@@ -1,1 +1,3 @@
 String b; //OK
+
+typedef T = void Function(); // OK


### PR DESCRIPTION
See false positives: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8867784516868845056/+/steps/analyze_flutter_flutter/0/stdout.

/cc @bwilkerson 