### PR TITLE
Increase break point for margin-0 transition

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -232,7 +232,7 @@ header a.style-type {
 
 /* Responsive style changes and corresponding transitions */
 
-@media screen and (max-width: 740px) {
+@media screen and (max-width: 1024px) {
     body {
         margin: 0;
         padding: 0;


### PR DESCRIPTION
Due to the wrapper width being increased a little while ago, the website can appear outside the browser window as the transition to the 100% contained version happened too late. This causes the transition to occur before the wrapper runs out of space.

This screenshot illustrates the issue:
![image](https://user-images.githubusercontent.com/18372958/104083379-add92200-5203-11eb-8b23-8b3a2ba8c5d5.png)
