### PR TITLE
prefer `dart format` in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To start working on a patch:
 
  * `git fetch upstream`
  * `git checkout upstream/master -b name_of_your_branch`
- * Hack away.  (Before committing, please be sure and run `dartfmt` on modified files; our build will fail if you don't!)
+ * Hack away.  (Before committing, please be sure and run `dart format` on modified files; our build will fail if you don't!)
  * `git commit -a -m "<your informative commit message>"`
  * `git push origin name_of_your_branch`
 

--- a/lib/src/rules/empty_statements.dart
+++ b/lib/src/rules/empty_statements.dart
@@ -23,7 +23,7 @@ if (complicated.expression.foo());
   bar();
 ```
 
-Formatted with `dartfmt` the bug becomes obvious:
+Formatted with `dart format` the bug becomes obvious:
 
 ```
 if (complicated.expression.foo()) ;

--- a/lib/src/rules/lines_longer_than_80_chars.dart
+++ b/lib/src/rules/lines_longer_than_80_chars.dart
@@ -26,9 +26,9 @@ compact. The main offender is usually `VeryLongCamelCaseClassNames`. Ask
 yourself, “Does each word in that type name tell me something critical or
 prevent a name collision?” If not, consider omitting it.
 
-Note that dartfmt does 99% of this for you, but the last 1% is you. It does not
-split long string literals to fit in 80 columns, so you have to do that
-manually.
+Note that `dart format` does 99% of this for you, but the last 1% is you. It 
+does not split long string literals to fit in 80 columns, so you have to do 
+that manually.
 
 We make an exception for URIs and file paths. When those occur in comments or
 strings (usually in imports and exports), they may remain on a single line even


### PR DESCRIPTION
Missed a few doc entries.

/cc @bwilkerson 