### PR TITLE
prefer `dart analyze`

### DIFF
--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import "dart:io"; // Should break build.
+import 'dart:io';
 
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/src/lint/config.dart'; // ignore: implementation_imports

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
+import "dart:io"; // Should break build.
 
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/src/lint/config.dart'; // ignore: implementation_imports

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -48,10 +48,7 @@ else
   echo "Running main linter bot"
 
   # Verify that the libraries are error free.
-  dartanalyzer --fatal-warnings \
-    bin/linter.dart \
-    lib/src/rules.dart \
-    test/all.dart
+  dart analyze --fatal-warnings .
 
   echo ""
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -48,7 +48,7 @@ else
   echo "Running main linter bot"
 
   # Verify that the libraries are error free.
-  dart analyze --fatal-warnings .
+  dart analyze --fatal-warnings --fatal-infos .
 
   echo ""
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -48,7 +48,7 @@ else
   echo "Running main linter bot"
 
   # Verify that the libraries are error free.
-  dart analyze --fatal-warnings --fatal-infos .
+  dart analyze --fatal-infos .
 
   echo ""
 


### PR DESCRIPTION
Migrate from `dartanalyzer` in build.

Sample of a breakage:

![image](https://user-images.githubusercontent.com/67586/101386810-8abcfa80-3872-11eb-8cb7-6ef7aa51600c.png)



/cc @bwilkerson @devoncarew 