### PR TITLE
publish machine json

### DIFF
--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -12,6 +12,7 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules.dart';
 import 'package:markdown/markdown.dart';
 
+import 'machine.dart';
 import 'since.dart';
 
 /// Generates lint rule docs for publishing to https://dart-lang.github.io/
@@ -61,13 +62,25 @@ These rules are under active development.  Feedback is
 
 const ruleLeadMatter = 'Rules are organized into familiar rule groups.';
 
+final effectiveDartRules = <String>[];
 final flutterRules = <String>[];
 final pedanticRules = <String>[];
-final effectiveDartRules = <String>[];
 
 /// Sorted list of contributed lint rules.
 final List<LintRule> rules =
     List<LintRule>.from(Registry.ruleRegistry, growable: false)..sort();
+
+Map<String, SinceInfo> sinceInfo;
+
+Future<String> get effectiveDartLatestVersion async {
+  var url =
+      'https://raw.githubusercontent.com/tenhobi/effective_dart/master/lib/analysis_options.yaml';
+  var client = http.Client();
+  print('loading $url...');
+  var req = await client.get(url);
+  var parts = req.body.split('package:effective_dart/analysis_options.');
+  return parts[1].split('.yaml')[0];
+}
 
 String get enumerateErrorRules => rules
     .where((r) => r.group == Group.errors)
@@ -99,15 +112,8 @@ Future<String> get pedanticLatestVersion async {
   return parts[1].split('.yaml')[0];
 }
 
-Future<String> get effectiveDartLatestVersion async {
-  var url =
-      'https://raw.githubusercontent.com/tenhobi/effective_dart/master/lib/analysis_options.yaml';
-  var client = http.Client();
-  print('loading $url...');
-  var req = await client.get(url);
-  var parts = req.body.split('package:effective_dart/analysis_options.');
-  return parts[1].split('.yaml')[0];
-}
+String describeMaturity(LintRule r) =>
+    r.maturity == Maturity.stable ? '' : ' (${r.maturity.name})';
 
 Future<void> fetchBadgeInfo() async {
   var latestPedantic = await pedanticLatestVersion;
@@ -132,10 +138,6 @@ Future<void> fetchBadgeInfo() async {
   }
 }
 
-Future<void> fetchSinceInfo() async {
-  sinceInfo = await sinceMap;
-}
-
 Future<LintConfig> fetchConfig(String url) async {
   var client = http.Client();
   print('loading $url...');
@@ -143,7 +145,9 @@ Future<LintConfig> fetchConfig(String url) async {
   return processAnalysisOptionsFile(req.body);
 }
 
-Map<String, SinceInfo> sinceInfo;
+Future<void> fetchSinceInfo() async {
+  sinceInfo = await sinceMap;
+}
 
 Future<void> generateDocs(String dir) async {
   var outDir = dir;
@@ -184,6 +188,9 @@ Future<void> generateDocs(String dir) async {
 
   // Generate options samples.
   OptionsSample(rules).generate(outDir);
+
+  // Generate a machine-readable summary of rules.
+  MachineSummaryGenerator(Registry.ruleRegistry).generate(outDir);
 }
 
 String getBadges(String rule) {
@@ -220,9 +227,6 @@ ${parser.usage}
 
 String qualify(LintRule r) => r.name.toString() + describeMaturity(r);
 
-String describeMaturity(LintRule r) =>
-    r.maturity == Maturity.stable ? '' : ' (${r.maturity.name})';
-
 String toDescription(LintRule r) =>
     '<!--suppress HtmlUnknownTarget --><strong><a href = "${r.name}.html">${qualify(r)}</a></strong><br/> ${getBadges(r.name)} ${markdownToHtml(r.description)}';
 
@@ -242,134 +246,15 @@ class CountBadger {
   }
 }
 
-class RuleMarkdownGenerator {
-  final LintRule rule;
+class HtmlIndexer {
+  final Iterable<LintRule> rules;
 
-  RuleMarkdownGenerator(this.rule);
+  HtmlIndexer(this.rules);
 
-  String get name => rule.name;
-
-  String get group => rule.group.name;
-
-  String get maturity => rule.maturity.name;
-
-  String get details => rule.details ?? '';
-
-  String get since {
-    var info = sinceInfo[name];
-    var version = info.sinceDartSdk != null
-        ? '>= ${info.sinceDartSdk}'
-        : '**unreleased**';
-    return 'Dart SDK: $version • (Linter v${info.sinceLinter})';
-  }
-
-  void generate({String filePath}) {
-    final buffer = StringBuffer();
-
-    buffer.writeln('# Rule $name');
-    buffer.writeln();
-    buffer.writeln('**Group**: $group\\');
-    buffer.writeln('**Maturity**: $maturity\\');
-    buffer.writeln('**Since**: $since\\');
-    buffer.writeln();
-
-    // badges
-    if (flutterRules.contains(name)) {
-      buffer.writeln('[![flutter](style-flutter.svg)]'
-          '(https://github.com/flutter/flutter/blob/master/packages/'
-          'flutter/lib/analysis_options_user.yaml)');
-    }
-    if (pedanticRules.contains(name)) {
-      buffer.writeln('[![pedantic](style-pedantic.svg)]'
-          '(https://github.com/dart-lang/pedantic/#enabled-lints)');
-    }
-    if (effectiveDartRules.contains(name)) {
-      buffer.writeln('[![effective dart](style-effective_dart.svg)]'
-          '(https://github.com/tenhobi/effective_dart)');
-    }
-
-    buffer.writeln();
-
-    buffer.writeln('## Description');
-    buffer.writeln();
-    buffer.writeln('${details.trim()}');
-
-    // incompatible rules
-    final incompatibleRules = rule.incompatibleRules;
-    if (incompatibleRules.isNotEmpty) {
-      buffer.writeln('## Incompatible With');
-      buffer.writeln();
-      for (var rule in incompatibleRules) {
-        buffer.writeln('- [$rule]($rule.md)');
-      }
-      buffer.writeln();
-    }
-
-    if (filePath == null) {
-      print(buffer.toString());
-    } else {
-      File('$filePath/$name.md').writeAsStringSync(buffer.toString());
-    }
-  }
-}
-
-class RuleHtmlGenerator {
-  final LintRule rule;
-
-  RuleHtmlGenerator(this.rule);
-
-  String get details => rule.details ?? '';
-
-  String get group => rule.group.name;
-
-  String get humanReadableName => rule.name;
-
-  String get maturity => rule.maturity.name;
-
-  String get maturityString {
-    switch (rule.maturity) {
-      case Maturity.deprecated:
-        return '<span style="color:orangered;font-weight:bold;" >$maturity</span>';
-      case Maturity.experimental:
-        return '<span style="color:hotpink;font-weight:bold;" >$maturity</span>';
-      default:
-        return maturity;
-    }
-  }
-
-  String get name => rule.name;
-
-  String get since {
-    var info = sinceInfo[name];
-    var version = info.sinceDartSdk != null
-        ? '>= ${info.sinceDartSdk}'
-        : '<strong>unreleased</strong>';
-    return 'Dart SDK: $version • <small>(Linter v${info.sinceLinter})</small>';
-  }
-
-  String get incompatibleRuleDetails {
-    final sb = StringBuffer();
-    var incompatibleRules = rule.incompatibleRules;
-    if (incompatibleRules.isNotEmpty) {
-      sb.writeln('<p>');
-      sb.write('Incompatible with: ');
-      var rule = incompatibleRules.first;
-      sb.write(
-          '<!--suppress HtmlUnknownTarget --><a href = "$rule.html" >$rule</a>');
-      for (var i = 1; i < incompatibleRules.length; ++i) {
-        rule = incompatibleRules[i];
-        sb.write(', <a href = "$rule.html" >$rule</a>');
-      }
-      sb.writeln('.');
-      sb.writeln('</p>');
-    }
-    return sb.toString();
-  }
-
-  void generate([String filePath]) {
+  void generate(String filePath) {
     var generated = _generate();
     if (filePath != null) {
-      var outPath = '$filePath/$name.html';
+      var outPath = '$filePath/index.html';
       print('Writing to $outPath');
       File(outPath).writeAsStringSync(generated);
     } else {
@@ -386,31 +271,45 @@ class RuleHtmlGenerator {
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
       <meta name="mobile-web-app-capable" content="yes">
       <meta name="apple-mobile-web-app-capable" content="yes">
-      <title>$name</title>
       <link rel="stylesheet" href="../styles.css">
+      <title>Linter for Dart</title>
    </head>
    <body>
       <div class="wrapper">
          <header>
-            <h1>$humanReadableName</h1>
-            <p>Group: $group</p>
-            <p>Maturity: $maturityString</p>
-            <div class="tooltip">
-               <p>$since</p>
-               <span class="tooltip-content">Since info is static, may be stale</span>
-            </div>
-            ${getBadges(name)}
+            <a href="../index.html">
+               <h1>Linter for Dart</h1>
+            </a>
+            <p>Lint Rules</p>
             <ul>
-               <li><a href="index.html">View all <strong>Lint Rules</strong></a></li>
-               <li><a href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></li>
+              <li><a href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></li>
             </ul>
-            <p><a class="overflow-link" href="index.html">View all <strong>Lint Rules</strong></a></p>
             <p><a class="overflow-link" href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></p>
          </header>
          <section>
 
-            ${markdownToHtml(details)}
-            $incompatibleRuleDetails
+            <h1>Supported Lint Rules</h1>
+            <p>
+               This list is auto-generated from our sources.
+            </p>
+            ${markdownToHtml(ruleLeadMatter)}
+            <ul>
+               $enumerateGroups
+            </ul>
+            ${markdownToHtml(ruleFootMatter)}
+
+            <h2>Error Rules</h2>
+
+               $enumerateErrorRules
+
+            <h2>Style Rules</h2>
+
+               $enumerateStyleRules
+
+            <h2>Pub Rules</h2>
+
+               $enumeratePubRules
+
          </section>
       </div>
       <footer>
@@ -420,6 +319,22 @@ class RuleHtmlGenerator {
    </body>
 </html>
 ''';
+}
+
+class MachineSummaryGenerator {
+  final Iterable<LintRule> rules;
+
+  MachineSummaryGenerator(this.rules);
+  void generate(String filePath) {
+    var generated = getMachineListing(rules);
+    if (filePath != null) {
+      var outPath = '$filePath/machine/rules.json';
+      print('Writing to $outPath');
+      File(outPath).writeAsStringSync(generated);
+    } else {
+      print(generated);
+    }
+  }
 }
 
 class MarkdownIndexer {
@@ -498,81 +413,6 @@ class MarkdownIndexer {
       File('$filePath/index.md').writeAsStringSync(buffer.toString());
     }
   }
-}
-
-class HtmlIndexer {
-  final Iterable<LintRule> rules;
-
-  HtmlIndexer(this.rules);
-
-  void generate(String filePath) {
-    var generated = _generate();
-    if (filePath != null) {
-      var outPath = '$filePath/index.html';
-      print('Writing to $outPath');
-      File(outPath).writeAsStringSync(generated);
-    } else {
-      print(generated);
-    }
-  }
-
-  String _generate() => '''
-<!DOCTYPE html>
-<html lang="en">
-   <head>
-      <meta charset="utf-8">
-      <link rel="shortcut icon" href="../dart-192.png">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-      <meta name="mobile-web-app-capable" content="yes">
-      <meta name="apple-mobile-web-app-capable" content="yes">
-      <link rel="stylesheet" href="../styles.css">
-      <title>Linter for Dart</title>
-   </head>
-   <body>
-      <div class="wrapper">
-         <header>
-            <a href="../index.html">
-               <h1>Linter for Dart</h1>
-            </a>
-            <p>Lint Rules</p>
-            <ul>
-              <li><a href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></li>
-            </ul>
-            <p><a class="overflow-link" href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></p>
-         </header>
-         <section>
-
-            <h1>Supported Lint Rules</h1>
-            <p>
-               This list is auto-generated from our sources.
-            </p>
-            ${markdownToHtml(ruleLeadMatter)}
-            <ul>
-               $enumerateGroups
-            </ul>
-            ${markdownToHtml(ruleFootMatter)}
-
-            <h2>Error Rules</h2>
-
-               $enumerateErrorRules
-
-            <h2>Style Rules</h2>
-
-               $enumerateStyleRules
-
-            <h2>Pub Rules</h2>
-
-               $enumeratePubRules
-
-         </section>
-      </div>
-      <footer>
-         <p>Maintained by the <a href="https://dart.dev/">Dart Team</a></p>
-         <p>Visit us on <a href="https://github.com/dart-lang/linter">Github</a></p>
-      </footer>
-   </body>
-</html>
-''';
 }
 
 class OptionsSample {
@@ -658,4 +498,184 @@ linter:
    </body>
 </html>
 ''';
+}
+
+class RuleHtmlGenerator {
+  final LintRule rule;
+
+  RuleHtmlGenerator(this.rule);
+
+  String get details => rule.details ?? '';
+
+  String get group => rule.group.name;
+
+  String get humanReadableName => rule.name;
+
+  String get incompatibleRuleDetails {
+    final sb = StringBuffer();
+    var incompatibleRules = rule.incompatibleRules;
+    if (incompatibleRules.isNotEmpty) {
+      sb.writeln('<p>');
+      sb.write('Incompatible with: ');
+      var rule = incompatibleRules.first;
+      sb.write(
+          '<!--suppress HtmlUnknownTarget --><a href = "$rule.html" >$rule</a>');
+      for (var i = 1; i < incompatibleRules.length; ++i) {
+        rule = incompatibleRules[i];
+        sb.write(', <a href = "$rule.html" >$rule</a>');
+      }
+      sb.writeln('.');
+      sb.writeln('</p>');
+    }
+    return sb.toString();
+  }
+
+  String get maturity => rule.maturity.name;
+
+  String get maturityString {
+    switch (rule.maturity) {
+      case Maturity.deprecated:
+        return '<span style="color:orangered;font-weight:bold;" >$maturity</span>';
+      case Maturity.experimental:
+        return '<span style="color:hotpink;font-weight:bold;" >$maturity</span>';
+      default:
+        return maturity;
+    }
+  }
+
+  String get name => rule.name;
+
+  String get since {
+    var info = sinceInfo[name];
+    var version = info.sinceDartSdk != null
+        ? '>= ${info.sinceDartSdk}'
+        : '<strong>unreleased</strong>';
+    return 'Dart SDK: $version • <small>(Linter v${info.sinceLinter})</small>';
+  }
+
+  void generate([String filePath]) {
+    var generated = _generate();
+    if (filePath != null) {
+      var outPath = '$filePath/$name.html';
+      print('Writing to $outPath');
+      File(outPath).writeAsStringSync(generated);
+    } else {
+      print(generated);
+    }
+  }
+
+  String _generate() => '''
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8">
+      <link rel="shortcut icon" href="../dart-192.png">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+      <meta name="mobile-web-app-capable" content="yes">
+      <meta name="apple-mobile-web-app-capable" content="yes">
+      <title>$name</title>
+      <link rel="stylesheet" href="../styles.css">
+   </head>
+   <body>
+      <div class="wrapper">
+         <header>
+            <h1>$humanReadableName</h1>
+            <p>Group: $group</p>
+            <p>Maturity: $maturityString</p>
+            <div class="tooltip">
+               <p>$since</p>
+               <span class="tooltip-content">Since info is static, may be stale</span>
+            </div>
+            ${getBadges(name)}
+            <ul>
+               <li><a href="index.html">View all <strong>Lint Rules</strong></a></li>
+               <li><a href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></li>
+            </ul>
+            <p><a class="overflow-link" href="index.html">View all <strong>Lint Rules</strong></a></p>
+            <p><a class="overflow-link" href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></p>
+         </header>
+         <section>
+
+            ${markdownToHtml(details)}
+            $incompatibleRuleDetails
+         </section>
+      </div>
+      <footer>
+         <p>Maintained by the <a href="https://dart.dev/">Dart Team</a></p>
+         <p>Visit us on <a href="https://github.com/dart-lang/linter">Github</a></p>
+      </footer>
+   </body>
+</html>
+''';
+}
+
+class RuleMarkdownGenerator {
+  final LintRule rule;
+
+  RuleMarkdownGenerator(this.rule);
+
+  String get details => rule.details ?? '';
+
+  String get group => rule.group.name;
+
+  String get maturity => rule.maturity.name;
+
+  String get name => rule.name;
+
+  String get since {
+    var info = sinceInfo[name];
+    var version = info.sinceDartSdk != null
+        ? '>= ${info.sinceDartSdk}'
+        : '**unreleased**';
+    return 'Dart SDK: $version • (Linter v${info.sinceLinter})';
+  }
+
+  void generate({String filePath}) {
+    final buffer = StringBuffer();
+
+    buffer.writeln('# Rule $name');
+    buffer.writeln();
+    buffer.writeln('**Group**: $group\\');
+    buffer.writeln('**Maturity**: $maturity\\');
+    buffer.writeln('**Since**: $since\\');
+    buffer.writeln();
+
+    // badges
+    if (flutterRules.contains(name)) {
+      buffer.writeln('[![flutter](style-flutter.svg)]'
+          '(https://github.com/flutter/flutter/blob/master/packages/'
+          'flutter/lib/analysis_options_user.yaml)');
+    }
+    if (pedanticRules.contains(name)) {
+      buffer.writeln('[![pedantic](style-pedantic.svg)]'
+          '(https://github.com/dart-lang/pedantic/#enabled-lints)');
+    }
+    if (effectiveDartRules.contains(name)) {
+      buffer.writeln('[![effective dart](style-effective_dart.svg)]'
+          '(https://github.com/tenhobi/effective_dart)');
+    }
+
+    buffer.writeln();
+
+    buffer.writeln('## Description');
+    buffer.writeln();
+    buffer.writeln('${details.trim()}');
+
+    // incompatible rules
+    final incompatibleRules = rule.incompatibleRules;
+    if (incompatibleRules.isNotEmpty) {
+      buffer.writeln('## Incompatible With');
+      buffer.writeln();
+      for (var rule in incompatibleRules) {
+        buffer.writeln('- [$rule]($rule.md)');
+      }
+      buffer.writeln();
+    }
+
+    if (filePath == null) {
+      print(buffer.toString());
+    } else {
+      File('$filePath/$name.md').writeAsStringSync(buffer.toString());
+    }
+  }
 }

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -325,6 +325,7 @@ class MachineSummaryGenerator {
   final Iterable<LintRule> rules;
 
   MachineSummaryGenerator(this.rules);
+
   void generate(String filePath) {
     var generated = getMachineListing(rules);
     if (filePath != null) {

--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -18,14 +18,16 @@ void main([List<String> args]) {
   var options = parser.parse(args);
 
   registerLintRules();
+  var json = getMachineListing(Registry.ruleRegistry,
+      pretty: options['pretty'] == true);
+  print(json);
+}
 
-  var rules = List<LintRule>.from(Registry.ruleRegistry, growable: false)
-    ..sort();
-
-  var encoder =
-      options['pretty'] == true ? JsonEncoder.withIndent('  ') : JsonEncoder();
-
-  print(encoder.convert([
+String getMachineListing(Iterable<LintRule> ruleRegistry,
+    {bool pretty = true}) {
+  var rules = List<LintRule>.from(ruleRegistry, growable: false)..sort();
+  var encoder = pretty ? JsonEncoder.withIndent('  ') : JsonEncoder();
+  var json = encoder.convert([
     for (var rule in rules)
       {
         'name': rule.name,
@@ -33,5 +35,7 @@ void main([List<String> args]) {
         'group': rule.group.name,
         'details': rule.details,
       }
-  ]));
+  ]);
+
+  return json;
 }


### PR DESCRIPTION
Follow-up from #2359, adds machine json to the published docs.

See: https://dart-lang.github.io/linter/lints/machine/rules.json

Ultimate format and desired metadata still TBD.

(If desired we could pull this into `tools_metadata` as well but doing the work here feels right.)

/fyi @csells

/cc @devoncarew  