### PR TITLE
type_init_formals: Allow types not equal to the field type

### DIFF
--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -59,12 +59,16 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFieldFormalParameter(FieldFormalParameter node) {
-    if (node.type != null) {
+    var nodeType = node.type;
+    if (nodeType != null) {
       var class_ =
           node.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
       var field = class_.getField(node.identifier.name);
-      if (node.type?.type == field.type) {
-        rule.reportLint(node.type);
+      // If no such field exists, the code is invalid; do not report lint.
+      if (field != null) {
+        if (nodeType.type == field.type) {
+          rule.reportLint(nodeType);
+        }
       }
     }
   }

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -60,7 +60,12 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitFieldFormalParameter(FieldFormalParameter node) {
     if (node.type != null) {
-      rule.reportLint(node.type);
+      var class_ =
+          node.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
+      var field = class_.getField(node.identifier.name);
+      if (node.type?.type == field.type) {
+        rule.reportLint(node.type);
+      }
     }
   }
 }

--- a/test/rules/experiments/nnbd/rules/type_init_formals.dart
+++ b/test/rules/experiments/nnbd/rules/type_init_formals.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N type_init_formals`
+
+class A {
+  String? p1;
+  String p2;
+
+  A.w({required String this.p1}); // OK
+  A.x({required String? this.p1}); // LINT
+  A.y({required String? this.p2}); // OK
+  A.z({required String this.p2}); // LINT
+}

--- a/test/rules/type_init_formals.dart
+++ b/test/rules/type_init_formals.dart
@@ -24,3 +24,7 @@ class Good3 {
   var a;
   Good3(int this.a); // OK
 }
+
+class Invalid {
+  Invalid(int this.x); // OK
+}

--- a/test/rules/type_init_formals.dart
+++ b/test/rules/type_init_formals.dart
@@ -19,3 +19,8 @@ class Good2 {
   Good2.i(int this.a); // OK
   Good2.d(double this.a); // OK
 }
+
+class Good3 {
+  var a;
+  Good3(int this.a); // OK
+}

--- a/test/rules/type_init_formals.dart
+++ b/test/rules/type_init_formals.dart
@@ -6,10 +6,16 @@
 
 class Good {
   String name;
-  Good(this.name);
+  Good(this.name); // OK
 }
 
 class Bad {
   String name;
   Bad(String this.name); //LINT [7:6]
+}
+
+class Good2 {
+  num a;
+  Good2.i(int this.a); // OK
+  Good2.d(double this.a); // OK
 }


### PR DESCRIPTION
# Description

If the type of the field formal parameter is different from the field type, it has implications, and should be left alone.

Fixes #2192