### PR TITLE
Initial commit of avoid_dynamic_calls.

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -16,6 +16,7 @@ linter:
     - avoid_catching_errors
     - avoid_classes_with_only_static_members
     - avoid_double_and_int_checks
+    - avoid_dynamic_calls
     - avoid_empty_else
     - avoid_equals_and_hash_code_on_mutable_classes
     - avoid_escaping_inner_quotes

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -17,6 +17,7 @@ import 'rules/avoid_catches_without_on_clauses.dart';
 import 'rules/avoid_catching_errors.dart';
 import 'rules/avoid_classes_with_only_static_members.dart';
 import 'rules/avoid_double_and_int_checks.dart';
+import 'rules/avoid_dynamic_calls.dart';
 import 'rules/avoid_empty_else.dart';
 import 'rules/avoid_equals_and_hash_code_on_mutable_classes.dart';
 import 'rules/avoid_escaping_inner_quotes.dart';
@@ -201,6 +202,7 @@ void registerLintRules() {
     ..register(AvoidCatchingErrors())
     ..register(AvoidClassesWithOnlyStaticMembers())
     ..register(AvoidDoubleAndIntChecks())
+    ..register(AvoidDynamicCalls())
     ..register(AvoidEmptyElse())
     ..register(AvoidEscapingInnerQuotes())
     ..register(AvoidFieldInitializersInConstClasses())

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -139,7 +139,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
     if (node.readType?.isDynamic != true) {
-      // An assignment expression can only be a dynamid call if it is a
+      // An assignment expression can only be a dynamic call if it is a
       // "compound assignment" (i.e. such as `x += 1`); so if `readType` is not
       // dynamic, we don't need to check further.
       return;

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -1,0 +1,221 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import '../analyzer.dart';
+
+const _desc = r'Avoid method calls and property access on a "dynamic" target.';
+
+const _details = r'''
+
+**DO** avoid method calls or property accessors on an object that is either
+explicitly or implicitly statically typed "dynamic". Dynamic calls are treated
+slightly different in every runtime environment and compiler, but most
+production modes (and even some development modes) have both compile size and
+runtime performance penalties associated with dynamic calls.
+
+Additionally, targets typed "dynamic" disabled most static analysis, meaning it
+is easier to lead to a runtime "NoSuchMethodError" or "NullError" than properly
+statically typed Dart code.
+
+Note, that despite "Function" being a type, the semantics are close to identical
+to "dynamic", and calls to an object that are typed "Function" will also trigger
+this lint.
+
+**BAD:**
+```
+void explicitDynamicType(dynamic object) {
+  print(object.foo());
+}
+
+void implicitDynamicType(object) {
+  print(object.foo());
+}
+
+abstract class SomeWrapper {
+  T doSomething<T>();
+}
+
+void inferredDynamicType(SomeWrapper wrapper) {
+  var object = wrapper.doSomething();
+  print(field.foo());
+}
+
+void functionType(Function function) {
+  function();
+}
+```
+
+**GOOD:**
+```
+void explicitType(Fooable object) {
+  object.foo();
+}
+
+void castedType(dynamic object) {
+  (object as Fooable).foo();
+}
+
+abstract class SomeWrapper {
+  T doSomething<T>();
+}
+
+void inferredType(SomeWrapper wrapper) {
+  var object = wrapper.doSomething<Fooable>();
+  object.foo();
+}
+```
+
+''';
+
+class AvoidDynamicCalls extends LintRule implements NodeLintRule {
+  AvoidDynamicCalls()
+      : super(
+          name: 'avoid_dynamic_calls',
+          description: _desc,
+          details: _details,
+          group: Group.errors,
+        );
+
+  @override
+  void registerNodeProcessors(
+    NodeLintRegistry registry,
+    LinterContext context,
+  ) {
+    assert(context != null);
+    final visitor = _Visitor(this);
+    registry
+      ..addAssignmentExpression(this, visitor)
+      ..addBinaryExpression(this, visitor)
+      ..addFunctionExpressionInvocation(this, visitor)
+      ..addIndexExpression(this, visitor)
+      ..addMethodInvocation(this, visitor)
+      ..addPostfixExpression(this, visitor)
+      ..addPrefixExpression(this, visitor)
+      ..addPrefixedIdentifier(this, visitor)
+      ..addPropertyAccess(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  bool _lintIfDynamic(Expression node) {
+    if (node?.staticType?.isDynamic == true) {
+      rule.reportLint(node);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void _lintIfDynamicOrFunction(Expression node) {
+    final staticType = node?.staticType;
+    if (staticType == null) {
+      return;
+    }
+    if (staticType.isDynamic || staticType.isDartCoreFunction) {
+      rule.reportLint(node);
+    }
+  }
+
+  @override
+  void visitAssignmentExpression(AssignmentExpression node) {
+    if (node.readType?.isDynamic != true) {
+      return;
+    }
+    if (node.operator.type == TokenType.QUESTION_QUESTION_EQ) {
+      // x ??= foo is not a dynamic call.
+      return;
+    }
+    rule.reportLint(node);
+  }
+
+  @override
+  void visitBinaryExpression(BinaryExpression node) {
+    switch (node.operator.type) {
+      case TokenType.QUESTION_QUESTION:
+        return;
+      case TokenType.EQ_EQ:
+      case TokenType.BANG_EQ:
+        if (node.rightOperand is NullLiteral) {
+          return;
+        }
+        break;
+    }
+    _lintIfDynamic(node.leftOperand);
+    // We don't check node.rightOperand, because that is an implicit cast, not a
+    // dynamic call (the call itself is based on leftOperand). While it would be
+    // useful to do so, it is better solved by other more specific lints to
+    // disallow implicit casts from dynamic.
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    if (node.function != null) {
+      _lintIfDynamicOrFunction(node.function);
+    }
+  }
+
+  @override
+  void visitIndexExpression(IndexExpression node) {
+    _lintIfDynamic(node.realTarget);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final receiverWasDynamic = _lintIfDynamic(node.realTarget);
+    if (!receiverWasDynamic && node.target == null) {
+      _lintIfDynamicOrFunction(node.function);
+    }
+  }
+
+  @override
+  void visitPrefixExpression(PrefixExpression node) {
+    if (_lintIfDynamic(node.operand)) {
+      return;
+    }
+    switch (node.operator.type) {
+      case TokenType.PLUS_PLUS:
+      case TokenType.MINUS_MINUS:
+        // The ++ and -- operator expressions don't resolve a static type.
+        if (node.staticType?.isDynamic == true) {
+          rule.reportLint(node.operand);
+        }
+    }
+  }
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    _lintIfDynamic(node.prefix);
+  }
+
+  @override
+  void visitPostfixExpression(PostfixExpression node) {
+    if (node.operator.type == TokenType.BANG) {
+      // x! is not a dynamic call, even if "x" is dynamic.
+      return;
+    }
+    if (_lintIfDynamic(node.operand)) {
+      return;
+    }
+    switch (node.operator.type) {
+      case TokenType.PLUS_PLUS:
+      case TokenType.MINUS_MINUS:
+        // The ++ and -- operator expressions don't resolve a static type.
+        if (node.staticType?.isDynamic == true) {
+          rule.reportLint(node.operand);
+        }
+    }
+  }
+
+  @override
+  void visitPropertyAccess(PropertyAccess astNode) {
+    _lintIfDynamic(astNode.realTarget);
+  }
+}

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 
-const _desc = r'Avoid method calls and property access on a "dynamic" target.';
+const _desc = r'Avoid method calls or property accesses on a "dynamic" target.';
 
 const _details = r'''
 
@@ -21,7 +21,7 @@ Additionally, targets typed "dynamic" disables most static analysis, meaning it
 is easier to lead to a runtime "NoSuchMethodError" or "NullError" than properly
 statically typed Dart code.
 
-Note, that despite "Function" being a type, the semantics are close to identical
+Note that despite "Function" being a type, the semantics are close to identical
 to "dynamic", and calls to an object that is typed "Function" will also trigger
 this lint.
 
@@ -94,7 +94,6 @@ class AvoidDynamicCalls extends LintRule implements NodeLintRule {
     NodeLintRegistry registry,
     LinterContext context,
   ) {
-    assert(context != null);
     final visitor = _Visitor(this);
     registry
       ..addAssignmentExpression(this, visitor)

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -148,6 +148,11 @@ class _Visitor extends SimpleAstVisitor<void> {
         }
         break;
     }
+    if (node.operator.type == TokenType.AS ||
+        node.operator.type == TokenType.IS) {
+      // Can't be included in switch statement due to Dart semantics.
+      return;
+    }
     _lintIfDynamic(node.leftOperand);
     // We don't check node.rightOperand, because that is an implicit cast, not a
     // dynamic call (the call itself is based on leftOperand). While it would be

--- a/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
+++ b/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
@@ -100,6 +100,8 @@ void binaryExpressions(dynamic a, int b, bool c) {
   a + b; // LINT
   a > b; // LINT
   a < b; // LINT
+  a >= b; // LINT
+  a <= b; // LINT
   a ^ b; // LINT
   a | b; // LINT
   a & b; // LINT
@@ -108,8 +110,8 @@ void binaryExpressions(dynamic a, int b, bool c) {
   a ~/ b; // LINT
   a >> b; // LINT
   a << b; // LINT
-  a || c; // LINT
-  a && c; // LINT
+  a || c; // OK; this is an implicit downcast, not a dynamic call
+  a && c; // OK; this is an implicit downcast, not a dynamic call
   b + a; // OK; this is an implicit downcast, not a dynamic call
   a ?? b; // OK; this is a null comparison, not a dynamic call.
   a is int; // OK

--- a/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
+++ b/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
@@ -126,14 +126,28 @@ void equalityExpressions(dynamic a, dynamic b) {
   a != null; // OK.
 }
 
-void membersThatExistOnObject(dynamic a) {
+void membersThatExistOnObject(dynamic a, Invocation b) {
   a.hashCode; // OK
   a.runtimeType; // OK
-  a.noSuchMethod(null as Invocation); // OK
+  a.noSuchMethod(); // LINT
+  a.noSuchMethod(b); // OK
+  a.noSuchMethod(b, 1); // LINT
+  a.noSuchMethod(b, name: 1); // LINT
   a.toString(); // OK
+  a.toString(1); // LINT
+  a.toString(name: 1); // LINT
+  '$a'; // OK
+  '${a}'; // OK
 }
 
-void assngmentExpressions(dynamic a) {
+void memberTearOffsOnObject(dynamic a, Invocation b) {
+  var tearOffNoSuchMethod = a.noSuchMethod; // OK
+  tearOffNoSuchMethod(b); // OK
+  var tearOffToString = a.toString; // OK
+  tearOffToString(); // OK
+}
+
+void assignmentExpressions(dynamic a) {
   a += 1; // LINT
   a -= 1; // LINT
   a *= 1; // LINT

--- a/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
+++ b/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test test/rule_test.dart -N avoid_dynamic_calls`
+
+void explicitDynamicType(dynamic object) {
+  object.foo(); // LINT
+  object.bar; // LINT
+}
+
+void implicitDynamicType(object) {
+  object.foo(); // LINT
+  object.bar; // LINT
+}
+
+// This would likely not pass at runtime, but we're using it for inference only.
+T genericType<T>() => null as T;
+
+void inferredDynamicType() {
+  var object = genericType();
+  object.foo(); // LINT
+  object.bar; // LINT
+}
+
+class Wrapper<T> {
+  final T field;
+  Wrapper(this.field);
+}
+
+void fieldDynamicType(Wrapper<dynamic> wrapper) {
+  final field = wrapper.field;
+  field.foo(); // LINT
+  field.bar; // LINT
+  wrapper.field(); // LINT
+}
+
+void cascadeExpressions(dynamic a, Wrapper<dynamic> b) {
+  a..b; // LINT
+  b..field; // OK
+  b
+    ..toString
+    ..field.a() // LINT
+    ..field.b; // LINT
+}
+
+void otherPropertyAccessOrCalls(dynamic a) {
+  a(); // LINT
+  a?.b; // LINT
+  a!.b; // LINT
+  a?.b(); // LINT
+  a!.b(); // LINT
+}
+
+void functionExpressionInvocations(dynamic a(), Function b()) {
+  a(); // OK
+  a()(); // LINT
+  b(); // OK
+  b()(); // LINT
+}
+
+void typedFunctionButBasicallyDynamic(Function a, Wrapper<Function> b) {
+  a(); // LINT
+  b.field(); // LINT
+}
+
+void binaryExpressions(dynamic a, int b) {
+  a + a; // LINT
+  a + b; // LINT
+  a > b; // LINT
+  a < b; // LINT
+  a ^ b; // LINT
+  a | b; // LINT
+  a & b; // LINT
+  a % b; // LINT
+  a / b; // LINT
+  a ~/ b; // LINT
+  a >> b; // LINT
+  a << b; // LINT
+  a || b; // LINT
+  a && b; // LINT
+  b + a; // OK; this is an implicit downcast, not a dynamic call
+  a ?? b; // OK; this is a null comparison, not a dynamic call.
+}
+
+void equalityExpressions(dynamic a, dynamic b) {
+  a == b; // LINT
+  a == null; // OK, special cased.
+  a != b; // LINT
+  a != null; // OK.
+}
+
+void assngmentExpressions(dynamic a) {
+  a += 1; // LINT
+  a -= 1; // LINT
+  a *= 1; // LINT
+  a ^= 1; // LINT
+  a /= 1; // LINT
+  a &= 1; // LINT
+  a |= 1; // LINT
+  a ??= 1; // OK
+}
+
+void prefixExpressions(dynamic a, int b) {
+  !a; // LINT
+  -a; // LINT
+  ++a; // LINT
+  --a; // LINT
+  ++b; // OK
+  --b; // OK
+}
+
+void postfixExpressions(dynamic a, int b) {
+  a!; // OK; this is not a dynamic call.
+  a++; // LINT
+  a--; // LINT
+  b++; // OK
+  b--; // OK
+}
+
+void indexExpressions(dynamic a) {
+  a[1]; // LINT
+  a[1] = 1; // LINT
+  a = a[1]; // LINT
+}

--- a/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
+++ b/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
@@ -120,10 +120,17 @@ void binaryExpressions(dynamic a, int b, bool c) {
 }
 
 void equalityExpressions(dynamic a, dynamic b) {
-  a == b; // LINT
-  a == null; // OK, special cased.
-  a != b; // LINT
+  a == b; // OK, see lint description for details.
+  a == null; // OK.
+  a != b; // OK
   a != null; // OK.
+}
+
+void membersThatExistOnObject(dynamic a) {
+  a.hashCode; // OK
+  a.runtimeType; // OK
+  a.noSuchMethod(null as Invocation); // OK
+  a.toString(); // OK
 }
 
 void assngmentExpressions(dynamic a) {

--- a/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
+++ b/test/rules/experiments/nnbd/rules/avoid_dynamic_calls.dart
@@ -81,6 +81,9 @@ void binaryExpressions(dynamic a, int b) {
   a && b; // LINT
   b + a; // OK; this is an implicit downcast, not a dynamic call
   a ?? b; // OK; this is a null comparison, not a dynamic call.
+  a is int; // OK
+  a is! int; // OK
+  a as int; // OK
 }
 
 void equalityExpressions(dynamic a, dynamic b) {


### PR DESCRIPTION
Closes https://github.com/dart-lang/linter/issues/1782.

---

This is a pretty difficult lint to get "right". I tried my best with the following principals:

1. Simple _existence_ of `dynamic` or a dynamic-ly typed expression should not cause a lint. 
    There are many places where a dynamic expression can be used in a way that does not "cause" a dynamic call:

    - Some types of expressions, such as `as`, `is`, `??`, or `x!` are non-virtual, and are not dynamic calls.
    - Some trickier cases like members that exist on `Object?` (`==`, `hashCode`, `runtimeType`, `toString`).

2. Implicit downcasts from `dynamic` to non-`dynamic`, while bad, is _not_ a dynamic call (it's a runtime cast).
    There are other lints and analysis modes that can lint these.

3. While not explicitly typed `dynamic`, a static type of `Function` being invoked _is_ a dynamic call.

---

Open to any and all suggestions. I'm also happy landing this is an experimental state for others to give more feedback. One thing I'd like to avoid is splitting this into like, half-a-dozen _different_ lints or too many ways to opt-out yet; I think `// ignore: avoid_dynamic_call` isn't great, but we can look at the UX of opting-out independent of landing this lint.