### PR TITLE
1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.0.0
+
+- full library migration to null-safety
+- new lint: `use_if_null_to_convert_nulls_to_bools`
+- new lint: `deprecated_consistency`
+- new lint: `use_named_constants`
+- deprecation of `avoid_as`
+
 # 0.1.129
 
 - fixed a bug where `avoid_dynamic_calls` produced false-positives for `.call()`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '0.1.129';
+const String version = '1.0.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 0.1.129
+version: 1.0.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.0.0

- full library migration to null-safety
- new lint: `use_if_null_to_convert_nulls_to_bools`
- new lint: `deprecated_consistency`
- new lint: `use_named_constants`
- deprecation of `avoid_as`


/cc @bwilkerson @devoncarew 
