### PR TITLE
prefer_constructors_over_static_methods: take generics into account

### DIFF
--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -78,12 +78,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitMethodDeclaration(MethodDeclaration node) {
     final returnType = node.returnType?.type;
     final parent = node.parent;
-    final typeParameters = node.typeParameters?.typeParameters ?? [];
     if (node.isStatic &&
         parent is ClassOrMixinDeclaration &&
         returnType is InterfaceType &&
-        returnType == parent.declaredElement.thisType &&
-        typeParameters.isEmpty &&
+        parent.typeParameters == null &&
+        node.typeParameters == null &&
         _hasNewInvocation(returnType, node.body)) {
       rule.reportLint(node.name);
     }

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -78,10 +78,12 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitMethodDeclaration(MethodDeclaration node) {
     final returnType = node.returnType?.type;
     final parent = node.parent;
+    final typeParameters = node.typeParameters?.typeParameters ?? [];
     if (node.isStatic &&
         parent is ClassOrMixinDeclaration &&
         returnType is InterfaceType &&
-        returnType.element == parent.declaredElement &&
+        returnType == parent.declaredElement.thisType &&
+        typeParameters.isEmpty &&
         _hasNewInvocation(returnType, node.body)) {
       rule.reportLint(node.name);
     }

--- a/test/rules/prefer_constructors_over_static_methods.dart
+++ b/test/rules/prefer_constructors_over_static_methods.dart
@@ -10,12 +10,12 @@ class A {
   A.internal();
 
   static A bad1() => // LINT
-  new A.internal();
+      new A.internal();
 
   static A get newA => // LINT
-  new A.internal();
+      new A.internal();
 
-  static A bad2(){ // LINT
+  static A bad2() { // LINT
     final a = new A.internal();
     return a;
   }
@@ -24,15 +24,31 @@ class A {
     return array[i];
   }
 
-  factory A.good2(){ // OK
+  factory A.good2() { // OK
     return new A.internal();
   }
 
-  factory A.good3(){ // OK
+  factory A.good3() { // OK
     return new A.internal();
   }
+
+  static A generic<T>() => // OK
+      A.internal();
+}
+
+class B<T> {
+  B.internal();
+
+  static B<T> good1<T>(T one) => // OK
+      B.internal();
+
+  static B good2() => // OK
+      B.internal();
+
+  static B<int> good3() => // OK
+      B<int>.internal();
 }
 
 extension E on A {
-  static A foo() => A(); // OK
+  static A foo() => A.internal(); // OK
 }


### PR DESCRIPTION
# Description

Compare the method's return _type_ with it's parent class's _type_ rather than
comparing _elements_ to account for generics (don't report a method which
returns `A<int>`).

And don't report any generic method, because it might use the type parameters
in its parameters, which a constructor cannot do.

Fixes #2149