### PR TITLE
update `registerNodeProcessors` calls

### DIFF
--- a/lib/src/rules/avoid_escaping_inner_quotes.dart
+++ b/lib/src/rules/avoid_escaping_inner_quotes.dart
@@ -35,8 +35,8 @@ class AvoidEscapingInnerQuotes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);

--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -47,8 +47,8 @@ class AvoidRedundantArgumentValues extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this, context);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -60,8 +60,8 @@ class AvoidTypeToString extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     assert(context != null);
     final visitor =
         _Visitor(this, context.typeSystem, context.typeProvider.typeType);

--- a/lib/src/rules/avoid_unnecessary_containers.dart
+++ b/lib/src/rules/avoid_unnecessary_containers.dart
@@ -55,8 +55,8 @@ class AvoidUnnecessaryContainers extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
 
     registry.addInstanceCreationExpression(this, visitor);

--- a/lib/src/rules/camel_case_extensions.dart
+++ b/lib/src/rules/camel_case_extensions.dart
@@ -39,8 +39,8 @@ class CamelCaseExtensions extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addExtensionDeclaration(this, visitor);
   }

--- a/lib/src/rules/do_not_use_environment.dart
+++ b/lib/src/rules/do_not_use_environment.dart
@@ -31,8 +31,8 @@ class DoNotUseEnvironment extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }

--- a/lib/src/rules/exhaustive_cases.dart
+++ b/lib/src/rules/exhaustive_cases.dart
@@ -83,8 +83,8 @@ class ExhaustiveCases extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addSwitchStatement(this, visitor);
   }

--- a/lib/src/rules/leading_newlines_in_multiline_strings.dart
+++ b/lib/src/rules/leading_newlines_in_multiline_strings.dart
@@ -44,8 +44,8 @@ class LeadingNewlinesInMultilineStrings extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
     registry.addSimpleStringLiteral(this, visitor);

--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -43,8 +43,8 @@ class MissingWhitespaceBetweenAdjacentStrings extends LintRule
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }

--- a/lib/src/rules/no_default_cases.dart
+++ b/lib/src/rules/no_default_cases.dart
@@ -57,8 +57,8 @@ class NoDefaultCases extends LintRule implements NodeLintRule {
             maturity: Maturity.experimental);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addSwitchStatement(this, visitor);
   }

--- a/lib/src/rules/no_logic_in_create_state.dart
+++ b/lib/src/rules/no_logic_in_create_state.dart
@@ -67,8 +67,8 @@ class NoLogicInCreateState extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/no_runtimeType_toString.dart
+++ b/lib/src/rules/no_runtimeType_toString.dart
@@ -49,8 +49,8 @@ class NoRuntimeTypeToString extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addInterpolationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -55,8 +55,8 @@ class SizedBoxForWhitespace extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
 
     registry.addInstanceCreationExpression(this, visitor);

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -46,8 +46,8 @@ class UnnecessaryNullChecks extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this, context);
     registry.addPostfixExpression(this, visitor);
   }

--- a/lib/src/rules/unnecessary_raw_strings.dart
+++ b/lib/src/rules/unnecessary_raw_strings.dart
@@ -36,8 +36,8 @@ class UnnecessaryRawStrings extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
   }

--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -38,8 +38,8 @@ class UnnecessaryStringEscapes extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);

--- a/lib/src/rules/unnecessary_string_interpolations.dart
+++ b/lib/src/rules/unnecessary_string_interpolations.dart
@@ -36,8 +36,8 @@ class UnnecessaryStringInterpolations extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addStringInterpolation(this, visitor);
   }

--- a/lib/src/rules/use_is_even_rather_than_modulo.dart
+++ b/lib/src/rules/use_is_even_rather_than_modulo.dart
@@ -38,8 +38,8 @@ class UseIsEvenRatherThanModuloCheck extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }

--- a/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/lib/src/rules/use_key_in_widget_constructors.dart
@@ -42,8 +42,8 @@ class UseKeyInWidgetConstructors extends LintRule implements NodeLintRule {
             group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addConstructorDeclaration(this, visitor);

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -50,8 +50,8 @@ class UseLateForPrivateFieldsAndVariables extends LintRule
         );
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
   }

--- a/lib/src/rules/use_raw_strings.dart
+++ b/lib/src/rules/use_raw_strings.dart
@@ -34,8 +34,8 @@ class UseRawStrings extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry,
-      [LinterContext context]) {
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
   }

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -132,7 +132,7 @@ class $className extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry, [LinterContext context]) {
+  void registerNodeProcessors(NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
     registry.addSimpleIdentifier(this, visitor);
   }


### PR DESCRIPTION
(`LinterContext` is no longer optional.)

/cc @bwilkerson 