### PR TITLE
tracked unfixable lints and updated scoring

### DIFF
--- a/tool/canonical/fix_excludes.json
+++ b/tool/canonical/fix_excludes.json
@@ -1,0 +1,94 @@
+[
+  {
+    "lint" : "avoid_renaming_method_parameters",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "avoid_shadowing_type_parameters",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "camel_case_extensions",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "camel_case_types",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "constant_identifier_names",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "control_flow_in_finally",
+    "notes" : "TODO"
+  },
+  {
+    "lint" : "exhaustive_cases",
+    "notes" : "infeasible"
+  },
+  {
+    "lint" : "file_names",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "implementation_imports",
+    "notes" : "potentially; but performance would be a concern"
+  },
+  {
+    "lint" : "iterable_contains_unrelated_type",
+    "notes" : "logic"
+  },
+  {
+    "lint" : "library_names",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "library_prefixes",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "list_remove_unrelated_type",
+    "notes" : "logic"
+  },
+  {
+    "lint" : "overridden_fields",
+    "notes" : "infeasible"
+  },
+  {
+    "lint" : "package_names",
+    "notes" : "naming"
+  },
+  {
+    "lint" : "package_prefixed_library_names",
+    "notes" : "naming; possible but low value"
+  },
+  {
+    "lint" : "prefer_function_declarations_over_variables",
+    "notes" : "potentially fixable but likely difficult to get right"
+  },
+  {
+    "lint" : "prefer_mixin",
+    "notes" : "potentially fixable, but there are lots of opportunities for getting this wrong"
+  },
+  {
+    "lint" : "provide_deprecation_message",
+    "notes" : "infeasible"
+  },
+  {
+    "lint" : "recursive_getters",
+    "notes" : "not fixable (impossible to know user's intent)"
+  },
+  {
+    "lint" : "unrelated_type_equality_checks",
+    "notes" : "infeasible"
+  },
+  {
+    "lint" : "valid_regexps",
+    "notes" : "infeasible"
+  },
+  {
+    "lint" : "void_checks",
+    "notes" : "invalid in NNBD?"
+  }
+]

--- a/tool/canonical/fix_excludes.json
+++ b/tool/canonical/fix_excludes.json
@@ -21,10 +21,6 @@
   },
   {
     "lint" : "control_flow_in_finally",
-    "notes" : "TODO"
-  },
-  {
-    "lint" : "exhaustive_cases",
     "notes" : "infeasible"
   },
   {


### PR DESCRIPTION
Follow-up from https://github.com/dart-lang/linter/issues/2405.

/cc @bwilkerson 

Sample run:


| name | fix | score | recommend | bug refs |
| :--- | :---: | :---: | :---: | :---  |
|  [`avoid_empty_else`](https://dart-lang.github.io/linter/lints/avoid_empty_else.html) | 💡 | ✅ | |  |
|  [`avoid_relative_lib_imports`](https://dart-lang.github.io/linter/lints/avoid_relative_lib_imports.html) | 💡 | ✅ | |  |
|  [`avoid_shadowing_type_parameters`](https://dart-lang.github.io/linter/lints/avoid_shadowing_type_parameters.html) | ➖ | ✅ | |  |
|  [`avoid_types_as_parameter_names`](https://dart-lang.github.io/linter/lints/avoid_types_as_parameter_names.html) | 💡 | ✅ | |  |
|  [`await_only_futures`](https://dart-lang.github.io/linter/lints/await_only_futures.html) | 💡 | ✅ | |  |
|  [`camel_case_extensions`](https://dart-lang.github.io/linter/lints/camel_case_extensions.html) | ➖ | ✅ | |  |
|  [`camel_case_types`](https://dart-lang.github.io/linter/lints/camel_case_types.html) | ➖ | ✅ | |  |
|  [`curly_braces_in_flow_control_structures`](https://dart-lang.github.io/linter/lints/curly_braces_in_flow_control_structures.html) | 💡 | ✅ | |  |
|  [`empty_catches`](https://dart-lang.github.io/linter/lints/empty_catches.html) | 💡 | ✅ | |  |
|  [`file_names`](https://dart-lang.github.io/linter/lints/file_names.html) | ➖ | ✅ | |  |
|  [`hash_and_equals`](https://dart-lang.github.io/linter/lints/hash_and_equals.html) | 💡 | ✅ | |  |
|  [`iterable_contains_unrelated_type`](https://dart-lang.github.io/linter/lints/iterable_contains_unrelated_type.html) | ➖ | ✅ | |  |
|  [`list_remove_unrelated_type`](https://dart-lang.github.io/linter/lints/list_remove_unrelated_type.html) | ➖ | ✅ | |  |
|  [`no_duplicate_case_values`](https://dart-lang.github.io/linter/lints/no_duplicate_case_values.html) | 💡 | ✅ | |  |
|  [`non_constant_identifier_names`](https://dart-lang.github.io/linter/lints/non_constant_identifier_names.html) | 💡 | ✅ | |  |
|  [`package_prefixed_library_names`](https://dart-lang.github.io/linter/lints/package_prefixed_library_names.html) | ➖ | ✅ | |  |
|  [`prefer_generic_function_type_aliases`](https://dart-lang.github.io/linter/lints/prefer_generic_function_type_aliases.html) | 💡 | ✅ | |  |
|  [`prefer_is_empty`](https://dart-lang.github.io/linter/lints/prefer_is_empty.html) | 💡 | ✅ | |  |
|  [`prefer_is_not_empty`](https://dart-lang.github.io/linter/lints/prefer_is_not_empty.html) | 💡 | ✅ | |  |
|  [`prefer_iterable_whereType`](https://dart-lang.github.io/linter/lints/prefer_iterable_whereType.html) | 💡 | ✅ | |  |
|  [`prefer_typing_uninitialized_variables`](https://dart-lang.github.io/linter/lints/prefer_typing_uninitialized_variables.html) | 🤔 | ✅ | |  |
|  [`provide_deprecation_message`](https://dart-lang.github.io/linter/lints/provide_deprecation_message.html) | ➖ | ✅ | |  |
|  [`unawaited_futures`](https://dart-lang.github.io/linter/lints/unawaited_futures.html) | 💡 | ✅ | |  |
|  [`unnecessary_overrides`](https://dart-lang.github.io/linter/lints/unnecessary_overrides.html) | 💡 | ✅ | |  |
|  [`unrelated_type_equality_checks`](https://dart-lang.github.io/linter/lints/unrelated_type_equality_checks.html) | ➖ | ✅ | |  |
|  [`valid_regexps`](https://dart-lang.github.io/linter/lints/valid_regexps.html) | ➖ | ✅ | |  |
|  [`void_checks`](https://dart-lang.github.io/linter/lints/void_checks.html) | ➖ | ✅ | |  |
|  [`always_require_non_null_named_parameters`](https://dart-lang.github.io/linter/lints/always_require_non_null_named_parameters.html) | 💡 | | ✅ |  |
|  [`annotate_overrides`](https://dart-lang.github.io/linter/lints/annotate_overrides.html) | 💡 | | ✅ |  |
|  [`avoid_function_literals_in_foreach_calls`](https://dart-lang.github.io/linter/lints/avoid_function_literals_in_foreach_calls.html) | 🤔 | | ✅ |  |
|  [`avoid_init_to_null`](https://dart-lang.github.io/linter/lints/avoid_init_to_null.html) | 💡 | | ✅ |  |
|  [`avoid_null_checks_in_equality_operators`](https://dart-lang.github.io/linter/lints/avoid_null_checks_in_equality_operators.html) | 🤔 | | ✅ |  |
|  [`avoid_private_typedef_functions`](https://dart-lang.github.io/linter/lints/avoid_private_typedef_functions.html) | 💡 | | ✅ |  |
|  [`avoid_renaming_method_parameters`](https://dart-lang.github.io/linter/lints/avoid_renaming_method_parameters.html) | ➖ | | ✅ |  |
|  [`avoid_return_types_on_setters`](https://dart-lang.github.io/linter/lints/avoid_return_types_on_setters.html) | 💡 | | ✅ |  |
|  [`avoid_returning_null_for_void`](https://dart-lang.github.io/linter/lints/avoid_returning_null_for_void.html) | 🤔 | | ✅ |  |
|  [`avoid_single_cascade_in_expression_statements`](https://dart-lang.github.io/linter/lints/avoid_single_cascade_in_expression_statements.html) | 💡 | | ✅ |  |
|  [`constant_identifier_names`](https://dart-lang.github.io/linter/lints/constant_identifier_names.html) | ➖ | | ✅ |  |
|  [`control_flow_in_finally`](https://dart-lang.github.io/linter/lints/control_flow_in_finally.html) | 🤔 | | ✅ |  |
|  [`empty_constructor_bodies`](https://dart-lang.github.io/linter/lints/empty_constructor_bodies.html) | 💡 | | ✅ |  |
|  [`empty_statements`](https://dart-lang.github.io/linter/lints/empty_statements.html) | 💡 | | ✅ |  |
|  [`exhaustive_cases`](https://dart-lang.github.io/linter/lints/exhaustive_cases.html) | ➖ | | ✅ |  |
|  [`implementation_imports`](https://dart-lang.github.io/linter/lints/implementation_imports.html) | ➖ | | ✅ |  |
|  [`library_names`](https://dart-lang.github.io/linter/lints/library_names.html) | ➖ | | ✅ |  |
|  [`library_prefixes`](https://dart-lang.github.io/linter/lints/library_prefixes.html) | ➖ | | ✅ |  |
|  [`null_closures`](https://dart-lang.github.io/linter/lints/null_closures.html) | 💡 | | ✅ |  |
|  [`omit_local_variable_types`](https://dart-lang.github.io/linter/lints/omit_local_variable_types.html) | 💡 | | ✅ |  |
|  [`overridden_fields`](https://dart-lang.github.io/linter/lints/overridden_fields.html) | ➖ | | ✅ |  |
|  [`package_names`](https://dart-lang.github.io/linter/lints/package_names.html) | ➖ | | ✅ |  |
|  [`prefer_adjacent_string_concatenation`](https://dart-lang.github.io/linter/lints/prefer_adjacent_string_concatenation.html) | 💡 | | ✅ |  |
|  [`prefer_collection_literals`](https://dart-lang.github.io/linter/lints/prefer_collection_literals.html) | 💡 | | ✅ |  |
|  [`prefer_conditional_assignment`](https://dart-lang.github.io/linter/lints/prefer_conditional_assignment.html) | 💡 | | ✅ |  |
|  [`prefer_contains`](https://dart-lang.github.io/linter/lints/prefer_contains.html) | 💡 | | ✅ |  |
|  [`prefer_equal_for_default_values`](https://dart-lang.github.io/linter/lints/prefer_equal_for_default_values.html) | 💡 | | ✅ |  |
|  [`prefer_final_fields`](https://dart-lang.github.io/linter/lints/prefer_final_fields.html) | 💡 | | ✅ |  |
|  [`prefer_for_elements_to_map_fromIterable`](https://dart-lang.github.io/linter/lints/prefer_for_elements_to_map_fromIterable.html) | 💡 | | ✅ |  |
|  [`prefer_function_declarations_over_variables`](https://dart-lang.github.io/linter/lints/prefer_function_declarations_over_variables.html) | ➖ | | ✅ |  |
|  [`prefer_if_null_operators`](https://dart-lang.github.io/linter/lints/prefer_if_null_operators.html) | 💡 | | ✅ |  |
|  [`prefer_initializing_formals`](https://dart-lang.github.io/linter/lints/prefer_initializing_formals.html) | 🤔 | | ✅ |  |
|  [`prefer_inlined_adds`](https://dart-lang.github.io/linter/lints/prefer_inlined_adds.html) | 💡 | | ✅ |  |
|  [`prefer_is_not_operator`](https://dart-lang.github.io/linter/lints/prefer_is_not_operator.html) | 🤔 | | ✅ |  |
|  [`prefer_mixin`](https://dart-lang.github.io/linter/lints/prefer_mixin.html) | ➖ | | ✅ |  |
|  [`prefer_null_aware_operators`](https://dart-lang.github.io/linter/lints/prefer_null_aware_operators.html) | 💡 | | ✅ |  |
|  [`prefer_spread_collections`](https://dart-lang.github.io/linter/lints/prefer_spread_collections.html) | 💡 | | ✅ |  |
|  [`prefer_void_to_null`](https://dart-lang.github.io/linter/lints/prefer_void_to_null.html) | 🤔 | | ✅ |  |
|  [`recursive_getters`](https://dart-lang.github.io/linter/lints/recursive_getters.html) | ➖ | | ✅ |  |
|  [`slash_for_doc_comments`](https://dart-lang.github.io/linter/lints/slash_for_doc_comments.html) | 💡 | | ✅ |  |
|  [`type_init_formals`](https://dart-lang.github.io/linter/lints/type_init_formals.html) | 💡 | | ✅ |  |
|  [`unnecessary_brace_in_string_interps`](https://dart-lang.github.io/linter/lints/unnecessary_brace_in_string_interps.html) | 💡 | | ✅ |  |
|  [`unnecessary_const`](https://dart-lang.github.io/linter/lints/unnecessary_const.html) | 💡 | | ✅ |  |
|  [`unnecessary_getters_setters`](https://dart-lang.github.io/linter/lints/unnecessary_getters_setters.html) | 🤔 | | ✅ |  |
|  [`unnecessary_new`](https://dart-lang.github.io/linter/lints/unnecessary_new.html) | 💡 | | ✅ |  |
|  [`unnecessary_null_in_if_null_operators`](https://dart-lang.github.io/linter/lints/unnecessary_null_in_if_null_operators.html) | 💡 | | ✅ |  |
|  [`unnecessary_string_escapes`](https://dart-lang.github.io/linter/lints/unnecessary_string_escapes.html) | 🤔 | | ✅ |  |
|  [`unnecessary_string_interpolations`](https://dart-lang.github.io/linter/lints/unnecessary_string_interpolations.html) | 🤔 | | ✅ |  |
|  [`unnecessary_this`](https://dart-lang.github.io/linter/lints/unnecessary_this.html) | 💡 | | ✅ |  |
|  [`use_function_type_syntax_for_parameters`](https://dart-lang.github.io/linter/lints/use_function_type_syntax_for_parameters.html) | 💡 | | ✅ |  |
|  [`use_rethrow_when_possible`](https://dart-lang.github.io/linter/lints/use_rethrow_when_possible.html) | 💡 | | ✅ |  |


78 lints: 27 score [15 fixes], rec 51 [30 fixes]

TODO: add bulk fixes for
  - [ ] `avoid_relative_lib_imports`
  - [ ] `avoid_types_as_parameter_names`
  - [ ] `avoid_private_typedef_functions`
  - [ ] `use_function_type_syntax_for_parameters`


TODO: add fixes for
  - [ ] `prefer_typing_uninitialized_variables`
  - [ ] `avoid_function_literals_in_foreach_calls`
  - [ ] `avoid_null_checks_in_equality_operators`
  - [ ] `avoid_returning_null_for_void`
  - [ ] `control_flow_in_finally`
  - [ ] `prefer_initializing_formals`
  - [ ] `prefer_is_not_operator`
  - [ ] `prefer_void_to_null`
  - [ ] `unnecessary_getters_setters`
  - [ ] `unnecessary_string_escapes`
  - [ ] `unnecessary_string_interpolations`
