### PR TITLE
0.1.127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.127
 
-* fixed crash in `prefer_collection_literals` when there is no static paramater
+* fixed crash in `prefer_collection_literals` when there is no static parameter
   element
 
 # 0.1.126

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 0.1.127-dev
+# 0.1.127
+
+* fixed crash in `prefer_collection_literals` when there is no static paramater
+  element
 
 # 0.1.126
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.127-dev';
+const String version = '0.1.127';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.127-dev
+version: 0.1.127
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 0.1.127

* fixed crash in `prefer_collection_literals` when there is no static parameter element

/cc @bwilkerson @natebosch 
