### PR TITLE
re-enable dev on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: dart
 dart:
-  # pending fix of: https://github.com/dart-lang/sdk/issues/43979
-  #- dev 
-  - beta
+  - dev
 sudo: false
 script: ./tool/travis.sh
 env:


### PR DESCRIPTION
I was hoping todays dev release would have the required fix but apparently not...

![image](https://user-images.githubusercontent.com/67586/97898493-c8b38580-1cec-11eb-8b9d-6d77464d00ae.png)


(HOLDING for the next one.)

See: https://github.com/dart-lang/sdk/issues/44027