### PR TITLE
Fix false negatives for collection assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # 0.1.126-dev
 
-* fixed false negatives for `prefer_collection_literals` when a Set
-  instantiation is passed as the argument to a function in any position other
-  than the first.
+* fixed false negatives for `prefer_collection_literals` when a LinkedHashSet or
+  LinkedHashMap instantiation is passed as the argument to a function in any
+  position other than the first
+* fixed false negatives for `prefer_collection_literals` when a LinkedHashSet or
+  LinkedHashMap instantiation is used in a place with a static type other than
+  Set or Map
 
 # 0.1.125
 

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -95,7 +95,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Lists, Maps.
     if (_isList(node) || _isMap(node) || _isHashMap(node)) {
-      if (_shouldSkipLinkedHashLint(node, _isTypeMap)) {
+      if (_shouldSkipLinkedHashLint(node, _isTypeHashMap)) {
         return;
       }
       if (constructorName == null && node.argumentList.arguments.isEmpty) {
@@ -106,7 +106,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Sets.
     if (_isSet(node) || _isHashSet(node)) {
-      if (_shouldSkipLinkedHashLint(node, _isTypeSet)) {
+      if (_shouldSkipLinkedHashLint(node, _isTypeHashSet)) {
         return;
       }
 
@@ -128,17 +128,21 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _isSet(Expression expression) => _isTypeSet(expression.staticType);
-  bool _isHashSet(Expression expression) => DartTypeUtilities.isClass(
-      expression.staticType, 'LinkedHashSet', 'dart.collection');
+  bool _isHashSet(Expression expression) =>
+      _isTypeHashSet(expression.staticType);
   bool _isList(Expression expression) =>
       DartTypeUtilities.isClass(expression.staticType, 'List', 'dart.core');
   bool _isMap(Expression expression) => _isTypeMap(expression.staticType);
-  bool _isHashMap(Expression expression) => DartTypeUtilities.isClass(
-      expression.staticType, 'LinkedHashMap', 'dart.collection');
+  bool _isHashMap(Expression expression) =>
+      _isTypeHashMap(expression.staticType);
   bool _isTypeSet(DartType type) =>
       DartTypeUtilities.isClass(type, 'Set', 'dart.core');
+  bool _isTypeHashSet(DartType type) =>
+      DartTypeUtilities.isClass(type, 'LinkedHashSet', 'dart.collection');
   bool _isTypeMap(DartType type) =>
       DartTypeUtilities.isClass(type, 'Map', 'dart.core');
+  bool _isTypeHashMap(DartType type) =>
+      DartTypeUtilities.isClass(type, 'LinkedHashMap', 'dart.collection');
 
   bool _shouldSkipLinkedHashLint(
       InstanceCreationExpression node, bool Function(DartType node) typeCheck) {
@@ -149,7 +153,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         var parent2 = parent.parent;
         if (parent2 is VariableDeclarationList) {
           var assignmentType = parent2.type?.type;
-          if (assignmentType != null && !typeCheck(assignmentType)) {
+          if (assignmentType != null && typeCheck(assignmentType)) {
             return true;
           }
         }
@@ -158,7 +162,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       // function(LinkedHashMap()); when function(LinkedHashMap myMap)
       if (parent is ArgumentList) {
         final paramType = node.staticParameterElement.type;
-        if (paramType != null && !typeCheck(paramType)) {
+        if (paramType != null && typeCheck(paramType)) {
           return true;
         }
       }
@@ -166,7 +170,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       // or <int, LinkedHashMap>{}.putIfAbsent(3, () => LinkedHashMap());
       if (parent is ExpressionFunctionBody) {
         var expressionType = parent.expression.staticType;
-        if (expressionType != null && !typeCheck(expressionType)) {
+        if (expressionType != null && typeCheck(expressionType)) {
           return true;
         }
       }

--- a/test/rules/prefer_collection_literals.dart
+++ b/test/rules/prefer_collection_literals.dart
@@ -50,8 +50,11 @@ void main() {
 
   Set<int> ss5 = LinkedHashSet<int>(); // LINT
   LinkedHashSet<int> ss6 = LinkedHashSet<int>(); // OK
+  Object ss7 = LinkedHashSet<int>(); // LINT
 
+  printObject(Set()); // LINT
   printSet(Set()); // LINT
+  printObject(LinkedHashSet()); // LINT
   printSet(LinkedHashSet<int>()); // LINT
   printIndentedSet(0, LinkedHashSet<int>()); // LINT
   printHashSet(LinkedHashSet<int>()); // OK
@@ -68,14 +71,18 @@ void main() {
   var lhs = LinkedHashSet(equals: (a, b) => false, hashCode: (o) => 13)..addAll({}); // OK
 
   LinkedHashMap hashMap = LinkedHashMap(); // OK
+  Object hashMap2 = LinkedHashMap(); // LINT
 
+  printObject(Map()); // LINT
   printMap(Map()); // LINT
+  printObject(LinkedHashMap()); // LINT
   printMap(LinkedHashMap<int, int>()); // LINT
   printHashMap(LinkedHashMap<int, int>()); // OK
 
   LinkedHashMap<String, String> lhm = <int, LinkedHashMap<String,String>>{}.putIfAbsent(3, () => LinkedHashMap<String, String>()); // OK
 }
 
+void printObject(Object o) => print('$o');
 void printSet(Set<int> ids) => print('$ids!');
 void printIndentedSet(int indent, Set<int> ids) => print('$ids!');
 void printHashSet(LinkedHashSet<int> ids) => printSet(ids);


### PR DESCRIPTION
Previously the lint would allow passing a `LinkedHashSet` instantiation
if the static type wasn't `Set`, and similarly for `LinkedHashMap`. This
allowed cases where the literal would also work when passed or assigned
to something requiring any supertype like `Object`, `dynamic`, or
`Iterable`.

Invert the condition used for the `typeCheck` callback and add checks
looking specifically for the `LinkedHash` variants of the static type.
Add tests demonstrating the new places the lint will trigger.
