### PR TITLE
Add font-weight 700 for Roboto Mono

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400&family=Roboto:ital,wght@0,300;0,400;0,700;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400&display=swap');
 
 body {
     background: #12202f;


### PR DESCRIPTION
A small change, but since we are using it for inline code text, the lack of 700 makes it slightly blurry.

The change is minor and I tried to include screenshots but compression makes the difference hard to tell.




