### PR TITLE
Clean up package_ rules NNBD migration

### DIFF
--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -94,7 +94,7 @@ class PackageApiDocs extends LintRule implements ProjectVisitor, NodeLintRule {
 }
 
 class _Visitor extends GeneralizingAstVisitor {
-  PackageApiDocs rule;
+  final PackageApiDocs rule;
 
   _Visitor(this.rule);
 

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -46,8 +46,10 @@ library my_package.src.private;
 
 ''';
 
-bool matchesOrIsPrefixedBy(String? name, String prefix) =>
-    name == prefix || name!.startsWith('$prefix.');
+/// Checks if the [name] is equivalent to the specified [prefix] or at least
+/// is prefixed by it with a delimiting `.`.
+bool matchesOrIsPrefixedBy(String name, String prefix) =>
+    name == prefix || name.startsWith('$prefix.');
 
 class PackagePrefixedLibraryNames extends LintRule
     implements ProjectVisitor, NodeLintRule {
@@ -81,23 +83,28 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
-  DartProject? get project => rule.project;
-
   @override
   void visitLibraryDirective(LibraryDirective node) {
     // If no project info is set, bail early.
     // https://github.com/dart-lang/linter/issues/154
-    if (project == null) {
+    final project = rule.project;
+    final element = node.element;
+    if (project == null || element == null) {
       return;
     }
-    final source = node.element!.source!;
-    var prefix = Analyzer.facade.createLibraryNamePrefix(
-        libraryPath: source.fullName,
-        projectRoot: project!.root.absolute.path,
-        packageName: project!.name);
 
-    var libraryName = node.element!.name;
-    if (!matchesOrIsPrefixedBy(libraryName, prefix)) {
+    final source = element.source;
+    if (source == null) {
+      return;
+    }
+
+    final prefix = Analyzer.facade.createLibraryNamePrefix(
+        libraryPath: source.fullName,
+        projectRoot: project.root.absolute.path,
+        packageName: project.name);
+
+    final name = element.name;
+    if (name == null || !matchesOrIsPrefixedBy(name, prefix)) {
       rule.reportLint(node.name);
     }
   }


### PR DESCRIPTION
Removes uses of the explicit `!` modifiers in the `package_` lints.
