### PR TITLE
always_require_non_null_named_parameters: skip in Null Safety

### DIFF
--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -2,10 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:meta/meta.dart';
 
 import '../analyzer.dart';
 import '../util/dart_type_utilities.dart';
@@ -51,26 +51,22 @@ class AlwaysRequireNonNullNamedParameters extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this,
-        isNullSafety: context
-            .currentUnit.unit.declaredElement.library.isNonNullableByDefault);
-    registry.addFormalParameterList(this, visitor);
+    // In a Null Safety library, this lint is covered by other formal static
+    // analysis.
+    if (!context.isEnabled(Feature.non_nullable)) {
+      final visitor = _Visitor(this);
+      registry.addFormalParameterList(this, visitor);
+    }
   }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  final bool isNullSafety;
-
-  _Visitor(this.rule, {@required this.isNullSafety});
+  _Visitor(this.rule);
 
   @override
   void visitFormalParameterList(FormalParameterList node) {
-    // In a Null Safety library, this lint is covered by other formal static
-    // analysis.
-    if (isNullSafety) return;
-
     List<DefaultFormalParameter> getParams() {
       final params = <DefaultFormalParameter>[];
       for (final p in node.parameters) {


### PR DESCRIPTION
# Description

This lint should not run in a Null Safety library; the "required" rules cover this in static analysis done by the Analyzer.

Without this new check, the new test results in an incorrect lint report.

Fixes #2236 
