### PR TITLE
Update required named parameters rule for new required keyword

### DIFF
--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -7,11 +7,21 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Put @required named parameters first.';
+const _desc = r'Put required named parameters first.';
 
 const _details = r'''
 
-**DO** specify `@required` on named parameter before other named parameters.
+**DO** specify `required` on named parameter before other named parameters.
+
+**GOOD:**
+```
+m({required a, b, c}) ;
+```
+
+**BAD:**
+```
+m({b, c, required a}) ;
+```
 
 **GOOD:**
 ```

--- a/test/rules/always_put_required_named_parameters_first.dart
+++ b/test/rules/always_put_required_named_parameters_first.dart
@@ -25,6 +25,25 @@ m2({
   @required f, // LINT
 }) {}
 
+n1(
+  a, // OK
+  {
+  b, // OK
+  required c, // LINT
+  required d, // LINT
+  e, // OK
+  required f, // LINT
+}) {}
+
+n2({
+  required a, // OK
+  required b, // OK
+  c, // OK
+  required d, // LINT
+  e, // OK
+  required f, // LINT
+}) {}
+
 class A {
   A.c1(
     a, // OK
@@ -42,5 +61,22 @@ class A {
     @required d, // LINT
     e, // OK
     @required f, // LINT
+  });
+  A.d1(
+    a, // OK
+    {
+    b, // OK
+    required c, // LINT
+    required d, // LINT
+    e, // OK
+    required f, // LINT
+  });
+  A.d2({
+    required a, // OK
+    required b, // OK
+    c, // OK
+    required d, // LINT
+    e, // OK
+    required f, // LINT
   });
 }


### PR DESCRIPTION
This updates the test to test the null safety feature with the `required` keyword and instead focuses on the `require` keyword in the rule documentation as that is what users should be using after the migration.
