### PR TITLE
add avoid_multiple_declarations_per_line

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -24,6 +24,7 @@ linter:
     - avoid_implementing_value_types
     - avoid_init_to_null
     - avoid_js_rounded_ints
+    - avoid_multiple_declarations_per_line
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_print

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -26,6 +26,7 @@ import 'rules/avoid_function_literals_in_foreach_calls.dart';
 import 'rules/avoid_implementing_value_types.dart';
 import 'rules/avoid_init_to_null.dart';
 import 'rules/avoid_js_rounded_ints.dart';
+import 'rules/avoid_multiple_declarations_per_line.dart';
 import 'rules/avoid_null_checks_in_equality_operators.dart';
 import 'rules/avoid_positional_boolean_parameters.dart';
 import 'rules/avoid_print.dart';
@@ -213,6 +214,7 @@ void registerLintRules() {
     ..register(AvoidImplementingValueTypes())
     ..register(AvoidInitToNull())
     ..register(AvoidJsRoundedInts())
+    ..register(AvoidMultipleDeclarationsPerLine())
     ..register(AvoidNullChecksInEqualityOperators())
     ..register(AvoidOperatorEqualsOnMutableClasses())
     ..register(AvoidPositionalBooleanParameters())

--- a/lib/src/rules/avoid_multiple_declarations_per_line.dart
+++ b/lib/src/rules/avoid_multiple_declarations_per_line.dart
@@ -55,7 +55,7 @@ class _Visitor extends SimpleAstVisitor {
 
     if (variables.length > 1) {
       final secondVariable = variables[1];
-      rule.reportLint(secondVariable);
+      rule.reportLint(secondVariable.name);
     }
   }
 }

--- a/lib/src/rules/avoid_multiple_declarations_per_line.dart
+++ b/lib/src/rules/avoid_multiple_declarations_per_line.dart
@@ -54,7 +54,8 @@ class _Visitor extends SimpleAstVisitor {
     final variables = node.variables;
 
     if (variables.length > 1) {
-      rule.reportLint(node);
+      final secondVariable = variables[1];
+      rule.reportLint(secondVariable);
     }
   }
 }

--- a/lib/src/rules/avoid_multiple_declarations_per_line.dart
+++ b/lib/src/rules/avoid_multiple_declarations_per_line.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r"Don't declare multiple variables on a single line.";
+
+const _details = r'''
+
+**DON'T** declare multiple variables on a single line.
+
+**BAD:**
+```
+String? foo, bar, baz;
+```
+
+**GOOD:**
+```
+String? foo;
+String? bar;
+String? baz;
+```
+
+''';
+
+class AvoidMultipleDeclarationsPerLine extends LintRule
+    implements NodeLintRule {
+  AvoidMultipleDeclarationsPerLine()
+      : super(
+            name: 'avoid_multiple_declarations_per_line',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    final visitor = _Visitor(this);
+    registry.addVariableDeclarationList(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitVariableDeclarationList(VariableDeclarationList node) {
+    final variables = node.variables;
+
+    if (variables.length > 1) {
+      rule.reportLint(node);
+    }
+  }
+}

--- a/test/rules/avoid_multiple_declarations_per_line.dart
+++ b/test/rules/avoid_multiple_declarations_per_line.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_multiple_declarations_per_line`
+
+// ignore_for_file: unused_local_variable
+
+String? badFoo, badBar, badBaz; // LINT
+
+String? goodFoo;
+String? goodBar;
+String? goodBaz;
+
+methodContainingBadDeclaration() {
+  String? badFoo, badBar, badBaz; // LINT
+}
+
+methodContainingGoodDeclaration() {
+  String? goodFoo;
+  String? goodBar;
+  String? goodBaz;
+}
+
+class BadClass {
+  String? foo, bar, baz; // LINT
+
+  methodContainingBadDeclaration() {
+    String? badFoo, badBar, badBaz; // LINT
+  }
+}
+
+class GoodClass {
+  String? foo;
+  String? bar;
+  String? baz;
+
+  methodContainingGoodDeclaration() {
+    String? goodFoo;
+    String? goodBar;
+    String? goodBaz;
+  }
+}
+
+extension BadExtension on Object {
+  static String? badFoo, badBar, badBaz; // LINT
+}
+
+extension GoodExtension on Object {
+  static String? foo;
+  static String? bar;
+  static String? baz;
+}


### PR DESCRIPTION
# Description

Lint on multiple variable declarations in a single line.

Fixes # (issue)

https://github.com/dart-lang/linter/issues/2501