### PR TITLE
prep for `0.1.129` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.129
+
 - fixed a bug where `avoid_dynamic_calls` produced false-positives for `.call()`
 
 # 0.1.128

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.128';
+const String version = '0.1.129';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.128
+version: 0.1.129
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
/cc @bwilkerson @matanlurey @devoncarew 
