### PR TITLE
Fix iterable_contains_unrelated_type

### DIFF
--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -20,18 +20,6 @@ _InterfaceTypePredicate _buildImplementsDefinitionPredicate(
         interface.element.name == definition.name &&
         interface.element.library.name == definition.library;
 
-/// Returns all implemented interfaces of [type].
-///
-/// This flattens all of the super-interfaces of [type] into one list.
-List<InterfaceType> _findImplementedInterfaces(InterfaceType type,
-        {List<InterfaceType> accumulator = const []}) =>
-    accumulator.contains(type)
-        ? accumulator
-        : type.interfaces.fold(
-            <InterfaceType>[type],
-            (List<InterfaceType> acc, InterfaceType e) => List.from(acc)
-              ..addAll(_findImplementedInterfaces(e, accumulator: acc)));
-
 /// Returns the first type argument on [definition], as implemented by [type].
 ///
 /// In the simplest case, [type] is the same class as [definition]. For
@@ -57,7 +45,7 @@ DartType? _findIterableTypeArgument(
     return type.typeArguments.first;
   }
 
-  final implementedInterfaces = _findImplementedInterfaces(type);
+  final implementedInterfaces = type.allSupertypes;
   final interface = implementedInterfaces.firstWhereOrNull(predicate);
   if (interface != null && interface.typeArguments.isNotEmpty) {
     return interface.typeArguments.first;

--- a/test/rules/iterable_contains_unrelated_type.dart
+++ b/test/rules/iterable_contains_unrelated_type.dart
@@ -151,12 +151,6 @@ abstract class B3 extends A3 {}
 
 bool takesB3(B3 b) => b.contains('a'); // OK
 
-abstract class A2 implements Iterable<String> {}
-
-abstract class B2 extends A2 {}
-
-bool takesB2(B2 b) => b.contains('a'); // OK
-
 abstract class AddlInterface {}
 
 abstract class SomeIterable<E> implements Iterable<E>, AddlInterface {}
@@ -172,9 +166,8 @@ abstract class MyDerivedClass extends MyClass {
 }
 
 abstract class MyMixedClass extends Object with MyClass {
-  // No lint since is not iterable.
-  bool myConcreteBadMethod(String thing) => this.contains(thing); // OK
-  bool myConcreteBadMethod1(String thing) => contains(thing); // OK
+  bool myConcreteBadMethod(String thing) => this.contains(thing); // LINT
+  bool myConcreteBadMethod1(String thing) => contains(thing); // LINT
 }
 
 abstract class MyIterableMixedClass extends Object

--- a/test/rules/list_remove_unrelated_type.dart
+++ b/test/rules/list_remove_unrelated_type.dart
@@ -161,9 +161,8 @@ abstract class MyDerivedClass extends MyClass {
 }
 
 abstract class MyMixedClass extends Object with MyClass {
-  // No lint since is not List.
-  bool myConcreteBadMethod(String thing) => this.remove(thing); // OK
-  bool myConcreteBadMethod1(String thing) => remove(thing); // OK
+  bool myConcreteBadMethod(String thing) => this.remove(thing); // LINT
+  bool myConcreteBadMethod1(String thing) => remove(thing); // LINT
 }
 
 abstract class MyListMixedClass extends Object


### PR DESCRIPTION
Fixes #1003

This is an attempt to fix `iterable_contains_unrelated_type`. This rule works in the test suite but not with a real SDK.

This is because the [MockSdk] defines the hierarchy as `List<T> implements Iterable<T>` ([analyzer/mock_sdk.dart](https://github.com/dart-lang/sdk/blob/caa31f55be518e2de0bf723c81c853c2362dafb5/pkg/analyzer/lib/src/test_utilities/mock_sdk.dart#L419)) while the real SDK defines `List<T> extends EfficientLengthIterable<T>` ([sdk/core/list.dart](https://github.com/dart-lang/sdk/blob/c5d01ec4f7078a75b038a2ed04312afb50154323/sdk/lib/core/list.dart#L52))
