### PR TITLE
add support for github actions

### DIFF
--- a/.github/install-dart.sh
+++ b/.github/install-dart.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Fast fail the script on failures.
+set -ex
+
+echo Installing Dart ${DART_VERSION}
+
+curl --connect-timeout 15 --retry 5 \
+  https://storage.googleapis.com/dart-archive/channels/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip > dartsdk.zip
+unzip dartsdk.zip -d . > /dev/null
+rm dartsdk.zip
+
+./dart-sdk/bin/dart --version

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: linter
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: "linter ${{ matrix.bot }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        linter-bot:
+          - main
+          - benchmark
+          - pana_baseline
+          - release
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dart
+        env:
+          DART_VERSION: beta/release/latest
+        run: |
+          ./.github/install-dart.sh
+          echo "::add-path::`pwd`/dart-sdk/bin"
+          echo "::add-path::$HOME/.pub-cache/bin"
+
+      - name: ./tool/travis.sh
+        env:
+          LINTER_BOT: ${{ matrix.linter-bot }}
+        run: ./tool/travis.sh


### PR DESCRIPTION
- add support for github actions

This add support for github actions. This is more or less a straight port of the existing travis.yaml file (https://github.com/dart-lang/linter/blob/master/.travis.yml). We may need to land this PR to see the actions run as there aren't any existing actions for the repo.

It would be great to evolve dart support for actions a bit so that a per-repo install-dart.sh isn't required. Perhaps there's some creative use of the std. dart docker container which would make the install script not needed.