### PR TITLE
`avoid_private_typedef_functions` support for nonfunction type aliases

### DIFF
--- a/lib/src/rules/avoid_private_typedef_functions.dart
+++ b/lib/src/rules/avoid_private_typedef_functions.dart
@@ -39,6 +39,7 @@ class AvoidPrivateTypedefFunctions extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     final visitor = _Visitor(this, context);
+    registry.addClassTypeAlias(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
     registry.addGenericTypeAlias(this, visitor);
   }
@@ -62,6 +63,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LinterContext context;
 
   _Visitor(this.rule, this.context);
+
+  @override
+  void visitClassTypeAlias(ClassTypeAlias node) {
+    _countAndReport(node.name);
+  }
 
   @override
   void visitFunctionTypeAlias(FunctionTypeAlias node) {

--- a/test/rules/experiments/nonfunction-type-aliases/rules/avoid_private_typedef_functions.dart
+++ b/test/rules/experiments/nonfunction-type-aliases/rules/avoid_private_typedef_functions.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `pub run test -N avoid_private_typedef_functions`
+
+typedef void _F1(); // LINT
+typedef void F1(); // OK
+
+typedef _F2 = void Function(); // LINT
+typedef F2 = void Function(); // OK
+
+typedef void _F3(); // LINT
+m3(_F3 f) => null;
+
+typedef void _F4(); // OK
+m4a(_F4 f) => null;
+m4b(_F4 f) => null;
+
+typedef void _F5(); // OK
+_F5 v5a;
+_F5 v5b;
+
+typedef void _F6(); // OK
+_F6 f6a() => null;
+_F6 f6b() => null;
+
+typedef _F7 = void Function(); // OK
+m7(_F7 f) => null;
+List<_F7> l7 = [];
+
+typedef void _F8(); // OK
+m8(_F8 f) => null;
+List<_F8> l8 = [];
+
+typedef _T = Object; // LINT
+mixin M { }
+class _C = Object with M; // LINT


### PR DESCRIPTION
See: #2509.

/cc @bwilkerson 
