### PR TITLE
Add a language label to the dart code blocks

### DIFF
--- a/lib/src/rules/always_declare_return_types.dart
+++ b/lib/src/rules/always_declare_return_types.dart
@@ -20,7 +20,7 @@ analyzer to more adequately check your code for errors that could occur during
 runtime.
 
 **BAD:**
-```
+```dart
 main() { }
 
 _bar() => _Foo();
@@ -31,7 +31,7 @@ class _Foo {
 ```
 
 **GOOD:**
-```
+```dart
 void main() { }
 
 _Foo _bar() => _Foo();

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -20,7 +20,7 @@ as the expression, even if it is short.  Doing so makes it unclear that there
 is relevant code there.  This is especially important for early returns.
 
 **GOOD:**
-```
+```dart
 if (notReady)
   return;
 
@@ -34,7 +34,7 @@ while (condition)
 ```
 
 **BAD:**
-```
+```dart
 if (notReady) return;
 
 if (notReady)

--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -14,22 +14,22 @@ const _details = r'''
 **DO** specify `required` on named parameter before other named parameters.
 
 **GOOD:**
-```
+```dart
 m({required a, b, c}) ;
 ```
 
 **BAD:**
-```
+```dart
 m({b, c, required a}) ;
 ```
 
 **GOOD:**
-```
+```dart
 m({@required a, b, c}) ;
 ```
 
 **BAD:**
-```
+```dart
 m({b, c, @required a}) ;
 ```
 

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -18,7 +18,7 @@ const _details = r'''
 an `assert(param != null)` is done.
 
 **GOOD:**
-```
+```dart
 m1({@required a}) {
   assert(a != null);
 }
@@ -29,7 +29,7 @@ m2({a: 1}) {
 ```
 
 **BAD:**
-```
+```dart
 m1({a}) {
   assert(a != null);
 }

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -24,7 +24,7 @@ unknown.  Use `Object` if you are being explicit that you want an object that
 implements `==` and `hashCode`.
 
 **GOOD:**
-```
+```dart
 int foo = 10;
 final Bar bar = Bar();
 String baz = 'hello';
@@ -32,7 +32,7 @@ const int quux = 20;
 ```
 
 **BAD:**
-```
+```dart
 var foo = 10;
 final bar = Bar();
 const quux = 20;
@@ -44,7 +44,7 @@ declaration should be treated as optional.  For example, suppose you have a
 `Key` object whose type parameter you'd like to treat as optional.  Using the
 `@optionalTypeArgs` would look like this:
 
-```
+```dart
 import 'package:meta/meta.dart';
 
 @optionalTypeArgs

--- a/lib/src/rules/always_use_package_imports.dart
+++ b/lib/src/rules/always_use_package_imports.dart
@@ -23,7 +23,7 @@ files within `lib/` directory outside of it. (for example `test/`)
 
 **GOOD:**
 
-```
+```dart
 import 'package:foo/bar.dart';
 
 import 'package:foo/baz.dart';
@@ -34,7 +34,7 @@ import 'package:foo/src/baz.dart';
 
 **BAD:**
 
-```
+```dart
 import 'baz.dart';
 
 import 'src/bag.dart'

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -18,7 +18,7 @@ This practice improves code readability and helps protect against
 unintentionally overriding superclass members.
 
 **GOOD:**
-```
+```dart
 abstract class Dog {
   String get breed;
   void bark() {}
@@ -33,7 +33,7 @@ class Husky extends Dog {
 ```
 
 **BAD:**
-```
+```dart
 class Cat {
   int get lives => 9;
 }

--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -17,7 +17,7 @@ As `dynamic` is the assumed return value of a function or method, it is usually
 not necessary to annotate it.
 
 **BAD:**
-```
+```dart
 dynamic lookUpOrDefault(String name, Map map, dynamic defaultValue) {
   var value = map[name];
   if (value != null) return value;
@@ -26,7 +26,7 @@ dynamic lookUpOrDefault(String name, Map map, dynamic defaultValue) {
 ```
 
 **GOOD:**
-```
+```dart
 lookUpOrDefault(String name, Map map, defaultValue) {
   var value = map[name];
   if (value != null) return value;

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -19,12 +19,12 @@ compiled out in release mode).  If you don't know whether the type is
 correct, check using `is` (this avoids the exception that `as` raises).
 
 **BAD:**
-```
+```dart
 (pm as Person).firstName = 'Seth';
 ```
 
 **GOOD:**
-```
+```dart
 if (pm is Person)
   pm.firstName = 'Seth';
 ```
@@ -32,7 +32,7 @@ if (pm is Person)
 but certainly not
 
 **BAD:**
-```
+```dart
 try {
    (pm as Person).firstName = 'Seth';
 } on CastError { }
@@ -42,7 +42,7 @@ Note that an exception is made in the case of `dynamic` since the cast has no
 performance impact.
 
 **OK:**
-```
+```dart
 HasScrollDirection scrollable = renderObject as dynamic;
 ```
 

--- a/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
+++ b/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
@@ -14,7 +14,7 @@ const _details = r'''
 **AVOID** bool literals in conditional expressions.
 
 **BAD:**
-```
+```dart
 condition ? true : boolExpression
 condition ? false : boolExpression
 condition ? boolExpression : true
@@ -22,7 +22,7 @@ condition ? boolExpression : false
 ```
 
 **GOOD:**
-```
+```dart
 condition || boolExpression
 !condition && boolExpression
 !condition || boolExpression

--- a/lib/src/rules/avoid_catches_without_on_clauses.dart
+++ b/lib/src/rules/avoid_catches_without_on_clauses.dart
@@ -17,7 +17,7 @@ Using catch clauses without on clauses make your code prone to encountering
 unexpected errors that won't be thrown (and thus will go unnoticed).
 
 **BAD:**
-```
+```dart
 try {
  somethingRisky()
 }
@@ -27,7 +27,7 @@ catch(e) {
 ```
 
 **GOOD:**
-```
+```dart
 try {
  somethingRisky()
 }

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -18,7 +18,7 @@ Errors differ from Exceptions in that Errors can be analyzed and prevented prior
 to runtime.  It should almost never be necessary to catch an error at runtime.
 
 **BAD:**
-```
+```dart
 try {
   somethingRisky();
 } on Error catch(e) {
@@ -27,7 +27,7 @@ try {
 ```
 
 **GOOD:**
-```
+```dart
 try {
   somethingRisky();
 } on Exception catch(e) {

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -19,7 +19,7 @@ methods is discouraged.  Dart allows functions to exist outside of classes for
 this very reason.
 
 **BAD:**
-```
+```dart
 class DateUtils {
   static DateTime mostRecent(List<DateTime> dates) {
     return dates.reduce((a, b) => a.isAfter(b) ? a : b);
@@ -32,7 +32,7 @@ class _Favorites {
 ```
 
 **GOOD:**
-```
+```dart
 DateTime mostRecent(List<DateTime> dates) {
   return dates.reduce((a, b) => a.isAfter(b) ? a : b);
 }

--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -19,7 +19,7 @@ some unexpected behavior when using either `is` or `is!` where the type is
 either `int` or `double`.
 
 **BAD:**
-```
+```dart
 f(num x) {
   if (x is double) {
     ...
@@ -30,7 +30,7 @@ f(num x) {
 ```
 
 **GOOD:**
-```
+```dart
 f(dynamic x) {
   if (x is num) {
     ...

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -38,7 +38,7 @@ to "dynamic", and calls to an object that is typed "Function" will also trigger
 this lint.
 
 **BAD:**
-```
+```dart
 void explicitDynamicType(dynamic object) {
   print(object.foo());
 }
@@ -66,7 +66,7 @@ void functionType(Function function) {
 ```
 
 **GOOD:**
-```
+```dart
 void explicitType(Fooable object) {
   object.foo();
 }

--- a/lib/src/rules/avoid_empty_else.dart
+++ b/lib/src/rules/avoid_empty_else.dart
@@ -14,7 +14,7 @@ const _details = r'''
 **AVOID** empty else statements.
 
 **BAD:**
-```
+```dart
 if (x > y)
   print("1");
 else ;

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -23,7 +23,7 @@ https://dart.dev/guides/language/effective-dart/design#avoid-defining-custom-equ
 for more information.
 
 **GOOD:**
-```
+```dart
 @immutable
 class A {
   final String key;
@@ -36,7 +36,7 @@ class A {
 ```
 
 **BAD:**
-```
+```dart
 class B {
   String key;
   const B(this.key);
@@ -51,7 +51,7 @@ NOTE: The lint checks the use of the @immutable annotation, and will trigger
 even if the class is otherwise not mutable. Thus:
 
 **BAD:**
-```
+```dart
 class C {
   final String key;
   const C(this.key);

--- a/lib/src/rules/avoid_escaping_inner_quotes.dart
+++ b/lib/src/rules/avoid_escaping_inner_quotes.dart
@@ -14,12 +14,12 @@ const _details = r'''
 Avoid escaping inner quotes by converting surrounding quotes.
 
 **BAD:**
-```
+```dart
 var s = 'It\'s not fun';
 ```
 
 **GOOD:**
-```
+```dart
 var s = "It's not fun";
 ```
 

--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -19,7 +19,7 @@ not allocate a useless field. As of April 2018 this is true for the VM, but not
 for code that will be compiled to JS.
 
 **BAD:**
-```
+```dart
 class A {
   final a = const [];
   const A();
@@ -27,7 +27,7 @@ class A {
 ```
 
 **GOOD:**
-```
+```dart
 class A {
   get a => const [];
   const A();

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -15,14 +15,14 @@ const _details = r'''
 **AVOID** using `forEach` with a function literal.
 
 **BAD:**
-```
+```dart
 people.forEach((person) {
   ...
 });
 ```
 
 **GOOD:**
-```
+```dart
 for (var person in people) {
   ...
 }

--- a/lib/src/rules/avoid_implementing_value_types.dart
+++ b/lib/src/rules/avoid_implementing_value_types.dart
@@ -24,7 +24,7 @@ nearly impossible to follow the contract of `==`. Classes that override `==`
 typically are usable directly in tests _without_ creating mocks or fakes as
 well. For example, for a given class `Size`:
 
-```
+```dart
 class Size {
   final int inBytes;
   const Size(this.inBytes);
@@ -38,7 +38,7 @@ class Size {
 ```
 
 **BAD**:
-```
+```dart
 class CustomSize implements Size {
   final int inBytes;
   const CustomSize(this.inBytes);
@@ -48,7 +48,7 @@ class CustomSize implements Size {
 ```
 
 **BAD**:
-```
+```dart
 import 'package:test/test.dart';
 import 'size.dart';
 
@@ -64,7 +64,7 @@ void main() {
 ```
 
 **GOOD**:
-```
+```dart
 class ExtendedSize extends Size {
   ExtendedSize(int inBytes) : super(inBytes);
 
@@ -73,7 +73,7 @@ class ExtendedSize extends Size {
 ```
 
 **GOOD**:
-```
+```dart
 import 'package:test/test.dart';
 import 'size.dart';
 

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -24,7 +24,7 @@ no concept of "uninitialized memory" in Dart.  Adding `= null` is redundant and
 unneeded.
 
 **GOOD:**
-```
+```dart
 int _nextId;
 
 class LazyId {
@@ -40,7 +40,7 @@ class LazyId {
 ```
 
 **BAD:**
-```
+```dart
 int _nextId = null;
 
 class LazyId {

--- a/lib/src/rules/avoid_js_rounded_ints.dart
+++ b/lib/src/rules/avoid_js_rounded_ints.dart
@@ -22,12 +22,12 @@ For instance `1000000000000000001` cannot be represented exactly as a JavaScript
 Number, so `1000000000000000000` will be used instead.
 
 **BAD:**
-```
+```dart
 int value = 9007199254740995;
 ```
 
 **GOOD:**
-```
+```dart
 BigInt value = BigInt.parse('9007199254740995');
 ```
 

--- a/lib/src/rules/avoid_multiple_declarations_per_line.dart
+++ b/lib/src/rules/avoid_multiple_declarations_per_line.dart
@@ -14,12 +14,12 @@ const _details = r'''
 **DON'T** declare multiple variables on a single line.
 
 **BAD:**
-```
+```dart
 String? foo, bar, baz;
 ```
 
 **GOOD:**
-```
+```dart
 String? foo;
 String? bar;
 String? baz;

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -20,7 +20,7 @@ As null is a special type, no class can be equivalent to it.  Thus, it is
 redundant to check whether the other instance is null. 
 
 **BAD:**
-```
+```dart
 class Person {
   final String name;
 
@@ -31,7 +31,7 @@ class Person {
 ```
 
 **GOOD:**
-```
+```dart
 class Person {
   final String name;
 

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -20,7 +20,7 @@ ambiguous.  Using named boolean parameters is much more readable because it
 inherently describes what the boolean value represents.
 
 **BAD:**
-```
+```dart
 Task(true);
 Task(false);
 ListBox(false, true, true);
@@ -28,7 +28,7 @@ Button(false);
 ```
 
 **GOOD:**
-```
+```dart
 Task.oneShot();
 Task.repeating();
 ListBox(scroll: true, showScrollbars: true);

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -14,7 +14,7 @@ const _details = r'''
 **DO** avoid `print` calls in production code.
 
 **BAD:**
-```
+```dart
 void f(int x) {
   print('debug: $x');
   ...

--- a/lib/src/rules/avoid_private_typedef_functions.dart
+++ b/lib/src/rules/avoid_private_typedef_functions.dart
@@ -15,13 +15,13 @@ const _details = r'''
 syntax.
 
 **BAD:**
-```
+```dart
 typedef void _F();
 m(_F f);
 ```
 
 **GOOD:**
-```
+```dart
 m(void Function() f);
 ```
 

--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -15,7 +15,7 @@ const _details = r'''Avoid redundant argument values.
 corresponding parameter.
 
 **BAD:**
-```
+```dart
 void f({bool valWithDefault = true, bool val}) {
   ...
 }
@@ -26,7 +26,7 @@ void main() {
 ```
 
 **GOOD:**
-```
+```dart
 void f({bool valWithDefault = true, bool val}) {
   ...
 }

--- a/lib/src/rules/avoid_relative_lib_imports.dart
+++ b/lib/src/rules/avoid_relative_lib_imports.dart
@@ -18,7 +18,7 @@ paths.
 
 **GOOD:**
 
-```
+```dart
 import 'package:foo/bar.dart';
 
 import 'baz.dart';
@@ -28,7 +28,7 @@ import 'baz.dart';
 
 **BAD:**
 
-```
+```dart
 import 'package:foo/bar.dart';
 
 import '../lib/baz.dart';

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -21,7 +21,7 @@ documentation. If the inherited method contains the name of the parameter (in
 square brackets), then dartdoc cannot link it correctly.
 
 **BAD:**
-```
+```dart
 abstract class A {
   m(a);
 }
@@ -32,7 +32,7 @@ abstract class B extends A {
 ```
 
 **GOOD:**
-```
+```dart
 abstract class A {
   m(a);
 }

--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -16,12 +16,12 @@ const _details = r'''
 As setters do not return a value, declaring the return type of one is redundant.
 
 **GOOD:**
-```
+```dart
 set speed(int ms);
 ```
 
 **BAD:**
-```
+```dart
 void set speed(int ms);
 ```
 

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -23,7 +23,7 @@ generally expected to return non-nullable values.  Thus, returning null where a
 primitive type was expected can lead to runtime exceptions.
 
 **BAD:**
-```
+```dart
 bool getBool() => null;
 num getNum() => null;
 int getInt() => null;
@@ -31,7 +31,7 @@ double getDouble() => null;
 ```
 
 **GOOD:**
-```
+```dart
 bool getBool() => false;
 num getNum() => -1;
 int getInt() => -1;

--- a/lib/src/rules/avoid_returning_null_for_void.dart
+++ b/lib/src/rules/avoid_returning_null_for_void.dart
@@ -21,7 +21,7 @@ value. To have a consistent way you should not return `null` and only use an
 empty return.
 
 **BAD:**
-```
+```dart
 void f1() {
   return null;
 }
@@ -31,7 +31,7 @@ Future<void> f2() async {
 ```
 
 **GOOD:**
-```
+```dart
 void f1() {
   return;
 }

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -27,7 +27,7 @@ Returning `this` is allowed for:
 - methods defined in extensions
 
 **BAD:**
-```
+```dart
 var buffer = StringBuffer()
   .write('one')
   .write('two')
@@ -35,7 +35,7 @@ var buffer = StringBuffer()
 ```
 
 **GOOD:**
-```
+```dart
 var buffer = StringBuffer()
   ..write('one')
   ..write('two')

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -19,7 +19,7 @@ inconsistencies.  Doing this could allow you to set a property to some value,
 but then upon observing the property's value, it could easily be different.
 
 **BAD:**
-```
+```dart
 class Bad {
   int l, r;
 
@@ -30,7 +30,7 @@ class Bad {
 ```
 
 **GOOD:**
-```
+```dart
 class Good {
   int l, r;
 

--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -14,14 +14,14 @@ const _details = r'''
 **AVOID** shadowing type parameters.
 
 **BAD:**
-```
+```dart
 class A<T> {
   void fn<T>() {}
 }
 ```
 
 **GOOD:**
-```
+```dart
 class A<T> {
   void fn<U>() {}
 }

--- a/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
+++ b/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
@@ -14,12 +14,12 @@ const _details = r'''
 **AVOID** single cascade in expression statements.
 
 **BAD:**
-```
+```dart
 o..m();
 ```
 
 **GOOD:**
-```
+```dart
 o.m();
 ```
 

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -28,7 +28,7 @@ much slower than their synchronous counterparts.
 * `FileSystemEntity.type`
 
 **BAD:**
-```
+```dart
 import 'dart:io';
 
 Future<Null> someFunction() async {
@@ -39,7 +39,7 @@ Future<Null> someFunction() async {
 ```
 
 **GOOD:**
-```
+```dart
 import 'dart:io';
 
 Future<Null> someFunction() async {

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -20,7 +20,7 @@ Development-mode compilers where code size is not a concern use the full name,
 but release-mode compilers often choose to minify these symbols.
 
 **BAD:**
-```
+```dart
 void bar(Object other) {
   if (other.runtimeType.toString() == 'Bar') {
     doThing();
@@ -33,7 +33,7 @@ Object baz(Thing myThing) {
 ```
 
 **GOOD:**
-```
+```dart
 void bar(Object other) {
   if (other is Bar) {
     doThing();

--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -15,12 +15,12 @@ const _details = r'''
 **AVOID** using a parameter name that is the same as an existing type.
 
 **BAD:**
-```
+```dart
 m(f(int));
 ```
 
 **GOOD:**
-```
+```dart
 m(f(int v));
 ```
 

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -18,12 +18,12 @@ because the parameter types can almost always be inferred from the context,
 thus making the practice redundant.
 
 **BAD:**
-```
+```dart
 var names = people.map((Person person) => person.name);
 ```
 
 **GOOD:**
-```
+```dart
 var names = people.map((person) => person.name);
 ```
 

--- a/lib/src/rules/avoid_unnecessary_containers.dart
+++ b/lib/src/rules/avoid_unnecessary_containers.dart
@@ -16,7 +16,7 @@ Wrapping a widget in `Container` with no other parameters set has no effect
 and makes code needlessly more complex.
 
 **BAD:**
-```
+```dart
 Widget buildRow() {
   return Container(
       child: Row(
@@ -32,7 +32,7 @@ Widget buildRow() {
 ```
 
 **GOOD:**
-```
+```dart
 Widget buildRow() {
   return Row(
     children: <Widget>[

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -16,7 +16,7 @@ const _details = r'''
 **AVOID** defining unused parameters in constructors.
 
 **BAD:**
-```
+```dart
 class BadOne {
   BadOne(int unusedParameter, [String unusedPositional]);
 }

--- a/lib/src/rules/avoid_void_async.dart
+++ b/lib/src/rules/avoid_void_async.dart
@@ -18,13 +18,13 @@ When declaring an async method or function which does not return a value,
 declare that it returns Future<void> and not just void.
 
 **BAD:**
-```
+```dart
 void f() async {}
 void f2() async => null;
 ```
 
 **GOOD:**
-```
+```dart
 Future<void> f() async {}
 Future<void> f2() async => null;
 ```

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -15,14 +15,14 @@ const _details = r'''
 **AVOID** using await on anything other than a future.
 
 **BAD:**
-```
+```dart
 main() async {
   print(await 23);
 }
 ```
 
 **GOOD:**
-```
+```dart
 main() async {
   print(await Future.value(23));
 }

--- a/lib/src/rules/camel_case_extensions.dart
+++ b/lib/src/rules/camel_case_extensions.dart
@@ -19,7 +19,7 @@ Extensions should capitalize the first letter of each word (including
 the first word), and use no separators.
 
 **GOOD:**
-```
+```dart
 extension MyFancyList<T> on List<T> { 
   // ... 
 }

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -20,7 +20,7 @@ Classes and typedefs should capitalize the first letter of each word (including
 the first word), and use no separators.
 
 **GOOD:**
-```
+```dart
 class SliderMenu {
   // ...
 }

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -18,7 +18,7 @@ Cancelling instances of StreamSubscription prevents memory leaks and unexpected
 behavior.
 
 **BAD:**
-```
+```dart
 class A {
   StreamSubscription _subscriptionA; // LINT
   void init(Stream stream) {
@@ -28,14 +28,14 @@ class A {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction() {
   StreamSubscription _subscriptionF; // LINT
 }
 ```
 
 **GOOD:**
-```
+```dart
 class B {
   StreamSubscription _subscriptionB; // OK
   void init(Stream stream) {
@@ -49,7 +49,7 @@ class B {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunctionOK() {
   StreamSubscription _subscriptionB; // OK
   _subscriptionB.cancel();

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -18,14 +18,14 @@ const _details = r'''
 reference.
 
 **BAD:**
-```
+```dart
 SomeClass someReference = SomeClass();
 someReference.firstMethod();
 someReference.secondMethod();
 ```
 
 **BAD:**
-```
+```dart
 SomeClass someReference = SomeClass();
 ...
 someReference.firstMethod();
@@ -34,7 +34,7 @@ someReference.secondMethod();
 ```
 
 **GOOD:**
-```
+```dart
 SomeClass someReference = SomeClass()
     ..firstMethod()
     ..aProperty = value
@@ -42,7 +42,7 @@ SomeClass someReference = SomeClass()
 ```
 
 **GOOD:**
-```
+```dart
 SomeClass someReference = SomeClass();
 ...
 someReference

--- a/lib/src/rules/cast_nullable_to_non_nullable.dart
+++ b/lib/src/rules/cast_nullable_to_non_nullable.dart
@@ -16,7 +16,7 @@ Don't cast a nullable value to a non nullable type. This hides a null check
 and most of the time it is not what is expected.
 
 **BAD:**
-```
+```dart
 class A {}
 class B extends A {}
 
@@ -26,7 +26,7 @@ var v = a as A;
 ```
 
 **GOOD:**
-```
+```dart
 class A {}
 class B extends A {}
 

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -17,7 +17,7 @@ const _details = r'''
 Closing instances of Sink prevents memory leaks and unexpected behavior.
 
 **BAD:**
-```
+```dart
 class A {
   IOSink _sinkA;
   void init(filename) {
@@ -27,14 +27,14 @@ class A {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction() {
   IOSink _sinkF; // LINT
 }
 ```
 
 **GOOD:**
-```
+```dart
 class B {
   IOSink _sinkB;
   void init(filename) {
@@ -48,7 +48,7 @@ class B {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunctionOK() {
   IOSink _sinkFOK; // OK
   _sinkFOK.close();

--- a/lib/src/rules/comment_references.dart
+++ b/lib/src/rules/comment_references.dart
@@ -21,7 +21,7 @@ identifiers in docs wrapped in brackets are in scope.
 For example,
 
 **GOOD:**
-```
+```dart
 /// Return the larger of [a] or [b].
 int max_int(int a, int b) { ... }
 ```
@@ -29,7 +29,7 @@ int max_int(int a, int b) { ... }
 On the other hand, assuming `outOfScopeId` is out of scope:
 
 **BAD:**
-```
+```dart
 /// Return true if [value] is larger than [outOfScopeId].
 bool isOutOfRange(int value) { ... }
 ```

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -20,7 +20,7 @@ In existing code that uses `ALL_CAPS_WITH_UNDERSCORES` for constants, you may
 continue to use all caps to stay consistent.
 
 **GOOD:**
-```
+```dart
 const pi = 3.14;
 const defaultTimeout = 1000;
 final urlScheme = RegExp('^([a-z]+):');
@@ -31,7 +31,7 @@ class Dice {
 ```
 
 **BAD:**
-```
+```dart
 const PI = 3.14;
 const kDefaultTimeout = 1000;
 final URL_SCHEME = RegExp('^([a-z]+):');

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -17,7 +17,7 @@ Using control flow in finally blocks will inevitably cause unexpected behavior
 that is hard to debug.
 
 **GOOD:**
-```
+```dart
 class Ok {
   double compliantMethod() {
     var i = 5;
@@ -32,7 +32,7 @@ class Ok {
 ```
 
 **BAD:**
-```
+```dart
 class BadReturn {
   double nonCompliantMethod() {
     try {
@@ -47,7 +47,7 @@ class BadReturn {
 ```
 
 **BAD:**
-```
+```dart
 class BadContinue {
   double nonCompliantMethod() {
     for (var o in [1, 2]) {
@@ -65,7 +65,7 @@ class BadContinue {
 ```
 
 **BAD:**
-```
+```dart
 class BadBreak {
   double nonCompliantMethod() {
     for (var o in [1, 2]) {

--- a/lib/src/rules/curly_braces_in_flow_control_structures.dart
+++ b/lib/src/rules/curly_braces_in_flow_control_structures.dart
@@ -17,7 +17,7 @@ Doing so avoids the [dangling else](http://en.wikipedia.org/wiki/Dangling_else)
 problem.
 
 **GOOD:**
-```
+```dart
 if (isWeekDay) {
   print('Bike to work!');
 } else {
@@ -30,14 +30,14 @@ the entire `if` statement and the then body all fit in one line. In that case,
 you may leave off the braces if you prefer:
 
 **GOOD:**
-```
+```dart
 if (arg == null) return defaultValue;
 ```
 
 If the body wraps to the next line, though, use braces:
 
 **GOOD:**
-```
+```dart
 if (overflowChars != other.overflowChars) {
   return overflowChars < other.overflowChars;
 }

--- a/lib/src/rules/deprecated_consistency.dart
+++ b/lib/src/rules/deprecated_consistency.dart
@@ -19,7 +19,7 @@ Do apply `@Deprecated()` consistently:
 - if a constructor parameter pointing to a field is deprecated, the field should also be deprecated.
 
 **BAD:**
-```
+```dart
 @deprecated
 class A {
   A();
@@ -33,7 +33,7 @@ class B {
 ```
 
 **GOOD:**
-```
+```dart
 @deprecated
 class A {
   @deprecated

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -33,7 +33,7 @@ For the purposes of diagnostics, a property `foo` and a prefixed property
 sufficient to refer to one or the other.
 
 **BAD:**
-```
+```dart
 class Absorber extends Widget {
   bool get absorbing => _absorbing;
   bool _absorbing;
@@ -49,7 +49,7 @@ class Absorber extends Widget {
 ```
 
 **GOOD:**
-```
+```dart
 class Absorber extends Widget {
   bool get absorbing => _absorbing;
   bool _absorbing;

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -16,7 +16,7 @@ const _details = r'''
 **DO** place “dart:” imports before other imports.
 
 **BAD:**
-```
+```dart
 import 'package:bar/bar.dart';
 import 'package:foo/foo.dart';
 
@@ -25,7 +25,7 @@ import 'dart:html';  // LINT
 ```
 
 **BAD:**
-```
+```dart
 import 'dart:html';  // OK
 import 'package:bar/bar.dart';
 
@@ -34,7 +34,7 @@ import 'package:foo/foo.dart';
 ```
 
 **GOOD:**
-```
+```dart
 import 'dart:async';  // OK
 import 'dart:html';  // OK
 
@@ -45,15 +45,16 @@ import 'package:foo/foo.dart';
 **DO** place “package:” imports before relative imports.
 
 **BAD:**
-```
+```dart
 import 'a.dart';
 import 'b.dart';
 
 import 'package:bar/bar.dart';  // LINT
 import 'package:foo/foo.dart';  // LINT
 ```
+
 **BAD:**
-```
+```dart
 import 'package:bar/bar.dart';  // OK
 import 'a.dart';
 
@@ -62,7 +63,7 @@ import 'b.dart';
 ```
 
 **GOOD:**
-```
+```dart
 import 'package:bar/bar.dart';  // OK
 import 'package:foo/foo.dart';  // OK
 
@@ -73,14 +74,14 @@ import 'b.dart';
 **DO** specify exports in a separate section after all imports.
 
 **BAD:**
-```
+```dart
 import 'src/error.dart';
 export 'src/error.dart'; // LINT
 import 'src/string_source.dart';
 ```
 
 **GOOD:**
-```
+```dart
 import 'src/error.dart';
 import 'src/string_source.dart';
 
@@ -90,7 +91,7 @@ export 'src/error.dart'; // OK
 **DO** sort sections alphabetically.
 
 **BAD:**
-```
+```dart
 import 'package:foo/bar.dart'; // OK
 import 'package:bar/bar.dart'; // LINT
 
@@ -99,7 +100,7 @@ import 'a.dart'; // LINT
 ```
 
 **GOOD:**
-```
+```dart
 import 'package:bar/bar.dart'; // OK
 import 'package:foo/bar.dart'; // OK
 

--- a/lib/src/rules/do_not_use_environment.dart
+++ b/lib/src/rules/do_not_use_environment.dart
@@ -16,7 +16,7 @@ hidden global state and makes applications hard to understand and maintain.
 **DO NOT** use `fromEnvironment` or `hasEnvironment` factory constructors.
 
 **BAD:**
-```
+```dart
 const loggingLevel =
   bool.hasEnvironment('logging') ? String.fromEnvironment('logging') : null;
 ```

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -20,14 +20,14 @@ caught and suppressed.  Alternatively, the exception identifier can be named wit
 underscores (e.g., `_`) to indicate that we intend to skip it.
 
 **BAD:**
-```
+```dart
 try {
   ...
 } catch(exception) { }
 ```
 
 **GOOD:**
-```
+```dart
 try {
   ...
 } catch(e) {

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -20,7 +20,7 @@ semicolon.  This is required for const constructors.  For consistency and
 brevity, other constructors should also do this.
 
 **GOOD:**
-```
+```dart
 class Point {
   int x, y;
   Point(this.x, this.y);
@@ -28,7 +28,7 @@ class Point {
 ```
 
 **BAD:**
-```
+```dart
 class Point {
   int x, y;
   Point(this.x, this.y) {}

--- a/lib/src/rules/empty_statements.dart
+++ b/lib/src/rules/empty_statements.dart
@@ -18,14 +18,14 @@ Empty statements almost always indicate a bug.
 For example,
 
 **BAD:**
-```
+```dart
 if (complicated.expression.foo());
   bar();
 ```
 
 Formatted with `dart format` the bug becomes obvious:
 
-```
+```dart
 if (complicated.expression.foo()) ;
 bar();
 
@@ -34,7 +34,7 @@ bar();
 Better to avoid the empty statement altogether.
 
 **GOOD:**
-```
+```dart
 if (complicated.expression.foo())
   bar();
 ```

--- a/lib/src/rules/exhaustive_cases.dart
+++ b/lib/src/rules/exhaustive_cases.dart
@@ -23,7 +23,7 @@ Enum-like classes are defined as concrete (non-abstract) classes that have:
 **DO** define case clauses for all constants in enum-like classes.
 
 **BAD:**
-```
+```dart
 class EnumLike {
   final int i;
   const E._(this.i);
@@ -47,7 +47,7 @@ void bad(EnumLike e) {
 ```
 
 **GOOD:**
-```
+```dart
 class EnumLike {
   final int i;
   const E._(this.i);

--- a/lib/src/rules/flutter_style_todos.dart
+++ b/lib/src/rules/flutter_style_todos.dart
@@ -20,7 +20,7 @@ From the [Flutter docs](https://github.com/flutter/flutter/wiki/Style-guide-for-
 > TODOs should include the string TODO in all caps, followed by the GitHub username of the person with the best context about the problem referenced by the TODO in parenthesis. A TODO is not a commitment that the person referenced will fix the problem, it is intended to be the person with enough context to explain the problem. Thus, when you create a TODO, it is almost always your username that is given.
 
 **GOOD:**
-```
+```dart
 // TODO(username): message.
 // TODO(username): message, https://URL-to-issue.
 ```

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -22,7 +22,7 @@ map implementation to function properly.  Thus, when overriding `==`, the
 `hashCode` is overridden, `==` should be also.
 
 **BAD:**
-```
+```dart
 class Bad {
   final int value;
   Bad(this.value);
@@ -33,7 +33,7 @@ class Bad {
 ```
 
 **GOOD:**
-```
+```dart
 class Better {
   final int value;
   Better(this.value);

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -28,7 +28,7 @@ directory.  Those files are not part of the package's public API, and they
 might change in ways that could break your code.
 
 **BAD:**
-```
+```dart
 // In 'road_runner'
 import 'package:acme/lib/src/internals.dart;
 ```

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -30,13 +30,13 @@ not always evaluate to `true` or `false` and does not perform redundant tests.
 This rule will hint to the test conflicting with the linted one.
 
 **BAD:**
-```
+```dart
 // foo can't be both equal and not equal to bar in the same expression
 if(foo == bar && something && foo != bar) {...}
 ```
 
 **BAD:**
-```
+```dart
 void compute(int foo) {
   if (foo == 4) {
     doSomething();
@@ -49,7 +49,7 @@ void compute(int foo) {
 ```
 
 **BAD:**
-```
+```dart
 void compute(bool foo) {
   if (foo) {
     return;
@@ -62,7 +62,7 @@ void compute(bool foo) {
 ```
 
 **GOOD:**
-```
+```dart
 void nestedOK() {
   if (foo == bar) {
     foo = baz;
@@ -72,7 +72,7 @@ void nestedOK() {
 ```
 
 **GOOD:**
-```
+```dart
 void nestedOk2() {
   if (foo == bar) {
     return;
@@ -84,7 +84,7 @@ void nestedOk2() {
 ```
 
 **GOOD:**
-```
+```dart
 void nestedOk5() {
   if (foo != null) {
     if (bar != null) {

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -17,7 +17,7 @@ than the parameter type.
 Doing this will invoke `==` on its elements and most likely will return `false`.
 
 **BAD:**
-```
+```dart
 void someFunction() {
   var list = <int>[];
   if (list.contains('1')) print('someFunction'); // LINT
@@ -25,7 +25,7 @@ void someFunction() {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction3() {
   List<int> list = <int>[];
   if (list.contains('1')) print('someFunction3'); // LINT
@@ -33,7 +33,7 @@ void someFunction3() {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction8() {
   List<DerivedClass2> list = <DerivedClass2>[];
   DerivedClass3 instance;
@@ -42,7 +42,7 @@ void someFunction8() {
 ```
 
 **BAD:**
-```
+```dart
 abstract class SomeIterable<E> implements Iterable<E> {}
 
 abstract class MyClass implements SomeIterable<int> {
@@ -51,7 +51,7 @@ abstract class MyClass implements SomeIterable<int> {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction10() {
   var list = [];
   if (list.contains(1)) print('someFunction10'); // OK
@@ -59,7 +59,7 @@ void someFunction10() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction1() {
   var list = <int>[];
   if (list.contains(1)) print('someFunction1'); // OK
@@ -67,7 +67,7 @@ void someFunction1() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction4() {
   List<int> list = <int>[];
   if (list.contains(1)) print('someFunction4'); // OK
@@ -75,7 +75,7 @@ void someFunction4() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction5() {
   List<ClassBase> list = <ClassBase>[];
   DerivedClass1 instance;
@@ -88,7 +88,7 @@ class DerivedClass1 extends ClassBase {}
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction6() {
   List<Mixin> list = <Mixin>[];
   DerivedClass2 instance;
@@ -103,7 +103,7 @@ class DerivedClass2 extends ClassBase with Mixin {}
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction7() {
   List<Mixin> list = <Mixin>[];
   DerivedClass3 instance;

--- a/lib/src/rules/join_return_with_assignment.dart
+++ b/lib/src/rules/join_return_with_assignment.dart
@@ -15,7 +15,7 @@ const _details = r'''
 **DO** join return statement with assignment when possible.
 
 **BAD:**
-```
+```dart
 class A {
   B _lazyInstance;
   static B get instance {
@@ -26,7 +26,7 @@ class A {
 ```
 
 **GOOD:**
-```
+```dart
 class A {
   B _lazyInstance;
   static B get instance => _lazyInstance ??= B();

--- a/lib/src/rules/leading_newlines_in_multiline_strings.dart
+++ b/lib/src/rules/leading_newlines_in_multiline_strings.dart
@@ -14,7 +14,7 @@ Multiline strings are easier to read when they start with a newline (a newline
 starting a multiline string is ignored).
 
 **BAD:**
-```
+```dart
 var s1 = '''{
   "a": 1,
   "b": 2
@@ -22,7 +22,7 @@ var s1 = '''{
 ```
 
 **GOOD:**
-```
+```dart
 var s1 = '''
 {
   "a": 1,

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -21,12 +21,14 @@ a valid Dart identifier, which may be helpful if the language later supports
 symbolic imports.
 
 **GOOD:**
-
-* `library peg_parser;`
+```dart
+library peg_parser;
+```
 
 **BAD:**
-
-* `library peg-parser;`
+```dart
+library peg-parser;
+```
 
 The lint `file_names` can be used to enforce the same kind of naming on the
 file.

--- a/lib/src/rules/library_prefixes.dart
+++ b/lib/src/rules/library_prefixes.dart
@@ -16,7 +16,7 @@ const _details = r'''
 **DO** use `lowercase_with_underscores` when specifying a library prefix.
 
 **GOOD:**
-```
+```dart
 import 'dart:math' as math;
 import 'dart:json' as json;
 import 'package:js/js.dart' as js;
@@ -24,7 +24,7 @@ import 'package:javascript_utils/javascript_utils.dart' as js_utils;
 ```
 
 **BAD:**
-```
+```dart
 import 'dart:math' as Math;
 import 'dart:json' as JSON;
 import 'package:js/js.dart' as JS;

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -17,7 +17,7 @@ Doing this will invoke `==` on its elements and most likely will
 return `false`.
 
 **BAD:**
-```
+```dart
 void someFunction() {
   var list = <int>[];
   if (list.remove('1')) print('someFunction'); // LINT
@@ -25,7 +25,7 @@ void someFunction() {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction3() {
   List<int> list = <int>[];
   if (list.remove('1')) print('someFunction3'); // LINT
@@ -33,7 +33,7 @@ void someFunction3() {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction8() {
   List<DerivedClass2> list = <DerivedClass2>[];
   DerivedClass3 instance;
@@ -42,7 +42,7 @@ void someFunction8() {
 ```
 
 **BAD:**
-```
+```dart
 abstract class SomeList<E> implements List<E> {}
 
 abstract class MyClass implements SomeList<int> {
@@ -51,7 +51,7 @@ abstract class MyClass implements SomeList<int> {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction10() {
   var list = [];
   if (list.remove(1)) print('someFunction10'); // OK
@@ -59,7 +59,7 @@ void someFunction10() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction1() {
   var list = <int>[];
   if (list.remove(1)) print('someFunction1'); // OK
@@ -67,7 +67,7 @@ void someFunction1() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction4() {
   List<int> list = <int>[];
   if (list.remove(1)) print('someFunction4'); // OK
@@ -75,7 +75,7 @@ void someFunction4() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction5() {
   List<ClassBase> list = <ClassBase>[];
   DerivedClass1 instance;
@@ -88,7 +88,7 @@ class DerivedClass1 extends ClassBase {}
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction6() {
   List<Mixin> list = <Mixin>[];
   DerivedClass2 instance;
@@ -103,7 +103,7 @@ class DerivedClass2 extends ClassBase with Mixin {}
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction7() {
   List<Mixin> list = <Mixin>[];
   DerivedClass3 instance;

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -24,56 +24,56 @@ Either the condition should be removed or it should be updated so that it does
 not always evaluate to `true` or `false`.
 
 **BAD:**
-```
+```dart
 void bad() {
   if (true) {} // LINT
 }
 ```
 
 **BAD:**
-```
+```dart
 void bad() {
   if (true && 1 != 0) {} // LINT
 }
 ```
 
 **BAD:**
-```
+```dart
 void bad() {
   if (1 != 0 && true) {} // LINT
 }
 ```
 
 **BAD:**
-```
+```dart
 void bad() {
   if (1 < 0 && true) {} // LINT
 }
 ```
 
 **BAD:**
-```
+```dart
 void bad() {
   if (true && false) {} // LINT
 }
 ```
 
 **BAD:**
-```
+```dart
 void bad() {
   if (1 != 0) {} // LINT
 }
 ```
 
 **BAD:**
-```
+```dart
 void bad() {
   if (true && 1 != 0 || 3 < 4) {} // LINT
 }
 ```
 
 **BAD:**
-```
+```dart
 void bad() {
   if (1 != 0 || 3 < 4 && true) {} // LINT
 }

--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -18,14 +18,14 @@ With long text split accross adjacent strings it's easy to forget a whitespace
 between strings.
 
 **BAD:**
-```
+```dart
 var s =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed'
   'do eiusmod tempor incididunt ut labore et dolore magna';
 ```
 
 **GOOD:**
-```
+```dart
 var s =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed '
   'do eiusmod tempor incididunt ut labore et dolore magna';

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -16,7 +16,7 @@ const _details = r'''
 This can be sign of forgotten comma.
 
 **GOOD:**
-```
+```dart
 List<String> list = <String>[
   'a' +
   'b',
@@ -25,7 +25,7 @@ List<String> list = <String>[
 ```
 
 **BAD:**
-```
+```dart
 List<String> list = <String>[
   'a'
   'b',

--- a/lib/src/rules/no_default_cases.dart
+++ b/lib/src/rules/no_default_cases.dart
@@ -23,7 +23,7 @@ Enum-like classes are defined as concrete (non-abstract) classes that have:
 **DO** define default behavior outside switch statements.
 
 **GOOD:**
-```
+```dart
   switch (testEnum) {
     case TestEnum.A:
       return '123';
@@ -35,7 +35,7 @@ Enum-like classes are defined as concrete (non-abstract) classes that have:
 ```
 
 **BAD:**
-```
+```dart
   switch (testEnum) {
     case TestEnum.A:
       return '123';

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -17,7 +17,7 @@ const _details = r'''
 This is usually a typo or changed value of constant.
 
 **GOOD:**
-```
+```dart
 const int A = 1;
 switch (v) {
   case A:
@@ -26,7 +26,7 @@ switch (v) {
 ```
 
 **BAD:**
-```
+```dart
 const int A = 1;
 switch (v) {
   case 1:

--- a/lib/src/rules/no_logic_in_create_state.dart
+++ b/lib/src/rules/no_logic_in_create_state.dart
@@ -20,7 +20,7 @@ constructor parameters should also be avoided and so further, the State
 constructor is required to be passed no arguments.
 
 **BAD:**
-```
+```dart
 MyState global;
 
 class MyStateful extends StatefulWidget {
@@ -32,14 +32,14 @@ class MyStateful extends StatefulWidget {
 }
 ```
 
-```
+```dart
 class MyStateful extends StatefulWidget {
   @override
   MyState createState() => MyState()..field = 42;
 }
 ```
 
-```
+```dart
 class MyStateful extends StatefulWidget {
   @override
   MyState createState() => MyState(42);
@@ -48,7 +48,7 @@ class MyStateful extends StatefulWidget {
 
 
 **GOOD:**
-```
+```dart
 class MyStateful extends StatefulWidget {
   @override
   MyState createState() {

--- a/lib/src/rules/no_runtimeType_toString.dart
+++ b/lib/src/rules/no_runtimeType_toString.dart
@@ -17,14 +17,14 @@ Calling `toString` on a runtime type is a non-trivial operation that can
 negatively impact performance. It's better to avoid it.
 
 **BAD:**
-```
+```dart
 class A {
   String toString() => '$runtimeType()';
 }
 ```
 
 **GOOD:**
-```
+```dart
 class A {
   String toString() => 'A()';
 }

--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -19,7 +19,7 @@ and named constructors should capitalize the first letter of each word
 except the first word, and use no separators.
 
 **GOOD:**
-```
+```dart
 var item;
 
 HttpRequest httpRequest;

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -25,7 +25,7 @@ A common mistake is to do so using `x!`. This is almost always incorrect, since
 if `T` is a nullable type, `x` may validly hold `null` as a value of type `T`.
 
 **BAD:**
-```
+```dart
 T run<T>(T callback()) {
   T? result;
    (() { result = callback(); })();
@@ -34,7 +34,7 @@ T run<T>(T callback()) {
 ```
 
 **GOOD:**
-```
+```dart
 T run<T>(T callback()) {
   T? result;
    (() { result = callback(); })();

--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -72,12 +72,12 @@ in the following locations:
   * `String.splitMapJoin` at the named parameters `onMatch` and `onNonMatch`
 
 **BAD:**
-```
+```dart
 [1, 3, 5].firstWhere((e) => e.isOdd, orElse: null);
 ```
 
 **GOOD:**
-```
+```dart
 [1, 3, 5].firstWhere((e) => e.isOdd, orElse: () => null);
 ```
 

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -19,7 +19,7 @@ Usually, the types of local variables can be easily inferred, so it isn't
 necessary to annotate them.
 
 **BAD:**
-```
+```dart
 Map<int, List<Person>> groupByZip(Iterable<Person> people) {
   Map<int, List<Person>> peopleByZip = <int, List<Person>>{};
   for (Person person in people) {
@@ -31,7 +31,7 @@ Map<int, List<Person>> groupByZip(Iterable<Person> people) {
 ```
 
 **GOOD:**
-```
+```dart
 Map<int, List<Person>> groupByZip(Iterable<Person> people) {
   var peopleByZip = <int, List<Person>>{};
   for (var person in people) {

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -23,12 +23,12 @@ with a meaningless name like `call` or `invoke`, there is a good chance
 you just want a function.
 
 **GOOD:**
-```
+```dart
 typedef Predicate = bool Function(item);
 ```
 
 **BAD:**
-```
+```dart
 abstract class Predicate {
   bool test(item);
 }

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -24,14 +24,14 @@ doing this is usually a hack for something that should be implemented more
 thoroughly.
 
 **BAD:**
-```
+```dart
 void throwString() {
   throw 'hello world!'; // LINT
 }
 ```
 
 **GOOD:**
-```
+```dart
 void throwArgumentError() {
   Error error = ArgumentError('oh!');
   throw error; // OK

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -20,7 +20,7 @@ Overriding fields is almost always done unintentionally.  Regardless, it is a
 bad practice to do so.
 
 **BAD:**
-```
+```dart
 class Base {
   Object field = 'lorem';
 
@@ -39,7 +39,7 @@ class Bad2 extends Base {
 ```
 
 **GOOD:**
-```
+```dart
 class Base {
   Object field = 'lorem';
 
@@ -54,7 +54,7 @@ class Ok extends Base {
 ```
 
 **GOOD:**
-```
+```dart
 abstract class BaseLoggingHandler {
   Base transformer;
 }

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -20,7 +20,7 @@ implementation files in `lib/src`, adding elements explicitly exported with an
 `export` directive.
 
 For example, given `lib/foo.dart`:
-```
+```dart
 export 'src/bar.dart' show Bar;
 export 'src/baz.dart';
 
@@ -37,7 +37,7 @@ its API includes:
 All public API members should be documented with `///` doc-style comments.
 
 **GOOD:**
-```
+```dart
 /// A Foo.
 abstract class Foo {
   /// Start foo-ing.
@@ -48,7 +48,7 @@ abstract class Foo {
 ```
 
 **BAD:**
-```
+```dart
 class Bar {
   void bar();
 }

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -27,7 +27,7 @@ For example, say the package name is `my_package`.  Here are the library names
 for various files in the package:
 
 **GOOD:**
-```
+```dart
 // In lib/my_package.dart
 library my_package;
 

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -21,28 +21,28 @@ operator such as `??=` is used.  Otherwise, arbitrarily reassigning parameters
 is usually a mistake.
 
 **BAD:**
-```
+```dart
 void badFunction(int parameter) { // LINT
   parameter = 4;
 }
 ```
 
 **BAD:**
-```
+```dart
 void badFunction(int required, {int optional: 42}) { // LINT
   optional ??= 8;
 }
 ```
 
 **BAD:**
-```
+```dart
 void badFunctionPositional(int required, [int optional = 42]) { // LINT
   optional ??= 8;
 }
 ```
 
 **BAD:**
-```
+```dart
 class A {
     void badMethod(int parameter) { // LINT
     parameter = 4;
@@ -51,28 +51,28 @@ class A {
 ```
 
 **GOOD:**
-```
+```dart
 void ok(String parameter) {
   print(parameter);
 }
 ```
 
 **GOOD:**
-```
+```dart
 void actuallyGood(int required, {int optional}) { // OK
   optional ??= ...;
 }
 ```
 
 **GOOD:**
-```
+```dart
 void actuallyGoodPositional(int required, [int optional]) { // OK
   optional ??= ...;
 }
 ```
 
 **GOOD:**
-```
+```dart
 class A {
   void ok(String parameter) {
     print(parameter);

--- a/lib/src/rules/prefer_adjacent_string_concatenation.dart
+++ b/lib/src/rules/prefer_adjacent_string_concatenation.dart
@@ -14,14 +14,14 @@ const _details = r'''
 **DO** use adjacent strings to concatenate string literals.
 
 **BAD:**
-```
+```dart
 raiseAlarm(
     'ERROR: Parts of the spaceship are on fire. Other ' +
     'parts are overrun by martians. Unclear which are which.');
 ```
 
 **GOOD:**
-```
+```dart
 raiseAlarm(
     'ERROR: Parts of the spaceship are on fire. Other '
     'parts are overrun by martians. Unclear which are which.');

--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -16,14 +16,14 @@ const _details = r'''
 their body.
 
 **GOOD:**
-```
+```dart
 class A {
   A(int a) : assert(a != null);
 }
 ```
 
 **BAD:**
-```
+```dart
 class A {
   A(int a) {
     assert(a != null);

--- a/lib/src/rules/prefer_asserts_with_message.dart
+++ b/lib/src/rules/prefer_asserts_with_message.dart
@@ -15,7 +15,7 @@ When assertions fail it's not always simple to understand why. Adding a message
 to the `assert` helps the developer to understand why the AssertionError occurs.
 
 **BAD:**
-```
+```dart
 f(a) {
   assert(a != null);
 }
@@ -26,7 +26,7 @@ class A {
 ```
 
 **GOOD:**
-```
+```dart
 f(a) {
   assert(a != null, 'a must not be null');
 }

--- a/lib/src/rules/prefer_bool_in_asserts.dart
+++ b/lib/src/rules/prefer_bool_in_asserts.dart
@@ -18,7 +18,7 @@ Not using booleans in assert conditions can lead to code where it isn't clear
 what the intention of the assert statement is.
 
 **BAD:**
-```
+```dart
 assert(() {
   f();
   return true;
@@ -26,7 +26,7 @@ assert(() {
 ```
 
 **GOOD:**
-```
+```dart
 assert(() {
   f();
   return true;

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -16,7 +16,7 @@ const _details = r'''
 **DO** use collection literals when possible.
 
 **BAD:**
-```
+```dart
 var points = List();
 var addresses = Map();
 var uniqueNames = Set();
@@ -25,7 +25,7 @@ var coordinates = LinkedHashMap();
 ```
 
 **GOOD:**
-```
+```dart
 var points = [];
 var addresses = <String,String>{};
 var uniqueNames = <String>{};
@@ -38,7 +38,7 @@ var coordinates = <int,int>{};
 There are cases with `LinkedHashSet` or `LinkedHashMap` where a literal constructor
 will trigger a type error so those will be excluded from the lint.
 
-```
+```dart
 void main() {
   LinkedHashSet<int> linkedHashSet =  LinkedHashSet.from([1, 2, 3]); // OK
   LinkedHashMap linkedHashMap = LinkedHashMap(); // OK

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -19,7 +19,7 @@ As Dart has the `??=` operator, it is advisable to use it where applicable to
 improve the brevity of your code.
 
 **BAD:**
-```
+```dart
 String get fullName {
   if (_fullName == null) {
     _fullName = getFullUserName(this);
@@ -29,7 +29,7 @@ String get fullName {
 ```
 
 **GOOD:**
-```
+```dart
 String get fullName {
   return _fullName ??= getFullUserName(this);
 }

--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -17,7 +17,7 @@ const _details = r'''
 If a const constructor is available, it is preferable to use it.
 
 **GOOD:**
-```
+```dart
 class A {
   const A();
 }
@@ -28,7 +28,7 @@ void accessA() {
 ```
 
 **GOOD:**
-```
+```dart
 class A {
   final int x;
 
@@ -39,7 +39,7 @@ A foo(int x) => new A(x);
 ```
 
 **BAD:**
-```
+```dart
 class A {
   const A();
 }

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -19,7 +19,7 @@ If a class is immutable, it is usually a good idea to make its constructor a
 const constructor.
 
 **GOOD:**
-```
+```dart
 @immutable
 class A {
   final a;
@@ -28,7 +28,7 @@ class A {
 ```
 
 **BAD:**
-```
+```dart
 @immutable
 class A {
   final a;

--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -19,7 +19,7 @@ Const declarations are more hot-reload friendly and allow to use const
 constructors if an instantiation references this declaration.
 
 **GOOD:**
-```
+```dart
 const o = <int>[];
 
 class A {
@@ -28,7 +28,7 @@ class A {
 ```
 
 **BAD:**
-```
+```dart
 final o = const <int>[];
 
 class A {

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -20,7 +20,7 @@ const details = '''
 parameters in immutable class instantiations.
 
 **BAD:**
-```
+```dart
 @immutable
 class A {
   A(this.v);
@@ -32,7 +32,7 @@ A a2 = new A({});
 ```
 
 **GOOD:**
-```
+```dart
 A a1 = new A(const [1]);
 A a2 = new A(const {});
 ```

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -20,7 +20,7 @@ In most cases, it makes more sense to use a named constructor rather than a
 static method because it makes instantiation clearer.
 
 **BAD:**
-```
+```dart
 class Point {
   num x, y;
   Point(this.x, this.y);
@@ -32,7 +32,7 @@ class Point {
 ```
 
 **GOOD:**
-```
+```dart
 class Point {
   num x, y;
   Point(this.x, this.y);

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -28,12 +28,12 @@ and may have poor performance.
 Instead, prefer `contains`.
 
 **GOOD:**
-```
+```dart
 if (!lunchBox.contains('sandwich') return 'so hungry...';
 ```
 
 **BAD:**
-```
+```dart
 if (lunchBox.indexOf('sandwich') == -1 return 'so hungry...';
 ```
 

--- a/lib/src/rules/prefer_double_quotes.dart
+++ b/lib/src/rules/prefer_double_quotes.dart
@@ -22,7 +22,7 @@ quotes are allowed either within, or containing, an interpolated string literal.
 Arguably strings within string interpolations should be its own type of lint.
 
 **BAD:**
-```
+```dart
 useStrings(
     'should be double quote',
     r'should be double quote',
@@ -30,7 +30,7 @@ useStrings(
 ```
 
 **GOOD:**
-```
+```dart
 useStrings(
     "should be double quote",
     r"should be double quote",

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -17,12 +17,12 @@ From the [style guide](https://dart.dev/guides/language/effective-dart/usage):
 **DO** Use `=` to separate a named parameter from its default value.
 
 **BAD:**
-```
+```dart
 m({a: 1})
 ```
 
 **GOOD:**
-```
+```dart
 m({a = 1})
 ```
 

--- a/lib/src/rules/prefer_expression_function_bodies.dart
+++ b/lib/src/rules/prefer_expression_function_bodies.dart
@@ -15,38 +15,38 @@ const _details = r'''
 **CONSIDER** using => for short members whose body is a single return statement.
 
 **BAD:**
-```
+```dart
 get width {
   return right - left;
 }
 ```
 
 **BAD:**
-```
+```dart
 bool ready(num time) {
   return minTime == null || minTime <= time;
 }
 ```
 
 **BAD:**
-```
+```dart
 containsValue(String value) {
   return getValues().contains(value);
 }
 ```
 
 **GOOD:**
-```
+```dart
 get width => right - left;
 ```
 
 **GOOD:**
-```
+```dart
 bool ready(num time) => minTime == null || minTime <= time;
 ```
 
 **GOOD:**
-```
+```dart
 containsValue(String value) => getValues().contains(value);
 ```
 

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -23,7 +23,7 @@ Declaring fields as final when possible is a good practice because it helps
 avoid accidental reassignments and allows the compiler to do optimizations.
 
 **BAD:**
-```
+```dart
 class BadImmutable {
   var _label = 'hola mundo! BadImmutable'; // LINT
   var label = 'hola mundo! BadImmutable'; // OK
@@ -31,7 +31,7 @@ class BadImmutable {
 ```
 
 **BAD:**
-```
+```dart
 class MultipleMutable {
   var _label = 'hola mundo! GoodMutable', _offender = 'mumble mumble!'; // LINT
   var _someOther; // LINT
@@ -47,7 +47,7 @@ class MultipleMutable {
 ```
 
 **GOOD:**
-```
+```dart
 class GoodImmutable {
   final label = 'hola mundo! BadImmutable', bla = 5; // OK
   final _label = 'hola mundo! BadImmutable', _bla = 5; // OK
@@ -55,7 +55,7 @@ class GoodImmutable {
 ```
 
 **GOOD:**
-```
+```dart
 class GoodMutable {
   var _label = 'hola mundo! GoodMutable';
 
@@ -66,7 +66,7 @@ class GoodMutable {
 ```
 
 **BAD:**
-```
+```dart
 class AssignedInAllConstructors {
   var _label; // LINT
   AssignedInAllConstructors(this._label);
@@ -75,7 +75,7 @@ class AssignedInAllConstructors {
 ```
 
 **GOOD:**
-```
+```dart
 class NotAssignedInAllConstructors {
   var _label; // OK
   NotAssignedInAllConstructors();

--- a/lib/src/rules/prefer_final_in_for_each.dart
+++ b/lib/src/rules/prefer_final_in_for_each.dart
@@ -20,21 +20,21 @@ because it helps avoid accidental reassignments and allows the compiler to do
 optimizations.
 
 **BAD:**
-```
+```dart
 for (var element in elements) { // LINT
   print('Element: $element');
 }
 ```
 
 **GOOD:**
-```
+```dart
 for (final element in elements) {
   print('Element: $element');
 }
 ```
 
 **GOOD:**
-```
+```dart
 for (var element in elements) {
   element = element + element;
   print('Element: $element');

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -19,7 +19,7 @@ Declaring variables as final when possible is a good practice because it helps
 avoid accidental reassignments and allows the compiler to do optimizations.
 
 **BAD:**
-```
+```dart
 void badMethod() {
   var label = 'hola mundo! badMethod'; // LINT
   print(label);
@@ -27,7 +27,7 @@ void badMethod() {
 ```
 
 **GOOD:**
-```
+```dart
 void goodMethod() {
   final label = 'hola mundo! goodMethod';
   print(label);
@@ -35,7 +35,7 @@ void goodMethod() {
 ```
 
 **GOOD:**
-```
+```dart
 void mutableCase() {
   var label = 'hola mundo! mutableCase';
   print(label);

--- a/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
+++ b/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
@@ -14,7 +14,7 @@ const _details = r'''
 When building maps from iterables, it is preferable to use for elements.
 
 **BAD:**
-```
+```dart
 Map<String, WidgetBuilder>.fromIterable(
   kAllGalleryDemos,
   key: (demo) => '${demo.routeName}',
@@ -24,7 +24,7 @@ Map<String, WidgetBuilder>.fromIterable(
 ```
 
 **GOOD:**
-```
+```dart
 return {
   for (var demo in kAllGalleryDemos)
     '${demo.routeName}': demo.buildRoute,

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -21,20 +21,20 @@ elements of an iterable is a good practice because it makes your code more
 terse.
 
 **BAD:**
-```
+```dart
 for (final key in map.keys.toList()) {
   map.remove(key);
 }
 ```
 
 **GOOD:**
-```
+```dart
 map.keys.toList().forEach(map.remove);
 ```
 
 **NOTE:** Replacing a for each statement with a forEach call may change the 
 behavior in the case where there are side-effects on the iterable itself.
-```
+```dart
 for (final v in myList) {
   foo().f(v); // This code invokes foo() many times.
 }

--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -17,7 +17,7 @@ As Dart allows local function declarations, it is a good practice to use them in
 the place of function literals.
 
 **BAD:**
-```
+```dart
 void main() {
   var localFunction = () {
     ...
@@ -26,7 +26,7 @@ void main() {
 ```
 
 **GOOD:**
-```
+```dart
 void main() {
   localFunction() {
     ...

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -22,12 +22,12 @@ For consistency and readability reasons, it's better to only use one syntax and
 thus prefer generic function type aliases.
 
 **BAD:**
-```
+```dart
 typedef void F();
 ```
 
 **GOOD:**
-```
+```dart
 typedef F = void Function();
 ```
 

--- a/lib/src/rules/prefer_if_elements_to_conditional_expressions.dart
+++ b/lib/src/rules/prefer_if_elements_to_conditional_expressions.dart
@@ -14,7 +14,7 @@ When building collections, it is preferable to use `if` elements rather than
 conditionals.
 
 **BAD:**
-```
+```dart
 Widget build(BuildContext context) {
   return Row(
     children: [
@@ -27,7 +27,7 @@ Widget build(BuildContext context) {
 ```
 
 **GOOD:**
-```
+```dart
 Widget build(BuildContext context) {
   return Row(
     children: [

--- a/lib/src/rules/prefer_if_null_operators.dart
+++ b/lib/src/rules/prefer_if_null_operators.dart
@@ -16,12 +16,12 @@ Prefer using if null operators instead of null checks in conditional
 expressions.
 
 **BAD:**
-```
+```dart
 v = a == null ? b : a;
 ```
 
 **GOOD:**
-```
+```dart
 v = a ?? b;
 ```
 

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -18,7 +18,7 @@ const _details = r'''
 Using initializing formals when possible makes your code more terse.
 
 **BAD:**
-```
+```dart
 class Point {
   num x, y;
   Point(num x, num y) {
@@ -29,7 +29,7 @@ class Point {
 ```
 
 **GOOD:**
-```
+```dart
 class Point {
   num x, y;
   Point(this.x, this.y);
@@ -37,7 +37,7 @@ class Point {
 ```
 
 **BAD:**
-```
+```dart
 class Point {
   num x, y;
   Point({num x, num y}) {
@@ -48,7 +48,7 @@ class Point {
 ```
 
 **GOOD:**
-```
+```dart
 class Point {
   num x, y;
   Point({this.x, this.y});
@@ -62,7 +62,7 @@ such a lint would require either renaming the field or renaming the parameter,
 and both of those actions would potentially be a breaking change. For example,
 the following will not generate a lint:
 
-```
+```darts
 class Point {
   bool isEnabled;
   Point({bool enabled}) {

--- a/lib/src/rules/prefer_inlined_adds.dart
+++ b/lib/src/rules/prefer_inlined_adds.dart
@@ -15,13 +15,13 @@ Declare elements in list literals inline, rather than using `add` and
 
 
 **BAD:**
-```
+```dart
 var l = ['a']..add('b')..add('c');
 var l2 = ['a']..addAll(['b', 'c'])
 ```
 
 **GOOD:**
-```
+```dart
 var l = ['a', 'b', 'c'];
 var 2 = ['a', 'b', 'c'];
 ```

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -15,7 +15,7 @@ const _details = '''
 **DO** use int literals rather than the corresponding double literal.
 
 **BAD:**
-```
+```dart
 const double myDouble = 8.0;
 final anotherDouble = myDouble + 7.0e2;
 main() {
@@ -24,7 +24,7 @@ main() {
 ```
 
 **GOOD:**
-```
+```dart
 const double myDouble = 8;
 final anotherDouble = myDouble + 700;
 main() {

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -19,12 +19,12 @@ Using interpolation when composing strings and values is usually easier to write
 and read than concatenation.
 
 **BAD:**
-```
+```dart
 'Hello, ' + name + '! You are ' + (year - birth) + ' years old.';
 ```
 
 **GOOD:**
-```
+```dart
 'Hello, $name! You are ${year - birth} years old.';
 ```
 

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -31,13 +31,13 @@ Instead, there are faster and more readable getters: `isEmpty` and
 `isNotEmpty`.  Use the one that doesn't require you to negate the result.
 
 **GOOD:**
-```
+```dart
 if (lunchBox.isEmpty) return 'so hungry...';
 if (words.isNotEmpty) return words.join(' ');
 ```
 
 **BAD:**
-```
+```dart
 if (lunchBox.length == 0) return 'so hungry...';
 if (words.length != 0) return words.join(' ');
 ```

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -26,14 +26,14 @@ When testing whether an iterable or map is empty, prefer `isNotEmpty` over
 `!isEmpty` to improve code readability.
 
 **GOOD:**
-```
+```dart
 if (todo.isNotEmpty) {
   sendResults(request, todo.isEmpty);
 }
 ```
 
 **BAD:**
-```
+```dart
 if (!sources.isEmpty) {
   process(sources);
 }

--- a/lib/src/rules/prefer_is_not_operator.dart
+++ b/lib/src/rules/prefer_is_not_operator.dart
@@ -14,14 +14,14 @@ const _details = r'''
 When checking if an object is not of a specified type, it is preferable to use the 'is!' operator.
 
 **BAD:**
-```
+```dart
 if (!(foo is Foo)) {
   ...
 }
 ```
 
 **GOOD:**
-```
+```dart
 if (foo is! Foo) {
   ...
 }

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -16,12 +16,12 @@ const _details = r'''
 **PREFER** `iterable.whereType<T>()` over `iterable.where((e) => e is T)`.
 
 **BAD:**
-```
+```dart
 iterable.where((e) => e is MyClass)
 ```
 
 **GOOD:**
-```
+```dart
 iterable.whereType<MyClass>()
 ```
 

--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -19,13 +19,13 @@ be used for types that are to be mixed in. As a result, this lint will flag any
 uses of a class in a `with` clause.
 
 **BAD:**
-```
+```dart
 class A {}
 class B extends Object with A {}
 ```
 
 **OK:**
-```
+```dart
 mixin M {}
 class C with M {}
 ```

--- a/lib/src/rules/prefer_null_aware_operators.dart
+++ b/lib/src/rules/prefer_null_aware_operators.dart
@@ -16,12 +16,12 @@ Prefer using null aware operators instead of null checks in conditional
 expressions.
 
 **BAD:**
-```
+```dart
 v = a == null ? null : a.b;
 ```
 
 **GOOD:**
-```
+```dart
 v = a?.b;
 ```
 

--- a/lib/src/rules/prefer_relative_imports.dart
+++ b/lib/src/rules/prefer_relative_imports.dart
@@ -21,13 +21,13 @@ that is to ensure you consistently use relative imports for files withing the
 
 **GOOD:**
 
-```
+```dart
 import 'bar.dart';
 ```
 
 **BAD:**
 
-```
+```dart
 import 'package:my_package/bar.dart';
 ```
 

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -23,7 +23,7 @@ quotes are allowed either within, or containing, an interpolated string literal.
 Arguably strings within string interpolations should be its own type of lint.
 
 **BAD:**
-```
+```dart
 useStrings(
     "should be single quote",
     r"should be single quote",
@@ -31,7 +31,7 @@ useStrings(
 ```
 
 **GOOD:**
-```
+```dart
 useStrings(
     'should be single quote',
     r'should be single quote',

--- a/lib/src/rules/prefer_spread_collections.dart
+++ b/lib/src/rules/prefer_spread_collections.dart
@@ -20,7 +20,7 @@ collection, spread collection syntax leads to simpler code.
 
 **BAD:**
 
-```
+```dart
 Widget build(BuildContext context) {
   return CupertinoPageScaffold(
     child: ListView(
@@ -32,12 +32,12 @@ Widget build(BuildContext context) {
 }
 ```
 
-```
+```dart
 var ints = [1, 2, 3];
 print(['a']..addAll(ints.map((i) => i.toString()))..addAll(['c']));
 ```
 
-```
+```dart
 var things;
 var l = ['a']..addAll(things ?? const []);
 ```
@@ -45,7 +45,7 @@ var l = ['a']..addAll(things ?? const []);
 
 **GOOD:**
 
-```
+```dart
 Widget build(BuildContext context) {
   return CupertinoPageScaffold(
     child: ListView(
@@ -58,12 +58,12 @@ Widget build(BuildContext context) {
 }
 ```
 
-```
+```dart
 var ints = [1, 2, 3];
 print(['a', ...ints.map((i) => i.toString()), 'c');
 ```
 
-```
+```dart
 var things;
 var l = ['a', ...?things];
 ```

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -17,7 +17,7 @@ Forgoing type annotations for uninitialized variables is a bad practice because
 you may accidentally assign them to a type that you didn't originally intend to.
 
 **BAD:**
-```
+```dart
 class BadClass {
   static var bar; // LINT
   var foo; // LINT
@@ -31,7 +31,7 @@ class BadClass {
 ```
 
 **BAD:**
-```
+```dart
 void aFunction() {
   var bar; // LINT
   bar = 5;
@@ -40,7 +40,7 @@ void aFunction() {
 ```
 
 **GOOD:**
-```
+```dart
 class GoodClass {
   static var bar = 7;
   var foo = 42;

--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -15,7 +15,7 @@ const _details = r'''
 **DO NOT** use the type Null where void would work.
 
 **BAD:**
-```
+```dart
 Null f() {}
 Future<Null> f() {}
 Stream<Null> f() {}
@@ -23,7 +23,7 @@ f(Null x) {}
 ```
 
 **GOOD:**
-```
+```dart
 void f() {}
 Future<void> f() {}
 Stream<void> f() {}
@@ -32,14 +32,14 @@ f(void x) {}
 
 Some exceptions include formulating special function types:
 
-```
+```dart
 Null Function(Null, Null);
 ```
 
 and for making empty literals which are safe to pass into read-only locations
 for any type of map or list:
 
-```
+```dart
 <Null>[];
 <int, Null>{};
 ```

--- a/lib/src/rules/provide_deprecation_message.dart
+++ b/lib/src/rules/provide_deprecation_message.dart
@@ -15,13 +15,13 @@ const _details = r'''
 removal schedule) in the Deprecation constructor.
 
 **BAD:**
-```
+```dart
 @deprecated
 void oldFunction(arg1, arg2) {}
 ```
 
 **GOOD:**
-```
+```dart
 @Deprecated("""
 [oldFunction] is being deprecated in favor of [newFunction] (with slightly
 different parameters; see [newFunction] for more information). [oldFunction]

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -19,7 +19,7 @@ All non-overriding public members should be documented with `///` doc-style
 comments.
 
 **GOOD:**
-```
+```dart
 /// A good thing.
 abstract class Good {
   /// Start doing your thing.
@@ -30,7 +30,7 @@ abstract class Good {
 ```
 
 **BAD:**
-```
+```dart
 class Bad {
   void meh() { }
 }
@@ -41,7 +41,7 @@ to provide documentation.  For example, in the following, `Sub` needn't
 document `init` (though it certainly may, if there's need).
 
 **GOOD:**
-```
+```dart
 /// Base of all things.
 abstract class Base {
   /// Initialize the base.

--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -19,19 +19,19 @@ Recursive getters are getters which return themselves as a value.  This is
 usually a typo.
 
 **BAD:**
-```
+```dart
 int get field => field; // LINT
 ```
 
 **BAD:**
-```
+```dart
 int get otherField {
   return otherField; // LINT
 }
 ```
 
 **GOOD:**
-```
+```dart
 int get field => _field;
 ```
 

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -16,7 +16,7 @@ A `Container` is a heavier Widget than a `SizedBox`, and as bonus, `SizedBox`
 has a `const` constructor.
 
 **BAD:**
-```
+```dart
 Widget buildRow() {
   return Row(
     children: <Widget>[
@@ -31,7 +31,7 @@ Widget buildRow() {
 ```
 
 **GOOD:**
-```
+```dart
 Widget buildRow() {
   return Row(
     children: const <Widget>[

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -19,7 +19,7 @@ Although Dart supports two syntaxes of doc comments (`///` and `/**`), we
 prefer using `///` for doc comments.
 
 **GOOD:**
-```
+```dart
 /// Parses a set of option strings. For each option:
 ///
 /// * If it is `null`, then it is ignored.

--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -18,7 +18,7 @@ appear clearly associated with the constructor call and separated from the
 children.
 
 **BAD:**
-```
+```dart
 return Scaffold(
   appBar: AppBar(
     title: Text(widget.title),
@@ -47,7 +47,7 @@ return Scaffold(
 ```
 
 **GOOD:**
-```
+```dart
 return Scaffold(
   appBar: AppBar(
     title: Text(widget.title),

--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -14,7 +14,7 @@ const _details = r'''
 **DO** sort constructor declarations before other members.
 
 **GOOD:**
-```
+```dart
 abstract class Animation<T> {
   const Animation(this.value);
   double value;
@@ -23,7 +23,7 @@ abstract class Animation<T> {
 ```
 
 **BAD:**
-```
+```dart
 abstract class Visitor {
   double value;
   visitSomething(Something s);

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -14,7 +14,7 @@ const _details = r'''
 **DO** sort unnamed constructor declarations first, before named ones.
 
 **GOOD:**
-```
+```dart
 abstract class CancelableFuture<T> implements Future<T>  {
   factory CancelableFuture(computation()) => ...
   factory CancelableFuture.delayed(Duration duration, [computation()]) => ...
@@ -23,7 +23,7 @@ abstract class CancelableFuture<T> implements Future<T>  {
 ```
 
 **BAD:**
-```
+```dart
 class _PriorityItem {
   factory _PriorityItem.forName(bool isStatic, String name, _MemberKind kind) => ...
   _PriorityItem(this.isStatic, this.kind, this.isPrivate);

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -31,14 +31,14 @@ reinforces when the superclass's constructor body is run, and may help
 performance.
 
 **GOOD:**
-```
+```dart
 View(Style style, List children)
     : _children = children,
       super(style) {
 ```
 
 **BAD:**
-```
+```dart
 View(Style style, List children)
     : super(style),
       _children = children {

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -17,7 +17,7 @@ Not testing types might result in null pointer exceptions which will be
 unexpected for consumers of your class.
 
 **GOOD:**
-```
+```dart
 class Field {
 }
 
@@ -43,7 +43,7 @@ class Good {
 ```
 
 **BAD:**
-```
+```dart
 class Field {
 }
 

--- a/lib/src/rules/throw_in_finally.dart
+++ b/lib/src/rules/throw_in_finally.dart
@@ -18,7 +18,7 @@ Throwing exceptions in finally blocks will inevitably cause unexpected behavior
 that is hard to debug.
 
 **GOOD:**
-```
+```dart
 class Ok {
   double compliantMethod() {
     var i = 5;
@@ -33,7 +33,7 @@ class Ok {
 ```
 
 **BAD:**
-```
+```dart
 class BadThrow {
   double nonCompliantMethod() {
     try {

--- a/lib/src/rules/tighten_type_of_initializing_formals.dart
+++ b/lib/src/rules/tighten_type_of_initializing_formals.dart
@@ -18,7 +18,7 @@ Tighten type of initializing formal if a non-null assert exists. This allows the
 type system to catch problems rather than have them only be caught at run-time.
 
 **BAD:**
-```
+```dart
 class A {
   A.c1(this.p) : assert(p != null);
   A.c2(this.p);
@@ -27,7 +27,7 @@ class A {
 ```
 
 **GOOD:**
-```
+```dart
 class A {
   A.c1(String this.p) : assert(p != null);
   A.c2(this.p);

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -29,7 +29,7 @@ For code internal to a library (either private, or things like nested functions)
 annotate where you feel it helps, but don't feel that you *must* provide them.
 
 **BAD:**
-```
+```dart
 install(id, destination) {
   // ...
 }
@@ -39,7 +39,7 @@ Here, it's unclear what `id` is.  A string? And what is `destination`? A string
 or a `File` object? Is this method synchronous or asynchronous?
 
 **GOOD:**
-```
+```dart
 Future<bool> install(PackageId id, String destination) {
   // ...
 }

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -19,7 +19,7 @@ If a constructor parameter is using `this.x` to initialize a field, then the
 type of the parameter is understood to be the same type as the field.
 
 **GOOD:**
-```
+```dart
 class Point {
   int x, y;
   Point(this.x, this.y);
@@ -27,7 +27,7 @@ class Point {
 ```
 
 **BAD:**
-```
+```dart
 class Point {
   int x, y;
   Point(int this.x, int this.y);

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -24,7 +24,7 @@ way is to use `unawaited` from `package:pedantic`. The `// ignore` and
 `// ignore_for_file` comments also work.
 
 **GOOD:**
-```
+```dart
 Future doSomething() => ...;
 
 void main() async {
@@ -35,7 +35,7 @@ void main() async {
 ```
 
 **BAD:**
-```
+```dart
 void main() async {
   doSomething(); // Likely a bug.
 }

--- a/lib/src/rules/unnecessary_await_in_return.dart
+++ b/lib/src/rules/unnecessary_await_in_return.dart
@@ -17,7 +17,7 @@ the function's return type.
 
 
 **BAD:**
-```
+```dart
 Future<int> future;
 Future<int> f1() async => await future;
 Future<int> f2() async {
@@ -26,7 +26,7 @@ Future<int> f2() async {
 ```
 
 **GOOD:**
-```
+```dart
 Future<int> future;
 Future<int> f1() => future;
 Future<int> f2() {

--- a/lib/src/rules/unnecessary_brace_in_string_interps.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interps.dart
@@ -18,12 +18,12 @@ If you're just interpolating a simple identifier, and it's not immediately
 followed by more alphanumeric text, the `{}` can and should be omitted.
 
 **GOOD:**
-```
+```dart
 print("Hi, $name!");
 ```
 
 **BAD:**
-```
+```dart
 print("Hi, ${name}!");
 ```
 

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -15,7 +15,7 @@ const _details = r'''
 **AVOID** repeating const keyword in a const context.
 
 **BAD:**
-```
+```dart
 class A { const A(); }
 m(){
   const a = const A();
@@ -24,7 +24,7 @@ m(){
 ```
 
 **GOOD:**
-```
+```dart
 class A { const A(); }
 m(){
   const a = A();

--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -15,7 +15,7 @@ const _details = r'''
 `var` is shorter, and `final` does not change the meaning of the code.
 
 **BAD:**
-```
+```dart
 void badMethod() {
   final label = 'Final or var?';
   for (final char in ['v', 'a', 'r']) {
@@ -25,7 +25,7 @@ void badMethod() {
 ```
 
 **GOOD:**
-```
+```dart
 void goodMethod() {
   var label = 'Final or var?';
   for (var char in ['v', 'a', 'r']) {

--- a/lib/src/rules/unnecessary_getters.dart
+++ b/lib/src/rules/unnecessary_getters.dart
@@ -24,14 +24,14 @@ If you have a field that outside code should be able to see but not assign to
 that works in many cases is to just mark it `final`.
 
 **GOOD:**
-```
+```dart
 class Box {
   final contents = [];
 }
 ```
 
 **BAD:**
-```
+```dart
 class Box {
   var _contents;
   get contents => _contents;

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -30,7 +30,7 @@ getter and setter without having to touch any code that uses that field.
 
 **GOOD:**
 
-```
+```dart
 class Box {
   var contents;
 }
@@ -38,7 +38,7 @@ class Box {
 
 **BAD:**
 
-```
+```dart
 class Box {
   var _contents;
   get contents => _contents;

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -17,14 +17,14 @@ const _details = r'''
 **DON'T** create a lambda when a tear-off will do.
 
 **BAD:**
-```
+```dart
 names.forEach((name) {
   print(name);
 });
 ```
 
 **GOOD:**
-```
+```dart
 names.forEach(print);
 ```
 

--- a/lib/src/rules/unnecessary_new.dart
+++ b/lib/src/rules/unnecessary_new.dart
@@ -15,7 +15,7 @@ const _details = r'''
 **AVOID** new keyword to create instances.
 
 **BAD:**
-```
+```dart
 class A { A(); }
 m(){
   final a = new A();
@@ -23,7 +23,7 @@ m(){
 ```
 
 **GOOD:**
-```
+```dart
 class A { A(); }
 m(){
   final a = A();

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -19,13 +19,13 @@ Using `null` on the right-hand side of a null-aware assignment effectively makes
 the assignment redundant.
 
 **GOOD:**
-```
+```dart
 var x;
 x ??= 1;
 ```
 
 **BAD:**
-```
+```dart
 var x;
 x ??= null;
 ```

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -16,7 +16,7 @@ const _details = r'''
 Don't apply a null check when a nullable value is accepted.
 
 **BAD:**
-```
+```dart
 f(int? i);
 m() {
   int? j;
@@ -26,7 +26,7 @@ m() {
 ```
 
 **GOOD:**
-```
+```dart
 f(int? i);
 m() {
   int? j;

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -19,12 +19,12 @@ Using `null` in an `if null` operator is redundant, regardless of which side
 `null` is used on.
 
 **GOOD:**
-```
+```dart
 var x = a ?? 1;
 ```
 
 **BAD:**
-```
+```dart
 var x = a ?? null;
 var y = null ?? 1;
 ```

--- a/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
+++ b/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
@@ -17,12 +17,12 @@ Use a non-nullable type for a final variable initialized with a non-nullable
 value.
 
 **BAD:**
-```
+```dart
 final int? i = 1;
 ```
 
 **GOOD:**
-```
+```dart
 final int i = 1;
 ```
 

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -18,7 +18,7 @@ const _details = r'''
 **DON'T** override a method to do a super method invocation with same parameters.
 
 **BAD:**
-```
+```dart
 class A extends B {
   @override
   void foo() {
@@ -28,7 +28,7 @@ class A extends B {
 ```
 
 **GOOD:**
-```
+```dart
 class A extends B {
   @override
   void foo() {

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -14,12 +14,12 @@ const _details = r'''
 **AVOID** using parenthesis when not needed.
 
 **GOOD:**
-```
+```dart
 a = b;
 ```
 
 **BAD:**
-```
+```dart
 a = (b);
 ```
 

--- a/lib/src/rules/unnecessary_raw_strings.dart
+++ b/lib/src/rules/unnecessary_raw_strings.dart
@@ -14,12 +14,12 @@ const _details = r'''
 Use raw string only when needed.
 
 **BAD:**
-```
+```dart
 var s1 = r'a';
 ```
 
 **GOOD:**
-```
+```dart
 var s1 = 'a';
 var s2 = r'$a';
 var s3 = r'\a';

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -21,7 +21,7 @@ broken up.
 For example,
 
 **BAD:**
-```
+```dart
 myvar;
 list.clear;
 1 + 2;
@@ -35,7 +35,7 @@ unless there is some magical overload of the + operator.
 Usually code like this indicates an incomplete thought, and is a bug.
 
 **GOOD:**
-```
+```dart
 some.method();
 const SomeClass();
 methodOne();

--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -15,13 +15,13 @@ const _details = r'''
 Remove unnecessary backslashes in strings.
 
 **BAD:**
-```
+```dart
 'this string contains 2 \"double quotes\" ';
 "this string contains 2 \'single quotes\' ";
 ```
 
 **GOOD:**
-```
+```dart
 'this string contains 2 "double quotes" ';
 "this string contains 2 'single quotes' ";
 ```

--- a/lib/src/rules/unnecessary_string_interpolations.dart
+++ b/lib/src/rules/unnecessary_string_interpolations.dart
@@ -14,13 +14,13 @@ const _details = r'''
 Don't use string interpolation if there's only a string expression in it.
 
 **BAD:**
-```
+```dart
 String message;
 String o = '$message';
 ```
 
 **GOOD:**
-```
+```dart
 String message;
 String o = message;
 ```

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -18,7 +18,7 @@ From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
 **DON'T** use `this` when not needed to avoid shadowing.
 
 **BAD:**
-```
+```dart
 class Box {
   var value;
   void update(new_value) {
@@ -28,7 +28,7 @@ class Box {
 ```
 
 **GOOD:**
-```
+```dart
 class Box {
   var value;
   void update(new_value) {
@@ -38,7 +38,7 @@ class Box {
 ```
 
 **GOOD:**
-```
+```dart
 class Box {
   var value;
   void update(value) {

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -25,7 +25,7 @@ likely will return `false` and might not reflect programmer's intent.
 the `int` is on the right hand side. The lint allows this as a special case. 
 
 **BAD:**
-```
+```dart
 void someFunction() {
   var x = '1';
   if (x == 1) print('someFunction'); // LINT
@@ -33,7 +33,7 @@ void someFunction() {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction1() {
   String x = '1';
   if (x == 1) print('someFunction1'); // LINT
@@ -41,7 +41,7 @@ void someFunction1() {
 ```
 
 **BAD:**
-```
+```dart
 void someFunction13(DerivedClass2 instance) {
   var other = DerivedClass3();
 
@@ -60,7 +60,7 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction2() {
   var x = '1';
   var y = '2';
@@ -69,7 +69,7 @@ void someFunction2() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction3() {
   for (var i = 0; i < 10; i++) {
     if (i == 0) print(someFunction3); // OK
@@ -78,7 +78,7 @@ void someFunction3() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction4() {
   var x = '1';
   if (x == null) print(someFunction4); // OK
@@ -86,7 +86,7 @@ void someFunction4() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction7() {
   List someList;
 
@@ -95,7 +95,7 @@ void someFunction7() {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction8(ClassBase instance) {
   DerivedClass1 other;
 
@@ -104,7 +104,7 @@ void someFunction8(ClassBase instance) {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction10(unknown) {
   var what = unknown - 1;
   for (var index = 0; index < unknown; index++) {
@@ -114,7 +114,7 @@ void someFunction10(unknown) {
 ```
 
 **GOOD:**
-```
+```dart
 void someFunction11(Mixin instance) {
   var other = DerivedClass2();
 

--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -29,7 +29,7 @@ const _details = r'''
 
 
 **BAD:**
-```
+```dart
 var script = ScriptElement()..src = 'foo.js';
 ```
 ''';

--- a/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
+++ b/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
@@ -18,13 +18,13 @@ have four 8-bit channels, which adds up to 32 bits, so Colors are described
 using a 32 bit integer.
 
 **BAD:**
-```
+```dart
 Color(1);
 Color(0x000001);
 ```
 
 **GOOD:**
-```
+```dart
 Color(0x00000001);
 ```
 

--- a/lib/src/rules/use_function_type_syntax_for_parameters.dart
+++ b/lib/src/rules/use_function_type_syntax_for_parameters.dart
@@ -14,12 +14,12 @@ const _details = r'''
 Use generic function type syntax for parameters.
 
 **BAD:**
-```
+```dart
 Iterable<T> where(bool predicate(T element)) {}
 ```
 
 **GOOD:**
-```
+```dart
 Iterable<T> where(bool Function(T) predicate) {}
 ```
 

--- a/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
+++ b/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
@@ -17,7 +17,7 @@ const _details = r'''
 Use if-null operators to convert nulls to bools.
 
 **BAD:**
-```
+```dart
 if (nullableBool == true) {
 }
 if (nullableBool != false) {
@@ -25,7 +25,7 @@ if (nullableBool != false) {
 ```
 
 **GOOD:**
-```
+```dart
 if (nullableBool ?? false) {
 }
 if (nullableBool ?? true) {

--- a/lib/src/rules/use_is_even_rather_than_modulo.dart
+++ b/lib/src/rules/use_is_even_rather_than_modulo.dart
@@ -16,13 +16,13 @@ const _details = r'''
 **PREFER** the use of intValue.isOdd/isEven to check for evenness.
 
 **BAD:**
-```
+```dart
 bool isEven = 1 % 2 == 0;
 bool isOdd = 13 % 2 == 1;
 ```
 
 **GOOD:**
-```
+```dart
 bool isEven = 1.isEven;
 bool isOdd = 13.isOdd;
 ```

--- a/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/lib/src/rules/use_key_in_widget_constructors.dart
@@ -20,13 +20,13 @@ It's a good practice to expose the ability to provide a key when creating public
 widgets.
 
 **BAD:**
-```
+```dart
 class MyPublicWidget extends StatelessWidget {
 }
 ```
 
 **GOOD:**
-```
+```dart
 class MyPublicWidget extends StatelessWidget {
   MyPublicWidget({Key key}) : super(key: key);
 }

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -21,7 +21,7 @@ be non-null. Thus it's clear that the field is not expected to be `null` and it
 avoids null checks.
 
 **BAD:**
-```
+```dart
 int? _i;
 m() {
   _i!.abs();
@@ -29,7 +29,7 @@ m() {
 ```
 
 **GOOD:**
-```
+```dart
 late int _i;
 m() {
   _i.abs();

--- a/lib/src/rules/use_named_constants.dart
+++ b/lib/src/rules/use_named_constants.dart
@@ -15,12 +15,12 @@ const _details = r'''
 Where possible, use already defined const values.
 
 **BAD:**
-```
+```dart
 const Duration(seconds: 0);
 ```
 
 **GOOD:**
-```
+```dart
 Duration.zero;
 ```
 

--- a/lib/src/rules/use_raw_strings.dart
+++ b/lib/src/rules/use_raw_strings.dart
@@ -14,12 +14,12 @@ const _details = r'''
 A raw string can be used to avoid escaping only backslashes and dollars.
 
 **BAD:**
-```
+```dart
 var s = 'A string with only \\ and \$';
 ```
 
 **GOOD:**
-```
+```dart
 var s = r'A string with only \ and $';
 ```
 

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -18,7 +18,7 @@ As Dart provides rethrow as a feature, it should be used to improve terseness
 and readability.
 
 **BAD:**
-```
+```dart
 try {
   somethingRisky();
 } catch(e) {
@@ -28,7 +28,7 @@ try {
 ```
 
 **GOOD:**
-```
+```dart
 try {
   somethingRisky();
 } catch(e) {

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -18,13 +18,13 @@ const _details = r'''
 **DO** use a setter for operations that conceptually change a property.
 
 **BAD:**
-```
+```dart
 rectangle.setWidth(3);
 button.setVisible(false);
 ```
 
 **GOOD:**
-```
+```dart
 rectangle.width = 3;
 button.visible = false;
 ```

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -20,7 +20,7 @@ In most cases, using a string buffer is preferred for composing strings due to
 its improved performance.
 
 **BAD:**
-```
+```dart
 String foo() {
   final buffer = '';
   for (int i = 0; i < 10; i++) {
@@ -31,7 +31,7 @@ String foo() {
 ```
 
 **GOOD:**
-```
+```dart
 String foo() {
   final buffer = StringBuffer();
   for (int i = 0; i < 10; i++) {

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -20,7 +20,7 @@ From the [design guide](https://dart.dev/guides/language/effective-dart/design):
 **PREFER** naming a method as___() if it returns a different representation backed by the original object.
 
 **BAD:**
-```
+```dart
 class Bar {
   Foo myMethod() {
     return Foo.from(this);
@@ -29,7 +29,7 @@ class Bar {
 ```
 
 **GOOD:**
-```
+```dart
 class Bar {
   Foo toFoo() {
     return Foo.from(this);
@@ -38,7 +38,7 @@ class Bar {
 ```
 
 **GOOD:**
-```
+```dart
 class Bar {
   Foo asFoo() {
     return Foo.from(this);

--- a/lib/src/rules/valid_regexps.dart
+++ b/lib/src/rules/valid_regexps.dart
@@ -18,12 +18,12 @@ Regular expressions created with invalid syntax will throw a `FormatException`
 at runtime so should be avoided.
 
 **BAD:**
-```
+```dart
 print(RegExp(r'(').hasMatch('foo()'));
 ```
 
 **GOOD:**
-```
+```dart
 print(RegExp(r'\(').hasMatch('foo()'));
 ```
 

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -16,7 +16,7 @@ const _details = r'''
 **DO NOT** assign to void.
 
 **BAD:**
-```
+```dart
 class A<T> {
   T value;
   void test(T arg) { }


### PR DESCRIPTION
Adds a language label to the markdown fenced code blocks in descriptions.

This is to enable better syntax highlighting for https://github.com/dart-lang/site-www/pull/3064 and potentially any other client using the definitions.