### PR TITLE
Remove avoid_private_typedef_functions from recommend.yaml

### DIFF
--- a/tool/canonical/recommend.yaml
+++ b/tool/canonical/recommend.yaml
@@ -5,7 +5,6 @@ linter:
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null
     - avoid_null_checks_in_equality_operators
-    - avoid_private_typedef_functions
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     - avoid_returning_null_for_void


### PR DESCRIPTION
As discussed in our meeting today.

In the future: could be replaced with https://github.com/dart-lang/linter/issues/2519.

/cc @pq @Hixie @mit-mit @munificent @devoncarew