### PR TITLE
Cleanup and organize some code

### DIFF
--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -65,10 +65,10 @@ class C {
 ''';
 
 /// The name of the top-level variable used to mark a immutable class.
-String _immutableVarName = 'immutable';
+const _immutableVarName = 'immutable';
 
 /// The name of `meta` library, used to define analysis annotations.
-String _metaLibName = 'meta';
+const _metaLibName = 'meta';
 
 bool _isImmutable(Element element) =>
     element is PropertyAccessorElement &&

--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -55,7 +55,7 @@ class AvoidFieldInitializersInConstClasses extends LintRule
 }
 
 class HasParameterReferenceVisitor extends RecursiveAstVisitor {
-  Iterable<ParameterElement> parameters;
+  final Iterable<ParameterElement> parameters;
 
   bool useParameter = false;
 

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -51,18 +51,18 @@ Future<Null> someFunction() async {
 
 ''';
 
-const List<String> _fileMethodNames = <String>[
+const _fileMethodNames = <String>[
   'lastModified',
   'exists',
   'stat',
 ];
 
-const List<String> _dirMethodNames = <String>[
+const _dirMethodNames = <String>[
   'exists',
   'stat',
 ];
 
-const List<String> _fileSystemEntityMethodNames = <String>[
+const _fileSystemEntityMethodNames = <String>[
   'isDirectory',
   'isFile',
   'isLink',

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -46,7 +46,7 @@ class AvoidTypesOnClosureParameters extends LintRule implements NodeLintRule {
 }
 
 class AvoidTypesOnClosureParametersVisitor extends SimpleAstVisitor {
-  LintRule rule;
+  final LintRule rule;
 
   AvoidTypesOnClosureParametersVisitor(this.rule);
 

--- a/lib/src/rules/cast_nullable_to_non_nullable.dart
+++ b/lib/src/rules/cast_nullable_to_non_nullable.dart
@@ -60,10 +60,10 @@ class CastNullableToNonNullable extends LintRule implements NodeLintRule {
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  _Visitor(this.rule, this.context);
-
   final LintRule rule;
   final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitAsExpression(AsExpression node) {

--- a/lib/src/rules/comment_references.dart
+++ b/lib/src/rules/comment_references.dart
@@ -64,6 +64,8 @@ class CommentReferences extends LintRule implements NodeLintRule {
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
+  static const _parserSpecialCases = {'this', 'null', 'true', 'false'};
+
   final LintRule rule;
 
   _Visitor(this.rule);
@@ -102,8 +104,5 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _isParserSpecialCase(String reference) =>
-      reference == 'this' ||
-      reference == 'null' ||
-      reference == 'true' ||
-      reference == 'false';
+      _parserSpecialCases.contains(reference);
 }

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -136,7 +136,7 @@ class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
 }
 
 class _Visitor extends UnrelatedTypesProcessors {
-  static final _definition = InterfaceTypeDefinition('Iterable', 'dart.core');
+  static const _definition = InterfaceTypeDefinition('Iterable', 'dart.core');
 
   _Visitor(LintRule rule, TypeSystem typeSystem) : super(rule, typeSystem);
 

--- a/lib/src/rules/leading_newlines_in_multiline_strings.dart
+++ b/lib/src/rules/leading_newlines_in_multiline_strings.dart
@@ -54,9 +54,9 @@ class LeadingNewlinesInMultilineStrings extends LintRule
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  _Visitor(this.rule);
-
   final LintRule rule;
+
+  _Visitor(this.rule);
 
   LineInfo lineInfo;
 

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -136,7 +136,7 @@ class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
 }
 
 class _Visitor extends UnrelatedTypesProcessors {
-  static final _definition = InterfaceTypeDefinition('List', 'dart.core');
+  static const _definition = InterfaceTypeDefinition('List', 'dart.core');
 
   _Visitor(LintRule rule, TypeSystem typeSystem) : super(rule, typeSystem);
 

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -69,10 +69,10 @@ class NullCheckOnNullableTypeParameter extends LintRule
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  _Visitor(this.rule, this.context);
-
   final LintRule rule;
   final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitPostfixExpression(PostfixExpression node) {

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -94,7 +94,7 @@ class PackageApiDocs extends LintRule implements ProjectVisitor, NodeLintRule {
 }
 
 class _Visitor extends GeneralizingAstVisitor {
-  PackageApiDocs rule;
+  final PackageApiDocs rule;
 
   _Visitor(this.rule);
 

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -76,6 +76,7 @@ class PreferCollectionLiterals extends LintRule implements NodeLintRule {
 
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
+
   _Visitor(this.rule);
 
   @override

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -38,10 +38,10 @@ class A {
 ''';
 
 /// The name of the top-level variable used to mark a immutable class.
-String _immutableVarName = 'immutable';
+const _immutableVarName = 'immutable';
 
 /// The name of `meta` library, used to define analysis annotations.
-String _metaLibName = 'meta';
+const _metaLibName = 'meta';
 
 bool _isImmutable(Element element) =>
     element is PropertyAccessorElement &&

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -40,10 +40,10 @@ A a2 = new A(const {});
 ''';
 
 /// The name of the top-level variable used to mark a immutable class.
-String _immutableVarName = 'immutable';
+const _immutableVarName = 'immutable';
 
 /// The name of `meta` library, used to define analysis annotations.
-String _metaLibName = 'meta';
+const _metaLibName = 'meta';
 
 bool _isImmutable(Element element) =>
     element is PropertyAccessorElement &&

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -102,7 +102,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     if (!DartTypeUtilities.implementsAnyInterface(
-        type, <InterfaceTypeDefinition>[
+        type, const <InterfaceTypeDefinition>[
       InterfaceTypeDefinition('Iterable', 'dart.core'),
       InterfaceTypeDefinition('String', 'dart.core'),
     ])) {

--- a/lib/src/rules/tighten_type_of_initializing_formals.dart
+++ b/lib/src/rules/tighten_type_of_initializing_formals.dart
@@ -60,10 +60,10 @@ class TightenTypeOfInitializingFormals extends LintRule
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  _Visitor(this.rule, this.context);
-
   final LintRule rule;
   final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -74,6 +74,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   final _VisitorHelper v;
 
   _Visitor(this.rule) : v = _VisitorHelper(rule);
+
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
     if (node.fields.type == null) {

--- a/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
+++ b/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
@@ -54,10 +54,10 @@ class UnnecessaryNullableForFinalVariableDeclarations extends LintRule
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  _Visitor(this.rule, this.context);
-
   final LintRule rule;
   final LinterContext context;
+
+  _Visitor(this.rule, this.context);
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {

--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -127,7 +127,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   /// The special escaped chars listed in language specification
-  static const allowedEscapedChars = [
+  static const allowedEscapedChars = {
     '"',
     "'",
     r'$',
@@ -140,5 +140,5 @@ class _Visitor extends SimpleAstVisitor<void> {
     'v',
     'x',
     'u',
-  ];
+  };
 }

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -72,7 +72,7 @@ class UseStringBuffers extends LintRule implements NodeLintRule {
 
 class _IdentifierIsPrefixVisitor extends SimpleAstVisitor {
   final LintRule rule;
-  SimpleIdentifier identifier;
+  final SimpleIdentifier identifier;
 
   _IdentifierIsPrefixVisitor(this.rule, this.identifier);
 

--- a/lib/src/test_utilities/annotation.dart
+++ b/lib/src/test_utilities/annotation.dart
@@ -20,8 +20,7 @@ Annotation extractAnnotation(int lineNumber, String line) {
   final column = match[5].toInt();
   final length = match[6].toInt();
   final message = match[8].toNullIfBlank();
-  return Annotation.forLint(message, column, length)
-    ..lineNumber = lineNumber + relativeLine;
+  return Annotation.forLint(message, column, length, lineNumber + relativeLine);
 }
 
 /// Information about a 'LINT' annotation/comment.
@@ -30,7 +29,7 @@ class Annotation implements Comparable<Annotation> {
   final int length;
   final String message;
   final ErrorType type;
-  int lineNumber;
+  final int lineNumber;
 
   Annotation(this.message, this.type, this.lineNumber,
       {this.column, this.length});
@@ -41,8 +40,9 @@ class Annotation implements Comparable<Annotation> {
             column: lineInfo.getLocation(error.offset).columnNumber,
             length: error.length);
 
-  Annotation.forLint([String message, int column, int length])
-      : this(message, ErrorType.LINT, null, column: column, length: length);
+  Annotation.forLint([String message, int column, int length, int lineNumber])
+      : this(message, ErrorType.LINT, lineNumber,
+            column: column, length: length);
 
   @override
   int compareTo(Annotation other) {

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -23,7 +23,7 @@ List<Expression> _splitConjunctions(Expression rawExpression) {
 }
 
 class BreakScope {
-  var environment = <BreakStatement>[];
+  final environment = <BreakStatement>[];
 
   void add(BreakStatement element) {
     if (element.target != null) {
@@ -32,7 +32,7 @@ class BreakScope {
   }
 
   void deleteBreaksWithTarget(AstNode node) {
-    environment = environment.where((e) => e.target != node).toList();
+    environment.removeWhere((e) => e.target == node);
   }
 
   bool hasBreak(AstNode node) => environment.any((e) => e.target == node);
@@ -388,8 +388,8 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
 }
 
 class _ConditionExpression extends _ExpressionBox {
-  Expression expression;
-  bool value;
+  final Expression expression;
+  final bool value;
 
   _ConditionExpression(this.expression, {this.value = true});
 
@@ -413,7 +413,7 @@ class _UndefinedAllExpression extends _ExpressionBox {
 }
 
 class _UndefinedExpression extends _ExpressionBox {
-  Element element;
+  final Element element;
 
   factory _UndefinedExpression(Element element) {
     final canonicalElement = DartTypeUtilities.getCanonicalElement(element);

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -507,7 +507,7 @@ class DartTypeUtilities {
 }
 
 class EnumLikeClassDescription {
-  List<String> enumConstantNames;
+  final List<String> enumConstantNames;
   EnumLikeClassDescription(this.enumConstantNames);
 }
 
@@ -515,7 +515,7 @@ class InterfaceTypeDefinition {
   final String name;
   final String library;
 
-  InterfaceTypeDefinition(this.name, this.library);
+  const InterfaceTypeDefinition(this.name, this.library);
 
   @override
   int get hashCode => name.hashCode ^ library.hashCode;

--- a/lib/src/util/flutter_utils.dart
+++ b/lib/src/util/flutter_utils.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../util/dart_type_utilities.dart';
 
-var _collectionInterfaces = <InterfaceTypeDefinition>[
+const _collectionInterfaces = <InterfaceTypeDefinition>[
   InterfaceTypeDefinition('List', 'dart.core'),
   InterfaceTypeDefinition('Map', 'dart.core'),
   InterfaceTypeDefinition('LinkedHashMap', 'dart.collection'),


### PR DESCRIPTION
There isn't any functional changes here, mostly just cleanup and standardization:

- Switching to const when appropriate
- Switching to final if field isn't reassigned
- Switching from a list to a set if just used for a `contains` check
- Reorganizes some constructors and fields to be consistent
- Minor miscellaneous changes