### PR TITLE
fix legacy dart:collection mixin uris

### DIFF
--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -77,7 +77,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   /// (See: https://github.com/dart-lang/linter/issues/2082)
   static bool isAllowed(ClassElement element) =>
       // todo (pq): remove allowlist once legacy mixins are otherwise annotated.
-      // see: https://github.com/dart-lang/linter/issues/2514
+      // see: https://github.com/dart-lang/sdk/issues/45343
       DartTypeUtilities.isClassElement(
           element, _iterableMixinName, _dartCollectionUri) ||
       DartTypeUtilities.isClassElement(

--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -9,6 +9,9 @@ import 'package:analyzer/dart/element/element.dart';
 import '../analyzer.dart';
 import '../util/dart_type_utilities.dart';
 
+const _dartCollectionUri = 'dart.collection';
+const _dartConvertUri = 'dart.convert';
+
 const _desc = r'Prefer using mixins.';
 
 const _details = r'''
@@ -31,6 +34,12 @@ class C with M {}
 ```
 
 ''';
+
+const _iterableMixinName = 'IterableMixin';
+const _listMixinName = 'ListMixin';
+const _mapMixinName = 'MapMixin';
+const _setMixinName = 'SetMixin';
+const _stringConversionSinkName = 'StringConversionSinkMixin';
 
 class PreferMixin extends LintRule implements NodeLintRule {
   PreferMixin()
@@ -67,10 +76,16 @@ class _Visitor extends SimpleAstVisitor<void> {
   /// compatibility reasons.
   /// (See: https://github.com/dart-lang/linter/issues/2082)
   static bool isAllowed(ClassElement element) =>
-      DartTypeUtilities.isClassElement(element, 'IterableMixin', 'dart.core') ||
-      DartTypeUtilities.isClassElement(element, 'ListMixin', 'dart.core') ||
-      DartTypeUtilities.isClassElement(element, 'MapMixin', 'dart.core') ||
-      DartTypeUtilities.isClassElement(element, 'SetMixin', 'dart.core') ||
+      // todo (pq): remove allowlist once legacy mixins are otherwise annotated.
+      // see: https://github.com/dart-lang/linter/issues/2514
       DartTypeUtilities.isClassElement(
-          element, 'StringConversionSinkMixin', 'dart.convert');
+          element, _iterableMixinName, _dartCollectionUri) ||
+      DartTypeUtilities.isClassElement(
+          element, _listMixinName, _dartCollectionUri) ||
+      DartTypeUtilities.isClassElement(
+          element, _mapMixinName, _dartCollectionUri) ||
+      DartTypeUtilities.isClassElement(
+          element, _setMixinName, _dartCollectionUri) ||
+      DartTypeUtilities.isClassElement(
+          element, _stringConversionSinkName, _dartConvertUri);
 }

--- a/test/_data/prefer_mixin/lib.dart
+++ b/test/_data/prefer_mixin/lib.dart
@@ -1,8 +1,6 @@
-// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
-// test w/ `pub run test -N prefer_mixin`
 
 import 'dart:collection';
 import 'dart:convert';

--- a/test/_data/prefer_mixin/lib.dart
+++ b/test/_data/prefer_mixin/lib.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N prefer_mixin`
+
+import 'dart:collection';
+import 'dart:convert';
+
+class A {}
+
+class B extends Object with A {} // LINT
+
+mixin M {}
+
+class C with M {} // OK
+
+abstract class I with IterableMixin {} //OK
+
+abstract class L with ListMixin {} //OK
+
+abstract class MM with MapMixin {} //OK
+
+abstract class S with SetMixin {} //OK
+
+abstract class SCS with StringConversionSinkMixin {} //OK

--- a/test/integration/prefer_mixin.dart
+++ b/test/integration/prefer_mixin.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:analyzer/src/lint/io.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/cli.dart' as cli;
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group('prefer_mixin', () {
+    final currentOut = outSink;
+    final collectingOut = CollectingSink();
+    setUp(() {
+      exitCode = 0;
+      outSink = collectingOut;
+    });
+    tearDown(() {
+      collectingOut.buffer.clear();
+      outSink = currentOut;
+      exitCode = 0;
+    });
+
+    test('analysis', () async {
+      await cli.runLinter([
+        'test/_data/prefer_mixin',
+        '--rules=prefer_mixin',
+        '--packages',
+        'test/rules/.mock_packages',
+      ], LinterOptions());
+      expect(
+          collectingOut.trim(),
+          stringContainsInOrder(
+              ['class B extends Object with A {} // LINT', '1 file analyzed, 1 issue found, in']));
+      expect(exitCode, 1);
+    });
+  });
+}

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -37,6 +37,7 @@ import 'integration/prefer_asserts_in_initializer_lists.dart'
     as prefer_asserts_in_initializer_lists;
 import 'integration/prefer_const_constructors_in_immutables.dart'
     as prefer_const_constructors_in_immutables;
+import 'integration/prefer_mixin.dart' as prefer_mixin;
 import 'integration/prefer_relative_imports.dart' as prefer_relative_imports;
 import 'integration/public_member_api_docs.dart' as public_member_api_docs;
 import 'integration/sort_pub_dependencies.dart' as sort_pub_dependencies;
@@ -184,6 +185,7 @@ void ruleTests() {
     avoid_private_typedef_functions.main();
     sort_pub_dependencies.main();
     unnecessary_string_escapes.main();
+    prefer_mixin.main();
   });
 }
 


### PR DESCRIPTION
Dart collection legacy mixins had the wrong library name and so were not being allowed as expected.  This fixes that.


See: https://github.com/dart-lang/linter/issues/2514

/cc @bwilkerson 

/fyi @goderbauer
