### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.1.0
+
+- fixed `prefer_mixin` to properly make exceptions for `dart.collection` legacy
+  mixins
+- improved formatting of source examples in docs  
+- new lint: `use_build_context_synchronously` (experimental)
+- new lint: `avoid_multiple_declarations_per_line`
+
 # 1.0.0
 
 - full library migration to null-safety

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.0.0';
+const String version = '1.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.0.0
+version: 1.1.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.1.0

- fixed `prefer_mixin` to properly make exceptions for `dart.collection` legacy
  mixins
- improved formatting of source examples in docs  
- new lint: `use_build_context_synchronously` (experimental)
- new lint: `avoid_multiple_declarations_per_line`

/cc @bwilkerson 