### PR TITLE
short-circuit node processor registration when not in `lib`

### DIFF
--- a/lib/src/rules/always_use_package_imports.dart
+++ b/lib/src/rules/always_use_package_imports.dart
@@ -57,8 +57,11 @@ class AlwaysUsePackageImports extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
+    if (!isInLibDir(context.currentUnit.unit, context.package)) {
+      return;
+    }
+
     final visitor = _Visitor(this, context);
-    registry.addCompilationUnit(this, visitor);
     registry.addImportDirective(this, visitor);
   }
 }
@@ -67,14 +70,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
   final LinterContext context;
 
-  bool isInLibFolder;
-
   _Visitor(this.rule, this.context);
 
   bool isRelativeImport(ImportDirective node) {
-    // Ignore this compilation unit if it's not in the lib/ folder.
-    if (!isInLibFolder) return false;
-
     try {
       final uri = Uri.parse(node.uriContent);
       return uri.scheme.isEmpty;
@@ -83,11 +81,6 @@ class _Visitor extends SimpleAstVisitor<void> {
       // Ignore.
     }
     return false;
-  }
-
-  @override
-  void visitCompilationUnit(CompilationUnit node) {
-    isInLibFolder = isInLibDir(node, context.package);
   }
 
   @override

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -55,9 +55,12 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
+    if (!isInLibDir(context.currentUnit.unit, context.package)) {
+      return;
+    }
+
     final visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
-    registry.addCompilationUnit(this, visitor);
   }
 }
 
@@ -65,21 +68,10 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
   final LinterContext context;
 
-  /// Tracks if we are in a compilation unit within a `lib/` dir so we can
-  /// short-circuit needless checking of method declarations.
-  bool isInLib;
-
   _Visitor(this.rule, this.context);
 
   @override
-  void visitCompilationUnit(CompilationUnit node) {
-    isInLib = isInLibDir(node, context.package);
-  }
-
-  @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    if (!isInLib) return;
-
     if (node.isStatic) return;
     if (node.documentationComment != null) return;
 


### PR DESCRIPTION
See: #2259

/cc @scheglov @bwilkerson 
