### PR TITLE
Fix RangeError in unnecessary_string_escapes

### DIFF
--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -105,7 +105,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (var i = 0; i < lexeme.length; i++) {
       var current = lexeme[i];
       var escaped = false;
-      if (current == r'\') {
+      if (current == r'\' && i < lexeme.length - 1) {
         escaped = true;
         i += 1;
         current = lexeme[i];

--- a/lib/src/rules/use_raw_strings.dart
+++ b/lib/src/rules/use_raw_strings.dart
@@ -54,7 +54,7 @@ class _Visitor extends SimpleAstVisitor {
         node.contentsOffset - node.literal.offset,
         node.contentsEnd - node.literal.offset);
     var hasEscape = false;
-    for (var i = 0; i < lexeme.length; i++) {
+    for (var i = 0; i < lexeme.length - 1; i++) {
       var current = lexeme[i];
       if (current == r'\') {
         hasEscape = true;

--- a/test/_data/unnecessary_string_escapes/no_closing_quote.dart
+++ b/test/_data/unnecessary_string_escapes/no_closing_quote.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Note that putting `''` on the new line is important to get a token
+/// with `'\` with no closing quote.
+String unclosedQuote() => '\
+'';

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -40,6 +40,23 @@ void defineTests() {
       });
     });
 
+    group('unnecessary_string_escapes', () {
+      final currentOut = outSink;
+      final collectingOut = CollectingSink();
+      setUp(() => outSink = collectingOut);
+      tearDown(() {
+        collectingOut.buffer.clear();
+        outSink = currentOut;
+      });
+      test('no_closing_quote', () async {
+        await cli.runLinter([
+          'test/_data/unnecessary_string_escapes/no_closing_quote.dart',
+          '--rules=unnecessary_string_escapes',
+        ], LinterOptions());
+        // No exception.
+      });
+    });
+
     group('exhaustive_cases', () {
       final currentOut = outSink;
       final collectingOut = CollectingSink();


### PR DESCRIPTION
This happens for
```dart
/// Note that putting `''` on the new line is important to get a token
/// with `'\` with no closing quote.
String unclosedQuote() => '\
    '';
```
  Reported internally [in here](https://crash.corp.google.com/browse?q=product_name%3D%27Dart_analysis_server%27+AND+product.Version%3D%272.11.337030498-edge%2Bgoogle3-v2%27&stbtiq=&reportid=9a128a0e6f2659b4&index=9#0) for example.

  I did not put it into the test because it is a parse error, and there are subsequence crashes during reporting a logical failure (OK vs. LINT) when the file also has parse errors. I'd put this test case into a separate file, but there is not support for multiple files (yet). Should we have it?