### PR TITLE
Fix false negative for collections as parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.126-dev
+
+* fixed false negatives for `prefer_collection_literals` when a Set
+  instantiation is passed as the argument to a function in any position other
+  than the first.
+
 # 0.1.125
 
 * (internal): update to new `PhysicalResourceProvider` API

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -157,7 +157,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       // Skip: function(LinkedHashSet()); when function(LinkedHashSet mySet) or
       // function(LinkedHashMap()); when function(LinkedHashMap myMap)
       if (parent is ArgumentList) {
-        final paramType = parent.arguments.first.staticParameterElement?.type;
+        final paramType = node.staticParameterElement.type;
         if (paramType != null && !typeCheck(paramType)) {
           return true;
         }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.125';
+const String version = '0.1.126-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.125
+version: 0.1.126-dev
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.

--- a/test/rules/prefer_collection_literals.dart
+++ b/test/rules/prefer_collection_literals.dart
@@ -53,7 +53,9 @@ void main() {
 
   printSet(Set()); // LINT
   printSet(LinkedHashSet<int>()); // LINT
+  printIndentedSet(0, LinkedHashSet<int>()); // LINT
   printHashSet(LinkedHashSet<int>()); // OK
+  printIndentedHashSet(0, LinkedHashSet<int>()); // OK
 
   Set<int> ss7 = LinkedHashSet.from([1, 2, 3]); // LINT
   LinkedHashSet<int> ss8 =  LinkedHashSet.from([1, 2, 3]); // OK
@@ -75,6 +77,8 @@ void main() {
 }
 
 void printSet(Set<int> ids) => print('$ids!');
+void printIndentedSet(int indent, Set<int> ids) => print('$ids!');
 void printHashSet(LinkedHashSet<int> ids) => printSet(ids);
+void printIndentedHashSet(int indent, LinkedHashSet<int> ids) => printSet(ids);
 void printMap(Map map) => print('$map!');
 void printHashMap(LinkedHashMap map) => printMap(map);


### PR DESCRIPTION
Check the parameter element type for the specific collection
instantiation argument rather than check the parameter type of the first
argument.