### PR TITLE
The first step to migrate to ErrorCode constructor with named parameters

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.41.0
+  analyzer: ^0.41.1
   args: '>=1.4.0 <2.0.0'
   charcode: ^1.0.0
   glob: ^1.0.3

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -263,5 +263,10 @@ class TestErrorCode extends ErrorCode {
   @override
   ErrorType type;
 
-  TestErrorCode(String name, String message) : super(name, message);
+  TestErrorCode(String name, String message)
+      : super.temporary2(
+          message: message,
+          name: name,
+          uniqueName: 'TestErrorCode.$name',
+        );
 }


### PR DESCRIPTION
This is a step to do https://dart-review.googlesource.com/c/sdk/+/174322