### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.0
+
+- improvements to `iterable_contains_unrelated_type` to better support `List`
+  content checks
+- fixes to `camel_case_types` and `prefer_mixin` to support non-function
+  type aliases
+
 # 1.1.0
 
 - fixed `prefer_mixin` to properly make exceptions for `dart.collection` legacy

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.1.0';
+const String version = '1.2.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.1.0
+version: 1.2.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.2.0

- improvements to `iterable_contains_unrelated_type` to better support `List`
  content checks
- fixes to `camel_case_types` and `prefer_mixin` to support non-function
  type aliases

/cc @bwilkerson 