### PR TITLE
disable pana baselining

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,8 @@ jobs:
         linter-bot:
           - main
           - release
-          - pana_baseline
+          # re-enable when pana CI issues are resolved: https://github.com/dart-lang/linter/issues/2504
+          # - pana_baseline
           - benchmark
 
     steps:


### PR DESCRIPTION
Pana is crashing the build.  This disables baselining pending a fix: https://github.com/dart-lang/linter/issues/2504.

/cc @bwilkerson 

/fyi @jonasfj 