### PR TITLE
Switch from http to https in curly braces lint

### DIFF
--- a/lib/src/rules/curly_braces_in_flow_control_structures.dart
+++ b/lib/src/rules/curly_braces_in_flow_control_structures.dart
@@ -13,7 +13,7 @@ const _details = r'''
 
 **DO** use curly braces for all flow control structures.
 
-Doing so avoids the [dangling else](http://en.wikipedia.org/wiki/Dangling_else)
+Doing so avoids the [dangling else](https://en.wikipedia.org/wiki/Dangling_else)
 problem.
 
 **GOOD:**


### PR DESCRIPTION
Switches from an `http` Wikipedia link to a `https` one in curly_braces_in_flow_control_structures
