### PR TITLE
Use analyzer 0.40.4 and CompoundAssignmentExpression.

### DIFF
--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../ast.dart';
 
 const _desc = r'Prefer putting asserts in initializer list.';
 
@@ -59,7 +60,7 @@ class _AssertVisitor extends RecursiveAstVisitor {
 
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
-    final element = node.staticElement;
+    final element = getWriteOrReadElement(node);
 
     // use method
     needInstance = needInstance ||

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -121,13 +121,13 @@ class _MutatedFieldsCollector extends RecursiveAstVisitor<void> {
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
-    _addMutatedFieldElement(node.leftHandSide);
+    _addMutatedFieldElement(node);
     super.visitAssignmentExpression(node);
   }
 
   @override
   void visitPostfixExpression(PostfixExpression node) {
-    _addMutatedFieldElement(node.operand);
+    _addMutatedFieldElement(node);
     super.visitPostfixExpression(node);
   }
 
@@ -136,14 +136,14 @@ class _MutatedFieldsCollector extends RecursiveAstVisitor<void> {
     final operator = node.operator;
     if (operator.type == TokenType.MINUS_MINUS ||
         operator.type == TokenType.PLUS_PLUS) {
-      _addMutatedFieldElement(node.operand);
+      _addMutatedFieldElement(node);
     }
     super.visitPrefixExpression(node);
   }
 
-  void _addMutatedFieldElement(Expression expression) {
+  void _addMutatedFieldElement(CompoundAssignmentExpression assignment) {
     final element =
-        DartTypeUtilities.getCanonicalElementFromIdentifier(expression);
+        DartTypeUtilities.getCanonicalElement(assignment.writeElement);
     if (element is FieldElement) {
       _mutatedFields.add(element);
     }

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -90,8 +90,7 @@ Iterable<ConstructorFieldInitializer>
         node.initializers.whereType<ConstructorFieldInitializer>();
 
 Element _getLeftElement(AssignmentExpression assignment) =>
-    DartTypeUtilities.getCanonicalElementFromIdentifier(
-        assignment.leftHandSide);
+    DartTypeUtilities.getCanonicalElement(assignment.writeElement);
 
 Iterable<Element> _getParameters(ConstructorDeclaration node) =>
     node.parameters.parameters.map((e) => e.identifier.staticElement);

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -89,7 +89,7 @@ DartType getExpectedType(PostfixExpression node) {
   }
   // assignment
   if (parent is AssignmentExpression) {
-    return parent.leftHandSide.staticType;
+    return parent.writeType;
   }
   // in variable declaration
   if (parent is VariableDeclaration) {

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -255,14 +255,10 @@ class _UnnecessarySetterOverrideVisitor
                 node.rightHandSide)) {
       final leftPart = node.leftHandSide.unParenthesized;
       if (leftPart is PropertyAccess) {
-        _visitPropertyAccess(leftPart);
+        if (node.writeElement == inheritedMethod) {
+          leftPart.target?.accept(this);
+        }
       }
-    }
-  }
-
-  void _visitPropertyAccess(PropertyAccess node) {
-    if (node.propertyName.staticElement == inheritedMethod) {
-      node.target?.accept(this);
     }
   }
 }

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../ast.dart';
 
 const _desc = r"Don't access members with `this` unless avoiding shadowing.";
 
@@ -85,7 +86,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     Element element;
     if (parent is PropertyAccess && !parent.isNullAware) {
-      element = parent.propertyName.staticElement;
+      element = getWriteOrReadElement(parent.propertyName);
     } else if (parent is MethodInvocation && !parent.isNullAware) {
       element = parent.methodName.staticElement;
     } else {

--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -92,7 +92,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitAssignmentExpression(AssignmentExpression node) {
     final leftPart = node.leftHandSide.unParenthesized;
     if (leftPart is SimpleIdentifier) {
-      var leftPartElement = leftPart.staticElement;
+      var leftPartElement = node.writeElement;
       if (leftPartElement == null) return;
       var enclosingElement = leftPartElement.enclosingElement;
       if (enclosingElement is ClassElement) {

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -99,9 +99,16 @@ class _Visitor extends UnifyingAstVisitor<void> {
 
   @override
   void visitNode(AstNode node) {
-    var element = DartTypeUtilities.getCanonicalElementFromIdentifier(node);
+    var parent = node.parent;
+
+    Element element;
+    if (parent is AssignmentExpression && parent.leftHandSide == node) {
+      element = DartTypeUtilities.getCanonicalElement(parent.writeElement);
+    } else {
+      element = DartTypeUtilities.getCanonicalElementFromIdentifier(node);
+    }
+
     if (element != null) {
-      var parent = node.parent;
       if (parent is Expression) {
         parent = (parent as Expression).unParenthesized;
       }

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -64,14 +64,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     void _visitExpression(Expression expression) {
       if (expression is AssignmentExpression &&
           expression.operator.type == TokenType.EQ) {
-        final leftOperand = DartTypeUtilities.getCanonicalElementFromIdentifier(
-            expression.leftHandSide);
+        final leftOperand =
+            DartTypeUtilities.getCanonicalElement(expression.writeElement);
         final rightOperand =
             DartTypeUtilities.getCanonicalElementFromIdentifier(
                 expression.rightHandSide);
-        final parameterElement =
-            DartTypeUtilities.getCanonicalElementFromIdentifier(
-                node.parameters.parameters.first.identifier);
+        final parameterElement = node.declaredElement.parameters.first;
         if (rightOperand == parameterElement && leftOperand is FieldElement) {
           rule.reportLint(node);
         }

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -43,11 +43,6 @@ String foo() {
 
 ''';
 
-SimpleIdentifier _getSimpleIdentifier(Expression rawExpression) {
-  final expression = rawExpression.unParenthesized;
-  return expression is SimpleIdentifier ? expression : null;
-}
-
 bool _isEmptyInterpolationString(AstNode node) =>
     node is InterpolationString && node.value == '';
 
@@ -125,17 +120,16 @@ class _UseStringBufferVisitor extends SimpleAstVisitor {
     if (node.operator.type != TokenType.PLUS_EQ &&
         node.operator.type != TokenType.EQ) return;
 
-    final identifier = _getSimpleIdentifier(node.leftHandSide);
-    if (identifier != null &&
-        DartTypeUtilities.isClass(
-            identifier.staticType, 'String', 'dart.core')) {
+    var left = node.leftHandSide;
+    if (left is SimpleIdentifier &&
+        DartTypeUtilities.isClass(node.writeType, 'String', 'dart.core')) {
       if (node.operator.type == TokenType.PLUS_EQ &&
-          !localElements.contains(DartTypeUtilities.getCanonicalElement(
-              identifier.staticElement))) {
+          !localElements.contains(
+              DartTypeUtilities.getCanonicalElement(node.writeElement))) {
         rule.reportLint(node);
       }
       if (node.operator.type == TokenType.EQ) {
-        final visitor = _IdentifierIsPrefixVisitor(rule, identifier);
+        final visitor = _IdentifierIsPrefixVisitor(rule, left);
         node.rightHandSide.accept(visitor);
       }
     }

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -74,7 +74,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
-    final type = node.leftHandSide?.staticType;
+    final type = node.writeType;
     _check(type, node.rightHandSide?.staticType, node,
         checkedNode: node.rightHandSide);
   }

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -10,8 +10,7 @@ import '../analyzer.dart';
 import '../util/dart_type_utilities.dart';
 
 Element _getLeftElement(AssignmentExpression assignment) =>
-    DartTypeUtilities.getCanonicalElementFromIdentifier(
-        assignment.leftHandSide);
+    DartTypeUtilities.getCanonicalElement(assignment.writeElement);
 
 List<Expression> _splitConjunctions(Expression rawExpression) {
   final expression = rawExpression?.unParenthesized;

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -9,6 +9,8 @@ import 'package:analyzer/dart/element/type_system.dart';
 import 'package:analyzer/src/dart/element/member.dart'; // ignore: implementation_imports
 import 'package:meta/meta.dart';
 
+import '../ast.dart';
+
 typedef AstNodePredicate = bool Function(AstNode node);
 
 class DartTypeUtilities {
@@ -100,8 +102,8 @@ class DartTypeUtilities {
 
     if (expression1 is SimpleIdentifier) {
       return expression2 is SimpleIdentifier &&
-          canonicalElementsAreEqual(
-              expression1.staticElement, expression2.staticElement);
+          canonicalElementsAreEqual(getWriteOrReadElement(expression1),
+              getWriteOrReadElement(expression2));
     }
 
     if (expression1 is PrefixedIdentifier) {
@@ -109,15 +111,17 @@ class DartTypeUtilities {
           canonicalElementsAreEqual(expression1.prefix.staticElement,
               expression2.prefix.staticElement) &&
           canonicalElementsAreEqual(
-              expression1.staticElement, expression2.staticElement);
+              getWriteOrReadElement(expression1.identifier),
+              getWriteOrReadElement(expression2.identifier));
     }
 
     if (expression1 is PropertyAccess && expression2 is PropertyAccess) {
       final target1 = expression1.target;
       final target2 = expression2.target;
       return canonicalElementsFromIdentifiersAreEqual(target1, target2) &&
-          canonicalElementsAreEqual(expression1.propertyName.staticElement,
-              expression2.propertyName.staticElement);
+          canonicalElementsAreEqual(
+              getWriteOrReadElement(expression1.propertyName),
+              getWriteOrReadElement(expression2.propertyName));
     }
 
     return false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.40.0
+  analyzer: ^0.40.4
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3


### PR DESCRIPTION
I have a version of analyzer that stops setting `SimpleIdentifier.staticElement/staticType` when the identifier is the final identifier of the LHS of an assignment (or increment/decrement). This will happen in a new breaking changes version of `analyzer`. This PR prepares the `linter` for using `CompoundAssignmentExpression` instead.