### PR TITLE
score support scoring

### DIFF
--- a/tool/canonical/scorecard.dart
+++ b/tool/canonical/scorecard.dart
@@ -94,7 +94,7 @@ StringBuffer buildFooter(ScoreCard scorecard, List<Detail> details) {
   if (needsBulkFix.isNotEmpty) {
     footer.writeln('\n\nTODO: add bulk fixes for');
     for (var lint in needsBulkFix) {
-      footer.writeln('  -[ ] $lint');
+      footer.writeln('  - [ ] $lint');
     }
   }
 

--- a/tool/canonical/scorecard.dart
+++ b/tool/canonical/scorecard.dart
@@ -1,0 +1,403 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/src/lint/config.dart'; // ignore: implementation_imports
+import 'package:analyzer/src/lint/registry.dart'; // ignore: implementation_imports
+import 'package:github/github.dart';
+import 'package:http/http.dart' as http;
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/rules.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+
+import '../parse.dart';
+
+/// Issue triage: go through all issues and tag bugs
+/// Consider new tags for canonical-blocking work
+/// False positive vs. false negative?
+
+void main() async {
+  var scorecard = await ScoreCard.calculate();
+  var details = [
+    Detail.rule,
+    Detail.fix,
+    // Detail.status,
+    Detail.score,
+    Detail.recommend,
+    Detail.bugs,
+  ];
+
+  var sorter = (LintScore s1, LintScore s2) {
+    var base = _compareRuleSets(s1.ruleSets, s2.ruleSets) * 1000;
+    return s1.name.compareTo(s2.name) + base;
+  };
+
+  print(scorecard.asMarkdown(details, sorter: sorter));
+
+  var footer = buildFooter(scorecard, details);
+  print(footer);
+}
+
+const bulb = '💡';
+const checkMark = '✅';
+
+Iterable<LintRule> _registeredLints;
+
+Iterable<String> get registeredLintNames => registeredLints.map((r) => r.name);
+
+Iterable<LintRule> get registeredLints {
+  if (_registeredLints == null) {
+    registerLintRules();
+    _registeredLints = Registry.ruleRegistry.toList()
+      ..sort((l1, l2) => l1.name.compareTo(l2.name));
+  }
+  return _registeredLints;
+}
+
+StringBuffer buildFooter(ScoreCard scorecard, List<Detail> details) {
+  var scoreLintCount = 0;
+  var scoreFixCount = 0;
+
+  var recommendLintCount = 0;
+  var recommendFixCount = 0;
+
+  var needsBulkFix = <String>[];
+
+  for (var score in scorecard.scores) {
+    for (var ruleSet in score.ruleSets) {
+      if (ruleSet == 'score') {
+        ++scoreLintCount;
+        if (score.hasFix) {
+          ++scoreFixCount;
+        }
+      }
+      if (ruleSet == 'recommend') {
+        ++recommendLintCount;
+        if (score.hasFix) {
+          ++recommendFixCount;
+        }
+      }
+      if (score.hasFix && !score.hasBulkFix) {
+        needsBulkFix.add(score.name);
+      }
+    }
+  }
+
+  var footer = StringBuffer('\n${scorecard.lintCount} lints: ');
+  footer.write('$scoreLintCount score [$scoreFixCount fixes], ');
+  footer.write('rec $recommendLintCount [$recommendFixCount fixes]');
+  if (needsBulkFix.isNotEmpty) {
+    footer.writeln('\n\nTODO: add bulk fixes for');
+    for (var lint in needsBulkFix) {
+      footer.writeln('  -[ ] $lint');
+    }
+  }
+
+  return footer;
+}
+
+int _compareRuleSets(List<String> s1, List<String> s2) {
+  if (s1.contains('score')) {
+    return s2.contains('score') ? 0 : -1;
+  }
+  if (s2.contains('score')) {
+    return 1;
+  }
+  return 0;
+}
+
+bool _isBug(Issue issue) => issue.labels.map((l) => l.name).contains('bug');
+
+class Detail {
+  static const Detail rule = Detail('name', header: Header.left);
+  static const Detail fix = Detail('fix');
+  static const Detail status = Detail('status');
+  static const Detail score = Detail('score');
+  static const Detail recommend = Detail('recommend');
+  static const Detail bugs = Detail('bug refs', header: Header.left);
+  final String name;
+  final Header header;
+  const Detail(this.name, {this.header = Header.center});
+}
+
+class Header {
+  static const Header left = Header('| :--- ');
+
+  static const Header center = Header('| :---: ');
+
+  final String markdown;
+  const Header(this.markdown);
+}
+
+class LintScore {
+  String name;
+  bool hasBulkFix;
+  bool hasFix;
+  String maturity;
+
+  List<String> ruleSets;
+  List<String> bugReferences;
+
+  LintScore({
+    @required this.name,
+    @required this.hasFix,
+    @required this.hasBulkFix,
+    @required this.maturity,
+    @required this.ruleSets,
+    @required this.bugReferences,
+  });
+
+  String get _ruleSets => ruleSets.isNotEmpty ? ' ${ruleSets.toString()}' : '';
+
+  String toMarkdown(List<Detail> details) {
+    var sb = StringBuffer('| ');
+    for (var detail in details) {
+      switch (detail) {
+        case Detail.rule:
+          sb.write(
+              ' [$name](https://dart-lang.github.io/linter/lints/$name.html) |');
+          break;
+        case Detail.fix:
+          sb.write('${hasFix ? " $bulb" : ""} |');
+          break;
+        case Detail.status:
+          sb.write('${maturity != 'stable' ? ' **$maturity** ' : ""} |');
+          break;
+        case Detail.score:
+          sb.write('${ruleSets.contains('score') ? " $checkMark" : ""} |');
+          break;
+        case Detail.recommend:
+          sb.write('${ruleSets.contains('recommend') ? " $checkMark" : ""} |');
+          break;
+        case Detail.bugs:
+          sb.write(' ${bugReferences.join(", ")} |');
+          break;
+      }
+    }
+    return sb.toString();
+  }
+
+  @override
+  String toString() => '$name$_ruleSets${hasFix ? " $bulb" : ""}';
+}
+
+class ScoreCard {
+  List<LintScore> scores = <LintScore>[];
+
+  int get lintCount => scores.length;
+
+  void add(LintScore score) {
+    scores.add(score);
+  }
+
+  String asMarkdown(List<Detail> details,
+      {int Function(LintScore s1, LintScore s2) sorter}) {
+    // Header.
+    var sb = StringBuffer();
+    details.forEach((detail) => sb.write('| ${detail.name} '));
+    sb.write('|\n');
+    details.forEach((detail) => sb.write(detail.header.markdown));
+    sb.write(' |\n');
+
+    if (sorter != null) {
+      scores.sort(sorter);
+    }
+
+    // Body.
+    forEach((lint) => sb.write('${lint.toMarkdown(details)}\n'));
+    return sb.toString();
+  }
+
+  void forEach(void Function(LintScore element) f) {
+    scores.forEach(f);
+  }
+
+  void removeWhere(bool Function(LintScore element) test) {
+    scores.removeWhere(test);
+  }
+
+  static Future<ScoreCard> calculate() async {
+    var lintsWithFixes = await _getLintsWithFixes();
+    var lintsWithBulkFixes = await _getLintsWithBulkFixes();
+    var lintsWithAssists = await _getLintsWithAssists();
+
+    // var issues = await _getIssues();
+    // var bugs = issues.where(_isBug).toList();
+    var bugs = <Issue>[];
+
+    var scoreRuleset = _readScoreLints();
+    var recommendRuleset = _readRecommendLints();
+
+    var scorecard = ScoreCard();
+    for (var lint in registeredLints) {
+      var ruleSets = <String>[];
+      if (scoreRuleset.contains(lint.name)) {
+        ruleSets.add('score');
+      }
+      if (recommendRuleset.contains(lint.name)) {
+        ruleSets.add('recommend');
+      }
+
+      if (ruleSets.isEmpty) {
+        continue;
+      }
+
+      var bugReferences = <String>[];
+      for (var bug in bugs) {
+        if (bug.title.contains(lint.name)) {
+          bugReferences.add('#${bug.number.toString()}');
+        }
+      }
+
+      var lintName = lint.name;
+      scorecard.add(LintScore(
+        name: lintName,
+        hasFix: lintsWithFixes.contains(lintName) ||
+            lintsWithAssists.contains(lintName),
+        hasBulkFix: lintsWithBulkFixes.contains(lintName),
+        maturity: lint.maturity.name,
+        ruleSets: ruleSets,
+        bugReferences: bugReferences,
+      ));
+    }
+
+    return scorecard;
+  }
+
+  static Future<List<Issue>> _getIssues() async {
+    var github = GitHub();
+    var slug = RepositorySlug('dart-lang', 'linter');
+    try {
+      return github.issues.listByRepo(slug).toList();
+    } on Exception catch (e) {
+      print('exception caught fetching github issues');
+      print(e);
+      print('(defaulting to an empty list)');
+      return Future.value(<Issue>[]);
+    }
+  }
+
+  static Future<List<String>> _getLintsWithBulkFixes() async {
+    var client = http.Client();
+    var req = await client.get(
+        'https://raw.githubusercontent.com/dart-lang/sdk/master/pkg/analysis_server/lib/src/services/correction/bulk_fix_processor.dart');
+
+    var parser = CompilationUnitParser();
+    var cu = parser.parse(contents: req.body, name: 'bulk_fix_processor.dart');
+    var fixProcessor = cu.declarations.firstWhere(
+        (m) => m is ClassDeclaration && m.name.name == 'BulkFixProcessor');
+
+    var collector = _BulkFixCollector();
+    fixProcessor.accept(collector);
+    return collector.lintNames;
+  }
+
+  static Future<List<String>> _getLintsWithAssists() async {
+    var client = http.Client();
+    var req = await client.get(
+        'https://raw.githubusercontent.com/dart-lang/sdk/master/pkg/analysis_server/lib/src/services/correction/assist.dart');
+    var parser = CompilationUnitParser();
+    var cu = parser.parse(contents: req.body, name: 'assist.dart');
+    var assistKindClass = cu.declarations.firstWhere(
+        (m) => m is ClassDeclaration && m.name.name == 'DartAssistKind');
+
+    var collector = _AssistCollector();
+    assistKindClass.accept(collector);
+    return collector.lintNames;
+  }
+
+  static Future<List<String>> _getLintsWithFixes() async {
+    var client = http.Client();
+    var req = await client.get(
+        'https://raw.githubusercontent.com/dart-lang/sdk/master/pkg/analysis_server/lib/src/services/linter/lint_names.dart');
+
+    var parser = CompilationUnitParser();
+    var cu = parser.parse(contents: req.body, name: 'lint_names.dart');
+    var lintNamesClass = cu.declarations
+        .firstWhere((m) => m is ClassDeclaration && m.name.name == 'LintNames');
+
+    var collector = _FixCollector();
+    lintNamesClass.accept(collector);
+    return collector.lintNames;
+  }
+
+  static List<String> _readLints(String filePath) {
+    var file = File(filePath);
+    var contents = file.readAsStringSync();
+    var lintConfigs = processAnalysisOptionsFile(contents);
+    if (lintConfigs == null) {
+      return [];
+    }
+    return lintConfigs.ruleConfigs.map((c) => c.name ?? '<unknown>').toList();
+  }
+
+  static List<String> _readRecommendLints() =>
+      _readLints(path.join('tool', 'canonical', 'recommend.yaml'));
+
+  static List<String> _readScoreLints() =>
+      _readLints(path.join('tool', 'canonical', 'score.yaml'));
+}
+
+class _AssistCollector extends GeneralizingAstVisitor<void> {
+  final List<String> lintNames = <String>[];
+
+  @override
+  void visitNamedExpression(NamedExpression node) {
+    if (node.name.toString() == 'associatedErrorCodes:') {
+      final list = node.expression as ListLiteral;
+      for (var element in list.elements) {
+        var name =
+            element.toString().substring(1, element.toString().length - 1);
+        lintNames.add(name);
+        if (!registeredLintNames.contains(name)) {
+          print('WARNING: unrecognized lint in assists: $name');
+        }
+      }
+    }
+  }
+}
+
+class _LintNameCollector extends GeneralizingAstVisitor<void> {
+  final List<String> lintNames = <String>[];
+
+  void addLint(String name) {
+    lintNames.add(name);
+    if (!registeredLintNames.contains(name)) {
+      print('WARNING: unrecognized lint in fixes: $name');
+    }
+  }
+}
+
+class _FixCollector extends _LintNameCollector {
+  @override
+  void visitFieldDeclaration(FieldDeclaration node) {
+    for (var v in node.fields.variables) {
+      addLint(v.name.name);
+    }
+  }
+}
+
+class _BulkFixCollector extends _LintNameCollector {
+  @override
+  void visitFieldDeclaration(FieldDeclaration node) {
+    for (var field in node.fields.variables) {
+      if (field.name.name == 'lintProducerMap') {
+        var map = field.initializer as SetOrMapLiteral;
+        for (var element in map.elements) {
+          var entry = element as MapLiteralEntry;
+          var key = entry.key;
+          if (key is PrefixedIdentifier) {
+            if (key.prefix.name == 'LintNames') {
+              addLint(key.identifier.name);
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Stats gathering and punch-list generation for scored lints support.  This will evolve.

/cc @bwilkerson 

Sample run:

| name | fix | score | recommend | bug refs |
| :--- | :---: | :---: | :---: | :---  |
|  [avoid_empty_else](https://dart-lang.github.io/linter/lints/avoid_empty_else.html) | 💡 | ✅ | |  |
|  [avoid_relative_lib_imports](https://dart-lang.github.io/linter/lints/avoid_relative_lib_imports.html) | 💡 | ✅ | |  |
|  [avoid_shadowing_type_parameters](https://dart-lang.github.io/linter/lints/avoid_shadowing_type_parameters.html) | | ✅ | |  |
|  [avoid_types_as_parameter_names](https://dart-lang.github.io/linter/lints/avoid_types_as_parameter_names.html) | 💡 | ✅ | |  |
|  [await_only_futures](https://dart-lang.github.io/linter/lints/await_only_futures.html) | 💡 | ✅ | |  |
|  [camel_case_extensions](https://dart-lang.github.io/linter/lints/camel_case_extensions.html) | | ✅ | |  |
|  [camel_case_types](https://dart-lang.github.io/linter/lints/camel_case_types.html) | | ✅ | |  |
|  [curly_braces_in_flow_control_structures](https://dart-lang.github.io/linter/lints/curly_braces_in_flow_control_structures.html) | 💡 | ✅ | |  |
|  [empty_catches](https://dart-lang.github.io/linter/lints/empty_catches.html) | 💡 | ✅ | |  |
|  [file_names](https://dart-lang.github.io/linter/lints/file_names.html) | | ✅ | |  |
|  [hash_and_equals](https://dart-lang.github.io/linter/lints/hash_and_equals.html) | 💡 | ✅ | |  |
|  [iterable_contains_unrelated_type](https://dart-lang.github.io/linter/lints/iterable_contains_unrelated_type.html) | | ✅ | |  |
|  [list_remove_unrelated_type](https://dart-lang.github.io/linter/lints/list_remove_unrelated_type.html) | | ✅ | |  |
|  [no_duplicate_case_values](https://dart-lang.github.io/linter/lints/no_duplicate_case_values.html) | 💡 | ✅ | |  |
|  [non_constant_identifier_names](https://dart-lang.github.io/linter/lints/non_constant_identifier_names.html) | 💡 | ✅ | |  |
|  [package_prefixed_library_names](https://dart-lang.github.io/linter/lints/package_prefixed_library_names.html) | | ✅ | |  |
|  [prefer_generic_function_type_aliases](https://dart-lang.github.io/linter/lints/prefer_generic_function_type_aliases.html) | 💡 | ✅ | |  |
|  [prefer_is_empty](https://dart-lang.github.io/linter/lints/prefer_is_empty.html) | 💡 | ✅ | |  |
|  [prefer_is_not_empty](https://dart-lang.github.io/linter/lints/prefer_is_not_empty.html) | 💡 | ✅ | |  |
|  [prefer_iterable_whereType](https://dart-lang.github.io/linter/lints/prefer_iterable_whereType.html) | 💡 | ✅ | |  |
|  [prefer_typing_uninitialized_variables](https://dart-lang.github.io/linter/lints/prefer_typing_uninitialized_variables.html) | | ✅ | |  |
|  [provide_deprecation_message](https://dart-lang.github.io/linter/lints/provide_deprecation_message.html) | | ✅ | |  |
|  [unawaited_futures](https://dart-lang.github.io/linter/lints/unawaited_futures.html) | 💡 | ✅ | |  |
|  [unnecessary_overrides](https://dart-lang.github.io/linter/lints/unnecessary_overrides.html) | 💡 | ✅ | |  |
|  [unrelated_type_equality_checks](https://dart-lang.github.io/linter/lints/unrelated_type_equality_checks.html) | | ✅ | |  |
|  [valid_regexps](https://dart-lang.github.io/linter/lints/valid_regexps.html) | | ✅ | |  |
|  [void_checks](https://dart-lang.github.io/linter/lints/void_checks.html) | | ✅ | |  |
|  [always_require_non_null_named_parameters](https://dart-lang.github.io/linter/lints/always_require_non_null_named_parameters.html) | 💡 | | ✅ |  |
|  [annotate_overrides](https://dart-lang.github.io/linter/lints/annotate_overrides.html) | 💡 | | ✅ |  |
|  [avoid_function_literals_in_foreach_calls](https://dart-lang.github.io/linter/lints/avoid_function_literals_in_foreach_calls.html) | | | ✅ |  |
|  [avoid_init_to_null](https://dart-lang.github.io/linter/lints/avoid_init_to_null.html) | 💡 | | ✅ |  |
|  [avoid_null_checks_in_equality_operators](https://dart-lang.github.io/linter/lints/avoid_null_checks_in_equality_operators.html) | | | ✅ |  |
|  [avoid_private_typedef_functions](https://dart-lang.github.io/linter/lints/avoid_private_typedef_functions.html) | 💡 | | ✅ |  |
|  [avoid_renaming_method_parameters](https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html) | | | ✅ |  |
|  [avoid_return_types_on_setters](https://dart-lang.github.io/linter/lints/avoid_return_types_on_setters.html) | 💡 | | ✅ |  |
|  [avoid_returning_null_for_void](https://dart-lang.github.io/linter/lints/avoid_returning_null_for_void.html) | | | ✅ |  |
|  [avoid_single_cascade_in_expression_statements](https://dart-lang.github.io/linter/lints/avoid_single_cascade_in_expression_statements.html) | 💡 | | ✅ |  |
|  [constant_identifier_names](https://dart-lang.github.io/linter/lints/constant_identifier_names.html) | | | ✅ |  |
|  [control_flow_in_finally](https://dart-lang.github.io/linter/lints/control_flow_in_finally.html) | | | ✅ |  |
|  [empty_constructor_bodies](https://dart-lang.github.io/linter/lints/empty_constructor_bodies.html) | 💡 | | ✅ |  |
|  [empty_statements](https://dart-lang.github.io/linter/lints/empty_statements.html) | 💡 | | ✅ |  |
|  [exhaustive_cases](https://dart-lang.github.io/linter/lints/exhaustive_cases.html) | | | ✅ |  |
|  [implementation_imports](https://dart-lang.github.io/linter/lints/implementation_imports.html) | | | ✅ |  |
|  [library_names](https://dart-lang.github.io/linter/lints/library_names.html) | | | ✅ |  |
|  [library_prefixes](https://dart-lang.github.io/linter/lints/library_prefixes.html) | | | ✅ |  |
|  [null_closures](https://dart-lang.github.io/linter/lints/null_closures.html) | 💡 | | ✅ |  |
|  [omit_local_variable_types](https://dart-lang.github.io/linter/lints/omit_local_variable_types.html) | 💡 | | ✅ |  |
|  [overridden_fields](https://dart-lang.github.io/linter/lints/overridden_fields.html) | | | ✅ |  |
|  [package_names](https://dart-lang.github.io/linter/lints/package_names.html) | | | ✅ |  |
|  [prefer_adjacent_string_concatenation](https://dart-lang.github.io/linter/lints/prefer_adjacent_string_concatenation.html) | 💡 | | ✅ |  |
|  [prefer_collection_literals](https://dart-lang.github.io/linter/lints/prefer_collection_literals.html) | 💡 | | ✅ |  |
|  [prefer_conditional_assignment](https://dart-lang.github.io/linter/lints/prefer_conditional_assignment.html) | 💡 | | ✅ |  |
|  [prefer_contains](https://dart-lang.github.io/linter/lints/prefer_contains.html) | 💡 | | ✅ |  |
|  [prefer_equal_for_default_values](https://dart-lang.github.io/linter/lints/prefer_equal_for_default_values.html) | 💡 | | ✅ |  |
|  [prefer_final_fields](https://dart-lang.github.io/linter/lints/prefer_final_fields.html) | 💡 | | ✅ |  |
|  [prefer_for_elements_to_map_fromIterable](https://dart-lang.github.io/linter/lints/prefer_for_elements_to_map_fromIterable.html) | 💡 | | ✅ |  |
|  [prefer_function_declarations_over_variables](https://dart-lang.github.io/linter/lints/prefer_function_declarations_over_variables.html) | | | ✅ |  |
|  [prefer_if_null_operators](https://dart-lang.github.io/linter/lints/prefer_if_null_operators.html) | 💡 | | ✅ |  |
|  [prefer_initializing_formals](https://dart-lang.github.io/linter/lints/prefer_initializing_formals.html) | | | ✅ |  |
|  [prefer_inlined_adds](https://dart-lang.github.io/linter/lints/prefer_inlined_adds.html) | 💡 | | ✅ |  |
|  [prefer_is_not_operator](https://dart-lang.github.io/linter/lints/prefer_is_not_operator.html) | | | ✅ |  |
|  [prefer_mixin](https://dart-lang.github.io/linter/lints/prefer_mixin.html) | | | ✅ |  |
|  [prefer_null_aware_operators](https://dart-lang.github.io/linter/lints/prefer_null_aware_operators.html) | 💡 | | ✅ |  |
|  [prefer_spread_collections](https://dart-lang.github.io/linter/lints/prefer_spread_collections.html) | 💡 | | ✅ |  |
|  [prefer_void_to_null](https://dart-lang.github.io/linter/lints/prefer_void_to_null.html) | | | ✅ |  |
|  [recursive_getters](https://dart-lang.github.io/linter/lints/recursive_getters.html) | | | ✅ |  |
|  [slash_for_doc_comments](https://dart-lang.github.io/linter/lints/slash_for_doc_comments.html) | 💡 | | ✅ |  |
|  [type_init_formals](https://dart-lang.github.io/linter/lints/type_init_formals.html) | 💡 | | ✅ |  |
|  [unnecessary_brace_in_string_interps](https://dart-lang.github.io/linter/lints/unnecessary_brace_in_string_interps.html) | 💡 | | ✅ |  |
|  [unnecessary_const](https://dart-lang.github.io/linter/lints/unnecessary_const.html) | 💡 | | ✅ |  |
|  [unnecessary_getters_setters](https://dart-lang.github.io/linter/lints/unnecessary_getters_setters.html) | | | ✅ |  |
|  [unnecessary_new](https://dart-lang.github.io/linter/lints/unnecessary_new.html) | 💡 | | ✅ |  |
|  [unnecessary_null_in_if_null_operators](https://dart-lang.github.io/linter/lints/unnecessary_null_in_if_null_operators.html) | 💡 | | ✅ |  |
|  [unnecessary_string_escapes](https://dart-lang.github.io/linter/lints/unnecessary_string_escapes.html) | | | ✅ |  |
|  [unnecessary_string_interpolations](https://dart-lang.github.io/linter/lints/unnecessary_string_interpolations.html) | | | ✅ |  |
|  [unnecessary_this](https://dart-lang.github.io/linter/lints/unnecessary_this.html) | 💡 | | ✅ |  |
|  [use_function_type_syntax_for_parameters](https://dart-lang.github.io/linter/lints/use_function_type_syntax_for_parameters.html) | 💡 | | ✅ |  |
|  [use_rethrow_when_possible](https://dart-lang.github.io/linter/lints/use_rethrow_when_possible.html) | 💡 | | ✅ |  |


78 lints: 27 score [15 fixes], rec 51 [30 fixes]

TODO: add bulk fixes for
  - [ ] avoid_relative_lib_imports
  - [ ] avoid_types_as_parameter_names
  - [ ] always_require_non_null_named_parameters
  - [ ] avoid_private_typedef_functions
  - [ ] unnecessary_null_in_if_null_operators
  - [ ] use_function_type_syntax_for_parameters
