### PR TITLE
void_checks: Specify individual types which a FutureOr<void> target can accept

### DIFF
--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -42,7 +42,6 @@ class VoidChecks extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this, context);
-    registry.addCompilationUnit(this, visitor);
     registry.addMethodInvocation(this, visitor);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addAssignmentExpression(this, visitor);
@@ -55,8 +54,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   final LinterContext context;
   final TypeSystem typeSystem;
-
-  InterfaceType _futureDynamicType;
 
   _Visitor(this.rule, this.context) : typeSystem = context.typeSystem;
 
@@ -88,13 +85,6 @@ class _Visitor extends SimpleAstVisitor<void> {
     final type = node.writeType;
     _check(type, node.rightHandSide?.staticType, node,
         checkedNode: node.rightHandSide);
-  }
-
-  @override
-  void visitCompilationUnit(CompilationUnit node) {
-    _futureDynamicType = context.typeSystem.leastUpperBound(
-        context.typeProvider.futureDynamicType,
-        context.typeProvider.nullType) as InterfaceType;
   }
 
   @override

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -65,8 +65,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (type.isDartCoreNull) return true;
     if (type.isDartAsyncFuture &&
         type is InterfaceType &&
-        (type.typeArguments.first.isVoid ||
-            type.typeArguments.first.isDartCoreNull)) {
+        isTypeAcceptableWhenExpectingVoid(type.typeArguments.first)) {
       return true;
     }
     return false;
@@ -134,11 +133,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (expectedType == null || type == null) {
       return;
     }
-
-    var futureOrVoidType =
-        context.typeProvider.futureOrType2(context.typeProvider.voidType);
     if (expectedType.isVoid && !isTypeAcceptableWhenExpectingVoid(type) ||
-        expectedType == futureOrVoidType &&
+        expectedType.isDartAsyncFutureOr &&
+            (expectedType as InterfaceType).typeArguments.first.isVoid &&
             !typeSystem.isAssignableTo(type, _futureDynamicType)) {
       rule.reportLint(node);
     } else if (checkedNode is FunctionExpression &&

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -81,7 +81,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    _futureDynamicType = context.typeProvider.futureDynamicType;
+    _futureDynamicType = context.typeSystem.leastUpperBound(
+        context.typeProvider.futureDynamicType,
+        context.typeProvider.nullType) as InterfaceType;
   }
 
   @override
@@ -131,10 +133,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     checkedNode ??= node;
     if (expectedType == null || type == null) {
       return;
-    } else if (expectedType.isVoid &&
-            !isTypeAcceptableWhenExpectingVoid(type) ||
-        expectedType.isDartAsyncFutureOr &&
-            (expectedType as InterfaceType).typeArguments.first.isVoid &&
+    }
+
+    var futureOrVoidType =
+        context.typeProvider.futureOrType2(context.typeProvider.voidType);
+    if (expectedType.isVoid && !isTypeAcceptableWhenExpectingVoid(type) ||
+        expectedType == futureOrVoidType &&
             !typeSystem.isAssignableTo(type, _futureDynamicType)) {
       rule.reportLint(node);
     } else if (checkedNode is FunctionExpression &&

--- a/test/rules/experiments/nnbd/rules/void_checks.dart
+++ b/test/rules/experiments/nnbd/rules/void_checks.dart
@@ -1,3 +1,9 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N void_checks`
+
 import 'dart:async';
 
 void emptyFunctionExpressionReturningFutureOrVoid(FutureOr<void> Function() f) {

--- a/test/rules/experiments/nnbd/rules/void_checks.dart
+++ b/test/rules/experiments/nnbd/rules/void_checks.dart
@@ -1,0 +1,5 @@
+import 'dart:async';
+
+void emptyFunctionExpressionReturningFutureOrVoid(FutureOr<void> Function() f) {
+  f = () {}; // OK
+}

--- a/test/rules/void_checks.dart
+++ b/test/rules/void_checks.dart
@@ -207,3 +207,7 @@ missing_parameter_for_argument() {
   void foo() {}
   foo(0);
 }
+
+void emptyFunctionExpressionReturningFutureOrVoid(FutureOr<void> Function() f) {
+  f = () {}; // OK
+}


### PR DESCRIPTION
# Description

The type of `() {}` changed to `Null Function()` (from `void Function()` in Null Safety. The check performed in void_checks must then compare assignability with `Future<dynamic>?`.

Fixes #2185 
