### PR TITLE
`camel_case_types` support for nonfunction type aliases

### DIFF
--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -46,6 +46,7 @@ class CamelCaseTypes extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this);
+    registry.addGenericTypeAlias(this, visitor);
     registry.addClassDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
   }
@@ -56,17 +57,24 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
-  @override
-  void visitClassDeclaration(ClassDeclaration node) {
-    if (!isCamelCase(node.name.toString())) {
-      rule.reportLint(node.name);
+  void check(SimpleIdentifier name) {
+    if (!isCamelCase(name.toString())) {
+      rule.reportLint(name);
     }
   }
 
   @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    check(node.name);
+  }
+
+  @override
   void visitFunctionTypeAlias(FunctionTypeAlias node) {
-    if (!isCamelCase(node.name.toString())) {
-      rule.reportLint(node.name);
-    }
+    check(node.name);
+  }
+
+  @override
+  void visitGenericTypeAlias(GenericTypeAlias node) {
+    check(node.name);
   }
 }

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -48,6 +48,7 @@ class CamelCaseTypes extends LintRule implements NodeLintRule {
     final visitor = _Visitor(this);
     registry.addGenericTypeAlias(this, visitor);
     registry.addClassDeclaration(this, visitor);
+    registry.addClassTypeAlias(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
   }
 }
@@ -65,6 +66,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
+    check(node.name);
+  }
+
+  @override
+  void visitClassTypeAlias(ClassTypeAlias node) {
     check(node.name);
   }
 

--- a/test/rules/experiments/nonfunction-type-aliases/rules/camel_case_types.dart
+++ b/test/rules/experiments/nonfunction-type-aliases/rules/camel_case_types.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2015, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N camel_case_types`
+
+class A {}
+
+class DB {}
+
+class FooBar {}
+
+class _Foo {}
+
+class Foo extends _Foo {}
+
+typedef bool predicate(); //LINT [14:9]
+
+typedef bool Predicate(); //OK
+
+class fooBar // LINT
+{}
+
+class Foo$Bar //OK
+{}
+
+class Foo_Bar //LINT
+{}
+
+class $FooBar //OK
+{}
+
+typedef foo = Foo; //LINT
+
+typedef F = Foo; //OK

--- a/test/rules/experiments/nonfunction-type-aliases/rules/camel_case_types.dart
+++ b/test/rules/experiments/nonfunction-type-aliases/rules/camel_case_types.dart
@@ -33,3 +33,7 @@ class $FooBar //OK
 typedef foo = Foo; //LINT
 
 typedef F = Foo; //OK
+
+typedef f = void Function(); //LINT
+
+class c = Object with M; //LINT


### PR DESCRIPTION
See: #2509.

/cc @bwilkerson 
