### PR TITLE
fix failing lines_longer_than_80_chars integration test

### DIFF
--- a/test/_data/lines_longer_than_80_chars/a.dart
+++ b/test/_data/lines_longer_than_80_chars/a.dart
@@ -29,5 +29,5 @@
  * line with a CRLF at its end                                                 a
  */
 
-// ignore: lines_longer_than_80_chars,lines_longer_than_80_chars,lines_longer_than_80_chars
+// ignore: lines_longer_than_80_chars, lines_longer_than_80_chars, lines_longer_than_80_chars
 var a = 'abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde ';

--- a/test/_data/lines_longer_than_80_chars/a.dart
+++ b/test/_data/lines_longer_than_80_chars/a.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 // abcde abcde abcde abcde abcde abcde abcde abcde
 // abcde abcde abcde abcde abcde abcde abcde abcde http://url.com/abcde/abcde/abcde/abcde.dart
 // abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde
@@ -25,5 +29,5 @@
  * line with a CRLF at its end                                                 a
  */
 
-// ignore: lines_longer_than_80_chars, lines_longer_than_80_chars, lines_longer_than_80_chars
+// ignore: lines_longer_than_80_chars,lines_longer_than_80_chars,lines_longer_than_80_chars
 var a = 'abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde abcde ';

--- a/test/integration/lines_longer_than_80_chars.dart
+++ b/test/integration/lines_longer_than_80_chars.dart
@@ -36,8 +36,8 @@ void main() {
             'a.dart 11:1 [lint] AVOID lines longer than 80 characters',
             'a.dart 20:1 [lint] AVOID lines longer than 80 characters',
             'a.dart 25:1 [lint] AVOID lines longer than 80 characters',
-            "a.dart 32:39 [hint] The diagnostic 'lines_longer_than_80_chars' does not need to be ignored here because it is already being ignored.",
-            "a.dart 32:66 [hint] The diagnostic 'lines_longer_than_80_chars' does not need to be ignored here because it is already being ignored.",
+            "a.dart 32:40 [hint] The diagnostic 'lines_longer_than_80_chars' does not need to be ignored here because it is already being ignored.",
+            "a.dart 32:68 [hint] The diagnostic 'lines_longer_than_80_chars' does not need to be ignored here because it is already being ignored.",
             '1 file analyzed, 6 issues found, in'
           ]));
       expect(exitCode, 1);

--- a/test/integration/lines_longer_than_80_chars.dart
+++ b/test/integration/lines_longer_than_80_chars.dart
@@ -32,11 +32,13 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'a.dart 3:1 [lint] AVOID lines longer than 80 characters',
             'a.dart 7:1 [lint] AVOID lines longer than 80 characters',
-            'a.dart 16:1 [lint] AVOID lines longer than 80 characters',
-            'a.dart 21:1 [lint] AVOID lines longer than 80 characters',
-            '1 file analyzed, 4 issues found, in'
+            'a.dart 11:1 [lint] AVOID lines longer than 80 characters',
+            'a.dart 20:1 [lint] AVOID lines longer than 80 characters',
+            'a.dart 25:1 [lint] AVOID lines longer than 80 characters',
+            "a.dart 32:39 [hint] The diagnostic 'lines_longer_than_80_chars' does not need to be ignored here because it is already being ignored.",
+            "a.dart 32:66 [hint] The diagnostic 'lines_longer_than_80_chars' does not need to be ignored here because it is already being ignored.",
+            '1 file analyzed, 6 issues found, in'
           ]));
       expect(exitCode, 1);
     });


### PR DESCRIPTION
~With analyzer 0.40.5, comma-separated ignores appear to no longer allow for spaces. I'm not sure if this is a big (@bwilkerson?) but this fix updates our newly failing test:~

https://travis-ci.org/github/dart-lang/linter/jobs/740287956#L438-L462


**EDIT:** real issue was new diagnostics.


/cc @a14n @bwilkerson 
