### PR TITLE
add lint function_expression_with_incorrect_types

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -69,6 +69,7 @@ linter:
     - exhaustive_cases
     - file_names
     - flutter_style_todos
+    - function_expression_with_incorrect_types
     - hash_and_equals
     - implementation_imports
     - invariant_booleans

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -71,6 +71,7 @@ import 'rules/empty_statements.dart';
 import 'rules/exhaustive_cases.dart';
 import 'rules/file_names.dart';
 import 'rules/flutter_style_todos.dart';
+import 'rules/function_expression_with_incorrect_types.dart';
 import 'rules/hash_and_equals.dart';
 import 'rules/implementation_imports.dart';
 import 'rules/invariant_booleans.dart';
@@ -266,6 +267,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(ExhaustiveCases())
     ..register(FileNames())
     ..register(FlutterStyleTodos())
+    ..register(FunctionExpressionWithIncorrectTypes())
     ..register(HashAndEquals())
     ..register(ImplementationImports())
     ..register(InvariantBooleans())

--- a/lib/src/rules/function_expression_with_incorrect_types.dart
+++ b/lib/src/rules/function_expression_with_incorrect_types.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:collection/collection.dart';
+
+import '../analyzer.dart';
+
+const _desc =
+    r'Use the parameter types expected by the target in function expression.';
+
+const _details = r'''
+
+Use the parameter types expected by the target in function expression.
+
+**BAD:**
+```
+f(void Function(int a) p) {}
+
+f((int? a) {});
+f((num a) {});
+```
+
+**GOOD:**
+```
+f(void Function(int a) p) {}
+
+f((a) {});
+f((int a) {});
+```
+
+''';
+
+class FunctionExpressionWithIncorrectTypes extends LintRule
+    implements NodeLintRule {
+  FunctionExpressionWithIncorrectTypes()
+      : super(
+            name: 'function_expression_with_incorrect_types',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this, context);
+    registry.addFunctionExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final LintRule rule;
+  final LinterContext context;
+
+  @override
+  void visitFunctionExpression(FunctionExpression node) {
+    var currentType = node.staticType;
+    if (currentType is! FunctionType) return;
+
+    var parameterElement = node
+        .thisOrAncestorMatching<Expression>(
+            (e) => e.parent is! ParenthesizedExpression)
+        ?.staticParameterElement;
+    if (parameterElement == null) return;
+
+    var expectedType = parameterElement.type;
+    if (expectedType is! FunctionType) return;
+
+    // too hard to check cross nullability
+    var currentNullability = context.isEnabled(Feature.non_nullable);
+    var expectedNullability =
+        (parameterElement.library ?? parameterElement.declaration.library)
+            ?.featureSet
+            .isEnabled(Feature.non_nullable);
+    if (expectedNullability == null ||
+        currentNullability ^ expectedNullability) {
+      return;
+    }
+
+    // check type of each parameters
+    var currentParams = currentType.parameters;
+    var expectedParams = expectedType.parameters;
+    for (var i = 0; i < currentParams.length; i++) {
+      var currentParam = currentParams[i];
+      // if param is mutated, no lint
+      if (node.body.isPotentiallyMutatedInScope(currentParam) ||
+          node.body.isPotentiallyMutatedInClosure(currentParam)) {
+        continue;
+      }
+
+      // if param is not found on target, no lint
+      var expectedParam = currentParam.isPositional
+          ? expectedParams[i]
+          : expectedParams
+              .where((e) => e.name == currentParam.name)
+              .firstOrNull;
+      if (expectedParam == null) {
+        continue;
+      }
+
+      var typeSystem = context.typeSystem;
+      var currentType = currentParam.type;
+      var expectedType = expectedParam.type;
+      // if type are not consistent, lint!
+      if (currentParam.isRequiredPositional && currentType != expectedType ||
+          currentParam.isOptional &&
+              (currentNullability &&
+                      (typeSystem.isNonNullable(expectedType) &&
+                              expectedType !=
+                                  typeSystem.promoteToNonNull(currentType) ||
+                          typeSystem.isNullable(expectedType) &&
+                              expectedType != currentType) ||
+                  !currentNullability && expectedType != currentType)) {
+        rule.reportLint(node.parameters!.parameters
+            .firstWhere((e) => e.declaredElement == currentParam));
+      }
+    }
+  }
+}

--- a/test_data/rules/function_expression_with_incorrect_types.dart
+++ b/test_data/rules/function_expression_with_incorrect_types.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N function_expression_with_incorrect_types`
+
+f(void Function(int a) p) {}
+f1(Function p) {}
+f2(dynamic p) {}
+f3(void Function([int a]) p) {}
+f4(void Function({int a}) p) {}
+f5(void Function({bool a, bool b, Uri c}) p) {}
+f6(void Function(dynamic a) p) {}
+f7(void Function(Object? a) p) {}
+
+class MyMap<K, V> {
+  void f(void Function(int a) p) {}
+  void ff(void Function(K a) p) {}
+}
+
+Function(int a)? p;
+
+g1(int a) {}
+g2(int? a) {}
+g3(num a) {}
+
+m() {
+  f((a) {}); // OK
+  f((int? a) {}); // LINT
+  f((num a) {}); // LINT
+  f(g1); // OK
+  f(g2); // OK
+  f(g3); // OK
+
+  p = (a) {}; // OK
+  p = (int? a) {}; // LINT
+  p = (num a) {}; // LINT
+  p = g1; // OK
+  p = g2; // OK
+  p = g3; // OK
+
+  f1((int? a) {}); // OK
+  f2((int? a) {}); // OK
+
+  // mutation of param
+  f((int? a) { a = null; }); // OK
+  f((int? a) { () {a = null;}(); }); // OK
+
+  // optional params
+  f3(([int? a]) {}); // OK
+  f3(([int a = 1]) {}); // OK
+  f4(({int? a}) {}); // OK
+  f4(({int a = 1}) {}); // OK
+  f4(({num? a}) {}); // LINT
+  f4(({num a = 1}) {}); // LINT
+
+  // different name
+  f((num b) {}); // LINT
+
+  // inversed names
+  f5(({bool b, bool a, Uri c}) {}); // OK
+
+  // Object? vs. dynamic
+  f6((Object? a) {}); // OK
+  f7((dynamic a) {}); // OK
+  MyMap().f((int? a) {}); // LINT
+  MyMap().ff((Object? a) {}); // LINT
+  MyMap<int, String>().ff((int? a) {}); // LINT
+}


### PR DESCRIPTION
# Description

Use the parameter types expected by the target in function expression.

**BAD:**
```
f(void Function(int a) p) {}

f((int? a) {});
f((num a) {});
```
**GOOD:**
```
f(void Function(int a) p) {}

f((a) {});
f((int a) {});
```

