### PR TITLE
+ `sort_pub_dependencies` test cases

### DIFF
--- a/test/_data/sort_pub_dependencies/pubspec.yaml
+++ b/test/_data/sort_pub_dependencies/pubspec.yaml
@@ -1,16 +1,33 @@
-name: test
+name: fancy
+description: Fancy pre-built things.
+version: 1.1.1
+homepage: https://github.com/dart-lang/linter
+
+environment:
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
-  a: any
-  c: any
-  b: any
+  baz: ^0.1.1
+  flutter:
+    sdk: flutter
+  intl: ^0.15.8
+  transmogrify:
+    hosted:
+      name: transmogrify
+      url: http://some-package-server.com
+    version: ^1.0.0
+  js: ^0.6.0 # lint
+  zap: any
 
 dev_dependencies:
-  e: any
-  d: any
-  f: any
+  flutter_test:
+    sdk: flutter
+  vector_math: ^2.0.8
+  test: '>=0.5.0 <0.12.0' # lint
 
 dependency_overrides:
-  i: any
-  h: any
-  g: any
+  kittens:
+    git: https://github.com/munificent/kittens.git
+  transmogrify:
+    path: ../../../transmogrify_patch/
+  lemur: '1.0.0' # lint

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -856,9 +856,9 @@ void defineTests() {
         expect(
             collectingOut.trim(),
             stringContainsInOrder([
-              'pubspec.yaml 6:3 [lint] Sort pub dependencies.',
-              'pubspec.yaml 10:3 [lint] Sort pub dependencies.',
-              'pubspec.yaml 15:3 [lint] Sort pub dependencies.',
+              'pubspec.yaml 19:3 [lint] Sort pub dependencies.',
+              'pubspec.yaml 26:3 [lint] Sort pub dependencies.',
+              'pubspec.yaml 33:3 [lint] Sort pub dependencies.',
               '1 file analyzed, 3 issues found',
             ]));
         expect(exitCode, 1);


### PR DESCRIPTION
The false positive was mis-reported but did identify some untested cases.


Fixes #2271 

/cc @bwilkerson 
