### PR TITLE
0.1.124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.124
+
+* fixed false positives in `prefer_constructors_over_static_methods`
+* updated `package_names` to allow leading underscores
+
 # 0.1.123
 
 * fixed NPEs in `unnecessary_null_checks`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.123';
+const String version = '0.1.124';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.123
+version: 0.1.124
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.124

* fixed false positives in `prefer_constructors_over_static_methods`
* updated `package_names` to allow leading underscores

/cc @bwilkerson 
