### PR TITLE
Fix false positives in prefer_collection_literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.125-dev
+
+* fixed false positives in `prefer_colleciton_literals`.
+
 # 0.1.124
 
 * fixed false positives in `prefer_constructors_over_static_methods`

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -42,7 +42,7 @@ will trigger a type error so those will be excluded from the lint.
 void main() {
   LinkedHashSet<int> linkedHashSet =  LinkedHashSet.from([1, 2, 3]); // OK
   LinkedHashMap linkedHashMap = LinkedHashMap(); // OK
-  
+
   printSet(LinkedHashSet<int>()); // LINT
   printHashSet(LinkedHashSet<int>()); // OK
 
@@ -150,7 +150,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 }
 
 /// Returns the static type which is pushed into an expression by it's parent.
-DartType _enforcedType(AstNode parent) {
+DartType/*?*/ _enforcedType(AstNode parent) {
   if (parent is VariableDeclaration) {
     var parent2 = parent.parent;
     if (parent2 is VariableDeclarationList) {
@@ -172,4 +172,5 @@ DartType _enforcedType(AstNode parent) {
   if (parent is BinaryExpression) {
     return parent.staticType;
   }
+  return null;
 }

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -150,7 +150,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 }
 
 /// Returns the static type which is pushed into an expression by it's parent.
-DartType/*?*/ _enforcedType(AstNode parent) {
+DartType /*?*/ _enforcedType(AstNode parent) {
   if (parent is VariableDeclaration) {
     var parent2 = parent.parent;
     if (parent2 is VariableDeclarationList) {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.124';
+const String version = '0.1.125-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.124
+version: 0.1.125-dev
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.

--- a/test/rules/prefer_collection_literals.dart
+++ b/test/rules/prefer_collection_literals.dart
@@ -10,7 +10,7 @@ import 'dart:collection';
 void main() {
   var listToLint = new List(); //LINT
   var mapToLint = new Map(); // LINT
-  var LinkedHashMapToLint = new LinkedHashMap(); // LINT
+  var linkedHashMapToLint = new LinkedHashMap(); // LINT
 
   var m1 = Map.unmodifiable({}); //OK
   var m2 = Map.fromIterable([]); //OK
@@ -50,31 +50,42 @@ void main() {
 
   Set<int> ss5 = LinkedHashSet<int>(); // LINT
   LinkedHashSet<int> ss6 = LinkedHashSet<int>(); // OK
+  ss6 = LinkedHashSet(); // OK
+  ss6 = null ?? LinkedHashSet(); // OK
 
   printSet(Set()); // LINT
   printSet(LinkedHashSet<int>()); // LINT
   printHashSet(LinkedHashSet<int>()); // OK
+  printHashSetNamedArgument(ids: LinkedHashSet<int>()); // OK
 
   Set<int> ss7 = LinkedHashSet.from([1, 2, 3]); // LINT
-  LinkedHashSet<int> ss8 =  LinkedHashSet.from([1, 2, 3]); // OK
+  LinkedHashSet<int> ss8 = LinkedHashSet.from([1, 2, 3]); // OK
 
   Iterable iter = Iterable.empty(); // OK
   var sss = Set.from(iter); // OK
 
-  LinkedHashSet<String> sss1 = <int, LinkedHashSet<String>>{}.putIfAbsent(3, () => LinkedHashSet<String>()); // OK
+  LinkedHashSet<String> sss1 = <int, LinkedHashSet<String>>{}
+      .putIfAbsent(3, () => LinkedHashSet<String>()); // OK
 
-  var lhs = LinkedHashSet(equals: (a, b) => false, hashCode: (o) => 13)..addAll({}); // OK
+  var lhs = LinkedHashSet(equals: (a, b) => false, hashCode: (o) => 13)
+    ..addAll({}); // OK
 
   LinkedHashMap hashMap = LinkedHashMap(); // OK
+  hashMap = LinkedHashMap(); // OK
+  hashMap = null ?? LinkedHashMap(); // OK
 
   printMap(Map()); // LINT
   printMap(LinkedHashMap<int, int>()); // LINT
   printHashMap(LinkedHashMap<int, int>()); // OK
+  printHashMapNamedArgument(map: LinkedHashMap<int, int>()); // OK
 
-  LinkedHashMap<String, String> lhm = <int, LinkedHashMap<String,String>>{}.putIfAbsent(3, () => LinkedHashMap<String, String>()); // OK
+  LinkedHashMap<String, String> lhm = <int, LinkedHashMap<String, String>>{}
+      .putIfAbsent(3, () => LinkedHashMap<String, String>()); // OK
 }
 
 void printSet(Set<int> ids) => print('$ids!');
 void printHashSet(LinkedHashSet<int> ids) => printSet(ids);
+void printHashSetNamedArgument({LinkedHashSet<int> ids}) => printSet(ids);
 void printMap(Map map) => print('$map!');
 void printHashMap(LinkedHashMap map) => printMap(map);
+void printHashMapNamedArgument({LinkedHashMap<int, int> map}) => printMap(map);


### PR DESCRIPTION
Towards #1649

Allow using `LinkedHashSet` and `LinkedHashMap` for named arguments,
assignment to a variable, and when used in a binary expression where a
static type is pushed down to the arguments.

Refactor `_shouldSkipLinkedHashLint`. Extract a method to determine the
type that is enforced statically for the expression rather than
duplicate the subsequent check for each type of parent node.