### PR TITLE
simple machine readable rule listing

### DIFF
--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2015, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:analyzer/src/lint/registry.dart';
+import 'package:args/args.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/rules.dart';
+
+/// Generates a list of lint rules in machine format suitable for consumption by
+/// other tools.
+void main([List<String> args]) {
+  var parser = ArgParser()
+    ..addFlag('pretty',
+        abbr: 'p', help: 'Pretty-print output.', defaultsTo: true);
+  var options = parser.parse(args);
+
+  registerLintRules();
+
+  var rules = List<LintRule>.from(Registry.ruleRegistry, growable: false)
+    ..sort();
+
+  var encoder =
+      options['pretty'] == true ? JsonEncoder.withIndent('  ') : JsonEncoder();
+
+  print(encoder.convert([
+    for (var rule in rules)
+      {
+        'name': rule.name,
+        'description': rule.description,
+        'group': rule.group.name,
+        'details': rule.details,
+      }
+  ]));
+}

--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Sample (snipped) output:

```json
[
  {
    "name": "always_use_package_imports",
    "description": "Avoid relative imports for files in `lib/`.",
    "group": "errors",
    "details": "*DO* avoid relative imports for files in `lib/`.\n\nWhen mixing relative and absolute imports it's possible to create confusion\nwhere the same member gets imported in two different ways. One way to avoid\nthat is to ensure you consistently use absolute imports for files withing the\n`lib/` directory.\n\nThis is the opposite of 'prefer_relative_imports'.\nMight be used with 'avoid_relative_lib_imports' to avoid relative imports of\nfiles within `lib/` directory outside of it. (for example `test/`)\n\n**GOOD:**\n\n```\nimport 'package:foo/bar.dart';\n\nimport 'package:foo/baz.dart';\n\nimport 'package:foo/src/baz.dart';\n...\n```\n\n**BAD:**\n\n```\nimport 'baz.dart';\n\nimport 'src/bag.dart'\n\nimport '../lib/baz.dart';\n\n...\n```\n\n"
  },
  {
    "name": "avoid_empty_else",
    "description": "Avoid empty else statements.",
    "group": "errors",
    "details": "\n**AVOID** empty else statements.\n\n**BAD:**\n```\nif (x > y)\n  print(\"1\");\nelse ;\n  print(\"2\");\n```\n\n"
  },
  {
    "name": "avoid_print",
    "description": "Avoid `print` calls in production code.",
    "group": "errors",
    "details": "**DO** avoid `print` calls in production code.\n\n**BAD:**\n```\nvoid f(int x) {\n  print('debug: $x');\n  ...\n}\n```\n"
  }
]
```



/cc @csells @devoncarew 