### PR TITLE
update docs to prefer `dart analyze` (over `dartanalyzer`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Linter for Dart
 
 The Dart Linter package defines lint rules that identify and report on "lints" found in Dart code.  Linting is performed by the Dart
-analysis server and the `dart analyze` command in the [Dart command-line tool](https://dart.dev/tools/dart-tool).
+analysis server and the `dart analyze` command in the [Dart command-line tool][dart_cli].
 
 [![Lint Count](https://dart-lang.github.io/linter/lints/count-badge.svg)](https://dart-lang.github.io/linter/lints/)
 [![Build Status](https://github.com/dart-lang/linter/workflows/linter/badge.svg)](https://github.com/dart-lang/linter/actions)
@@ -18,7 +18,10 @@ Alternatively, if you want to contribute to the linter or examine the source, cl
 
 ## Usage
 
-The linter gives you feedback to help you catch potential errors and keep your code in line with the published [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style/). Currently enforceable lint rules (or "lints") are catalogued [here][lints] and can be configured via an [analysis options file][options_file].  The linter is run from within the `dartanalyzer` [command-line tool](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli#dartanalyzer) shipped with the Dart SDK.  Assuming you have lints configured in an `analysis_options.yaml` file with these contents:
+The linter gives you feedback to help you catch potential errors and keep your code in line with the published 
+[Dart Style Guide][style_guide]. Enforceable lint rules (or "lints") are catalogued [here][lints] and can be configured via an 
+[analysis options file][options_file].  The linter is run from within the `dart analyze` [command-line tool][analyzer_cli] shipped with the 
+Dart SDK.  Assuming you have lints configured in an `analysis_options.yaml` file at the root of your project with these contents:
 
 ```yaml
 linter:
@@ -29,9 +32,12 @@ linter:
 ```
 you could lint your package like this:
 
-    $ dartanalyzer --options analysis_options.yaml .
+    $ dart analyze .
     
-and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose the rules you want to enable for your package, we have provided a [complete list of rules][lints].  For the lints that are enforced internally at Google, see [`package:pedantic`][package-pedantic].  For a set of rules corresponding to the [Effective Dart](https://dart.dev/guides/language/effective-dart) guide, see [`package:effective_dart`][package-effective-dart].
+and see any violations of the `annotate_overrides`, `hash_and_equals`, and `prefer_is_not_empty` rules in the console.  To help you choose 
+the rules you want to enable for your package, we have provided a [complete list of rules][lints].  For the lints that are enforced 
+internally at Google, see [`package:pedantic`][package-pedantic].  For a set of rules corresponding to the 
+[Effective Dart][effective_dart] guide, see [`package:effective_dart`][package-effective-dart].
 
 If a specific lint warning should be ignored, it can be flagged with a comment.  For example, 
 
@@ -40,7 +46,7 @@ If a specific lint warning should be ignored, it can be flagged with a comment. 
    (pm as Person).firstName = 'Seth';
 ```
 
-tells the `dartanalyzer` to ignore this instance of the `avoid_as` warning.
+tells the Dart analyzer to ignore this instance of the `avoid_as` warning.
 
 End-of-line comments are supported as well.  The following communicates the same thing:
 
@@ -59,9 +65,10 @@ void main() {
 }
 ```
 
-tells the `dartanalyzer` to ignore all occurences of the `avoid_as` warning in this file.
+tells the Dart analyzer to ignore all occurrences of the `avoid_as` warning in this file.
 
-As lints are treated the same as errors and warnings by the analyzer, their severity can similarly be configured in an options file.  For example, an analysis options file that specifies
+As lints are treated the same as errors and warnings by the analyzer, their severity can similarly be configured in an options file.  For 
+example, an analysis options file that specifies
 
 ```yaml
 linter:
@@ -83,8 +90,12 @@ Feedback is greatly appreciated and contributions are welcome! Please read the
 
 Please file feature requests and bugs in the [issue tracker][tracker].
 
-[tracker]: https://github.com/dart-lang/linter/issues
+[analyzer_cli]: https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli#dartanalyzer
+[dart_cli]: https://dart.dev/tools/dart-tool
+[effective_dart]:https://dart.dev/guides/language/effective-dart
 [lints]: https://dart-lang.github.io/linter/lints/
-[package-pedantic]: https://github.com/dart-lang/pedantic/blob/master/lib/analysis_options.yaml
-[package-effective-dart]: https://github.com/tenhobi/effective_dart
 [options_file]: https://dart.dev/guides/language/analysis-options#the-analysis-options-file
+[package-effective-dart]: https://github.com/tenhobi/effective_dart
+[package-pedantic]: https://github.com/dart-lang/pedantic/blob/master/lib/analysis_options.yaml
+[style_guide]:https://dart.dev/guides/language/effective-dart/style/
+[tracker]: https://github.com/dart-lang/linter/issues


### PR DESCRIPTION
/cc @bwilkerson 

/fyi @scheglov 
