### PR TITLE
Enable `unnecessary_final`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -98,6 +98,7 @@ linter:
     - throw_in_finally
 #    - type_annotate_public_apis
     - unnecessary_brace_in_string_interps
+    - unnecessary_final
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_null_aware_assignments

--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -53,10 +53,10 @@ Future<Iterable<AnalysisErrorInfo>> lintFiles(
     DartLinter linter, List<File> filesToLint) async {
   // Setup an error watcher to track whether an error was logged to stderr so
   // we can set the exit code accordingly.
-  final errorWatcher = ErrorWatchingSink(errorSink);
+  var errorWatcher = ErrorWatchingSink(errorSink);
   errorSink = errorWatcher;
 
-  final errors = await linter.lintFiles(filesToLint);
+  var errors = await linter.lintFiles(filesToLint);
   if (errorWatcher.encounteredError) {
     exitCode = loggedAnalyzerErrorExitCode;
   } else if (errors.isNotEmpty) {
@@ -74,7 +74,7 @@ Iterable<AnalysisError> _filtered(
 
 int _maxSeverity(List<AnalysisErrorInfo> errors, LintFilter? filter) {
   var max = 0;
-  for (final info in errors) {
+  for (var info in errors) {
     _filtered(info.errors, filter).forEach((AnalysisError e) {
       max = math.max(max, e.errorCode.errorSeverity.ordinal);
     });

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -16,7 +16,7 @@ import 'utils.dart';
 
 /// Returns direct children of [parent].
 List<Element> getChildren(Element parent, [String? name]) {
-  final children = <Element>[];
+  var children = <Element>[];
   visitChildren(parent, (Element element) {
     if (name == null || element.displayName == name) {
       children.add(element);
@@ -43,7 +43,7 @@ SimpleIdentifier? getFieldIdentifier(FieldDeclaration decl, String name) {
 
 /// Returns the most specific AST node appropriate for associating errors.
 AstNode getNodeToAnnotate(Declaration node) {
-  final mostSpecific = _getNodeToAnnotate(node);
+  var mostSpecific = _getNodeToAnnotate(node);
   return mostSpecific ?? node;
 }
 
@@ -65,7 +65,7 @@ bool hasConstantError(LinterContext context, Expression node) {
 
 /// Returns `true` if this [element] has a `@literal` annotation.
 bool hasLiteralAnnotation(Element element) {
-  final metadata = element.metadata;
+  var metadata = element.metadata;
   for (var i = 0; i < metadata.length; i++) {
     if (metadata[i].isLiteral) {
       return true;
@@ -76,7 +76,7 @@ bool hasLiteralAnnotation(Element element) {
 
 /// Returns `true` if this [element] has an `@override` annotation.
 bool hasOverrideAnnotation(Element element) {
-  final metadata = element.metadata;
+  var metadata = element.metadata;
   for (var i = 0; i < metadata.length; i++) {
     if (metadata[i].isOverride) {
       return true;
@@ -88,7 +88,7 @@ bool hasOverrideAnnotation(Element element) {
 /// Returns `true` if this [node] is the child of a private compilation unit
 /// member.
 bool inPrivateMember(AstNode node) {
-  final parent = node.parent;
+  var parent = node.parent;
   if (parent is NamedCompilationUnitMember) {
     return isPrivate(parent.name);
   }
@@ -123,9 +123,9 @@ bool isHashCode(ClassMember element) =>
 /// [package]'s `lib/` directory tree.
 bool isInLibDir(CompilationUnit node, WorkspacePackage? package) {
   if (package == null) return false;
-  final cuPath = node.declaredElement?.library.source.fullName;
+  var cuPath = node.declaredElement?.library.source.fullName;
   if (cuPath == null) return false;
-  final libDir = path.join(package.root, 'lib');
+  var libDir = path.join(package.root, 'lib');
   return path.isWithin(libDir, cuPath);
 }
 
@@ -171,7 +171,7 @@ bool isSimpleGetter(MethodDeclaration declaration) {
   if (body is ExpressionFunctionBody) {
     return _checkForSimpleGetter(declaration, body.expression);
   } else if (body is BlockFunctionBody) {
-    final block = body.block;
+    var block = body.block;
     if (block.statements.length == 1) {
       var statement = block.statements[0];
       if (statement is ReturnStatement) {
@@ -201,7 +201,7 @@ bool isSimpleSetter(MethodDeclaration setter) {
   if (body is ExpressionFunctionBody) {
     return _checkForSimpleSetter(setter, body.expression);
   } else if (body is BlockFunctionBody) {
-    final block = body.block;
+    var block = body.block;
     if (block.statements.length == 1) {
       var statement = block.statements[0];
       if (statement is ExpressionStatement) {
@@ -221,22 +221,22 @@ bool isVar(Token token) => isKeyword(token, Keyword.VAR);
 
 /// Return the nearest enclosing pubspec file.
 File? locatePubspecFile(CompilationUnit compilationUnit) {
-  final fullName = compilationUnit.declaredElement?.source.fullName;
+  var fullName = compilationUnit.declaredElement?.source.fullName;
   if (fullName == null) {
     return null;
   }
 
-  final resourceProvider =
+  var resourceProvider =
       compilationUnit.declaredElement?.session.resourceProvider;
   if (resourceProvider == null) {
     return null;
   }
 
-  final file = resourceProvider.getFile(fullName);
+  var file = resourceProvider.getFile(fullName);
 
   // Look for a pubspec.yaml file.
   for (var folder in file.parent2.withAncestors) {
-    final pubspecFile = folder.getChildAssumingFile('pubspec.yaml');
+    var pubspecFile = folder.getChildAssumingFile('pubspec.yaml');
     if (pubspecFile.exists) {
       return pubspecFile;
     }
@@ -270,7 +270,7 @@ bool _checkForSimpleSetter(MethodDeclaration setter, Expression expression) {
   if (expression is! AssignmentExpression) {
     return false;
   }
-  final assignment = expression;
+  var assignment = expression;
 
   var leftHandSide = assignment.leftHandSide;
   var rightHandSide = assignment.rightHandSide;
@@ -378,7 +378,7 @@ class _ElementVisitorAdapter extends GeneralizingElementVisitor {
 
   @override
   void visitElement(Element element) {
-    final visitChildren = processor(element);
+    var visitChildren = processor(element);
     if (visitChildren == true) {
       element.visitChildren(this);
     }

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -132,7 +132,7 @@ Future runLinter(List<String> args, LinterOptions initialLintOptions) async {
     ..packageConfigPath = packageConfigFile
     ..resourceProvider = PhysicalResourceProvider.INSTANCE;
 
-  final filesToLint = <File>[];
+  var filesToLint = <File>[];
   for (var path in options.rest) {
     filesToLint.addAll(collectFiles(path));
   }
@@ -142,11 +142,11 @@ Future runLinter(List<String> args, LinterOptions initialLintOptions) async {
     return;
   }
 
-  final linter = DartLinter(lintOptions);
+  var linter = DartLinter(lintOptions);
 
   try {
-    final timer = Stopwatch()..start();
-    final errors = await lintFiles(linter, filesToLint);
+    var timer = Stopwatch()..start();
+    var errors = await lintFiles(linter, filesToLint);
     timer.stop();
 
     var commonRoot = getRoot(options.rest);

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -15,8 +15,8 @@ import 'util/score_utils.dart';
 const benchmarkRuns = 10;
 
 String getLineContents(int? lineNumber, AnalysisError error) {
-  final path = error.source.fullName;
-  final file = File(path);
+  var path = error.source.fullName;
+  var file = File(path);
   String failureDetails;
   if (!file.existsSync()) {
     failureDetails = 'file at $path does not exist';
@@ -43,12 +43,12 @@ String shorten(String? fileRoot, String fullName) {
 
 Future writeBenchmarks(
     IOSink out, List<File> filesToLint, LinterOptions lintOptions) async {
-  final timings = <String, int>{};
+  var timings = <String, int>{};
   for (var i = 0; i < benchmarkRuns; ++i) {
     await lintFiles(DartLinter(lintOptions), filesToLint);
     lintRegistry.timers.forEach((n, t) {
-      final timing = t.elapsedMilliseconds;
-      final previous = timings[n];
+      var timing = t.elapsedMilliseconds;
+      var previous = timings[n];
       if (previous == null) {
         timings[n] = timing;
       } else {
@@ -57,9 +57,9 @@ Future writeBenchmarks(
     });
   }
 
-  final pedanticRuleset = await pedanticRules;
-  final stats = timings.keys.map((t) {
-    final details = pedanticRuleset.contains(t) ? ' [pedantic]' : '';
+  var pedanticRuleset = await pedanticRules;
+  var stats = timings.keys.map((t) {
+    var details = pedanticRuleset.contains(t) ? ' [pedantic]' : '';
     return _Stat('$t$details', timings[t] ?? 0);
   }).toList();
   _writeTimings(out, stats, 0);
@@ -77,14 +77,14 @@ String _escapePipe(String input) {
 }
 
 void _writeTimings(IOSink out, List<_Stat> timings, int summaryLength) {
-  final names = timings.map((s) => s.name).toList();
+  var names = timings.map((s) => s.name).toList();
 
   var longestName =
       names.fold<int>(0, (prev, element) => max(prev, element.length));
-  final longestTime = 8;
-  final tableWidth = max(summaryLength, longestName + longestTime);
-  final pad = tableWidth - longestName;
-  final line = ''.padLeft(tableWidth, '-');
+  var longestTime = 8;
+  var tableWidth = max(summaryLength, longestName + longestTime);
+  var pad = tableWidth - longestName;
+  var line = ''.padLeft(tableWidth, '-');
 
   out
     ..writeln()
@@ -298,8 +298,8 @@ class SimpleFormatter implements ReportFormatter {
   }
 
   void writeTimings() {
-    final timers = lintRegistry.timers;
-    final timings = timers.keys
+    var timers = lintRegistry.timers;
+    var timings = timers.keys
         .map((t) => _Stat(t, timers[t]?.elapsedMilliseconds ?? 0))
         .toList();
     _writeTimings(out, timings, _summaryLength);

--- a/lib/src/rules/always_declare_return_types.dart
+++ b/lib/src/rules/always_declare_return_types.dart
@@ -56,7 +56,7 @@ class AlwaysDeclareReturnTypes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
     registry.addMethodDeclaration(this, visitor);

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -57,7 +57,7 @@ class AlwaysPutControlBodyOnNewLine extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForStatement(this, visitor);
     registry.addIfStatement(this, visitor);
@@ -98,8 +98,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   void _checkNodeOnNextLine(AstNode? node, int controlEnd) {
     if (node == null || node is Block && node.statements.isEmpty) return;
 
-    final unit = node.root as CompilationUnit;
-    final offsetFirstStatement =
+    var unit = node.root as CompilationUnit;
+    var offsetFirstStatement =
         node is Block ? node.statements.first.offset : node.offset;
     var lineInfo = unit.lineInfo;
     if (lineInfo == null) {

--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -47,7 +47,7 @@ class AlwaysPutRequiredNamedParametersFirst extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFormalParameterList(this, visitor);
   }
 }

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -54,7 +54,7 @@ class AlwaysRequireNonNullNamedParameters extends LintRule
     // In a Null Safety library, this lint is covered by other formal static
     // analysis.
     if (!context.isEnabled(Feature.non_nullable)) {
-      final visitor = _Visitor(this);
+      var visitor = _Visitor(this);
       registry.addFormalParameterList(this, visitor);
     }
   }
@@ -68,11 +68,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitFormalParameterList(FormalParameterList node) {
     List<DefaultFormalParameter> getParams() {
-      final params = <DefaultFormalParameter>[];
-      for (final p in node.parameters) {
+      var params = <DefaultFormalParameter>[];
+      for (var p in node.parameters) {
         // Only named parameters
         if (p.isNamed) {
-          final parameter = p as DefaultFormalParameter;
+          var parameter = p as DefaultFormalParameter;
           // Without a default value or marked required
           if (parameter.defaultValue == null) {
             var declaredElement = parameter.declaredElement;
@@ -85,7 +85,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return params;
     }
 
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is FunctionExpression) {
       _checkParams(getParams(), parent.body);
     } else if (parent is ConstructorDeclaration) {
@@ -98,7 +98,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _checkAssert(
       Expression assertExpression, List<DefaultFormalParameter> params) {
-    for (final param in params) {
+    for (var param in params) {
       var identifier = param.identifier;
       if (identifier != null &&
           _hasAssertNotNull(assertExpression, identifier.name)) {
@@ -111,7 +111,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _checkInitializerList(List<DefaultFormalParameter> params,
       NodeList<ConstructorInitializer> initializers) {
-    for (final initializer in initializers) {
+    for (var initializer in initializers) {
       if (initializer is AssertInitializer) {
         _checkAssert(initializer.condition, params);
       }
@@ -120,7 +120,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _checkParams(List<DefaultFormalParameter> params, FunctionBody? body) {
     if (body is BlockFunctionBody) {
-      for (final statement in body.block.statements) {
+      for (var statement in body.block.statements) {
         if (statement is AssertStatement) {
           _checkAssert(statement.condition, params);
         } else {
@@ -133,18 +133,18 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   bool _hasAssertNotNull(Expression node, String name) {
     bool _hasSameName(Expression rawExpression) {
-      final expression = rawExpression.unParenthesized;
+      var expression = rawExpression.unParenthesized;
       return expression is SimpleIdentifier && expression.name == name;
     }
 
-    final expression = node.unParenthesized;
+    var expression = node.unParenthesized;
     if (expression is BinaryExpression) {
       if (expression.operator.type == TokenType.AMPERSAND_AMPERSAND) {
         return _hasAssertNotNull(expression.leftOperand, name) ||
             _hasAssertNotNull(expression.rightOperand, name);
       }
       if (expression.operator.type == TokenType.BANG_EQ) {
-        final operands = [expression.leftOperand, expression.rightOperand];
+        var operands = [expression.leftOperand, expression.rightOperand];
         return operands.any(DartTypeUtilities.isNullLiteral) &&
             operands.any(_hasSameName);
       }

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -67,7 +67,7 @@ String _metaLibName = 'meta';
 String _optionalTypeArgsVarName = 'optionalTypeArgs';
 
 bool _isOptionallyParameterized(InterfaceType type) {
-  final metadata = type.element.metadata;
+  var metadata = type.element.metadata;
   return metadata.any((ElementAnnotation a) => _isOptionalTypeArgs(a.element));
 }
 
@@ -90,7 +90,7 @@ class AlwaysSpecifyTypes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addDeclaredIdentifier(this, visitor);
     registry.addListLiteral(this, visitor);
     registry.addSetOrMapLiteral(this, visitor);
@@ -124,7 +124,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void visitNamedType(NamedType namedType) {
-    final type = namedType.type;
+    var type = namedType.type;
     if (type is InterfaceType) {
       if (type.element.typeParameters.isNotEmpty &&
           namedType.typeArguments == null &&

--- a/lib/src/rules/always_use_package_imports.dart
+++ b/lib/src/rules/always_use_package_imports.dart
@@ -61,7 +61,7 @@ class AlwaysUsePackageImports extends LintRule implements NodeLintRule {
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addImportDirective(this, visitor);
   }
 }
@@ -75,7 +75,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   bool isRelativeImport(ImportDirective node) {
     var uriContent = node.uriContent;
     if (uriContent != null) {
-      final uri = Uri.tryParse(uriContent);
+      var uri = Uri.tryParse(uriContent);
       return uri != null && uri.scheme.isEmpty;
     }
     return false;

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -56,7 +56,7 @@ class AnnotateOverrides extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
     registry.addFieldDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);
@@ -70,7 +70,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   _Visitor(this.rule, this.context);
 
   Element? getOverriddenMember(Element member) {
-    final classElement = member.thisOrAncestorOfType<ClassElement>();
+    var classElement = member.thisOrAncestorOfType<ClassElement>();
     if (classElement == null) {
       return null;
     }
@@ -79,7 +79,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return null;
     }
 
-    final libraryUri = classElement.library.source.uri;
+    var libraryUri = classElement.library.source.uri;
     return context.inheritanceManager.getInherited(
       classElement.thisType,
       Name(libraryUri, name),
@@ -91,7 +91,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (var field in node.fields.variables) {
       var element = field.declaredElement;
       if (element != null && !element.hasOverride) {
-        final member = getOverriddenMember(element);
+        var member = getOverriddenMember(element);
         if (member != null) {
           rule.reportLint(field);
         }
@@ -103,7 +103,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitMethodDeclaration(MethodDeclaration node) {
     var element = node.declaredElement;
     if (element != null && !element.hasOverride) {
-      final member = getOverriddenMember(element);
+      var member = getOverriddenMember(element);
       if (member != null) {
         rule.reportLint(node.name);
       }

--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -47,7 +47,7 @@ class AvoidAnnotatingWithDynamic extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleFormalParameter(this, visitor);
   }
 }
@@ -59,7 +59,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitSimpleFormalParameter(SimpleFormalParameter node) {
-    final type = node.type;
+    var type = node.type;
     if (type is TypeName && type.name.name == 'dynamic') {
       rule.reportLint(node);
     }

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -65,7 +65,7 @@ class AvoidAs extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addAsExpression(this, visitor);
   }
 }
@@ -77,7 +77,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitAsExpression(AsExpression node) {
-    final typeAnnotation = node.type;
+    var typeAnnotation = node.type;
     if (typeAnnotation is NamedType && typeAnnotation.name.name != 'dynamic') {
       rule.reportLint(typeAnnotation);
     }

--- a/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
+++ b/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
@@ -43,7 +43,7 @@ class AvoidBoolLiteralsInConditionalExpressions extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addConditionalExpression(this, visitor);
   }
 }
@@ -57,9 +57,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitConditionalExpression(ConditionalExpression node) {
-    final typeProvider = context.typeProvider;
-    final thenExp = node.thenExpression;
-    final elseExp = node.elseExpression;
+    var typeProvider = context.typeProvider;
+    var thenExp = node.thenExpression;
+    var elseExp = node.elseExpression;
 
     if (thenExp.staticType == typeProvider.boolType &&
         elseExp.staticType == typeProvider.boolType) {

--- a/lib/src/rules/avoid_catches_without_on_clauses.dart
+++ b/lib/src/rules/avoid_catches_without_on_clauses.dart
@@ -49,7 +49,7 @@ class AvoidCatchesWithoutOnClauses extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCatchClause(this, visitor);
   }
 }

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -48,7 +48,7 @@ class AvoidCatchingErrors extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCatchClause(this, visitor);
   }
 }
@@ -60,7 +60,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCatchClause(CatchClause node) {
-    final exceptionType = node.exceptionType?.type;
+    var exceptionType = node.exceptionType?.type;
     if (DartTypeUtilities.implementsInterface(
         exceptionType, 'Error', 'dart.core')) {
       rule.reportLint(node);

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -66,7 +66,7 @@ class AvoidClassesWithOnlyStaticMembers extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }

--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -53,7 +53,7 @@ class AvoidDoubleAndIntChecks extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addIfStatement(this, visitor);
   }
 }
@@ -67,14 +67,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitIfStatement(IfStatement node) {
-    final elseStatement = node.elseStatement;
+    var elseStatement = node.elseStatement;
     if (elseStatement is IfStatement) {
-      final ifCondition = node.condition;
-      final elseCondition = elseStatement.condition;
+      var ifCondition = node.condition;
+      var elseCondition = elseStatement.condition;
       if (ifCondition is IsExpression && elseCondition is IsExpression) {
-        final typeProvider = context.typeProvider;
-        final ifExpression = ifCondition.expression;
-        final elseIsExpression = elseCondition.expression;
+        var typeProvider = context.typeProvider;
+        var ifExpression = ifCondition.expression;
+        var elseIsExpression = elseCondition.expression;
         if (ifExpression is SimpleIdentifier &&
             elseIsExpression is SimpleIdentifier &&
             ifExpression.name == elseIsExpression.name &&

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -106,7 +106,7 @@ class AvoidDynamicCalls extends LintRule implements NodeLintRule {
     NodeLintRegistry registry,
     LinterContext context,
   ) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry
       ..addAssignmentExpression(this, visitor)
       ..addBinaryExpression(this, visitor)
@@ -195,7 +195,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    final methodName = node.methodName.name;
+    var methodName = node.methodName.name;
     if (node.target != null) {
       if (methodName == 'noSuchMethod' &&
           node.argumentList.arguments.length == 1 &&
@@ -208,7 +208,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         return;
       }
     }
-    final receiverWasDynamic = _lintIfDynamic(node.realTarget);
+    var receiverWasDynamic = _lintIfDynamic(node.realTarget);
     if (!receiverWasDynamic) {
       var target = node.target;
       // The ".call" method is special, where "a.call()" is treated ~as "a()".
@@ -232,7 +232,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
     if (root is CompoundAssignmentExpression) {
       // Not promoted by "is" since the type would lose capabilities.
-      final rootAsAssignment = root as CompoundAssignmentExpression;
+      var rootAsAssignment = root as CompoundAssignmentExpression;
       if (rootAsAssignment.readType?.isDynamic == true) {
         // An assignment expression can only be a dynamic call if it is a
         // "compound assignment" (i.e. such as `x += 1`); so if `readType` is
@@ -249,7 +249,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitPrefixedIdentifier(PrefixedIdentifier node) {
-    final property = node.identifier.name;
+    var property = node.identifier.name;
     if (const {
       'hashCode',
       'noSuchMethod',

--- a/lib/src/rules/avoid_empty_else.dart
+++ b/lib/src/rules/avoid_empty_else.dart
@@ -34,7 +34,7 @@ class AvoidEmptyElse extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addIfStatement(this, visitor);
   }
 }
@@ -46,7 +46,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitIfStatement(IfStatement node) {
-    final elseStatement = node.elseStatement;
+    var elseStatement = node.elseStatement;
     if (elseStatement is EmptyStatement &&
         !elseStatement.semicolon.isSynthetic) {
       rule.reportLint(elseStatement);

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -87,7 +87,7 @@ class AvoidOperatorEqualsOnMutableClasses extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -102,7 +102,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
     if (node.name.token.type == TokenType.EQ_EQ || isHashCode(node)) {
-      final classElement = _getClassForMethod(node);
+      var classElement = _getClassForMethod(node);
       if (classElement != null && !_hasImmutableAnnotation(classElement)) {
         rule.reportLintForToken(node.firstTokenAfterCommentAndMetadata);
       }
@@ -114,11 +114,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       node.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
-    final inheritedAndSelfElements = <ClassElement>[
+    var inheritedAndSelfElements = <ClassElement>[
       ...clazz.allSupertypes.map((t) => t.element),
       clazz,
     ];
-    final inheritedAndSelfAnnotations = inheritedAndSelfElements
+    var inheritedAndSelfAnnotations = inheritedAndSelfElements
         .expand((c) => c.metadata)
         .map((m) => m.element);
     return inheritedAndSelfAnnotations.any(_isImmutable);

--- a/lib/src/rules/avoid_escaping_inner_quotes.dart
+++ b/lib/src/rules/avoid_escaping_inner_quotes.dart
@@ -36,7 +36,7 @@ class AvoidEscapingInnerQuotes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);
   }
@@ -60,7 +60,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitStringInterpolation(StringInterpolation node) {
     if (node.isRaw || node.isMultiline) return;
 
-    final text = node.elements
+    var text = node.elements
         .whereType<InterpolationString>()
         .map((e) => e.value)
         .reduce((a, b) => '$a$b');

--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -48,7 +48,7 @@ class AvoidFieldInitializersInConstClasses extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addConstructorFieldInitializer(this, visitor);
   }
@@ -78,18 +78,18 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitConstructorFieldInitializer(ConstructorFieldInitializer node) {
-    final declaration = node.parent;
+    var declaration = node.parent;
     if (declaration is ConstructorDeclaration) {
       if (declaration.constKeyword == null) return;
       // no lint if several constructors
-      final constructorCount = declaration
+      var constructorCount = declaration
           .thisOrAncestorOfType<ClassDeclaration>()!
           .members
           .whereType<ConstructorDeclaration>()
           .length;
       if (constructorCount > 1) return;
 
-      final visitor = HasParameterReferenceVisitor(
+      var visitor = HasParameterReferenceVisitor(
           declaration.parameters.parameterElements);
       node.expression.accept(visitor);
       if (!visitor.useParameter) {
@@ -103,7 +103,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isStatic) return;
     if (!node.fields.isFinal) return;
     // only const class
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is ClassDeclaration) {
       var declaredElement = parent.declaredElement;
       if (declaredElement == null) {
@@ -112,7 +112,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (declaredElement.constructors.every((e) => !e.isConst)) {
         return;
       }
-      for (final variable in node.fields.variables) {
+      for (var variable in node.fields.variables) {
         if (variable.initializer != null) {
           rule.reportLint(variable);
         }

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -43,7 +43,7 @@ class AvoidFunctionLiteralInForeachMethod extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }
 }

--- a/lib/src/rules/avoid_implementing_value_types.dart
+++ b/lib/src/rules/avoid_implementing_value_types.dart
@@ -97,7 +97,7 @@ class AvoidImplementingValueTypes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }
@@ -114,7 +114,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
     for (var interface in implementsClause.interfaces) {
-      final element = interface.type?.element;
+      var element = interface.type?.element;
       if (element is ClassElement && _overridesEquals(element)) {
         rule.reportLint(interface);
       }

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -68,7 +68,7 @@ class AvoidInitToNull extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addVariableDeclaration(this, visitor);
     registry.addDefaultFormalParameter(this, visitor);
   }

--- a/lib/src/rules/avoid_js_rounded_ints.dart
+++ b/lib/src/rules/avoid_js_rounded_ints.dart
@@ -44,7 +44,7 @@ class AvoidJsRoundedInts extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addIntegerLiteral(this, visitor);
   }
 }

--- a/lib/src/rules/avoid_multiple_declarations_per_line.dart
+++ b/lib/src/rules/avoid_multiple_declarations_per_line.dart
@@ -39,7 +39,7 @@ class AvoidMultipleDeclarationsPerLine extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addVariableDeclarationList(this, visitor);
   }
 }
@@ -51,10 +51,10 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitVariableDeclarationList(VariableDeclarationList node) {
-    final variables = node.variables;
+    var variables = node.variables;
 
     if (variables.length > 1) {
-      final secondVariable = variables[1];
+      var secondVariable = variables[1];
       rule.reportLint(secondVariable.name);
     }
   }

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -83,7 +83,7 @@ class AvoidNullChecksInEqualityOperators extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -95,12 +95,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    final parameters = node.parameters?.parameters;
+    var parameters = node.parameters?.parameters;
     if (parameters == null) {
       return;
     }
     if (node.name.token.type == TokenType.EQ_EQ && parameters.length == 1) {
-      final parameter = DartTypeUtilities.getCanonicalElementFromIdentifier(
+      var parameter = DartTypeUtilities.getCanonicalElementFromIdentifier(
           parameters.first.identifier);
       bool checkIfParameterIsNull(AstNode node) =>
           _isParameterWithQuestion(node, parameter) ||

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -49,7 +49,7 @@ class AvoidPositionalBooleanParameters extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
     registry.addConstructorDeclaration(this, visitor);
     registry.addFunctionDeclaration(this, visitor);
@@ -67,7 +67,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitConstructorDeclaration(ConstructorDeclaration node) {
     var declaredElement = node.declaredElement;
     if (declaredElement != null && !declaredElement.isPrivate) {
-      final parametersToLint =
+      var parametersToLint =
           node.parameters.parameters.where(_isFormalParameterToLint);
       if (parametersToLint.isNotEmpty == true) {
         rule.reportLint(parametersToLint.first);
@@ -79,7 +79,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitFunctionDeclaration(FunctionDeclaration node) {
     var declaredElement = node.declaredElement;
     if (declaredElement != null && !declaredElement.isPrivate) {
-      final parametersToLint = node.functionExpression.parameters?.parameters
+      var parametersToLint = node.functionExpression.parameters?.parameters
           .where(_isFormalParameterToLint);
       if (parametersToLint != null && parametersToLint.isNotEmpty) {
         rule.reportLint(parametersToLint.first);
@@ -96,7 +96,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         !node.isOperator &&
         !DartTypeUtilities.hasInheritedMethod(node) &&
         !_isOverridingMember(declaredElement)) {
-      final parametersToLint =
+      var parametersToLint =
           node.parameters?.parameters.where(_isFormalParameterToLint);
       if (parametersToLint != null && parametersToLint.isNotEmpty) {
         rule.reportLint(parametersToLint.first);
@@ -114,7 +114,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return false;
     }
 
-    final classElement = member.thisOrAncestorOfType<ClassElement>();
+    var classElement = member.thisOrAncestorOfType<ClassElement>();
     if (classElement == null) {
       return false;
     }
@@ -122,7 +122,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (name == null) {
       return false;
     }
-    final libraryUri = classElement.library.source.uri;
+    var libraryUri = classElement.library.source.uri;
     return context.inheritanceManager
             .getInherited(classElement.thisType, Name(libraryUri, name)) !=
         null;

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -33,7 +33,7 @@ class AvoidPrint extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -45,7 +45,7 @@ class _Visitor extends SimpleAstVisitor {
 
   void _validateArgument(Expression expression) {
     if (expression is SimpleIdentifier) {
-      final element = expression.staticElement;
+      var element = expression.staticElement;
       if (element is FunctionElement &&
           element.name == 'print' &&
           element.library.isDartCore) {

--- a/lib/src/rules/avoid_private_typedef_functions.dart
+++ b/lib/src/rules/avoid_private_typedef_functions.dart
@@ -38,7 +38,7 @@ class AvoidPrivateTypedefFunctions extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addFunctionTypeAlias(this, visitor);
     registry.addGenericTypeAlias(this, visitor);
   }
@@ -81,8 +81,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (!Identifier.isPrivateName(name)) {
       return;
     }
-    final visitor = _CountVisitor(name);
-    for (final unit in context.allUnits) {
+    var visitor = _CountVisitor(name);
+    for (var unit in context.allUnits) {
       unit.unit.accept(visitor);
     }
     if (visitor.count <= 1) {

--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -49,7 +49,7 @@ class AvoidRedundantArgumentValues extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
@@ -62,25 +62,25 @@ class _Visitor extends SimpleAstVisitor {
   _Visitor(this.rule, this.context);
 
   void check(ArgumentList argumentList) {
-    final arguments = argumentList.arguments;
+    var arguments = argumentList.arguments;
     if (arguments.isEmpty) {
       return;
     }
 
     for (var i = arguments.length - 1; i >= 0; --i) {
       var arg = arguments[i];
-      final param = arg.staticParameterElement;
+      var param = arg.staticParameterElement;
       if (param == null || param.hasRequired || param.isRequiredNamed) {
         continue;
       } else if (param.isRequiredPositional) {
         break;
       }
-      final value = param.computeConstantValue();
+      var value = param.computeConstantValue();
       if (value != null) {
         if (arg is NamedExpression) {
           arg = arg.expression;
         }
-        final expressionValue = context.evaluateConstant(arg);
+        var expressionValue = context.evaluateConstant(arg);
         if (expressionValue.value == value) {
           rule.reportLint(arg);
         }

--- a/lib/src/rules/avoid_relative_lib_imports.dart
+++ b/lib/src/rules/avoid_relative_lib_imports.dart
@@ -49,7 +49,7 @@ class AvoidRelativeLibImports extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addImportDirective(this, visitor);
   }
 }
@@ -65,7 +65,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     // See: https://github.com/dart-lang/linter/issues/2419
     var uriContent = node.uriContent;
     if (uriContent != null) {
-      final uri = Uri.tryParse(uriContent);
+      var uri = Uri.tryParse(uriContent);
       if (uri != null && uri.scheme.isEmpty) {
         return uri.path.contains('/lib/');
       }

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -59,7 +59,7 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -75,21 +75,21 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isStatic) return;
     if (node.documentationComment != null) return;
 
-    final parentNode = node.parent;
+    var parentNode = node.parent;
     if (parentNode is! Declaration) {
       return;
     }
-    final parentElement = parentNode.declaredElement;
+    var parentElement = parentNode.declaredElement;
     // Note: there are no override semantics with extension methods.
     if (parentElement is! ClassElement) {
       return;
     }
 
-    final classElement = parentElement;
+    var classElement = parentElement;
 
     if (classElement.isPrivate) return;
 
-    final parentMethod = classElement.lookUpInheritedMethod(
+    var parentMethod = classElement.lookUpInheritedMethod(
         node.name.name, classElement.library);
 
     if (parentMethod == null) return;
@@ -99,10 +99,10 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final parameters = nodeParams.parameters.where((p) => !p.isNamed).toList();
-    final parentParameters =
+    var parameters = nodeParams.parameters.where((p) => !p.isNamed).toList();
+    var parentParameters =
         parentMethod.parameters.where((p) => !p.isNamed).toList();
-    final count = math.min(parameters.length, parentParameters.length);
+    var count = math.min(parameters.length, parentParameters.length);
     for (var i = 0; i < count; i++) {
       if (parentParameters.length <= i) break;
       var paramIdentifier = parameters[i].identifier;

--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -38,7 +38,7 @@ class AvoidReturnTypesOnSetters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -62,7 +62,7 @@ class AvoidReturningNull extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionExpression(this, visitor);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_returning_null_for_future.dart
+++ b/lib/src/rules/avoid_returning_null_for_future.dart
@@ -30,7 +30,7 @@ class AvoidReturningNullForFuture extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addExpressionFunctionBody(this, visitor);
     registry.addReturnStatement(this, visitor);
   }
@@ -59,7 +59,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final parent = node.thisOrAncestorMatching(
+    var parent = node.thisOrAncestorMatching(
         (e) => e is FunctionExpression || e is MethodDeclaration);
     if (parent == null) return;
 

--- a/lib/src/rules/avoid_returning_null_for_void.dart
+++ b/lib/src/rules/avoid_returning_null_for_void.dart
@@ -53,7 +53,7 @@ class AvoidReturningNullForVoid extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addExpressionFunctionBody(this, visitor);
     registry.addReturnStatement(this, visitor);
   }
@@ -81,7 +81,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final parent = node.thisOrAncestorMatching(
+    var parent = node.thisOrAncestorMatching(
         (e) => e is FunctionExpression || e is MethodDeclaration);
     if (parent == null) return;
 

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -62,7 +62,7 @@ class AvoidReturningThis extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -76,7 +76,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitMethodDeclaration(MethodDeclaration node) {
     if (node.isOperator) return;
 
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is ClassOrMixinDeclaration) {
       if (DartTypeUtilities.overridesMethod(node)) {
         return;
@@ -93,9 +93,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final body = node.body;
+    var body = node.body;
     if (body is BlockFunctionBody) {
-      final returnStatements = DartTypeUtilities.traverseNodesInDFS(body.block,
+      var returnStatements = DartTypeUtilities.traverseNodesInDFS(body.block,
               excludeCriteria: _isFunctionExpression)
           .where(_isReturnStatement);
       if (returnStatements.isNotEmpty && returnStatements.every(_returnsThis)) {

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -61,7 +61,7 @@ class AvoidSettersWithoutGetters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }

--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -40,7 +40,7 @@ class AvoidShadowingTypeParameters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionDeclarationStatement(this, visitor);
     registry.addGenericTypeAlias(this, visitor);
     registry.addMethodDeclaration(this, visitor);

--- a/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
+++ b/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
@@ -37,7 +37,7 @@ class AvoidSingleCascadeInExpressionStatements extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCascadeExpression(this, visitor);
   }
 }

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -80,7 +80,7 @@ class AvoidSlowAsyncIo extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -93,7 +93,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodInvocation(MethodInvocation node) {
     if (node.argumentList.arguments.isEmpty) {
-      final type = node.target?.staticType;
+      var type = node.target?.staticType;
       _checkFileMethods(node, type);
       _checkDirectoryMethods(node, type);
       return;
@@ -120,9 +120,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _checkFileSystemEntityMethods(MethodInvocation node) {
-    final target = node.target;
+    var target = node.target;
     if (target is Identifier) {
-      final elem = target.staticElement;
+      var elem = target.staticElement;
       if (elem is ClassElement && elem.name == 'FileSystemEntity') {
         if (_fileSystemEntityMethodNames.contains(node.methodName.name)) {
           rule.reportLint(node);

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -62,7 +62,7 @@ class AvoidTypeToString extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor =
+    var visitor =
         _Visitor(this, context.typeSystem, context.typeProvider.typeType);
     // Gathering meta information at these nodes.
     // Nodes visited in DFS, so this will be called before
@@ -111,7 +111,7 @@ class _Visitor extends SimpleAstVisitor {
     visitArgumentList(node.argumentList);
 
     var staticType = node.realTarget?.staticType;
-    final targetType = staticType is InterfaceType ? staticType : thisType;
+    var targetType = staticType is InterfaceType ? staticType : thisType;
     _reportIfToStringOnCoreTypeClass(targetType, node.methodName);
   }
 
@@ -123,11 +123,11 @@ class _Visitor extends SimpleAstVisitor {
   void _validateArgument(Expression expression) {
     if (expression is PropertyAccess) {
       var expressionType = expression.realTarget.staticType;
-      final targetType =
+      var targetType =
           (expressionType is InterfaceType) ? expressionType : thisType;
       _reportIfToStringOnCoreTypeClass(targetType, expression.propertyName);
     } else if (expression is PrefixedIdentifier) {
-      final prefixType = expression.prefix.staticType;
+      var prefixType = expression.prefix.staticType;
       if (prefixType is InterfaceType) {
         _reportIfToStringOnCoreTypeClass(prefixType, expression.identifier);
       }
@@ -151,7 +151,7 @@ class _Visitor extends SimpleAstVisitor {
       typeSystem.isSubtypeOf(targetType, typeType);
 
   bool _isSimpleIdDeclByCoreObj(SimpleIdentifier simpleIdentifier) {
-    final encloser = simpleIdentifier.staticElement?.enclosingElement;
+    var encloser = simpleIdentifier.staticElement?.enclosingElement;
     return encloser is ClassElement && encloser.isDartCoreObject;
   }
 }

--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -37,7 +37,7 @@ class AvoidTypesAsParameterNames extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addFormalParameterList(this, visitor);
     registry.addCatchClause(this, visitor);
   }
@@ -51,7 +51,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCatchClause(CatchClause node) {
-    final parameter = node.exceptionParameter;
+    var parameter = node.exceptionParameter;
     if (parameter != null && _isTypeName(node, parameter)) {
       rule.reportLint(parameter);
     }
@@ -61,7 +61,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitFormalParameterList(FormalParameterList node) {
     if (node.parent is GenericFunctionType) return;
 
-    for (final parameter in node.parameters) {
+    for (var parameter in node.parameters) {
       var declaredElement = parameter.declaredElement;
       var identifier = parameter.identifier;
       if (declaredElement != null &&
@@ -74,9 +74,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _isTypeName(AstNode scope, SimpleIdentifier node) {
-    final result = context.resolveNameInScope(node.name, false, scope);
+    var result = context.resolveNameInScope(node.name, false, scope);
     if (result.isRequestedName) {
-      final element = result.element;
+      var element = result.element;
       return element is ClassElement || element is TypeAliasElement;
     }
     return false;

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -40,7 +40,7 @@ class AvoidTypesOnClosureParameters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionExpression(this, visitor);
   }
 }
@@ -62,7 +62,7 @@ class AvoidTypesOnClosureParametersVisitor extends SimpleAstVisitor {
     }
     var parameterList = node.parameters?.parameters;
     if (parameterList != null) {
-      for (final parameter in parameterList) {
+      for (var parameter in parameterList) {
         parameter.accept(this);
       }
     }
@@ -75,7 +75,7 @@ class AvoidTypesOnClosureParametersVisitor extends SimpleAstVisitor {
 
   @override
   void visitSimpleFormalParameter(SimpleFormalParameter node) {
-    final type = node.type;
+    var type = node.type;
     if (type is TypeName && type.name.name != 'dynamic') {
       rule.reportLint(node.type);
     }
@@ -89,7 +89,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFunctionExpression(FunctionExpression node) {
-    final visitor = AvoidTypesOnClosureParametersVisitor(rule);
+    var visitor = AvoidTypesOnClosureParametersVisitor(rule);
     visitor.visitFunctionExpression(node);
   }
 }

--- a/lib/src/rules/avoid_unnecessary_containers.dart
+++ b/lib/src/rules/avoid_unnecessary_containers.dart
@@ -57,7 +57,7 @@ class AvoidUnnecessaryContainers extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
 
     registry.addInstanceCreationExpression(this, visitor);
   }
@@ -73,11 +73,11 @@ class _Visitor extends SimpleAstVisitor {
     if (!isWidgetType(node.staticType)) {
       return;
     }
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is NamedExpression && parent.name.label.name == 'child') {
-      final args = parent.thisOrAncestorOfType<ArgumentList>();
+      var args = parent.thisOrAncestorOfType<ArgumentList>();
       if (args?.arguments.length == 1) {
-        final parentCreation =
+        var parentCreation =
             parent.thisOrAncestorOfType<InstanceCreationExpression>();
         if (parentCreation != null) {
           if (isExactWidgetTypeContainer(parentCreation.staticType)) {

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -44,7 +44,7 @@ class AvoidUnusedConstructorParameters extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }
 }
@@ -56,7 +56,7 @@ class _ConstructorVisitor extends RecursiveAstVisitor {
 
   _ConstructorVisitor(this.rule, this.element)
       : unusedParameters = element.parameters.parameters.where((p) {
-          final element = p.declaredElement;
+          var element = p.declaredElement;
           return element != null &&
               element is! FieldFormalParameterElement &&
               !element.hasDeprecated &&
@@ -80,7 +80,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.redirectedConstructor != null) return;
     if (node.externalKeyword != null) return;
 
-    final _constructorVisitor = _ConstructorVisitor(rule, node);
+    var _constructorVisitor = _ConstructorVisitor(rule, node);
     node.body.visitChildren(_constructorVisitor);
     node.initializers.forEach((i) => i.visitChildren(_constructorVisitor));
 

--- a/lib/src/rules/avoid_void_async.dart
+++ b/lib/src/rules/avoid_void_async.dart
@@ -42,7 +42,7 @@ class AvoidVoidAsync extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);
   }

--- a/lib/src/rules/avoid_web_libraries_in_flutter.dart
+++ b/lib/src/rules/avoid_web_libraries_in_flutter.dart
@@ -29,7 +29,7 @@ otherwise, imports of `dart:html`, `dart:js` and  `dart:js_util` are disallowed.
 /// todo (pq): consider making a utility and sharing w/ `prefer_relative_imports`
 YamlMap _parseYaml(String content) {
   try {
-    final doc = loadYamlNode(content);
+    var doc = loadYamlNode(content);
     if (doc is YamlMap) {
       return doc;
     }
@@ -52,7 +52,7 @@ class AvoidWebLibrariesInFlutter extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
     registry.addImportDirective(this, visitor);
   }
@@ -76,7 +76,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     YamlMap parsedPubspec;
     try {
-      final content = file.readAsStringSync();
+      var content = file.readAsStringSync();
       parsedPubspec = _parseYaml(content);
       // ignore: avoid_catches_without_on_clauses
     } catch (_) {
@@ -96,7 +96,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool isWebUri(String uri) {
-    final uriLength = uri.length;
+    var uriLength = uri.length;
     return (uriLength == 9 && uri == 'dart:html') ||
         (uriLength == 7 && uri == 'dart:js') ||
         (uriLength == 12 && uri == 'dart:js_util');

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -41,7 +41,7 @@ class AwaitOnlyFutures extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addAwaitExpression(this, visitor);
   }
 }
@@ -58,7 +58,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitAwaitExpression(AwaitExpression node) {
     if (node.expression is NullLiteral) return;
 
-    final type = node.expression.staticType;
+    var type = node.expression.staticType;
     if (!(type == null ||
         type.isDartAsyncFuture ||
         type.isDynamic ||

--- a/lib/src/rules/camel_case_extensions.dart
+++ b/lib/src/rules/camel_case_extensions.dart
@@ -41,7 +41,7 @@ class CamelCaseExtensions extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addExtensionDeclaration(this, visitor);
   }
 }
@@ -53,7 +53,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitExtensionDeclaration(ExtensionDeclaration node) {
-    final name = node.name;
+    var name = node.name;
     if (name != null && !isCamelCase(name.name)) {
       rule.reportLint(name);
     }

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -45,7 +45,7 @@ class CamelCaseTypes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addGenericTypeAlias(this, visitor);
     registry.addClassDeclaration(this, visitor);
     registry.addClassTypeAlias(this, visitor);

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -72,7 +72,7 @@ class CancelSubscriptions extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addVariableDeclarationStatement(this, visitor);
   }

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -55,7 +55,7 @@ someReference
 
 Element? _getElementFromVariableDeclarationStatement(
     VariableDeclarationStatement statement) {
-  final variables = statement.variables.variables;
+  var variables = statement.variables.variables;
   if (variables.length == 1) {
     var variable = variables.single;
     if (variable.initializer is AwaitExpression) {
@@ -74,7 +74,7 @@ Element? _getElementFromVariableDeclarationStatement(
 ExecutableElement? _getExecutableElementFromMethodInvocation(
     MethodInvocation node) {
   if (_isInvokedWithoutNullAwareOperator(node.operator)) {
-    final executableElement =
+    var executableElement =
         DartTypeUtilities.getCanonicalElementFromIdentifier(node.methodName);
     if (executableElement is ExecutableElement) {
       return executableElement;
@@ -84,7 +84,7 @@ ExecutableElement? _getExecutableElementFromMethodInvocation(
 }
 
 Element? _getPrefixElementFromExpression(Expression rawExpression) {
-  final expression = rawExpression.unParenthesized;
+  var expression = rawExpression.unParenthesized;
   if (expression is PrefixedIdentifier) {
     return DartTypeUtilities.getCanonicalElementFromIdentifier(
         expression.prefix);
@@ -120,7 +120,7 @@ class CascadeInvocations extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBlock(this, visitor);
   }
 }
@@ -152,7 +152,7 @@ class _CascadableExpression {
 
   factory _CascadableExpression.fromExpressionStatement(
       ExpressionStatement statement) {
-    final expression = statement.expression.unParenthesized;
+    var expression = statement.expression.unParenthesized;
     if (expression is AssignmentExpression) {
       return _CascadableExpression._fromAssignmentExpression(expression);
     }
@@ -174,14 +174,14 @@ class _CascadableExpression {
 
   factory _CascadableExpression.fromVariableDeclarationStatement(
       VariableDeclarationStatement node) {
-    final element = _getElementFromVariableDeclarationStatement(node);
+    var element = _getElementFromVariableDeclarationStatement(node);
     return _CascadableExpression._internal(element, [],
         canReceive: true, isCritical: true);
   }
 
   factory _CascadableExpression._fromAssignmentExpression(
       AssignmentExpression node) {
-    final leftExpression = node.leftHandSide.unParenthesized;
+    var leftExpression = node.leftHandSide.unParenthesized;
     if (leftExpression is SimpleIdentifier) {
       return _CascadableExpression._internal(
           DartTypeUtilities.getCanonicalElement(leftExpression.staticElement),
@@ -190,8 +190,8 @@ class _CascadableExpression {
           isCritical: true);
     }
     // setters
-    final variable = _getPrefixElementFromExpression(leftExpression);
-    final canReceive = node.operator.type != TokenType.QUESTION_QUESTION_EQ &&
+    var variable = _getPrefixElementFromExpression(leftExpression);
+    var canReceive = node.operator.type != TokenType.QUESTION_QUESTION_EQ &&
         variable is VariableElement &&
         !variable.isStatic;
     return _CascadableExpression._internal(variable, [node.rightHandSide],
@@ -205,10 +205,10 @@ class _CascadableExpression {
           canJoin: true, canReceive: true, canBeCascaded: true);
 
   factory _CascadableExpression._fromMethodInvocation(MethodInvocation node) {
-    final executableElement = _getExecutableElementFromMethodInvocation(node);
-    final isNonStatic = executableElement?.isStatic == false;
+    var executableElement = _getExecutableElementFromMethodInvocation(node);
+    var isNonStatic = executableElement?.isStatic == false;
     if (isNonStatic) {
-      final isSimpleIdentifier = node.target is SimpleIdentifier;
+      var isSimpleIdentifier = node.target is SimpleIdentifier;
       return _CascadableExpression._internal(
           _getTargetElementFromMethodInvocation(node), [node.argumentList],
           canJoin: isSimpleIdentifier,
@@ -294,7 +294,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
     var previousExpressionBox = _CascadableExpression.nullCascadableExpression;
-    for (final statement in node.statements) {
+    for (var statement in node.statements) {
       var currentExpressionBox = _CascadableExpression.nullCascadableExpression;
       if (statement is VariableDeclarationStatement) {
         currentExpressionBox =

--- a/lib/src/rules/cast_nullable_to_non_nullable.dart
+++ b/lib/src/rules/cast_nullable_to_non_nullable.dart
@@ -54,7 +54,7 @@ class CastNullableToNonNullable extends LintRule implements NodeLintRule {
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addAsExpression(this, visitor);
   }
 }
@@ -67,8 +67,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitAsExpression(AsExpression node) {
-    final expressionType = node.expression.staticType;
-    final type = node.type.type;
+    var expressionType = node.expression.staticType;
+    var type = node.type.type;
     if (expressionType != null &&
         type != null &&
         !expressionType.isDynamic &&

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -74,7 +74,7 @@ class CloseSinks extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addVariableDeclarationStatement(this, visitor);
   }

--- a/lib/src/rules/comment_references.dart
+++ b/lib/src/rules/comment_references.dart
@@ -57,7 +57,7 @@ class CommentReferences extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addComment(this, visitor);
     registry.addCommentReference(this, visitor);
   }
@@ -75,14 +75,14 @@ class _Visitor extends SimpleAstVisitor<void> {
     // Note that no special care is taken to handle embedded code blocks.
     for (var token in node.tokens) {
       if (!token.isSynthetic) {
-        final comment = token.lexeme;
+        var comment = token.lexeme;
         var leftIndex = comment.indexOf('[');
         while (leftIndex >= 0) {
           var rightIndex = comment.indexOf(']', leftIndex);
           if (rightIndex >= 0) {
-            final reference = comment.substring(leftIndex + 1, rightIndex);
+            var reference = comment.substring(leftIndex + 1, rightIndex);
             if (_isParserSpecialCase(reference)) {
-              final nameOffset = token.offset + leftIndex + 1;
+              var nameOffset = token.offset + leftIndex + 1;
               rule.reporter.reportErrorForOffset(
                   rule.lintCode, nameOffset, reference.length);
             }
@@ -95,7 +95,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCommentReference(CommentReference node) {
-    final identifier = node.identifier;
+    var identifier = node.identifier;
     if (!identifier.isSynthetic && identifier.staticElement == null) {
       rule.reportLint(identifier);
     }

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -55,7 +55,7 @@ class ConstantIdentifierNames extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addEnumConstantDeclaration(this, visitor);
     registry.addTopLevelVariableDeclaration(this, visitor);
     registry.addVariableDeclarationList(this, visitor);

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -95,7 +95,7 @@ class ControlFlowInFinally extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBreakStatement(this, visitor);
     registry.addContinueStatement(this, visitor);
     registry.addReturnStatement(this, visitor);
@@ -110,8 +110,8 @@ abstract class ControlFlowInFinallyBlockReporterMixin {
   LintRule get rule;
 
   void reportIfFinallyAncestorExists(AstNode node, {AstNode? ancestor}) {
-    final tryStatement = node.thisOrAncestorOfType<TryStatement>();
-    final finallyBlock = tryStatement?.finallyBlock;
+    var tryStatement = node.thisOrAncestorOfType<TryStatement>();
+    var finallyBlock = tryStatement?.finallyBlock;
     bool finallyBlockAncestorPredicate(AstNode n) => n == finallyBlock;
     if (tryStatement == null ||
         finallyBlock == null ||
@@ -119,7 +119,7 @@ abstract class ControlFlowInFinallyBlockReporterMixin {
       return;
     }
 
-    final enablerNode = _findEnablerNode(
+    var enablerNode = _findEnablerNode(
         ancestor, finallyBlockAncestorPredicate, node, tryStatement);
     if (enablerNode == null) {
       rule.reportLint(node);

--- a/lib/src/rules/curly_braces_in_flow_control_structures.dart
+++ b/lib/src/rules/curly_braces_in_flow_control_structures.dart
@@ -62,7 +62,7 @@ class CurlyBracesInFlowControlStructures extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForStatement(this, visitor);
     registry.addIfStatement(this, visitor);
@@ -91,7 +91,7 @@ class _Visitor extends SimpleAstVisitor {
     if (elseStatement == null) {
       if (node.thenStatement is Block) return;
 
-      final unit = node.root as CompilationUnit;
+      var unit = node.root as CompilationUnit;
       var lineInfo = unit.lineInfo;
       if (lineInfo != null &&
           lineInfo.getLocation(node.rightParenthesis.end).lineNumber !=

--- a/lib/src/rules/deprecated_consistency.dart
+++ b/lib/src/rules/deprecated_consistency.dart
@@ -61,7 +61,7 @@ class DeprecatedConsistency extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
     registry.addFieldFormalParameter(this, visitor);
   }

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -79,7 +79,7 @@ class DiagnosticsDescribeAllProperties extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addClassDeclaration(this, visitor);
   }
 }
@@ -123,12 +123,12 @@ class _Visitor extends SimpleAstVisitor {
   @override
   void visitClassDeclaration(ClassDeclaration node) {
     // We only care about Diagnosticables.
-    final type = node.declaredElement?.thisType;
+    var type = node.declaredElement?.thisType;
     if (!DartTypeUtilities.implementsInterface(type, 'Diagnosticable', '')) {
       return;
     }
 
-    final properties = <SimpleIdentifier>[];
+    var properties = <SimpleIdentifier>[];
     for (var member in node.members) {
       if (member is MethodDeclaration && member.isGetter) {
         if (!member.isStatic &&
@@ -159,8 +159,8 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    final debugFillProperties = node.getMethod('debugFillProperties');
-    final debugDescribeChildren = node.getMethod('debugDescribeChildren');
+    var debugFillProperties = node.getMethod('debugFillProperties');
+    var debugDescribeChildren = node.getMethod('debugDescribeChildren');
 
     // Remove any defined in debugFillProperties.
     removeReferences(debugFillProperties, properties);
@@ -177,7 +177,7 @@ class _Visitor extends SimpleAstVisitor {
       return false;
     }
 
-    final classElement = member.thisOrAncestorOfType<ClassElement>();
+    var classElement = member.thisOrAncestorOfType<ClassElement>();
     if (classElement == null) {
       return false;
     }
@@ -186,7 +186,7 @@ class _Visitor extends SimpleAstVisitor {
       return false;
     }
 
-    final libraryUri = classElement.library.source.uri;
+    var libraryUri = classElement.library.source.uri;
     return context.inheritanceManager
             .getInherited(classElement.thisType, Name(libraryUri, name)) !=
         null;

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -165,7 +165,7 @@ class DirectivesOrdering extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }
 
@@ -221,7 +221,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    final lintedNodes = <AstNode>{};
+    var lintedNodes = <AstNode>{};
     _checkDartDirectiveGoFirst(lintedNodes, node);
     _checkPackageDirectiveBeforeRelative(lintedNodes, node);
     _checkExportDirectiveAfterImportDirective(lintedNodes, node);
@@ -255,14 +255,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _checkDirectiveSectionOrderedAlphabetically(
       Set<AstNode> lintedNodes, CompilationUnit node) {
-    final importDirectives = _getImportDirectives(node);
-    final exportDirectives = _getExportDirectives(node);
+    var importDirectives = _getImportDirectives(node);
+    var exportDirectives = _getExportDirectives(node);
 
-    final dartImports = importDirectives.where(_isDartDirective);
-    final dartExports = exportDirectives.where(_isDartDirective);
+    var dartImports = importDirectives.where(_isDartDirective);
+    var dartExports = exportDirectives.where(_isDartDirective);
 
-    final relativeImports = importDirectives.where(_isRelativeDirective);
-    final relativeExports = exportDirectives.where(_isRelativeDirective);
+    var relativeImports = importDirectives.where(_isRelativeDirective);
+    var relativeExports = exportDirectives.where(_isRelativeDirective);
 
     _checkSectionInOrder(lintedNodes, dartImports);
     _checkSectionInOrder(lintedNodes, dartExports);
@@ -272,16 +272,16 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     var projectName = project?.name;
     if (projectName != null) {
-      final packageBox = _PackageBox(projectName);
+      var packageBox = _PackageBox(projectName);
 
-      final thirdPartyPackageImports =
+      var thirdPartyPackageImports =
           importDirectives.where(packageBox._isNotOwnPackageDirective);
-      final thirdPartyPackageExports =
+      var thirdPartyPackageExports =
           exportDirectives.where(packageBox._isNotOwnPackageDirective);
 
-      final ownPackageImports =
+      var ownPackageImports =
           importDirectives.where(packageBox._isOwnPackageDirective);
-      final ownPackageExports =
+      var ownPackageExports =
           exportDirectives.where(packageBox._isOwnPackageDirective);
 
       _checkSectionInOrder(lintedNodes, thirdPartyPackageImports);

--- a/lib/src/rules/do_not_use_environment.dart
+++ b/lib/src/rules/do_not_use_environment.dart
@@ -33,7 +33,7 @@ class DoNotUseEnvironment extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -60,7 +60,7 @@ class EmptyCatches extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCatchClause(this, visitor);
   }
 }
@@ -73,13 +73,13 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitCatchClause(CatchClause node) {
     // Skip exceptions named with underscores.
-    final exceptionParameter = node.exceptionParameter;
+    var exceptionParameter = node.exceptionParameter;
     if (exceptionParameter != null &&
         isJustUnderscores(exceptionParameter.name)) {
       return;
     }
 
-    final body = node.body;
+    var body = node.body;
     if (node.body.statements.isEmpty &&
         body.rightBracket.precedingComments == null) {
       rule.reportLint(body);

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -48,7 +48,7 @@ class EmptyConstructorBodies extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }
 }
@@ -62,7 +62,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitConstructorDeclaration(ConstructorDeclaration node) {
     var body = node.body;
     if (body is BlockFunctionBody) {
-      final block = body.block;
+      var block = body.block;
       if (block.statements.isEmpty) {
         if (block.endToken.precedingComments == null) {
           rule.reportLint(block);

--- a/lib/src/rules/empty_statements.dart
+++ b/lib/src/rules/empty_statements.dart
@@ -52,7 +52,7 @@ class EmptyStatements extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addEmptyStatement(this, visitor);
   }
 }

--- a/lib/src/rules/exhaustive_cases.dart
+++ b/lib/src/rules/exhaustive_cases.dart
@@ -85,7 +85,7 @@ class ExhaustiveCases extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSwitchStatement(this, visitor);
   }
 }

--- a/lib/src/rules/file_names.dart
+++ b/lib/src/rules/file_names.dart
@@ -54,7 +54,7 @@ class FileNames extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }
 }
@@ -68,7 +68,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitCompilationUnit(CompilationUnit node) {
     var declaredElement = node.declaredElement;
     if (declaredElement != null) {
-      final fileName = declaredElement.source.shortName;
+      var fileName = declaredElement.source.shortName;
       if (!isValidDartFileName(fileName)) {
         rule.reportLint(node);
       }

--- a/lib/src/rules/flutter_style_todos.dart
+++ b/lib/src/rules/flutter_style_todos.dart
@@ -38,7 +38,7 @@ class FlutterStyleTodos extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }
 }
@@ -72,7 +72,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _visitComment(Token node) {
-    final content = node.lexeme;
+    var content = node.lexeme;
     if (content.startsWith(_todoRegExp) &&
         !content.startsWith(_todoExpectedRegExp)) {
       rule.reportLintForToken(node);

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -58,7 +58,7 @@ class HashAndEquals extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -36,7 +36,7 @@ import 'package:acme/lib/src/internals.dart;
 ''';
 
 bool isImplementation(Uri? uri) {
-  final segments = uri?.pathSegments ?? const <String>[];
+  var segments = uri?.pathSegments ?? const <String>[];
   if (segments.length > 2) {
     if (segments[1] == 'src') {
       return true;
@@ -70,7 +70,7 @@ class ImplementationImports extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addImportDirective(this, visitor);
   }
 }
@@ -82,8 +82,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitImportDirective(ImportDirective node) {
-    final importUri = node.uriSource?.uri;
-    final sourceUri = node.element?.source.uri;
+    var importUri = node.uriSource?.uri;
+    var sourceUri = node.element?.source.uri;
 
     // Test for 'package:*/src/'.
     if (!isImplementation(importUri)) {

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -145,9 +145,9 @@ class _InvariantBooleansVisitor extends ConditionScopeVisitor {
       return;
     }
 
-    final testedNodes = _findPreviousTestedExpressions(node);
+    var testedNodes = _findPreviousTestedExpressions(node);
     testedNodes?.evaluateInvariant()?.forEach((ContradictoryComparisons e) {
-      final reportRule = _ContradictionReportRule(e);
+      var reportRule = _ContradictionReportRule(e);
       reportRule
         ..reporter = rule.reporter
         ..reportLint(e.second);
@@ -155,7 +155,7 @@ class _InvariantBooleansVisitor extends ConditionScopeVisitor {
 
     // In dart booleanVariable == true is a valid comparison since the variable
     // can be null.
-    final binaryExpression = node is BinaryExpression ? node : null;
+    var binaryExpression = node is BinaryExpression ? node : null;
     if (binaryExpression != null &&
         !BooleanExpressionUtilities.EQUALITY_OPERATIONS
             .contains(binaryExpression.operator.type) &&
@@ -167,9 +167,9 @@ class _InvariantBooleansVisitor extends ConditionScopeVisitor {
   }
 
   TestedExpressions? _findPreviousTestedExpressions(Expression node) {
-    final elements = _getElementsInExpression(node);
-    final conjunctions = getTrueExpressions(elements)?.toSet();
-    final negations = getFalseExpressions(elements)?.toSet();
+    var elements = _getElementsInExpression(node);
+    var conjunctions = getTrueExpressions(elements)?.toSet();
+    var negations = getFalseExpressions(elements)?.toSet();
     if (conjunctions == null || negations == null) {
       return null;
     }

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -130,7 +130,7 @@ class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context.typeSystem);
+    var visitor = _Visitor(this, context.typeSystem);
     registry.addMethodInvocation(this, visitor);
   }
 }

--- a/lib/src/rules/join_return_with_assignment.dart
+++ b/lib/src/rules/join_return_with_assignment.dart
@@ -36,7 +36,7 @@ class A {
 ''';
 
 Expression? _getExpressionFromAssignmentStatement(Statement node) {
-  final visitor = _AssignmentStatementVisitor();
+  var visitor = _AssignmentStatementVisitor();
   node.accept(visitor);
   return visitor.expression;
 }
@@ -55,7 +55,7 @@ class JoinReturnWithAssignment extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBlock(this, visitor);
   }
 }
@@ -95,16 +95,16 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitBlock(Block node) {
-    final statements = node.statements;
-    final length = statements.length;
+    var statements = node.statements;
+    var length = statements.length;
     if (length < 2) {
       return;
     }
-    final secondLastStatement = statements[length - 2];
-    final lastStatement = statements.last;
-    final secondLastExpression =
+    var secondLastStatement = statements[length - 2];
+    var lastStatement = statements.last;
+    var secondLastExpression =
         _getExpressionFromAssignmentStatement(secondLastStatement);
-    final lastExpression = _getExpressionFromReturnStatement(lastStatement);
+    var lastExpression = _getExpressionFromReturnStatement(lastStatement);
 
     // In this case, the last statement was not a return statement with a
     // simple target.
@@ -114,7 +114,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     Expression? thirdLastExpression;
     if (length >= 3) {
-      final thirdLastStatement = statements[length - 3];
+      var thirdLastStatement = statements[length - 3];
       thirdLastExpression =
           _getExpressionFromAssignmentStatement(thirdLastStatement);
     }

--- a/lib/src/rules/leading_newlines_in_multiline_strings.dart
+++ b/lib/src/rules/leading_newlines_in_multiline_strings.dart
@@ -46,7 +46,7 @@ class LeadingNewlinesInMultilineStrings extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -46,7 +46,7 @@ class LibraryNames extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addLibraryDirective(this, visitor);
   }
 }

--- a/lib/src/rules/library_prefixes.dart
+++ b/lib/src/rules/library_prefixes.dart
@@ -44,7 +44,7 @@ class LibraryPrefixes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addImportDirective(this, visitor);
   }
 }

--- a/lib/src/rules/lines_longer_than_80_chars.dart
+++ b/lib/src/rules/lines_longer_than_80_chars.dart
@@ -53,7 +53,7 @@ class LinesLongerThan80Chars extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
   }
 }
@@ -83,12 +83,12 @@ class _AllowedCommentVisitor extends SimpleAstVisitor {
   }
 
   void _visitComment(Token comment) {
-    final content = comment.lexeme;
-    final lines = <String>[];
+    var content = comment.lexeme;
+    var lines = <String>[];
     if (content.startsWith('///')) {
       lines.add(content.substring(3));
     } else if (content.startsWith('//')) {
-      final commentContent = content.substring(2);
+      var commentContent = content.substring(2);
       if (commentContent.trimLeft().startsWith('ignore:')) {
         allowedLines.add(lineInfo.getLocation(comment.offset).lineNumber);
       } else {
@@ -103,9 +103,9 @@ class _AllowedCommentVisitor extends SimpleAstVisitor {
           .expand((e) => e.split(_lf)));
     }
     for (var i = 0; i < lines.length; i++) {
-      final value = lines[i];
+      var value = lines[i];
       if (_looksLikeUriOrPath(value)) {
-        final line = lineInfo.getLocation(comment.offset).lineNumber + i;
+        var line = lineInfo.getLocation(comment.offset).lineNumber + i;
         allowedLines.add(line);
       }
     }
@@ -132,7 +132,7 @@ class _AllowedLongLineVisitor extends RecursiveAstVisitor {
     if (node.isMultiline) {
       _handleMultilines(node);
     } else {
-      final value = node.elements.map((e) {
+      var value = node.elements.map((e) {
         if (e is InterpolationString) return e.value;
         if (e is InterpolationExpression) return ' ' * e.length;
         throw ArgumentError(
@@ -143,8 +143,8 @@ class _AllowedLongLineVisitor extends RecursiveAstVisitor {
   }
 
   void _handleMultilines(SingleStringLiteral node) {
-    final startLine = lineInfo.getLocation(node.offset).lineNumber;
-    final endLine = lineInfo.getLocation(node.end).lineNumber;
+    var startLine = lineInfo.getLocation(node.offset).lineNumber;
+    var endLine = lineInfo.getLocation(node.end).lineNumber;
     for (var i = startLine; i <= endLine; i++) {
       allowedLines.add(i);
     }
@@ -152,7 +152,7 @@ class _AllowedLongLineVisitor extends RecursiveAstVisitor {
 
   void _handleSingleLine(AstNode node, String value) {
     if (_looksLikeUriOrPath(value)) {
-      final line = lineInfo.getLocation(node.offset).lineNumber;
+      var line = lineInfo.getLocation(node.offset).lineNumber;
       allowedLines.add(line);
     }
   }
@@ -175,20 +175,20 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    final lineInfo = node.lineInfo;
+    var lineInfo = node.lineInfo;
     if (lineInfo == null) {
       return;
     }
-    final lineCount = lineInfo.lineCount;
-    final longLines = <_LineInfo>[];
+    var lineCount = lineInfo.lineCount;
+    var longLines = <_LineInfo>[];
     for (var i = 0; i < lineCount; i++) {
-      final start = lineInfo.getOffsetOfLine(i);
+      var start = lineInfo.getOffsetOfLine(i);
       int end;
       if (i == lineCount - 1) {
         end = node.end;
       } else {
         end = lineInfo.getOffsetOfLine(i + 1) - 1;
-        final length = end - start;
+        var length = end - start;
         if (length > 80) {
           if (context.currentUnit.content[end] == _lf &&
               context.currentUnit.content[end - 1] == _cr) {
@@ -196,26 +196,26 @@ class _Visitor extends SimpleAstVisitor {
           }
         }
       }
-      final length = end - start;
+      var length = end - start;
       if (length > 80) {
-        final line = _LineInfo(index: i, offset: start, end: end);
+        var line = _LineInfo(index: i, offset: start, end: end);
         longLines.add(line);
       }
     }
 
     if (longLines.isEmpty) return;
 
-    final allowedLineVisitor = _AllowedLongLineVisitor(lineInfo);
+    var allowedLineVisitor = _AllowedLongLineVisitor(lineInfo);
     node.accept(allowedLineVisitor);
-    final allowedCommentVisitor = _AllowedCommentVisitor(lineInfo);
+    var allowedCommentVisitor = _AllowedCommentVisitor(lineInfo);
     node.accept(allowedCommentVisitor);
 
-    final allowedLines = [
+    var allowedLines = [
       ...allowedLineVisitor.allowedLines,
       ...allowedCommentVisitor.allowedLines
     ];
 
-    for (final line in longLines) {
+    for (var line in longLines) {
       if (allowedLines.contains(line.index + 1)) continue;
       rule.reporter
           .reportErrorForOffset(rule.lintCode, line.offset, line.length);

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -130,7 +130,7 @@ class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context.typeSystem);
+    var visitor = _Visitor(this, context.typeSystem);
     registry.addMethodInvocation(this, visitor);
   }
 }

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -82,7 +82,7 @@ void bad() {
 ''';
 
 bool _onlyLiterals(Expression? rawExpression) {
-  final expression = rawExpression?.unParenthesized;
+  var expression = rawExpression?.unParenthesized;
   if (expression is Literal) {
     return true;
   }
@@ -110,7 +110,7 @@ class LiteralOnlyBooleanExpressions extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForStatement(this, visitor);
     registry.addIfStatement(this, visitor);
@@ -132,7 +132,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitForStatement(ForStatement node) {
-    final loopParts = node.forLoopParts;
+    var loopParts = node.forLoopParts;
     if (loopParts is ForParts) {
       if (_onlyLiterals(loopParts.condition)) {
         rule.reportLint(node);

--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -45,7 +45,7 @@ class MissingWhitespaceBetweenAdjacentStrings extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
   }
 }
@@ -60,7 +60,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
     // skip regexp
     var parent = node.parent;
     if (parent is ArgumentList) {
-      final parentParent = parent.parent;
+      var parentParent = parent.parent;
       if (_isRegExpInstanceCreation(parentParent) ||
           parentParent is MethodInvocation &&
               parentParent.realTarget == null &&
@@ -71,8 +71,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
     }
 
     for (var i = 0; i < node.strings.length - 1; i++) {
-      final current = node.strings[i];
-      final next = node.strings[i + 1];
+      var current = node.strings[i];
+      var next = node.strings[i + 1];
       if (_visit(current, (l) => _endsWithWhitespace(l.last)) ||
           _visit(next, (l) => _startsWithWhitespace(l.first))) {
         continue;

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -46,7 +46,7 @@ class NoAdjacentStringsInList extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addListLiteral(this, visitor);
   }
 }

--- a/lib/src/rules/no_default_cases.dart
+++ b/lib/src/rules/no_default_cases.dart
@@ -59,7 +59,7 @@ class NoDefaultCases extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSwitchStatement(this, visitor);
   }
 }

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -52,7 +52,7 @@ class NoDuplicateCaseValues extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addSwitchStatement(this, visitor);
   }
 
@@ -83,16 +83,16 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     for (var member in node.members) {
       if (member is SwitchCase) {
-        final expression = member.expression;
+        var expression = member.expression;
 
-        final result = context.evaluateConstant(expression);
-        final value = result.value;
+        var result = context.evaluateConstant(expression);
+        var value = result.value;
 
         if (value == null || !value.hasKnownValue) {
           continue;
         }
 
-        final duplicateValue = values[value];
+        var duplicateValue = values[value];
         if (duplicateValue != null) {
           rule.reportLintWithDescription(member,
               message(duplicateValue.toString(), expression.toString()));

--- a/lib/src/rules/no_logic_in_create_state.dart
+++ b/lib/src/rules/no_logic_in_create_state.dart
@@ -69,7 +69,7 @@ class NoLogicInCreateState extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -85,17 +85,17 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is! ClassDeclaration ||
         !isStatefulWidget(parent.declaredElement)) {
       return;
     }
-    final body = node.body;
+    var body = node.body;
     Expression? expressionToTest;
     if (body is BlockFunctionBody) {
-      final statements = body.block.statements;
+      var statements = body.block.statements;
       if (statements.length == 1) {
-        final statement = statements[0];
+        var statement = statements[0];
         if (statement is ReturnStatement) {
           expressionToTest = statement.expression;
         }

--- a/lib/src/rules/no_runtimeType_toString.dart
+++ b/lib/src/rules/no_runtimeType_toString.dart
@@ -52,7 +52,7 @@ class NoRuntimeTypeToString extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInterpolationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
@@ -103,7 +103,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         if (n is ExtensionDeclaration) {
           var declaredElement = n.declaredElement;
           if (declaredElement != null) {
-            final extendedElement = declaredElement.extendedType.element;
+            var extendedElement = declaredElement.extendedType.element;
             return !(extendedElement is ClassElement &&
                 !extendedElement.isAbstract);
           }

--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -42,7 +42,7 @@ class NonConstantIdentifierNames extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
     registry.addFormalParameterList(this, visitor);
     registry.addFunctionDeclaration(this, visitor);

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -62,7 +62,7 @@ class NullCheckOnNullableTypeParameter extends LintRule
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
     registry.addPostfixExpression(this, visitor);
   }
@@ -78,8 +78,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitPostfixExpression(PostfixExpression node) {
     if (node.operator.type != TokenType.BANG) return;
 
-    final expectedType = getExpectedType(node);
-    final type = node.operand.staticType;
+    var expectedType = getExpectedType(node);
+    var type = node.operand.staticType;
     if (type is TypeParameterType &&
         context.typeSystem.isNullable(type) &&
         expectedType != null &&

--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -217,7 +217,7 @@ class NullClosures extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
@@ -245,9 +245,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    final target = node.target;
-    final methodName = node.methodName.name;
-    final element = target is Identifier ? target.staticElement : null;
+    var target = node.target;
+    var methodName = node.methodName.name;
+    var element = target is Identifier ? target.staticElement : null;
     if (element is ClassElement) {
       // Static function called, "target" is the class.
       for (var function in _staticFunctionsWithNonNullableArguments) {
@@ -260,7 +260,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
     } else {
       // Instance method called, "target" is the instance.
-      final targetType = target?.staticType;
+      var targetType = target?.staticType;
       var method = _getInstanceMethod(targetType, methodName);
       if (method == null) {
         return;
@@ -272,9 +272,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _checkNullArgForClosure(
       ArgumentList node, List<int> positions, List<String> names) {
-    final args = node.arguments;
+    var args = node.arguments;
     for (var i = 0; i < args.length; i++) {
-      final arg = args[i];
+      var arg = args[i];
 
       if (arg is NamedExpression) {
         if (arg.expression is NullLiteral &&
@@ -308,7 +308,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return method;
     }
 
-    final element = type.element;
+    var element = type.element;
     if (element.isSynthetic) {
       return null;
     }

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -58,7 +58,7 @@ class OmitLocalVariableTypes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addForStatement(this, visitor);
     registry.addVariableDeclarationStatement(this, visitor);
   }
@@ -71,18 +71,18 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitForStatement(ForStatement node) {
-    final loopParts = node.forLoopParts;
+    var loopParts = node.forLoopParts;
     if (loopParts is ForPartsWithDeclarations) {
       _visitVariableDeclarationList(loopParts.variables);
     } else if (loopParts is ForEachPartsWithDeclaration) {
-      final loopVariableType = loopParts.loopVariable.type;
-      final staticType = loopVariableType?.type;
+      var loopVariableType = loopParts.loopVariable.type;
+      var staticType = loopVariableType?.type;
       if (staticType == null || staticType.isDynamic) {
         return;
       }
-      final iterableType = loopParts.iterable.staticType;
+      var iterableType = loopParts.iterable.staticType;
       if (iterableType is InterfaceType) {
-        final iterableInterfaces = DartTypeUtilities.getImplementedInterfaces(
+        var iterableInterfaces = DartTypeUtilities.getImplementedInterfaces(
                 iterableType)
             .where((type) =>
                 DartTypeUtilities.isInterface(type, 'Iterable', 'dart.core'));
@@ -100,11 +100,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _visitVariableDeclarationList(VariableDeclarationList node) {
-    final staticType = node.type?.type;
+    var staticType = node.type?.type;
     if (staticType == null || staticType.isDynamic) {
       return;
     }
-    for (final child in node.variables) {
+    for (var child in node.variables) {
       if (child.initializer?.staticType != staticType) {
         return;
       }

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -47,7 +47,7 @@ class OneMemberAbstracts extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -66,7 +66,7 @@ class OnlyThrowErrors extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addThrowExpression(this, visitor);
   }
 }

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -76,8 +76,8 @@ Iterable<InterfaceType> _findAllSupertypesAndMixins(
   }
 
   accumulator.add(interface);
-  final superclass = interface.superclass;
-  final interfaces = <InterfaceType>[];
+  var superclass = interface.superclass;
+  var interfaces = <InterfaceType>[];
   if (superclass != null) {
     interfaces.add(superclass);
   }
@@ -88,8 +88,8 @@ Iterable<InterfaceType> _findAllSupertypesAndMixins(
 }
 
 Iterable<InterfaceType> _findAllSupertypesInMixin(ClassElement classElement) {
-  final supertypes = <InterfaceType>[];
-  final accumulator = <InterfaceType>[];
+  var supertypes = <InterfaceType>[];
+  var accumulator = <InterfaceType>[];
   for (var type in classElement.superclassConstraints) {
     supertypes.add(type);
     supertypes.addAll(_findAllSupertypesAndMixins(type, accumulator));
@@ -108,7 +108,7 @@ class OverriddenFields extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
   }
 }
@@ -127,7 +127,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     node.fields.variables.forEach((VariableDeclaration variable) {
       var declaredElement = variable.declaredElement;
       if (declaredElement != null) {
-        final field = _getOverriddenMember(declaredElement);
+        var field = _getOverriddenMember(declaredElement);
         if (field != null && !field.isAbstract) {
           rule.reportLint(variable.name);
         }
@@ -136,8 +136,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   PropertyAccessorElement? _getOverriddenMember(Element member) {
-    final memberName = member.name;
-    final library = member.library;
+    var memberName = member.name;
+    var library = member.library;
     bool isOverriddenMember(PropertyAccessorElement a) {
       if (memberName != null && a.isSynthetic && a.name == memberName) {
         // Ensure that private members are overriding a member of the same library.
@@ -151,11 +151,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     bool containsOverriddenMember(InterfaceType i) =>
         i.accessors.any(isOverriddenMember);
-    final enclosingElement = member.enclosingElement;
+    var enclosingElement = member.enclosingElement;
     if (enclosingElement is! ClassElement) {
       return null;
     }
-    final classElement = enclosingElement;
+    var classElement = enclosingElement;
 
     Iterable<InterfaceType> interfaces;
     if (classElement.isMixin) {
@@ -164,7 +164,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       interfaces =
           _findAllSupertypesAndMixins(classElement.thisType, <InterfaceType>[]);
     }
-    final interface = interfaces.firstWhereOrNull(containsOverriddenMember);
+    var interface = interfaces.firstWhereOrNull(containsOverriddenMember);
     return interface?.accessors.firstWhere(isOverriddenMember);
   }
 }

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -68,7 +68,7 @@ class PackagePrefixedLibraryNames extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addLibraryDirective(this, visitor);
   }
 
@@ -87,23 +87,23 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitLibraryDirective(LibraryDirective node) {
     // If no project info is set, bail early.
     // https://github.com/dart-lang/linter/issues/154
-    final project = rule.project;
-    final element = node.element;
+    var project = rule.project;
+    var element = node.element;
     if (project == null || element == null) {
       return;
     }
 
-    final source = element.source;
+    var source = element.source;
     if (source == null) {
       return;
     }
 
-    final prefix = Analyzer.facade.createLibraryNamePrefix(
+    var prefix = Analyzer.facade.createLibraryNamePrefix(
         libraryPath: source.fullName,
         projectRoot: project.root.absolute.path,
         packageName: project.name);
 
-    final name = element.name;
+    var name = element.name;
     if (name == null || !matchesOrIsPrefixedBy(name, prefix)) {
       rule.reportLint(node.name);
     }

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -119,7 +119,7 @@ class ParameterAssignments extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);
   }
@@ -132,7 +132,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
-    final parameters = node.functionExpression.parameters;
+    var parameters = node.functionExpression.parameters;
     if (parameters != null) {
       // Getter do not have formal parameters.
       parameters.parameters.forEach((e) {
@@ -148,7 +148,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    final parameterList = node.parameters;
+    var parameterList = node.parameters;
     if (parameterList != null) {
       // Getters don't have parameters.
       parameterList.parameters.forEach((e) {
@@ -163,12 +163,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _reportIfSimpleParameterOrWithDefaultValue(
       FormalParameter parameter, AstNode functionOrMethodDeclaration) {
-    final nodes =
+    var nodes =
         DartTypeUtilities.traverseNodesInDFS(functionOrMethodDeclaration);
 
     if (parameter is SimpleFormalParameter ||
         _isDefaultFormalParameterWithDefaultValue(parameter)) {
-      final mutatedNodes = nodes.where((n) =>
+      var mutatedNodes = nodes.where((n) =>
           (n is AssignmentExpression &&
               _isFormalParameterReassigned(parameter, n)) ||
           _preOrPostFixExpressionMutation(parameter, n));
@@ -176,20 +176,20 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final assignmentsNodes = nodes
+    var assignmentsNodes = nodes
         .where((n) =>
             n is AssignmentExpression &&
             _isDefaultFormalParameterWithoutDefaultValueReassigned(
                 parameter, n))
         .toList();
 
-    final nonNullCoalescingAssignments = assignmentsNodes.where((n) =>
+    var nonNullCoalescingAssignments = assignmentsNodes.where((n) =>
         (n as AssignmentExpression).operator.type !=
         TokenType.QUESTION_QUESTION_EQ);
 
     if (assignmentsNodes.length > 1 ||
         nonNullCoalescingAssignments.isNotEmpty) {
-      final node = assignmentsNodes.length > 1
+      var node = assignmentsNodes.length > 1
           ? assignmentsNodes.last
           : nonNullCoalescingAssignments.isNotEmpty
               ? nonNullCoalescingAssignments.first

--- a/lib/src/rules/prefer_adjacent_string_concatenation.dart
+++ b/lib/src/rules/prefer_adjacent_string_concatenation.dart
@@ -41,7 +41,7 @@ class PreferAdjacentStringConcatenation extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -44,7 +44,7 @@ class PreferAssertsInInitializerLists extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addConstructorDeclaration(this, visitor);
   }
@@ -60,7 +60,7 @@ class _AssertVisitor extends RecursiveAstVisitor {
 
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
-    final element = getWriteOrReadElement(node);
+    var element = getWriteOrReadElement(node);
 
     // use method
     needInstance = needInstance ||
@@ -133,12 +133,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     var declaredElement = node.declaredElement;
     if (declaredElement == null || declaredElement.isFactory) return;
 
-    final body = node.body;
+    var body = node.body;
     if (body is BlockFunctionBody) {
-      for (final statement in body.block.statements) {
+      for (var statement in body.block.statements) {
         if (statement is! AssertStatement) break;
 
-        final assertVisitor =
+        var assertVisitor =
             _AssertVisitor(declaredElement, _classAndSuperClasses);
         statement.visitChildren(assertVisitor);
         if (!assertVisitor.needInstance) {

--- a/lib/src/rules/prefer_asserts_with_message.dart
+++ b/lib/src/rules/prefer_asserts_with_message.dart
@@ -49,7 +49,7 @@ class PreferAssertsWithMessage extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addAssertInitializer(this, visitor);
     registry.addAssertStatement(this, visitor);
   }

--- a/lib/src/rules/prefer_bool_in_asserts.dart
+++ b/lib/src/rules/prefer_bool_in_asserts.dart
@@ -52,7 +52,7 @@ class PreferBoolInAsserts extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addAssertStatement(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -68,7 +68,7 @@ class PreferCollectionLiterals extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
@@ -91,7 +91,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    final constructorName = node.constructorName.name?.name;
+    var constructorName = node.constructorName.name?.name;
 
     // Lists, Maps.
     if (_isList(node) || _isMap(node) || _isHashMap(node)) {
@@ -161,7 +161,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       // Skip: function(LinkedHashSet()); when function(LinkedHashSet mySet) or
       // function(LinkedHashMap()); when function(LinkedHashMap myMap)
       if (parent is ArgumentList) {
-        final paramType = node.staticParameterElement?.type;
+        var paramType = node.staticParameterElement?.type;
         if (paramType == null || typeCheck(paramType)) {
           return true;
         }

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -53,7 +53,7 @@ bool _checkStatement(Statement statement, Expression condition) {
 }
 
 Expression? _getExpressionCondition(Expression rawExpression) {
-  final expression = rawExpression.unParenthesized;
+  var expression = rawExpression.unParenthesized;
   if (expression is BinaryExpression &&
       expression.operator.type == TokenType.EQ_EQ) {
     if (DartTypeUtilities.isNullLiteral(expression.rightOperand)) {
@@ -77,7 +77,7 @@ class PreferConditionalAssignment extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addIfStatement(this, visitor);
   }
 }
@@ -92,7 +92,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.elseStatement != null) {
       return;
     }
-    final expressionInCondition = _getExpressionCondition(node.condition);
+    var expressionInCondition = _getExpressionCondition(node.condition);
     if (expressionInCondition != null &&
         _checkStatement(node.thenStatement, expressionInCondition)) {
       rule.reportLint(node);

--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -62,7 +62,7 @@ class PreferConstConstructors extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -61,7 +61,7 @@ class PreferConstConstructorsInImmutables extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addConstructorDeclaration(this, visitor);
   }
 }
@@ -75,11 +75,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
-    final element = node.declaredElement;
+    var element = node.declaredElement;
     if (element == null) {
       return;
     }
-    final isRedirected =
+    var isRedirected =
         element.isFactory && element.redirectedConstructor != null;
     if (node.body is EmptyFunctionBody &&
         !element.isConst &&
@@ -98,16 +98,16 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (declaredElement == null) {
       return false;
     }
-    final clazz = declaredElement.enclosingElement;
+    var clazz = declaredElement.enclosingElement;
     // construct with super
-    final superInvocation = node.initializers
+    var superInvocation = node.initializers
             .firstWhereOrNull((e) => e is SuperConstructorInvocation)
         as SuperConstructorInvocation?;
     if (superInvocation != null) {
       return superInvocation.staticElement?.isConst == true;
     }
     // construct with this
-    final redirectInvocation = node.initializers
+    var redirectInvocation = node.initializers
             .firstWhereOrNull((e) => e is RedirectingConstructorInvocation)
         as RedirectingConstructorInvocation?;
     if (redirectInvocation != null) {
@@ -120,8 +120,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
-    final selfAndInheritedClasses = _getSelfAndInheritedClasses(clazz);
-    final selfAndInheritedAnnotations =
+    var selfAndInheritedClasses = _getSelfAndInheritedClasses(clazz);
+    var selfAndInheritedAnnotations =
         selfAndInheritedClasses.expand((c) => c.metadata).map((m) => m.element);
     return selfAndInheritedAnnotations.any(_isImmutable);
   }
@@ -131,7 +131,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   static Iterable<ClassElement> _getSelfAndInheritedClasses(
       ClassElement self) sync* {
     ClassElement? current = self;
-    final seenElements = <ClassElement>{};
+    var seenElements = <ClassElement>{};
     while (current != null && seenElements.add(current)) {
       yield current;
       current = current.supertype?.element;

--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -49,7 +49,7 @@ class PreferConstDeclarations extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addFieldDeclaration(this, visitor);
     registry.addTopLevelVariableDeclaration(this, visitor);
     registry.addVariableDeclarationStatement(this, visitor);

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -60,7 +60,7 @@ class PreferConstLiteralsToCreateImmutables extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addListLiteral(this, visitor);
     registry.addSetOrMapLiteral(this, visitor);
   }
@@ -97,8 +97,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       // that cannot be resolved.
       return false;
     }
-    final inheritedAndSelfTypes = _getSelfAndInheritedTypes(type);
-    final inheritedAndSelfAnnotations = inheritedAndSelfTypes
+    var inheritedAndSelfTypes = _getSelfAndInheritedTypes(type);
+    var inheritedAndSelfAnnotations = inheritedAndSelfTypes
         .map((type) => type.element)
         .expand((c) => c.metadata)
         .map((m) => m.element);

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -63,7 +63,7 @@ class PreferConstructorsInsteadOfStaticMethods extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -76,8 +76,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    final returnType = node.returnType?.type;
-    final parent = node.parent;
+    var returnType = node.returnType?.type;
+    var parent = node.parent;
     if (node.isStatic &&
         parent is ClassOrMixinDeclaration &&
         returnType is InterfaceType &&

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -50,7 +50,7 @@ class PreferContainsOverIndexOf extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addSimpleIdentifier(this, visitor);
   }
 
@@ -81,7 +81,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
     // Should be "indexOf".
-    final propertyElement = node.staticElement;
+    var propertyElement = node.staticElement;
     if (propertyElement?.name != 'indexOf') {
       return;
     }
@@ -89,7 +89,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     MethodInvocation indexOfAccess;
     InterfaceType type;
 
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is MethodInvocation && node == parent.methodName) {
       indexOfAccess = parent;
       var parentType = parent.target?.staticType;
@@ -128,13 +128,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final binaryExpression = search;
-    final operator = binaryExpression.operator;
+    var binaryExpression = search;
+    var operator = binaryExpression.operator;
 
     // Comparing constants with result of indexOf.
 
-    final rightOperand = binaryExpression.rightOperand;
-    final rightValue = context.evaluateConstant(rightOperand).value;
+    var rightOperand = binaryExpression.rightOperand;
+    var rightValue = context.evaluateConstant(rightOperand).value;
 
     if (rightValue != null && rightValue.type?.isDartCoreInt == true) {
       // Constant is on right side of comparison operator
@@ -142,8 +142,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final leftOperand = binaryExpression.leftOperand;
-    final leftValue = context.evaluateConstant(leftOperand).value;
+    var leftOperand = binaryExpression.leftOperand;
+    var leftValue = context.evaluateConstant(leftOperand).value;
     if (leftValue != null && leftValue.type?.isDartCoreInt == true) {
       // Constants is on left side of comparison operator
       _checkConstant(binaryExpression, leftValue.toIntValue(),

--- a/lib/src/rules/prefer_double_quotes.dart
+++ b/lib/src/rules/prefer_double_quotes.dart
@@ -56,7 +56,7 @@ class PreferDoubleQuotes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = QuoteVisitor(this, useSingle: false);
+    var visitor = QuoteVisitor(this, useSingle: false);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);
   }

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -39,7 +39,7 @@ class PreferEqualForDefaultValues extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addDefaultFormalParameter(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_expression_function_bodies.dart
+++ b/lib/src/rules/prefer_expression_function_bodies.dart
@@ -63,7 +63,7 @@ class PreferExpressionFunctionBodies extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBlockFunctionBody(this, visitor);
   }
 }
@@ -75,11 +75,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitBlockFunctionBody(BlockFunctionBody node) {
-    final statements = node.block.statements;
+    var statements = node.block.statements;
     if (statements.length != 1) {
       return;
     }
-    final uniqueStatement = node.block.statements.single;
+    var uniqueStatement = node.block.statements.single;
     if (uniqueStatement is! ReturnStatement) {
       return;
     }

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -85,7 +85,7 @@ class NotAssignedInAllConstructors {
 ''';
 
 bool _containedInFormal(Element element, FormalParameter formal) {
-  final formalField = formal.identifier?.staticElement;
+  var formalField = formal.identifier?.staticElement;
   return formalField is FieldFormalParameterElement &&
       formalField.field == element;
 }
@@ -108,7 +108,7 @@ class PreferFinalFields extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addCompilationUnit(this, visitor);
     registry.addFieldDeclaration(this, visitor);
   }
@@ -133,7 +133,7 @@ class _MutatedFieldsCollector extends RecursiveAstVisitor<void> {
 
   @override
   void visitPrefixExpression(PrefixExpression node) {
-    final operator = node.operator;
+    var operator = node.operator;
     if (operator.type == TokenType.MINUS_MINUS ||
         operator.type == TokenType.PLUS_PLUS) {
       _addMutatedFieldElement(node);
@@ -142,7 +142,7 @@ class _MutatedFieldsCollector extends RecursiveAstVisitor<void> {
   }
 
   void _addMutatedFieldElement(CompoundAssignmentExpression assignment) {
-    final element =
+    var element =
         DartTypeUtilities.getCanonicalElement(assignment.writeElement);
     if (element is FieldElement) {
       _mutatedFields.add(element);
@@ -164,13 +164,13 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
-    final fields = node.fields;
+    var fields = node.fields;
     if (fields.isFinal || fields.isConst) {
       return;
     }
 
     for (var variable in fields.variables) {
-      final element = variable.declaredElement;
+      var element = variable.declaredElement;
 
       if (element is PropertyInducingElement &&
           element.isPrivate &&
@@ -181,12 +181,12 @@ class _Visitor extends SimpleAstVisitor<void> {
             constructor.parameters.parameters.any((FormalParameter formal) =>
                 _containedInFormal(element, formal));
 
-        final classDeclaration = node.parent;
-        final constructors = classDeclaration is ClassDeclaration
+        var classDeclaration = node.parent;
+        var constructors = classDeclaration is ClassDeclaration
             ? classDeclaration.members.whereType<ConstructorDeclaration>()
             : <ConstructorDeclaration>[];
-        final isFieldInConstructors = constructors.any(fieldInConstructor);
-        final isFieldInAllConstructors = constructors.every(fieldInConstructor);
+        var isFieldInConstructors = constructors.any(fieldInConstructor);
+        var isFieldInAllConstructors = constructors.every(fieldInConstructor);
 
         if (isFieldInConstructors) {
           if (isFieldInAllConstructors) {

--- a/lib/src/rules/prefer_final_in_for_each.dart
+++ b/lib/src/rules/prefer_final_in_for_each.dart
@@ -54,7 +54,7 @@ class PreferFinalInForEach extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addForStatement(this, visitor);
   }
 }
@@ -72,13 +72,13 @@ class _Visitor extends SimpleAstVisitor<void> {
     // second case, notice `a` is not actually declared from within the
     // loop. `a` is a variable declared outside the loop.
     if (forLoopParts is ForEachPartsWithDeclaration) {
-      final loopVariable = forLoopParts.loopVariable;
+      var loopVariable = forLoopParts.loopVariable;
 
       if (loopVariable.isFinal) {
         return;
       }
 
-      final function = node.thisOrAncestorOfType<FunctionBody>();
+      var function = node.thisOrAncestorOfType<FunctionBody>();
       var loopVariableElement = loopVariable.declaredElement;
       if (function != null &&
           loopVariableElement != null &&

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -60,7 +60,7 @@ class PreferFinalLocals extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addVariableDeclaration(this, visitor);
   }
 }
@@ -79,7 +79,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final function = node.thisOrAncestorOfType<FunctionBody>();
+    var function = node.thisOrAncestorOfType<FunctionBody>();
     var declaredElement = node.declaredElement;
     if (function != null &&
         declaredElement != null &&

--- a/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
+++ b/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
@@ -44,7 +44,7 @@ class PreferForElementsToMapFromIterable extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }
@@ -57,7 +57,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression creation) {
-    final element = creation.constructorName.staticElement;
+    var element = creation.constructorName.staticElement;
     if (element == null ||
         element.name != 'fromIterable' ||
         element.enclosingElement != context.typeProvider.mapElement) {
@@ -67,22 +67,22 @@ class _Visitor extends SimpleAstVisitor<void> {
     //
     // Ensure that the arguments have the right form.
     //
-    final arguments = creation.argumentList.arguments;
+    var arguments = creation.argumentList.arguments;
     if (arguments.length != 3) {
       return;
     }
 
-    final secondArg = arguments[1];
-    final thirdArg = arguments[2];
+    var secondArg = arguments[1];
+    var thirdArg = arguments[2];
 
     Expression? extractBody(FunctionExpression expression) {
-      final body = expression.body;
+      var body = expression.body;
       if (body is ExpressionFunctionBody) {
         return body.expression;
       } else if (body is BlockFunctionBody) {
-        final statements = body.block.statements;
+        var statements = body.block.statements;
         if (statements.length == 1) {
-          final statement = statements[0];
+          var statement = statements[0];
           if (statement is ReturnStatement) {
             return statement.expression;
           }
@@ -93,9 +93,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     FunctionExpression? extractClosure(String name, Expression argument) {
       if (argument is NamedExpression && argument.name.label.name == name) {
-        final expression = argument.expression.unParenthesized;
+        var expression = argument.expression.unParenthesized;
         if (expression is FunctionExpression) {
-          final parameters = expression.parameters?.parameters;
+          var parameters = expression.parameters?.parameters;
           if (parameters != null &&
               parameters.length == 1 &&
               parameters[0].isRequired) {
@@ -108,9 +108,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       return null;
     }
 
-    final keyClosure =
+    var keyClosure =
         extractClosure('key', secondArg) ?? extractClosure('key', thirdArg);
-    final valueClosure =
+    var valueClosure =
         extractClosure('value', thirdArg) ?? extractClosure('value', secondArg);
     if (keyClosure == null || valueClosure == null) {
       return;

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -55,7 +55,7 @@ class PreferForeach extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addForStatement(this, visitor);
   }
 }
@@ -81,9 +81,9 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
 
   @override
   void visitForStatement(ForStatement node) {
-    final loopParts = node.forLoopParts;
+    var loopParts = node.forLoopParts;
     if (loopParts is ForEachPartsWithDeclaration) {
-      final element = loopParts.loopVariable.declaredElement;
+      var element = loopParts.loopVariable.declaredElement;
       if (element != null) {
         forEachStatement = node;
         this.element = element;
@@ -94,7 +94,7 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
 
   @override
   void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
-    final arguments = node.argumentList.arguments;
+    var arguments = node.argumentList.arguments;
     if (arguments.length == 1 &&
         DartTypeUtilities.getCanonicalElementFromIdentifier(arguments.first) ==
             element) {
@@ -104,7 +104,7 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    final arguments = node.argumentList.arguments;
+    var arguments = node.argumentList.arguments;
     var target = node.target;
     if (arguments.length == 1 &&
         DartTypeUtilities.getCanonicalElementFromIdentifier(arguments.first) ==
@@ -131,9 +131,9 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitForStatement(ForStatement node) {
-    final loopParts = node.forLoopParts;
+    var loopParts = node.forLoopParts;
     if (loopParts is ForEachParts) {
-      final visitor = _PreferForEachVisitor(rule);
+      var visitor = _PreferForEachVisitor(rule);
       node.accept(visitor);
     }
   }

--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -48,7 +48,7 @@ class PreferFunctionDeclarationsOverVariables extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addVariableDeclaration(this, visitor);
   }
 }
@@ -61,7 +61,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitVariableDeclaration(VariableDeclaration node) {
     if (node.initializer is FunctionExpression) {
-      final function = node.thisOrAncestorOfType<FunctionBody>();
+      var function = node.thisOrAncestorOfType<FunctionBody>();
       var declaredElement = node.declaredElement;
       if (function == null ||
           (declaredElement != null &&

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -45,7 +45,7 @@ class PreferGenericFunctionTypeAliases extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionTypeAlias(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_if_elements_to_conditional_expressions.dart
+++ b/lib/src/rules/prefer_if_elements_to_conditional_expressions.dart
@@ -51,7 +51,7 @@ class PreferIfElementsToConditionalExpressions extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConditionalExpression(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_if_null_operators.dart
+++ b/lib/src/rules/prefer_if_null_operators.dart
@@ -38,7 +38,7 @@ class PreferIfNullOperators extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConditionalExpression(this, visitor);
   }
 }
@@ -50,7 +50,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitConditionalExpression(ConditionalExpression node) {
-    final condition = node.condition;
+    var condition = node.condition;
     if (condition is BinaryExpression &&
         (condition.operator.type == TokenType.EQ_EQ ||
             condition.operator.type == TokenType.BANG_EQ)) {
@@ -64,7 +64,7 @@ class _Visitor extends SimpleAstVisitor {
         return;
       }
 
-      final exp = condition.operator.type == TokenType.EQ_EQ
+      var exp = condition.operator.type == TokenType.EQ_EQ
           ? node.elseExpression
           : node.thenExpression;
       if (exp.toString() == expression.toString()) {

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -75,8 +75,8 @@ class Point {
 
 Iterable<AssignmentExpression> _getAssignmentExpressionsInConstructorBody(
     ConstructorDeclaration node) {
-  final body = node.body;
-  final statements =
+  var body = node.body;
+  var statements =
       (body is BlockFunctionBody) ? body.block.statements : <Statement>[];
   return statements
       .whereType<ExpressionStatement>()
@@ -110,7 +110,7 @@ class PreferInitializingFormals extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }
 }
@@ -122,13 +122,13 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
-    final parameters = _getParameters(node);
-    final parametersUsedOnce = <Element?>{};
-    final parametersUsedMoreThanOnce = <Element?>{};
+    var parameters = _getParameters(node);
+    var parametersUsedOnce = <Element?>{};
+    var parametersUsedMoreThanOnce = <Element?>{};
 
     bool isAssignmentExpressionToLint(AssignmentExpression assignment) {
-      final leftElement = _getLeftElement(assignment);
-      final rightElement = _getRightElement(assignment);
+      var leftElement = _getLeftElement(assignment);
+      var rightElement = _getRightElement(assignment);
       return leftElement != null &&
           rightElement != null &&
           !leftElement.isPrivate &&
@@ -144,7 +144,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     bool isConstructorFieldInitializerToLint(
         ConstructorFieldInitializer constructorFieldInitializer) {
-      final expression = constructorFieldInitializer.expression;
+      var expression = constructorFieldInitializer.expression;
       if (expression is SimpleIdentifier) {
         var staticElement = expression.staticElement;
         return staticElement is ParameterElement &&

--- a/lib/src/rules/prefer_inlined_adds.dart
+++ b/lib/src/rules/prefer_inlined_adds.dart
@@ -38,7 +38,7 @@ class PreferInlinedAdds extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -50,16 +50,16 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitMethodInvocation(MethodInvocation invocation) {
-    final addAll = invocation.methodName.name == 'addAll';
+    var addAll = invocation.methodName.name == 'addAll';
     if ((invocation.methodName.name != 'add' && !addAll) ||
         !invocation.isCascaded ||
         invocation.argumentList.arguments.length != 1) {
       return;
     }
 
-    final cascade = invocation.thisOrAncestorOfType<CascadeExpression>();
-    final sections = cascade?.cascadeSections;
-    final target = cascade?.target;
+    var cascade = invocation.thisOrAncestorOfType<CascadeExpression>();
+    var sections = cascade?.cascadeSections;
+    var target = cascade?.target;
     if (target is! ListLiteral ||
         (sections != null && sections[0] != invocation)) {
       // todo (pq): consider extending to handle set literals.

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -57,7 +57,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   /// Determine if the given literal can be replaced by an int literal.
   bool canReplaceWithIntLiteral(DoubleLiteral literal) {
     // TODO(danrubel): Consider moving this into analyzer
-    final parent = literal.parent;
+    var parent = literal.parent;
     if (parent is PrefixExpression) {
       if (parent.operator.lexeme == '-') {
         return hasTypeDouble(parent);
@@ -70,7 +70,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   bool hasReturnTypeDouble(AstNode? node) {
     if (node is FunctionExpression) {
-      final functionDeclaration = node.parent;
+      var functionDeclaration = node.parent;
       if (functionDeclaration is FunctionDeclaration) {
         return _isDartCoreDoubleTypeAnnotation(functionDeclaration.returnType);
       }
@@ -81,25 +81,25 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool hasTypeDouble(Expression expression) {
-    final parent = expression.parent;
+    var parent = expression.parent;
     if (parent is ArgumentList) {
       return _isDartCoreDouble(expression.staticParameterElement?.type);
     } else if (parent is ListLiteral) {
-      final typeArguments = parent.typeArguments?.arguments;
+      var typeArguments = parent.typeArguments?.arguments;
       return typeArguments?.length == 1 &&
           _isDartCoreDoubleTypeAnnotation(typeArguments![0]);
     } else if (parent is NamedExpression) {
-      final argList = parent.parent;
+      var argList = parent.parent;
       if (argList is ArgumentList) {
         return _isDartCoreDouble(parent.staticParameterElement?.type);
       }
     } else if (parent is ExpressionFunctionBody) {
       return hasReturnTypeDouble(parent.parent);
     } else if (parent is ReturnStatement) {
-      final body = parent.thisOrAncestorOfType<BlockFunctionBody>();
+      var body = parent.thisOrAncestorOfType<BlockFunctionBody>();
       return body != null && hasReturnTypeDouble(body.parent);
     } else if (parent is VariableDeclaration) {
-      final varList = parent.parent;
+      var varList = parent.parent;
       if (varList is VariableDeclarationList) {
         return _isDartCoreDoubleTypeAnnotation(varList.type);
       }
@@ -111,7 +111,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitDoubleLiteral(DoubleLiteral node) {
     // Check if the double can be represented as an int
     try {
-      final value = node.value;
+      var value = node.value;
       if (value != value.truncate()) {
         return;
       }

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -42,7 +42,7 @@ class PreferInterpolationToComposeStrings extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -55,7 +55,7 @@ class PreferIsEmpty extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addSimpleIdentifier(this, visitor);
   }
 
@@ -85,7 +85,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitSimpleIdentifier(SimpleIdentifier identifier) {
     // Should be "length".
-    final propertyElement = identifier.staticElement;
+    var propertyElement = identifier.staticElement;
     if (propertyElement?.name != 'length') {
       return;
     }
@@ -93,7 +93,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     AstNode? lengthAccess;
     InterfaceType? type;
 
-    final parent = identifier.parent;
+    var parent = identifier.parent;
     if (parent is PropertyAccess && identifier == parent.propertyName) {
       lengthAccess = parent;
       var parentType = parent.target?.staticType;
@@ -129,13 +129,13 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (search is! BinaryExpression) {
       return;
     }
-    final binaryExpression = search;
+    var binaryExpression = search;
 
     // Don't lint if we're in a const constructor initializer.
-    final constructorInitializer =
+    var constructorInitializer =
         search.thisOrAncestorOfType<ConstructorInitializer>();
     if (constructorInitializer != null) {
-      final constructorDecl = constructorInitializer.parent;
+      var constructorDecl = constructorInitializer.parent;
       if (constructorDecl is! ConstructorDeclaration ||
           constructorDecl.constKeyword != null) {
         return;
@@ -144,12 +144,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Or in a const context.
     // See: https://github.com/dart-lang/linter/issues/1719
-    final impl = binaryExpression as ExpressionImpl;
+    var impl = binaryExpression as ExpressionImpl;
     if (impl.inConstantContext) {
       return;
     }
 
-    final operator = binaryExpression.operator;
+    var operator = binaryExpression.operator;
 
     // Comparing constants with length.
     var value = _getIntValue(binaryExpression.rightOperand);

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -52,7 +52,7 @@ class PreferIsNotEmpty extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleIdentifier(this, visitor);
   }
 }
@@ -67,7 +67,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     late AstNode isEmptyAccess;
     SimpleIdentifier? isEmptyIdentifier;
 
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is PropertyAccess) {
       isEmptyIdentifier = parent.propertyName;
       isEmptyAccess = parent;
@@ -81,12 +81,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // Should be "isEmpty".
-    final propertyElement = isEmptyIdentifier.staticElement;
+    var propertyElement = isEmptyIdentifier.staticElement;
     if (propertyElement == null || 'isEmpty' != propertyElement.name) {
       return;
     }
     // Should have "isNotEmpty".
-    final propertyTarget = propertyElement.enclosingElement;
+    var propertyTarget = propertyElement.enclosingElement;
     if (propertyTarget == null ||
         getChildren(propertyTarget, 'isNotEmpty').isEmpty) {
       return;

--- a/lib/src/rules/prefer_is_not_operator.dart
+++ b/lib/src/rules/prefer_is_not_operator.dart
@@ -40,7 +40,7 @@ class PreferIsNotOperator extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addIsExpression(this, visitor);
   }
 }
@@ -60,7 +60,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     var parent = node.parent;
     // Check whether is expression is inside parenthesis
     if (parent is ParenthesizedExpression) {
-      final prefixExpression = parent.parent;
+      var prefixExpression = parent.parent;
       // Check for NOT (!) operator
       if (prefixExpression is PrefixExpression &&
           prefixExpression.operator.type == TokenType.BANG) {

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -38,7 +38,7 @@ class PreferIterableWhereType extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -51,26 +51,26 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodInvocation(MethodInvocation node) {
     if (node.methodName.name != 'where') return;
-    final target = node.realTarget;
+    var target = node.realTarget;
     if (target == null ||
         !DartTypeUtilities.implementsInterface(
             target.staticType, 'Iterable', 'dart.core')) {
       return;
     }
 
-    final args = node.argumentList.arguments;
+    var args = node.argumentList.arguments;
     if (args.length != 1) return;
 
-    final arg = args.first;
+    var arg = args.first;
     if (arg is FunctionExpression) {
       if (arg.parameters?.parameters.length != 1) return;
 
-      final body = arg.body;
+      var body = arg.body;
       Expression? expression;
       if (body is BlockFunctionBody) {
-        final statements = body.block.statements;
+        var statements = body.block.statements;
         if (statements.length != 1) return;
-        final statement = body.block.statements.first;
+        var statement = body.block.statements.first;
         if (statement is ReturnStatement) {
           expression = statement.expression;
         }
@@ -79,7 +79,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
       expression = expression?.unParenthesized;
       if (expression is IsExpression && expression.notOperator == null) {
-        final target = expression.expression;
+        var target = expression.expression;
         if (target is SimpleIdentifier &&
             target.name == arg.parameters?.parameters.first.identifier?.name) {
           rule.reportLint(node.methodName);

--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -52,7 +52,7 @@ class PreferMixin extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addWithClause(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_null_aware_operators.dart
+++ b/lib/src/rules/prefer_null_aware_operators.dart
@@ -38,7 +38,7 @@ class PreferNullAwareOperators extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConditionalExpression(this, visitor);
   }
 }
@@ -50,7 +50,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitConditionalExpression(ConditionalExpression node) {
-    final condition = node.condition;
+    var condition = node.condition;
     if (condition is BinaryExpression &&
         (condition.operator.type == TokenType.EQ_EQ ||
             condition.operator.type == TokenType.BANG_EQ)) {

--- a/lib/src/rules/prefer_relative_imports.dart
+++ b/lib/src/rules/prefer_relative_imports.dart
@@ -48,7 +48,7 @@ class PreferRelativeImports extends LintRule implements NodeLintRule {
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addImportDirective(this, visitor);
   }
 }
@@ -61,14 +61,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   bool isPackageSelfReference(ImportDirective node) {
     // Is it a package: import?
-    final importUriContent = node.uriContent;
+    var importUriContent = node.uriContent;
     if (importUriContent?.startsWith('package:') != true) return false;
 
-    final source = node.uriSource;
+    var source = node.uriSource;
     if (source == null) return false;
 
-    final importUri = node.uriSource?.uri;
-    final sourceUri = node.element?.source.uri;
+    var importUri = node.uriSource?.uri;
+    var sourceUri = node.element?.source.uri;
     if (!samePackage(importUri, sourceUri)) return false;
 
     // todo (pq): context.package.contains(source) should work (but does not)

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -57,7 +57,7 @@ class PreferSingleQuotes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = QuoteVisitor(this, useSingle: true);
+    var visitor = QuoteVisitor(this, useSingle: true);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);
   }
@@ -74,7 +74,7 @@ class QuoteVisitor extends SimpleAstVisitor<void> {
 
   /// Strings interpolations can contain other string nodes. Check like this.
   bool containsString(StringInterpolation string) {
-    final checkHasString = _IsOrContainsStringVisitor();
+    var checkHasString = _IsOrContainsStringVisitor();
     return string.elements
         .any((child) => child.accept(checkHasString) ?? false);
   }
@@ -131,7 +131,7 @@ class _ImmediateChildrenVisitor extends UnifyingAstVisitor {
   }
 
   static List<AstNode> childrenOf(AstNode node) {
-    final visitor = _ImmediateChildrenVisitor();
+    var visitor = _ImmediateChildrenVisitor();
     node.visitChildren(visitor);
     return visitor._children;
   }

--- a/lib/src/rules/prefer_spread_collections.dart
+++ b/lib/src/rules/prefer_spread_collections.dart
@@ -80,7 +80,7 @@ class PreferSpreadCollections extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -98,9 +98,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final cascade = invocation.thisOrAncestorOfType<CascadeExpression>();
-    final sections = cascade?.cascadeSections;
-    final target = cascade?.target;
+    var cascade = invocation.thisOrAncestorOfType<CascadeExpression>();
+    var sections = cascade?.cascadeSections;
+    var target = cascade?.target;
     // todo (pq): add support for Set literals.
     if (target is! ListLiteral ||
         (target is ListLiteralImpl && target.inConstantContext) ||
@@ -108,7 +108,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final argument = invocation.argumentList.arguments[0];
+    var argument = invocation.argumentList.arguments[0];
     if (argument is ListLiteral) {
       // Handled by: prefer_inlined_adds
       return;

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -68,7 +68,7 @@ class PreferTypingUninitializedVariables extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addVariableDeclarationList(this, visitor);
   }
 }

--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -56,7 +56,7 @@ class PreferVoidToNull extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleIdentifier(this, visitor);
     registry.addTypeName(this, visitor);
   }
@@ -74,7 +74,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final parent = node.parent;
+    var parent = node.parent;
 
     // Null Function()
     if (parent is GenericFunctionType) {
@@ -90,7 +90,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // <Null>[] or <Null, Null>{}
     if (parent is TypeArgumentList) {
-      final literal = parent.parent;
+      var literal = parent.parent;
       if (literal is ListLiteral && literal.elements.isEmpty) {
         return;
       } else if (literal is SetOrMapLiteral && literal.elements.isEmpty) {

--- a/lib/src/rules/provide_deprecation_message.dart
+++ b/lib/src/rules/provide_deprecation_message.dart
@@ -43,7 +43,7 @@ class ProvideDeprecationMessage extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addAnnotation(this, visitor);
   }
 }

--- a/lib/src/rules/pub/sort_pub_dependencies.dart
+++ b/lib/src/rules/pub/sort_pub_dependencies.dart
@@ -55,13 +55,13 @@ class Visitor extends PubspecVisitor<void> {
       return lc1.compareTo(lc2);
     }
 
-    final depsByLocation = dependencies.toList()
+    var depsByLocation = dependencies.toList()
       ..sort((d1, d2) => compare(d1.name?.span.start, d2.name?.span.start));
     var previousName = '';
-    for (final dep in depsByLocation) {
-      final name = dep.name;
+    for (var dep in depsByLocation) {
+      var name = dep.name;
       if (name != null) {
-        final text = name.text;
+        var text = name.text;
         if (text != null) {
           if (text.compareTo(previousName) < 0) {
             rule.reportPubLint(name);

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -82,7 +82,7 @@ class PublicMemberApiDocs extends LintRule implements NodeLintRule {
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addClassDeclaration(this, visitor);
     registry.addClassTypeAlias(this, visitor);
     registry.addCompilationUnit(this, visitor);
@@ -117,7 +117,7 @@ class _Visitor extends SimpleAstVisitor {
       return null;
     }
 
-    final classElement = member.thisOrAncestorOfType<ClassElement>();
+    var classElement = member.thisOrAncestorOfType<ClassElement>();
     if (classElement == null) {
       return null;
     }
@@ -126,7 +126,7 @@ class _Visitor extends SimpleAstVisitor {
       return null;
     }
 
-    final libraryUri = classElement.library.source.uri;
+    var libraryUri = classElement.library.source.uri;
     return context.inheritanceManager.getInherited(
       classElement.thisType,
       Name(libraryUri, name),
@@ -150,13 +150,13 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitCompilationUnit(CompilationUnit node) {
-    final getters = <String, FunctionDeclaration>{};
-    final setters = <FunctionDeclaration>[];
+    var getters = <String, FunctionDeclaration>{};
+    var setters = <FunctionDeclaration>[];
 
     // Check functions.
 
     // Non-getters/setters.
-    final functions = <FunctionDeclaration>[];
+    var functions = <FunctionDeclaration>[];
 
     // Identify getter/setter pairs.
     for (var member in node.declarations) {
@@ -175,7 +175,7 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     // Check all getters, and collect offenders along the way.
-    final missingDocs = <FunctionDeclaration>{};
+    var missingDocs = <FunctionDeclaration>{};
     for (var getter in getters.values) {
       if (check(getter)) {
         missingDocs.add(getter);
@@ -184,7 +184,7 @@ class _Visitor extends SimpleAstVisitor {
 
     // But only setters whose getter is missing a doc.
     for (var setter in setters) {
-      final getter = getters[setter.name.name];
+      var getter = getters[setter.name.name];
       if (getter != null && missingDocs.contains(getter)) {
         check(setter);
       }
@@ -227,11 +227,11 @@ class _Visitor extends SimpleAstVisitor {
 
     // Check methods
 
-    final getters = <String, MethodDeclaration>{};
-    final setters = <MethodDeclaration>[];
+    var getters = <String, MethodDeclaration>{};
+    var setters = <MethodDeclaration>[];
 
     // Non-getters/setters.
-    final methods = <MethodDeclaration>[];
+    var methods = <MethodDeclaration>[];
 
     // Identify getter/setter pairs.
     for (var member in node.members) {
@@ -247,7 +247,7 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     // Check all getters, and collect offenders along the way.
-    final missingDocs = <MethodDeclaration>{};
+    var missingDocs = <MethodDeclaration>{};
     for (var getter in getters.values) {
       if (check(getter)) {
         missingDocs.add(getter);
@@ -256,7 +256,7 @@ class _Visitor extends SimpleAstVisitor {
 
     // But only setters whose getter is missing a doc.
     for (var setter in setters) {
-      final getter = getters[setter.name.name];
+      var getter = getters[setter.name.name];
       if (getter != null && missingDocs.contains(getter)) {
         check(setter);
       }
@@ -312,11 +312,11 @@ class _Visitor extends SimpleAstVisitor {
 
     // Check methods
 
-    final getters = <String, MethodDeclaration>{};
-    final setters = <MethodDeclaration>[];
+    var getters = <String, MethodDeclaration>{};
+    var setters = <MethodDeclaration>[];
 
     // Non-getters/setters.
-    final methods = <MethodDeclaration>[];
+    var methods = <MethodDeclaration>[];
 
     // Identify getter/setter pairs.
     for (var member in node.members) {
@@ -332,7 +332,7 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     // Check all getters, and collect offenders along the way.
-    final missingDocs = <MethodDeclaration>{};
+    var missingDocs = <MethodDeclaration>{};
     for (var getter in getters.values) {
       if (check(getter)) {
         missingDocs.add(getter);
@@ -346,9 +346,9 @@ class _Visitor extends SimpleAstVisitor {
 
     // But only setters whose getter is missing a doc.
     for (var setter in setters) {
-      final getter = getters[setter.name.name];
+      var getter = getters[setter.name.name];
       if (getter == null) {
-        final libraryUri = declaredElement.library.source.uri;
+        var libraryUri = declaredElement.library.source.uri;
         // Look for an inherited getter.
         Element? getter = context.inheritanceManager.getMember(
           declaredElement.thisType,

--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -48,7 +48,7 @@ class RecursiveGetters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);
   }
@@ -92,7 +92,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final element = node.declaredElement;
+    var element = node.declaredElement;
     _verifyElement(node.functionExpression, element);
   }
 
@@ -103,12 +103,12 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final element = node.declaredElement;
+    var element = node.declaredElement;
     _verifyElement(node.body, element);
   }
 
   void _verifyElement(AstNode node, ExecutableElement? element) {
-    final nodes = DartTypeUtilities.traverseNodesInDFS(node);
+    var nodes = DartTypeUtilities.traverseNodesInDFS(node);
     nodes
         .where((n) =>
             n is SimpleIdentifier &&

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -57,7 +57,7 @@ class SizedBoxForWhitespace extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
 
     registry.addInstanceCreationExpression(this, visitor);
   }
@@ -74,7 +74,7 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    final visitor = _WidthOrHeightArgumentVisitor();
+    var visitor = _WidthOrHeightArgumentVisitor();
     node.visitChildren(visitor);
     if (visitor.seenIncompatibleParams) {
       return;
@@ -94,7 +94,7 @@ class _WidthOrHeightArgumentVisitor extends SimpleAstVisitor<void> {
 
   @override
   void visitArgumentList(ArgumentList node) {
-    for (final name in node.arguments
+    for (var name in node.arguments
         .cast<NamedExpression>()
         .map((arg) => arg.name.label.name)) {
       if (name == 'width') {

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -54,7 +54,7 @@ class SlashForDocComments extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addClassTypeAlias(this, visitor);
     registry.addCompilationUnit(this, visitor);

--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -87,7 +87,7 @@ class SortChildPropertiesLast extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }

--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -44,7 +44,7 @@ class SortConstructorsFirst extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }
@@ -57,7 +57,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitClassDeclaration(ClassDeclaration node) {
     // Sort members by offset.
-    final members = node.members.toList()
+    var members = node.members.toList()
       ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
 
     var other = false;

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -44,7 +44,7 @@ class SortUnnamedConstructorsFirst extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }
@@ -57,7 +57,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitClassDeclaration(ClassDeclaration node) {
     // Sort members by offset.
-    final members = node.members.toList()
+    var members = node.members.toList()
       ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
 
     var seenConstructor = false;

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -64,7 +64,7 @@ class SuperGoesLast extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
   }
 }

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -79,7 +79,7 @@ class TestTypesInEquals extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addAsExpression(this, visitor);
   }
 }
@@ -91,15 +91,15 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitAsExpression(AsExpression node) {
-    final declaration = node.thisOrAncestorOfType<MethodDeclaration>();
+    var declaration = node.thisOrAncestorOfType<MethodDeclaration>();
     if (!_isEqualsOverride(declaration) ||
         node.expression is! SimpleIdentifier) {
       return;
     }
 
-    final identifier = node.expression as SimpleIdentifier;
+    var identifier = node.expression as SimpleIdentifier;
     var parameters = declaration?.parameters;
-    final parameterName = parameters?.parameterElements.first?.name;
+    var parameterName = parameters?.parameterElements.first?.name;
     if (identifier.name == parameterName) {
       rule.reportLint(node);
     }

--- a/lib/src/rules/throw_in_finally.dart
+++ b/lib/src/rules/throw_in_finally.dart
@@ -60,7 +60,7 @@ class ThrowInFinally extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addThrowExpression(this, visitor);
   }
 }

--- a/lib/src/rules/tighten_type_of_initializing_formals.dart
+++ b/lib/src/rules/tighten_type_of_initializing_formals.dart
@@ -54,7 +54,7 @@ class TightenTypeOfInitializingFormals extends LintRule
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addConstructorDeclaration(this, visitor);
   }
 }

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -60,7 +60,7 @@ class TypeAnnotatePublicApis extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFieldDeclaration(this, visitor);
     registry.addFunctionDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -47,7 +47,7 @@ class TypeInitFormals extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFieldFormalParameter(this, visitor);
   }
 }

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -54,7 +54,7 @@ class UnawaitedFutures extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addExpressionStatement(this, visitor);
     registry.addCascadeExpression(this, visitor);
   }
@@ -67,7 +67,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCascadeExpression(CascadeExpression node) {
-    for (final expr in node.cascadeSections) {
+    for (var expr in node.cascadeSections) {
       if (expr.staticType?.isDartAsyncFuture == true &&
           _isEnclosedInAsyncFunctionBody(expr) &&
           expr is! AssignmentExpression) {
@@ -101,7 +101,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _isEnclosedInAsyncFunctionBody(AstNode node) {
-    final enclosingFunctionBody = node.thisOrAncestorOfType<FunctionBody>();
+    var enclosingFunctionBody = node.thisOrAncestorOfType<FunctionBody>();
     return enclosingFunctionBody?.isAsynchronous == true;
   }
 

--- a/lib/src/rules/unnecessary_await_in_return.dart
+++ b/lib/src/rules/unnecessary_await_in_return.dart
@@ -47,7 +47,7 @@ class UnnecessaryAwaitInReturn extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context.typeSystem);
+    var visitor = _Visitor(this, context.typeSystem);
     registry.addExpressionFunctionBody(this, visitor);
     registry.addReturnStatement(this, visitor);
   }
@@ -75,12 +75,12 @@ class _Visitor extends SimpleAstVisitor<void> {
   void _visit(AstNode node, Expression expression) {
     if (expression is! AwaitExpression) return;
 
-    final type = expression.expression.staticType;
+    var type = expression.expression.staticType;
     if (type?.isDartAsyncFuture != true) {
       return;
     }
 
-    final parent = node.thisOrAncestorMatching((e) =>
+    var parent = node.thisOrAncestorMatching((e) =>
         e is FunctionExpression ||
         e is MethodDeclaration ||
         e is Block && e.parent is TryStatement);

--- a/lib/src/rules/unnecessary_brace_in_string_interps.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interps.dart
@@ -45,7 +45,7 @@ class UnnecessaryBraceInStringInterps extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addStringInterpolation(this, visitor);
   }
 }
@@ -61,8 +61,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     for (var expression in expressions) {
       var exp = expression.expression;
       if (exp is SimpleIdentifier) {
-        final identifier = exp;
-        final bracket = expression.rightBracket;
+        var identifier = exp;
+        var bracket = expression.rightBracket;
         if (bracket != null &&
             !isIdentifierPart(bracket.next) &&
             !identifier.name.contains('\$')) {

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -47,7 +47,7 @@ class UnnecessaryConst extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addListLiteral(this, visitor);
     registry.addSetOrMapLiteral(this, visitor);

--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -49,7 +49,7 @@ class UnnecessaryFinal extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry
       ..addFormalParameterList(this, visitor)
       ..addForStatement(this, visitor)
@@ -82,7 +82,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     // second case, notice `a` is not actually declared from within the
     // loop. `a` is a variable declared outside the loop.
     if (forLoopParts is ForEachPartsWithDeclaration) {
-      final loopVariable = forLoopParts.loopVariable;
+      var loopVariable = forLoopParts.loopVariable;
 
       if (loopVariable.isFinal) {
         rule.reportLintForToken(loopVariable.keyword);

--- a/lib/src/rules/unnecessary_getters.dart
+++ b/lib/src/rules/unnecessary_getters.dart
@@ -51,7 +51,7 @@ class UnnecessaryGetters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }
@@ -63,15 +63,15 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
-    final getters = <String, MethodDeclaration>{};
-    final setters = <String, MethodDeclaration>{};
+    var getters = <String, MethodDeclaration>{};
+    var setters = <String, MethodDeclaration>{};
 
     // Filter on public methods
     var members = node.members.where(isPublicMethod);
 
     // Build getter/setter maps
     for (var member in members) {
-      final method = member as MethodDeclaration;
+      var method = member as MethodDeclaration;
       if (method.isGetter) {
         getters[method.name.toString()] = method;
       } else if (method.isSetter) {

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -61,7 +61,7 @@ class UnnecessaryGettersSetters extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
   }
 }
@@ -73,14 +73,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
-    final getters = <String, MethodDeclaration>{};
-    final setters = <String, MethodDeclaration>{};
+    var getters = <String, MethodDeclaration>{};
+    var setters = <String, MethodDeclaration>{};
 
     // Build getter/setter maps
     var members = node.members.where(isMethod);
 
     for (var member in members) {
-      final method = member as MethodDeclaration;
+      var method = member as MethodDeclaration;
       if (method.isGetter) {
         getters[method.name.toString()] = method;
       } else if (method.isSetter) {

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -57,7 +57,7 @@ class UnnecessaryLambdas extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addFunctionExpression(this, visitor);
   }
 }
@@ -121,9 +121,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.declaredElement?.name != '' || node.body.keyword != null) {
       return;
     }
-    final body = node.body;
+    var body = node.body;
     if (body is BlockFunctionBody && body.block.statements.length == 1) {
-      final statement = body.block.statements.single;
+      var statement = body.block.statements.single;
 
       if (statement is ExpressionStatement &&
           statement.expression is InvocationExpression) {
@@ -164,7 +164,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return true;
     }
 
-    final parameters = nodeToLintParams.map((e) => e.declaredElement).toSet();
+    var parameters = nodeToLintParams.map((e) => e.declaredElement).toSet();
     if (node is FunctionExpressionInvocation) {
       // todo (pq): consider checking for assignability
       // see: https://github.com/dart-lang/linter/issues/1561

--- a/lib/src/rules/unnecessary_new.dart
+++ b/lib/src/rules/unnecessary_new.dart
@@ -43,7 +43,7 @@ class UnnecessaryNew extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -43,7 +43,7 @@ class UnnecessaryNullAwareAssignments extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addAssignmentExpression(this, visitor);
   }
 }

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -94,7 +94,7 @@ class UnnecessaryNullChecks extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addPostfixExpression(this, visitor);
   }
 }
@@ -109,7 +109,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitPostfixExpression(PostfixExpression node) {
     if (node.operator.type != TokenType.BANG) return;
 
-    final expectedType = getExpectedType(node);
+    var expectedType = getExpectedType(node);
     if (expectedType != null && context.typeSystem.isNullable(expectedType)) {
       rule.reportLintForToken(node.operator);
     }

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -43,7 +43,7 @@ class UnnecessaryNullInIfNullOperators extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }
 }

--- a/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
+++ b/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
@@ -45,7 +45,7 @@ class UnnecessaryNullableForFinalVariableDeclarations extends LintRule
       return;
     }
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
     registry.addFieldDeclaration(this, visitor);
     registry.addTopLevelVariableDeclaration(this, visitor);

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -60,7 +60,7 @@ class UnnecessaryOverrides extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -156,8 +156,8 @@ abstract class _AbstractUnnecessaryOverrideVisitor extends SimpleAstVisitor {
       return false;
     }
     for (var i = 0; i < inheritedMethod.parameters.length; i++) {
-      final superParam = inheritedMethod.parameters[i];
-      final param = declaredElement.parameters[i];
+      var superParam = inheritedMethod.parameters[i];
+      var param = declaredElement.parameters[i];
       if (param.type != superParam.type) return false;
       if (param.name != superParam.name) return false;
       if (param.isCovariant != superParam.isCovariant) return false;
@@ -225,14 +225,14 @@ class _UnnecessaryOperatorOverrideVisitor
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
-    final parameters = declaration.parameters?.parameters;
+    var parameters = declaration.parameters?.parameters;
     if (node.operator.type == declaration.name.token.type &&
         parameters != null &&
         parameters.length == 1 &&
         parameters.first.identifier?.staticElement ==
             DartTypeUtilities.getCanonicalElementFromIdentifier(
                 node.rightOperand)) {
-      final leftPart = node.leftOperand.unParenthesized;
+      var leftPart = node.leftOperand.unParenthesized;
       if (leftPart is SuperExpression) {
         visitSuperExpression(leftPart);
       }
@@ -241,11 +241,11 @@ class _UnnecessaryOperatorOverrideVisitor
 
   @override
   void visitPrefixExpression(PrefixExpression node) {
-    final parameters = declaration.parameters?.parameters;
+    var parameters = declaration.parameters?.parameters;
     if (parameters != null &&
         node.operator.type == declaration.name.token.type &&
         parameters.isEmpty) {
-      final operand = node.operand.unParenthesized;
+      var operand = node.operand.unParenthesized;
       if (operand is SuperExpression) {
         visitSuperExpression(operand);
       }
@@ -263,13 +263,13 @@ class _UnnecessarySetterOverrideVisitor
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
-    final parameters = declaration.parameters?.parameters;
+    var parameters = declaration.parameters?.parameters;
     if (parameters != null &&
         parameters.length == 1 &&
         parameters.first.identifier?.staticElement ==
             DartTypeUtilities.getCanonicalElementFromIdentifier(
                 node.rightHandSide)) {
-      final leftPart = node.leftHandSide.unParenthesized;
+      var leftPart = node.leftHandSide.unParenthesized;
       if (leftPart is PropertyAccess) {
         if (node.writeElement == inheritedMethod) {
           leftPart.target?.accept(this);
@@ -290,16 +290,16 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
     if (node.operatorKeyword != null) {
-      final visitor = _UnnecessaryOperatorOverrideVisitor(rule);
+      var visitor = _UnnecessaryOperatorOverrideVisitor(rule);
       visitor.visitMethodDeclaration(node);
     } else if (node.isGetter) {
-      final visitor = _UnnecessaryGetterOverrideVisitor(rule);
+      var visitor = _UnnecessaryGetterOverrideVisitor(rule);
       visitor.visitMethodDeclaration(node);
     } else if (node.isSetter) {
-      final visitor = _UnnecessarySetterOverrideVisitor(rule);
+      var visitor = _UnnecessarySetterOverrideVisitor(rule);
       visitor.visitMethodDeclaration(node);
     } else {
-      final visitor = _UnnecessaryMethodOverrideVisitor(rule);
+      var visitor = _UnnecessaryMethodOverrideVisitor(rule);
       visitor.visitMethodDeclaration(node);
     }
   }

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -36,7 +36,7 @@ class UnnecessaryParenthesis extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addParenthesizedExpression(this, visitor);
   }
 }
@@ -67,7 +67,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final parent = node.parent;
+    var parent = node.parent;
 
     if (parent is ParenthesizedExpression) {
       rule.reportLint(node);
@@ -133,7 +133,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _containsFunctionExpression(ParenthesizedExpression node) {
-    final containsFunctionExpressionVisitor =
+    var containsFunctionExpressionVisitor =
         _ContainsFunctionExpressionVisitor();
     node.accept(containsFunctionExpressionVisitor);
     return containsFunctionExpressionVisitor.hasFunctionExpression;

--- a/lib/src/rules/unnecessary_raw_strings.dart
+++ b/lib/src/rules/unnecessary_raw_strings.dart
@@ -38,7 +38,7 @@ class UnnecessaryRawStrings extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
   }
 }

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -57,7 +57,7 @@ class UnnecessaryStatements extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(_ReportNoClearEffectVisitor(this));
+    var visitor = _Visitor(_ReportNoClearEffectVisitor(this));
     registry.addAsExpression(this, visitor);
     registry.addExpressionStatement(this, visitor);
     registry.addForStatement(this, visitor);
@@ -221,7 +221,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitForStatement(ForStatement node) {
-    final loopParts = node.forLoopParts;
+    var loopParts = node.forLoopParts;
     if (loopParts is ForPartsWithExpression) {
       loopParts.initialization?.accept(reportNoClearEffect);
       loopParts.updaters.forEach((u) {

--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -39,7 +39,7 @@ class UnnecessaryStringEscapes extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
     registry.addStringInterpolation(this, visitor);
   }
@@ -86,10 +86,10 @@ class _Visitor extends SimpleAstVisitor<void> {
     // For multiline string we keep the list on pending quotes.
     // Starting from 3 consecutive quotes, we allow escaping.
     // index -> escaped
-    final pendingQuotes = <int, bool>{};
+    var pendingQuotes = <int, bool>{};
     void checkPendingQuotes() {
       if (isMultiline && pendingQuotes.length < 3) {
-        final escapeIndexes =
+        var escapeIndexes =
             pendingQuotes.entries.where((e) => e.value).map((e) => e.key);
         for (var index in escapeIndexes) {
           // case for '''___\'''' : without last backslash it leads a parsing error
@@ -99,7 +99,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
     }
 
-    final lexeme = token.lexeme
+    var lexeme = token.lexeme
         .substring(contentsOffset - token.offset, contentsEnd - token.offset);
     for (var i = 0; i < lexeme.length; i++) {
       var current = lexeme[i];

--- a/lib/src/rules/unnecessary_string_interpolations.dart
+++ b/lib/src/rules/unnecessary_string_interpolations.dart
@@ -38,7 +38,7 @@ class UnnecessaryStringInterpolations extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addStringInterpolation(this, visitor);
   }
 }
@@ -52,9 +52,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitStringInterpolation(StringInterpolation node) {
     if (node.parent is AdjacentStrings) return;
     if (node.elements.length == 3) {
-      final start = node.elements[0] as InterpolationString;
-      final interpolation = node.elements[1] as InterpolationExpression;
-      final end = node.elements[2] as InterpolationString;
+      var start = node.elements[0] as InterpolationString;
+      var interpolation = node.elements[1] as InterpolationExpression;
+      var end = node.elements[2] as InterpolationString;
       if (start.value.isEmpty && end.value.isEmpty) {
         var staticType = interpolation.expression.staticType;
         if (staticType != null && staticType.isDartCoreString) {

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -82,7 +82,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitThisExpression(ThisExpression node) {
-    final parent = node.parent;
+    var parent = node.parent;
 
     Element? element;
     if (parent is PropertyAccess && !parent.isNullAware) {

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -151,7 +151,7 @@ bool _isFixNumIntX(DartType type) {
   if (type is! InterfaceType) {
     return false;
   }
-  final Element element = type.element;
+  Element element = type.element;
   return (element.name == 'Int32' || element.name == 'Int64') &&
       element.library?.name == 'fixnum';
 }
@@ -167,7 +167,7 @@ class UnrelatedTypeEqualityChecks extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context.typeSystem);
+    var visitor = _Visitor(this, context.typeSystem);
     registry.addBinaryExpression(this, visitor);
   }
 }
@@ -180,7 +180,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
-    final isDartCoreBoolean = node.staticType?.isDartCoreBool ?? false;
+    var isDartCoreBoolean = node.staticType?.isDartCoreBool ?? false;
     if (!isDartCoreBoolean ||
         (node.operator.type != TokenType.EQ_EQ &&
             node.operator.type != TokenType.BANG_EQ)) {

--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -51,7 +51,7 @@ class UnsafeHtml extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addAssignmentExpression(this, visitor);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addFunctionExpressionInvocation(this, visitor);
@@ -93,7 +93,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
-    final leftPart = node.leftHandSide.unParenthesized;
+    var leftPart = node.leftHandSide.unParenthesized;
     if (leftPart is SimpleIdentifier) {
       var leftPartElement = node.writeElement;
       if (leftPartElement == null) return;

--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -78,7 +78,7 @@ class UseBuildContextSynchronously extends LintRule implements NodeLintRule {
       NodeLintRegistry registry, LinterContext context) {
     var unit = context.currentUnit.unit;
     if (inTestMode || !inTestDir(unit)) {
-      final visitor = _Visitor(this);
+      var visitor = _Visitor(this);
       registry.addMethodInvocation(this, visitor);
       registry.addInstanceCreationExpression(this, visitor);
       registry.addFunctionExpressionInvocation(this, visitor);

--- a/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
+++ b/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
@@ -42,7 +42,7 @@ class UseFullHexValuesForFlutterColors extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }
@@ -57,11 +57,11 @@ class _Visitor extends SimpleAstVisitor {
     var element = node.constructorName.staticElement;
     if (DartTypeUtilities.isConstructorElement(element,
         uriStr: 'dart.ui', className: 'Color', constructorName: '')) {
-      final arguments = node.argumentList.arguments;
+      var arguments = node.argumentList.arguments;
       if (arguments.isNotEmpty) {
-        final argument = arguments.first;
+        var argument = arguments.first;
         if (argument is IntegerLiteral) {
-          final value = argument.literal.lexeme;
+          var value = argument.literal.lexeme;
           if (!value.startsWith('0x') || value.length != 10) {
             rule.reportLint(argument);
           }

--- a/lib/src/rules/use_function_type_syntax_for_parameters.dart
+++ b/lib/src/rules/use_function_type_syntax_for_parameters.dart
@@ -37,7 +37,7 @@ class UseFunctionTypeSyntaxForParameters extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addFunctionTypedFormalParameter(this, visitor);
   }
 }

--- a/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
+++ b/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
@@ -48,7 +48,7 @@ class UseIfNullToConvertNullsToBools extends LintRule implements NodeLintRule {
       NodeLintRegistry registry, LinterContext context) {
     if (!context.isEnabled(Feature.non_nullable)) return;
 
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addBinaryExpression(this, visitor);
   }
 }

--- a/lib/src/rules/use_is_even_rather_than_modulo.dart
+++ b/lib/src/rules/use_is_even_rather_than_modulo.dart
@@ -40,7 +40,7 @@ class UseIsEvenRatherThanModuloCheck extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addBinaryExpression(this, visitor);
   }
 }

--- a/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/lib/src/rules/use_key_in_widget_constructors.dart
@@ -44,7 +44,7 @@ class UseKeyInWidgetConstructors extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addConstructorDeclaration(this, visitor);
   }

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -60,7 +60,7 @@ class UseLateForPrivateFieldsAndVariables extends LintRule
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addCompilationUnit(this, visitor);
   }
 }
@@ -90,11 +90,11 @@ class _Visitor extends UnifyingAstVisitor<void> {
 
       super.visitCompilationUnit(node);
 
-      final unitsInContext =
+      var unitsInContext =
           context.allUnits.map((e) => e.unit.declaredElement).toSet();
-      final libraryUnitsInContext =
+      var libraryUnitsInContext =
           declaredElement.library.units.where(unitsInContext.contains).toSet();
-      final areAllLibraryUnitsVisited =
+      var areAllLibraryUnitsVisited =
           libraryUnitsInContext.every(lateables.containsKey);
       if (areAllLibraryUnitsVisited) {
         _checkAccess(libraryUnitsInContext);
@@ -111,7 +111,7 @@ class _Visitor extends UnifyingAstVisitor<void> {
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
     for (var variable in node.fields.variables) {
-      final parent = node.parent;
+      var parent = node.parent;
       // see https://github.com/dart-lang/linter/pull/2189#issuecomment-660115569
       // We could also include public members in private classes but to do that
       // we'd need to ensure that there are no instances of either the
@@ -170,9 +170,9 @@ class _Visitor extends UnifyingAstVisitor<void> {
   }
 
   void _checkAccess(Iterable<CompilationUnitElement> units) {
-    final allNullableAccess =
+    var allNullableAccess =
         units.expand((unit) => nullableAccess[unit] ?? const {}).toSet();
-    for (final unit in units) {
+    for (var unit in units) {
       for (var variable in lateables[unit] ?? const <VariableDeclaration>[]) {
         if (!allNullableAccess.contains(variable.declaredElement)) {
           rule.reporter.reportError(AnalysisError(

--- a/lib/src/rules/use_named_constants.dart
+++ b/lib/src/rules/use_named_constants.dart
@@ -39,7 +39,7 @@ class UseNamedConstants extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }
@@ -53,9 +53,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     if (node.isConst) {
-      final element = node.staticType?.element;
+      var element = node.staticType?.element;
       if (element is ClassElement) {
-        final nodeField =
+        var nodeField =
             node.thisOrAncestorOfType<VariableDeclaration>()?.declaredElement;
 
         // avoid diagnostic for fields in the same class having the same value
@@ -66,9 +66,9 @@ class _Visitor extends SimpleAstVisitor<void> {
         // }
         if (nodeField?.enclosingElement == element) return;
 
-        final library = (node.root as CompilationUnit).declaredElement?.library;
-        final value = context.evaluateConstant(node).value;
-        for (final field
+        var library = (node.root as CompilationUnit).declaredElement?.library;
+        var value = context.evaluateConstant(node).value;
+        for (var field
             in element.fields.where((e) => e.isStatic && e.isConst)) {
           if (field.isAccessibleIn(library) &&
               field.computeConstantValue() == value) {

--- a/lib/src/rules/use_raw_strings.dart
+++ b/lib/src/rules/use_raw_strings.dart
@@ -36,7 +36,7 @@ class UseRawStrings extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleStringLiteral(this, visitor);
   }
 }
@@ -50,7 +50,7 @@ class _Visitor extends SimpleAstVisitor {
   void visitSimpleStringLiteral(SimpleStringLiteral node) {
     if (node.isRaw) return;
 
-    final lexeme = node.literal.lexeme.substring(
+    var lexeme = node.literal.lexeme.substring(
         node.contentsOffset - node.literal.offset,
         node.contentsEnd - node.literal.offset);
     var hasEscape = false;

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -50,7 +50,7 @@ class UseRethrowWhenPossible extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addThrowExpression(this, visitor);
   }
 }
@@ -62,11 +62,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitThrowExpression(ThrowExpression node) {
-    final element =
+    var element =
         DartTypeUtilities.getCanonicalElementFromIdentifier(node.expression);
     if (element != null) {
-      final catchClause = node.thisOrAncestorOfType<CatchClause>();
-      final exceptionParameter =
+      var catchClause = node.thisOrAncestorOfType<CatchClause>();
+      var exceptionParameter =
           DartTypeUtilities.getCanonicalElementFromIdentifier(
               catchClause?.exceptionParameter);
       if (element == exceptionParameter) {

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -42,7 +42,7 @@ class UseSettersToChangeAProperty extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -64,22 +64,22 @@ class _Visitor extends SimpleAstVisitor<void> {
     void _visitExpression(Expression expression) {
       if (expression is AssignmentExpression &&
           expression.operator.type == TokenType.EQ) {
-        final leftOperand =
+        var leftOperand =
             DartTypeUtilities.getCanonicalElement(expression.writeElement);
-        final rightOperand =
+        var rightOperand =
             DartTypeUtilities.getCanonicalElementFromIdentifier(
                 expression.rightHandSide);
-        final parameterElement = node.declaredElement?.parameters.first;
+        var parameterElement = node.declaredElement?.parameters.first;
         if (rightOperand == parameterElement && leftOperand is FieldElement) {
           rule.reportLint(node);
         }
       }
     }
 
-    final body = node.body;
+    var body = node.body;
     if (body is BlockFunctionBody) {
       if (body.block.statements.length == 1) {
-        final statement = body.block.statements.first;
+        var statement = body.block.statements.first;
         if (statement is ExpressionStatement) {
           _visitExpression(statement.expression);
         }

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -66,9 +66,8 @@ class _Visitor extends SimpleAstVisitor<void> {
           expression.operator.type == TokenType.EQ) {
         var leftOperand =
             DartTypeUtilities.getCanonicalElement(expression.writeElement);
-        var rightOperand =
-            DartTypeUtilities.getCanonicalElementFromIdentifier(
-                expression.rightHandSide);
+        var rightOperand = DartTypeUtilities.getCanonicalElementFromIdentifier(
+            expression.rightHandSide);
         var parameterElement = node.declaredElement?.parameters.first;
         if (rightOperand == parameterElement && leftOperand is FieldElement) {
           rule.reportLint(node);

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -63,7 +63,7 @@ class UseStringBuffers extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addDoStatement(this, visitor);
     registry.addForStatement(this, visitor);
     registry.addWhileStatement(this, visitor);
@@ -129,7 +129,7 @@ class _UseStringBufferVisitor extends SimpleAstVisitor {
         rule.reportLint(node);
       }
       if (node.operator.type == TokenType.EQ) {
-        final visitor = _IdentifierIsPrefixVisitor(rule, left);
+        var visitor = _IdentifierIsPrefixVisitor(rule, left);
         node.rightHandSide.accept(visitor);
       }
     }
@@ -152,7 +152,7 @@ class _UseStringBufferVisitor extends SimpleAstVisitor {
 
   @override
   void visitVariableDeclarationStatement(VariableDeclarationStatement node) {
-    for (final variable in node.variables.variables) {
+    for (var variable in node.variables.variables) {
       localElements.add(variable.declaredElement);
     }
   }
@@ -165,19 +165,19 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitDoStatement(DoStatement node) {
-    final visitor = _UseStringBufferVisitor(rule);
+    var visitor = _UseStringBufferVisitor(rule);
     node.body.accept(visitor);
   }
 
   @override
   void visitForStatement(ForStatement node) {
-    final visitor = _UseStringBufferVisitor(rule);
+    var visitor = _UseStringBufferVisitor(rule);
     node.body.accept(visitor);
   }
 
   @override
   void visitWhileStatement(WhileStatement node) {
-    final visitor = _UseStringBufferVisitor(rule);
+    var visitor = _UseStringBufferVisitor(rule);
     node.body.accept(visitor);
   }
 }

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -49,7 +49,7 @@ class Bar {
 ''';
 
 bool _beginsWithAsOrTo(String name) {
-  final regExp = RegExp(r'(to|as|_to|_as)[A-Z]');
+  var regExp = RegExp(r'(to|as|_to|_as)[A-Z]');
   return regExp.matchAsPrefix(name) != null;
 }
 
@@ -67,7 +67,7 @@ class UseToAndAsIfApplicable extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -95,7 +95,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (body is ExpressionFunctionBody) {
       return _checkExpression(body.expression);
     } else if (body is BlockFunctionBody && body.block.statements.length == 1) {
-      final statement = body.block.statements.first;
+      var statement = body.block.statements.first;
       if (statement is ReturnStatement) {
         return _checkExpression(statement.expression);
       }
@@ -104,7 +104,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _checkExpression(Expression? rawExpression) {
-    final expression = rawExpression?.unParenthesized;
+    var expression = rawExpression?.unParenthesized;
     return expression is InstanceCreationExpression &&
         expression.argumentList.arguments.length == 1 &&
         expression.argumentList.arguments.first is ThisExpression;

--- a/lib/src/rules/valid_regexps.dart
+++ b/lib/src/rules/valid_regexps.dart
@@ -40,7 +40,7 @@ class ValidRegExps extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }
@@ -52,16 +52,16 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    final element = node.constructorName.staticElement?.enclosingElement;
+    var element = node.constructorName.staticElement?.enclosingElement;
     if (element?.name == 'RegExp' && element?.library.name == 'dart.core') {
-      final args = node.argumentList.arguments;
+      var args = node.argumentList.arguments;
       if (args.isEmpty) {
         return;
       }
 
-      final sourceExpression = args.first;
+      var sourceExpression = args.first;
       if (sourceExpression is StringLiteral) {
-        final source = sourceExpression.stringValue;
+        var source = sourceExpression.stringValue;
         if (source != null) {
           try {
             RegExp(source);

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -41,7 +41,7 @@ class VoidChecks extends LintRule implements NodeLintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this, context);
+    var visitor = _Visitor(this, context);
     registry.addMethodInvocation(this, visitor);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addAssignmentExpression(this, visitor);
@@ -82,15 +82,15 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
-    final type = node.writeType;
+    var type = node.writeType;
     _check(type, node.rightHandSide.staticType, node,
         checkedNode: node.rightHandSide);
   }
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    final args = node.argumentList.arguments;
-    final parameters = node.constructorName.staticElement?.parameters;
+    var args = node.argumentList.arguments;
+    var parameters = node.constructorName.staticElement?.parameters;
     if (parameters != null) {
       _checkArgs(args, parameters);
     }
@@ -98,22 +98,22 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    final type = node.staticInvokeType;
+    var type = node.staticInvokeType;
     if (type is FunctionType) {
-      final args = node.argumentList.arguments;
-      final parameters = type.parameters;
+      var args = node.argumentList.arguments;
+      var parameters = type.parameters;
       _checkArgs(args, parameters);
     }
   }
 
   @override
   void visitReturnStatement(ReturnStatement node) {
-    final parent = node.thisOrAncestorMatching((e) =>
+    var parent = node.thisOrAncestorMatching((e) =>
         e is FunctionExpression ||
         e is MethodDeclaration ||
         e is FunctionDeclaration);
     if (parent is FunctionExpression) {
-      final type = parent.staticType;
+      var type = parent.staticType;
       if (type is FunctionType) {
         _check(type.returnType, node.expression?.staticType, node,
             checkedNode: node.expression);
@@ -152,11 +152,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _checkArgs(
       NodeList<Expression> args, List<ParameterElement> parameters) {
-    for (final arg in args) {
-      final parameterElement = arg.staticParameterElement;
+    for (var arg in args) {
+      var parameterElement = arg.staticParameterElement;
       if (parameterElement != null) {
-        final type = parameterElement.type;
-        final expression = arg is NamedExpression ? arg.expression : arg;
+        var type = parameterElement.type;
+        var expression = arg is NamedExpression ? arg.expression : arg;
         _check(type, expression.staticType, expression);
       }
     }

--- a/lib/src/test_utilities/annotation.dart
+++ b/lib/src/test_utilities/annotation.dart
@@ -6,20 +6,20 @@ import 'package:analyzer/error/error.dart';
 import 'package:analyzer/source/line_info.dart';
 
 Annotation? extractAnnotation(int lineNumber, String line) {
-  final regexp =
+  var regexp =
       RegExp(r'(//|#) ?LINT( \[([\-+]\d+)?(,?(\d+):(\d+))?\])?( (.*))?$');
-  final match = regexp.firstMatch(line);
+  var match = regexp.firstMatch(line);
   if (match == null) return null;
 
   // ignore lints on commented out lines
-  final index = match.start;
-  final comment = match[1]!;
+  var index = match.start;
+  var comment = match[1]!;
   if (line.indexOf(comment) != index) return null;
 
-  final relativeLine = match[3].toInt() ?? 0;
-  final column = match[5].toInt();
-  final length = match[6].toInt();
-  final message = match[8].toNullIfBlank();
+  var relativeLine = match[3].toInt() ?? 0;
+  var column = match[5].toInt();
+  var length = match[6].toInt();
+  var message = match[8].toNullIfBlank();
   return Annotation.forLint(message, column, length)
     ..lineNumber = lineNumber + relativeLine;
 }

--- a/lib/src/test_utilities/test_resource_provider.dart
+++ b/lib/src/test_utilities/test_resource_provider.dart
@@ -16,18 +16,18 @@ import '../analyzer.dart';
 /// Builds the [DartLinter] with appropriate mock SDK, resource providers, and
 /// package config path.
 DartLinter buildDriver(LintRule? rule, File file, {String? analysisOptions}) {
-  final memoryResourceProvider = MemoryResourceProvider(
+  var memoryResourceProvider = MemoryResourceProvider(
       context: PhysicalResourceProvider.INSTANCE.pathContext);
-  final resourceProvider = TestResourceProvider(memoryResourceProvider);
+  var resourceProvider = TestResourceProvider(memoryResourceProvider);
 
-  final pathContext = memoryResourceProvider.pathContext;
+  var pathContext = memoryResourceProvider.pathContext;
   String? packageConfigPath = memoryResourceProvider.convertPath(pathContext
       .join(pathContext.dirname(file.absolute.path), '.mock_packages'));
   if (!resourceProvider.getFile(packageConfigPath).exists) {
     packageConfigPath = null;
   }
 
-  final options = LinterOptions([rule!], analysisOptions)
+  var options = LinterOptions([rule!], analysisOptions)
     ..mockSdk = MockSdk(resourceProvider: memoryResourceProvider)
     ..resourceProvider = resourceProvider
     ..packageConfigPath = packageConfigPath;
@@ -47,19 +47,19 @@ class TestResourceProvider extends file_system.ResourceProvider {
 
   @override
   file_system.File getFile(String path) {
-    final file = memoryResourceProvider.getFile(path);
+    var file = memoryResourceProvider.getFile(path);
     return file.exists ? file : physicalResourceProvider.getFile(path);
   }
 
   @override
   file_system.Folder getFolder(String path) {
-    final folder = memoryResourceProvider.getFolder(path);
+    var folder = memoryResourceProvider.getFolder(path);
     return folder.exists ? folder : physicalResourceProvider.getFolder(path);
   }
 
   @override
   file_system.Resource getResource(String path) {
-    final resource = memoryResourceProvider.getResource(path);
+    var resource = memoryResourceProvider.getResource(path);
     return resource.exists
         ? resource
         : physicalResourceProvider.getResource(path);

--- a/lib/src/util/ascii_utils.dart
+++ b/lib/src/util/ascii_utils.dart
@@ -34,9 +34,9 @@ bool isValidDartFileName(String name) {
     return true;
   }
 
-  final length = name.length - 5;
+  var length = name.length - 5;
   for (var i = 1; i < length - 1; ++i) {
-    final character = name.codeUnitAt(i);
+    var character = name.codeUnitAt(i);
     // Indicates a prefixed suffix (like `.g.dart`) which is considered a
     // non-strict Dart filename.
     if (isDot(character)) {
@@ -45,7 +45,7 @@ bool isValidDartFileName(String name) {
   }
 
   for (var i = 0; i < length; ++i) {
-    final character = name.codeUnitAt(i);
+    var character = name.codeUnitAt(i);
     if (!isLowerCase(character) && !isUnderScore(character)) {
       if (isNumber(character)) {
         if (i == 0) {

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -219,10 +219,8 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
     if (elseScope != null) {
       _propagateUndefinedExpressions(elseScope);
     }
-    var addFalseCondition =
-        _isLastStatementAnExitStatement(node.thenStatement);
-    var addTrueCondition =
-        _isLastStatementAnExitStatement(node.elseStatement);
+    var addFalseCondition = _isLastStatementAnExitStatement(node.thenStatement);
+    var addTrueCondition = _isLastStatementAnExitStatement(node.elseStatement);
     // If addTrueCondition and addFalseCondition are true at the same time,
     // then the rest of the block is dead code.
     if (addTrueCondition && addFalseCondition) {

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -14,7 +14,7 @@ Element? _getLeftElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElement(assignment.writeElement);
 
 List<Expression?> _splitConjunctions(Expression? rawExpression) {
-  final expression = rawExpression?.unParenthesized;
+  var expression = rawExpression?.unParenthesized;
   if (expression is BinaryExpression &&
       expression.operator.type == TokenType.AMPERSAND_AMPERSAND) {
     return _splitConjunctions(expression.leftOperand)
@@ -57,7 +57,7 @@ class ConditionScope {
 
   Iterable<Expression> getExpressions(Iterable<Element?> elements,
       {bool? value}) {
-    final expressions = <Expression>[];
+    var expressions = <Expression>[];
     _recursiveGetExpressions(expressions, elements, value);
     return expressions;
   }
@@ -67,7 +67,7 @@ class ConditionScope {
 
   void _recursiveGetExpressions(
       List<Expression?> expressions, Iterable<Element?> elements, bool? value) {
-    for (final element in environment.reversed) {
+    for (var element in environment.reversed) {
       if (element.haveToStop(elements)) {
         return;
       }
@@ -184,7 +184,7 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
   @override
   void visitForStatement(ForStatement node) {
     _addScope();
-    final loopParts = node.forLoopParts;
+    var loopParts = node.forLoopParts;
     if (loopParts is ForParts) {
       _addTrueCondition(loopParts.condition);
 
@@ -214,14 +214,14 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
 
   @override
   void visitIfStatement(IfStatement node) {
-    final elseScope = _visitElseStatement(node.elseStatement, node.condition);
+    var elseScope = _visitElseStatement(node.elseStatement, node.condition);
     _visitIfStatement(node);
     if (elseScope != null) {
       _propagateUndefinedExpressions(elseScope);
     }
-    final addFalseCondition =
+    var addFalseCondition =
         _isLastStatementAnExitStatement(node.thenStatement);
-    final addTrueCondition =
+    var addTrueCondition =
         _isLastStatementAnExitStatement(node.elseStatement);
     // If addTrueCondition and addFalseCondition are true at the same time,
     // then the rest of the block is dead code.
@@ -239,7 +239,7 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
 
   @override
   void visitPostfixExpression(PostfixExpression node) {
-    final operand = node.operand;
+    var operand = node.operand;
     if (operand is SimpleIdentifier) {
       _addElementToEnvironment(
           _UndefinedExpression.forElement(operand.staticElement));
@@ -249,7 +249,7 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
 
   @override
   void visitPrefixExpression(PrefixExpression node) {
-    final operand = node.operand;
+    var operand = node.operand;
     if (operand is SimpleIdentifier) {
       _addElementToEnvironment(
           _UndefinedExpression.forElement(operand.staticElement));
@@ -345,7 +345,7 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
       return false;
     }
 
-    final loopParts = node.forLoopParts;
+    var loopParts = node.forLoopParts;
     if (loopParts is ForParts) {
       var condition = loopParts.condition;
       if (condition == null) {
@@ -376,7 +376,7 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
   }
 
   ConditionScope? _removeLastScope() {
-    final deletedScope = outerScope;
+    var deletedScope = outerScope;
     outerScope = outerScope?.outer;
     return deletedScope;
   }
@@ -428,7 +428,7 @@ class _UndefinedExpression extends _ExpressionBox {
   Element element;
 
   static _UndefinedExpression? forElement(Element? element) {
-    final canonicalElement = DartTypeUtilities.getCanonicalElement(element);
+    var canonicalElement = DartTypeUtilities.getCanonicalElement(element);
     if (canonicalElement == null) return null;
     return _UndefinedExpression._internal(canonicalElement);
   }

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -97,8 +97,8 @@ class DartTypeUtilities {
       Expression? rawExpression1, Expression? rawExpression2) {
     if (rawExpression1 == null || rawExpression2 == null) return false;
 
-    final expression1 = rawExpression1.unParenthesized;
-    final expression2 = rawExpression2.unParenthesized;
+    var expression1 = rawExpression1.unParenthesized;
+    var expression2 = rawExpression2.unParenthesized;
 
     if (expression1 is SimpleIdentifier) {
       return expression2 is SimpleIdentifier &&
@@ -116,8 +116,8 @@ class DartTypeUtilities {
     }
 
     if (expression1 is PropertyAccess && expression2 is PropertyAccess) {
-      final target1 = expression1.target;
-      final target2 = expression2.target;
+      var target1 = expression1.target;
+      var target2 = expression2.target;
       return canonicalElementsFromIdentifiersAreEqual(target1, target2) &&
           canonicalElementsAreEqual(
               getWriteOrReadElement(expression1.propertyName),
@@ -133,7 +133,7 @@ class DartTypeUtilities {
 
   static Element? getCanonicalElement(Element? element) {
     if (element is PropertyAccessorElement) {
-      final variable = element.variable;
+      var variable = element.variable;
       if (variable is FieldMember) {
         // A field element defined in a parameterized type where the values of
         // the type parameters are known.
@@ -153,7 +153,7 @@ class DartTypeUtilities {
 
   static Element? getCanonicalElementFromIdentifier(AstNode? rawNode) {
     if (rawNode is Expression) {
-      final node = rawNode.unParenthesized;
+      var node = rawNode.unParenthesized;
       if (node is Identifier) {
         return getCanonicalElement(node.staticElement);
       } else if (node is PropertyAccess) {
@@ -171,15 +171,15 @@ class DartTypeUtilities {
       }
       interfaceTypes.add(type);
       recursiveCall(type.superclass, alreadyVisited, interfaceTypes);
-      for (final interface in type.interfaces) {
+      for (var interface in type.interfaces) {
         recursiveCall(interface, alreadyVisited, interfaceTypes);
       }
-      for (final mixin in type.mixins) {
+      for (var mixin in type.mixins) {
         recursiveCall(mixin, alreadyVisited, interfaceTypes);
       }
     }
 
-    final interfaceTypes = <InterfaceType>[];
+    var interfaceTypes = <InterfaceType>[];
     recursiveCall(type, <ClassElement>{}, interfaceTypes);
     return interfaceTypes;
   }
@@ -188,7 +188,7 @@ class DartTypeUtilities {
     if (node.statements.isEmpty) {
       return null;
     }
-    final lastStatement = node.statements.last;
+    var lastStatement = node.statements.last;
     if (lastStatement is Block) {
       return getLastStatementInBlock(lastStatement);
     }
@@ -203,10 +203,10 @@ class DartTypeUtilities {
     if (type is! InterfaceType) {
       return false;
     }
-    final interfaceType = type;
+    var interfaceType = type;
     bool predicate(InterfaceType i) =>
         definitions.any((d) => isInterface(i, d.name, d.library));
-    final element = interfaceType.element;
+    var element = interfaceType.element;
     return predicate(interfaceType) ||
         !element.isSynthetic && element.allSupertypes.any(predicate);
   }
@@ -216,9 +216,9 @@ class DartTypeUtilities {
     if (type is! InterfaceType) {
       return false;
     }
-    final interfaceType = type;
+    var interfaceType = type;
     bool predicate(InterfaceType i) => isInterface(i, interface, library);
-    final element = interfaceType.element;
+    var element = interfaceType.element;
     return predicate(interfaceType) ||
         !element.isSynthetic && element.allSupertypes.any(predicate);
   }
@@ -257,7 +257,7 @@ class DartTypeUtilities {
     if (declaredElement == null) {
       return null;
     }
-    final parent = declaredElement.enclosingElement;
+    var parent = declaredElement.enclosingElement;
     if (parent is ClassElement) {
       return parent.lookUpGetter(node.name.name, declaredElement.library);
     }
@@ -273,7 +273,7 @@ class DartTypeUtilities {
     if (declaredElement == null) {
       return null;
     }
-    final parent = declaredElement.enclosingElement;
+    var parent = declaredElement.enclosingElement;
     if (parent is ClassElement) {
       return parent.lookUpInheritedConcreteGetter(
           node.name.name, declaredElement.library);
@@ -285,7 +285,7 @@ class DartTypeUtilities {
   static MethodElement? lookUpInheritedConcreteMethod(MethodDeclaration node) {
     var declaredElement = node.declaredElement;
     if (declaredElement != null) {
-      final parent = declaredElement.enclosingElement;
+      var parent = declaredElement.enclosingElement;
       if (parent is ClassElement) {
         return parent.lookUpInheritedConcreteMethod(
             node.name.name, declaredElement.library);
@@ -299,7 +299,7 @@ class DartTypeUtilities {
       MethodDeclaration node) {
     var declaredElement = node.declaredElement;
     if (declaredElement != null) {
-      final parent = declaredElement.enclosingElement;
+      var parent = declaredElement.enclosingElement;
       if (parent is ClassElement) {
         return parent.lookUpInheritedConcreteSetter(
             node.name.name, declaredElement.library);
@@ -312,7 +312,7 @@ class DartTypeUtilities {
   static MethodElement? lookUpInheritedMethod(MethodDeclaration node) {
     var declaredElement = node.declaredElement;
     if (declaredElement != null) {
-      final parent = declaredElement.enclosingElement;
+      var parent = declaredElement.enclosingElement;
       if (parent is ClassElement) {
         return parent.lookUpInheritedMethod(
             node.name.name, declaredElement.library);
@@ -324,7 +324,7 @@ class DartTypeUtilities {
   static PropertyAccessorElement? lookUpSetter(MethodDeclaration node) {
     var declaredElement = node.declaredElement;
     if (declaredElement != null) {
-      final parent = declaredElement.enclosingElement;
+      var parent = declaredElement.enclosingElement;
       if (parent is ClassElement) {
         return parent.lookUpSetter(node.name.name, declaredElement.library);
       }
@@ -337,11 +337,11 @@ class DartTypeUtilities {
 
   static bool matchesArgumentsWithParameters(
       NodeList<Expression> arguments, NodeList<FormalParameter> parameters) {
-    final namedParameters = <String, Element?>{};
-    final namedArguments = <String, Element>{};
-    final positionalParameters = <Element?>[];
-    final positionalArguments = <Element>[];
-    for (final parameter in parameters) {
+    var namedParameters = <String, Element?>{};
+    var namedArguments = <String, Element>{};
+    var positionalParameters = <Element?>[];
+    var positionalArguments = <Element>[];
+    for (var parameter in parameters) {
       var identifier = parameter.identifier;
       if (identifier != null) {
         if (parameter.isNamed) {
@@ -351,16 +351,16 @@ class DartTypeUtilities {
         }
       }
     }
-    for (final argument in arguments) {
+    for (var argument in arguments) {
       if (argument is NamedExpression) {
-        final element = DartTypeUtilities.getCanonicalElementFromIdentifier(
+        var element = DartTypeUtilities.getCanonicalElementFromIdentifier(
             argument.expression);
         if (element == null) {
           return false;
         }
         namedArguments[argument.name.label.name] = element;
       } else {
-        final element =
+        var element =
             DartTypeUtilities.getCanonicalElementFromIdentifier(argument);
         if (element == null) {
           return false;
@@ -378,7 +378,7 @@ class DartTypeUtilities {
       }
     }
 
-    for (final key in namedParameters.keys) {
+    for (var key in namedParameters.keys) {
       if (namedParameters[key] != namedArguments[key]) {
         return false;
       }
@@ -388,20 +388,20 @@ class DartTypeUtilities {
   }
 
   static bool overridesMethod(MethodDeclaration node) {
-    final parent = node.parent;
+    var parent = node.parent;
     if (parent is! ClassOrMixinDeclaration) {
       return false;
     }
-    final name = node.declaredElement?.name;
+    var name = node.declaredElement?.name;
     if (name == null) {
       return false;
     }
-    final clazz = parent;
-    final classElement = clazz.declaredElement;
+    var clazz = parent;
+    var classElement = clazz.declaredElement;
     if (classElement == null) {
       return false;
     }
-    final library = classElement.library;
+    var library = classElement.library;
     return classElement.allSupertypes
         .map(node.isGetter
             ? (InterfaceType t) => t.lookUpGetter2
@@ -416,7 +416,7 @@ class DartTypeUtilities {
   /// predicate returns true, if not provided, all is included.
   static Iterable<AstNode> traverseNodesInDFS(AstNode node,
       {AstNodePredicate? excludeCriteria}) {
-    final nodes = <AstNode>{};
+    var nodes = <AstNode>{};
     void recursiveCall(node) {
       if (node is AstNode &&
           (excludeCriteria == null || !excludeCriteria(node))) {
@@ -528,7 +528,7 @@ class DartTypeUtilities {
     if (type2 is FunctionType) {
       return false;
     }
-    final element2 = type2.element;
+    var element2 = type2.element;
     if (element2 is ClassElement &&
         element2.lookUpConcreteMethod('call', element2.library) != null) {
       return false;

--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -54,9 +54,9 @@ _VisitVariableDeclaration _buildVariableReporter(
         return;
       }
 
-      final containerNodes = DartTypeUtilities.traverseNodesInDFS(container);
+      var containerNodes = DartTypeUtilities.traverseNodesInDFS(container);
 
-      final validators = <Iterable<AstNode>>[];
+      var validators = <Iterable<AstNode>>[];
       predicateBuilders.forEach((f) {
         validators.add(containerNodes.where(f(variable)));
       });
@@ -82,7 +82,7 @@ _VisitVariableDeclaration _buildVariableReporter(
 
 Iterable<AstNode> _findMethodCallbackNodes(Iterable<AstNode> containerNodes,
     VariableDeclaration variable, Map<DartTypePredicate, String> predicates) {
-  final prefixedIdentifiers = containerNodes.whereType<PrefixedIdentifier>();
+  var prefixedIdentifiers = containerNodes.whereType<PrefixedIdentifier>();
   return prefixedIdentifiers.where((n) {
     var declaredElement = variable.declaredElement;
     return declaredElement != null &&
@@ -93,7 +93,7 @@ Iterable<AstNode> _findMethodCallbackNodes(Iterable<AstNode> containerNodes,
 
 Iterable<AstNode> _findMethodInvocationsWithVariableAsArgument(
     Iterable<AstNode> containerNodes, VariableDeclaration variable) {
-  final prefixedIdentifiers = containerNodes.whereType<MethodInvocation>();
+  var prefixedIdentifiers = containerNodes.whereType<MethodInvocation>();
   return prefixedIdentifiers.where((n) => n.argumentList.arguments
       .whereType<SimpleIdentifier>()
       .map((e) => e.staticElement)
@@ -158,9 +158,9 @@ bool _isInvocationThroughCascadeExpression(
     return false;
   }
 
-  final identifier = invocation.realTarget;
+  var identifier = invocation.realTarget;
   if (identifier is SimpleIdentifier) {
-    final element = identifier.staticElement;
+    var element = identifier.staticElement;
     if (element is PropertyAccessorElement) {
       return element.variable == variable.declaredElement;
     }
@@ -212,7 +212,7 @@ abstract class LeakDetectorProcessors extends SimpleAstVisitor<void> {
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
-    final unit = getCompilationUnit(node);
+    var unit = getCompilationUnit(node);
     if (unit != null) {
       node.fields.variables.forEach(_buildVariableReporter(
           unit, _fieldPredicateBuilders, rule, predicates));
@@ -221,7 +221,7 @@ abstract class LeakDetectorProcessors extends SimpleAstVisitor<void> {
 
   @override
   void visitVariableDeclarationStatement(VariableDeclarationStatement node) {
-    final function = node.thisOrAncestorOfType<FunctionBody>();
+    var function = node.thisOrAncestorOfType<FunctionBody>();
     if (function != null) {
       node.variables.variables.forEach(_buildVariableReporter(
           function, _variablePredicateBuilders, rule, predicates));

--- a/lib/src/util/score_utils.dart
+++ b/lib/src/util/score_utils.dart
@@ -40,7 +40,6 @@ Future<LintConfig?> _fetchConfig(Uri url) async {
 Future<List<String>> _fetchPedanticRules() async {
   print('loading $_pedanticOptionsUrl...');
   var req = await http.get(_pedanticOptionsUrl);
-  var includedOptions =
-      req.body.split('include: package:pedantic/')[1].trim();
+  var includedOptions = req.body.split('include: package:pedantic/')[1].trim();
   return fetchRules(_pedanticOptionsRootUrl.resolve(includedOptions));
 }

--- a/lib/src/util/score_utils.dart
+++ b/lib/src/util/score_utils.dart
@@ -16,12 +16,12 @@ Future<List<String>> get pedanticRules async =>
     _pedanticRules ??= await _fetchPedanticRules();
 
 Future<List<String>> fetchRules(Uri optionsUrl) async {
-  final config = await _fetchConfig(optionsUrl);
+  var config = await _fetchConfig(optionsUrl);
   if (config == null) {
     print('no config found for: $optionsUrl (SKIPPED)');
     return <String>[];
   }
-  final rules = <String>[];
+  var rules = <String>[];
   for (var ruleConfig in config.ruleConfigs) {
     var name = ruleConfig.name;
     if (name != null) {
@@ -33,14 +33,14 @@ Future<List<String>> fetchRules(Uri optionsUrl) async {
 
 Future<LintConfig?> _fetchConfig(Uri url) async {
   print('loading $url...');
-  final req = await http.get(url);
+  var req = await http.get(url);
   return processAnalysisOptionsFile(req.body);
 }
 
 Future<List<String>> _fetchPedanticRules() async {
   print('loading $_pedanticOptionsUrl...');
-  final req = await http.get(_pedanticOptionsUrl);
-  final includedOptions =
+  var req = await http.get(_pedanticOptionsUrl);
+  var includedOptions =
       req.body.split('include: package:pedantic/')[1].trim();
   return fetchRules(_pedanticOptionsRootUrl.resolve(includedOptions));
 }

--- a/lib/src/util/tested_expressions.dart
+++ b/lib/src/util/tested_expressions.dart
@@ -48,8 +48,7 @@ bool _isNegationOrComparison(
           BooleanExpressionUtilities.IMPLICATIONS[cOperatorType] ==
               BooleanExpressionUtilities.NEGATIONS[eOperatorType];
 
-  var isTrichotomyConjunction = BooleanExpressionUtilities
-          .TRICHOTOMY_OPERATORS
+  var isTrichotomyConjunction = BooleanExpressionUtilities.TRICHOTOMY_OPERATORS
           .contains(eOperatorType) &&
       BooleanExpressionUtilities.TRICHOTOMY_OPERATORS.contains(cOperatorType) &&
       tokenType == TokenType.AMPERSAND_AMPERSAND;

--- a/lib/src/util/tested_expressions.dart
+++ b/lib/src/util/tested_expressions.dart
@@ -18,7 +18,7 @@ void _addNodeComparisons(Expression node, Set<Expression> comparisons) {
 }
 
 Set<Expression> _extractComparisons(BinaryExpression node) {
-  final Set<Expression> comparisons = HashSet<Expression>.identity();
+  Set<Expression> comparisons = HashSet<Expression>.identity();
   if (_isComparison(node)) {
     comparisons.add(node);
   }
@@ -43,25 +43,25 @@ bool _isComparison(Expression expression) =>
 
 bool _isNegationOrComparison(
     TokenType cOperatorType, TokenType eOperatorType, TokenType tokenType) {
-  final isNegationOperation =
+  var isNegationOperation =
       cOperatorType == BooleanExpressionUtilities.NEGATIONS[eOperatorType] ||
           BooleanExpressionUtilities.IMPLICATIONS[cOperatorType] ==
               BooleanExpressionUtilities.NEGATIONS[eOperatorType];
 
-  final isTrichotomyConjunction = BooleanExpressionUtilities
+  var isTrichotomyConjunction = BooleanExpressionUtilities
           .TRICHOTOMY_OPERATORS
           .contains(eOperatorType) &&
       BooleanExpressionUtilities.TRICHOTOMY_OPERATORS.contains(cOperatorType) &&
       tokenType == TokenType.AMPERSAND_AMPERSAND;
-  final isNegationOrComparison = isNegationOperation || isTrichotomyConjunction;
+  var isNegationOrComparison = isNegationOperation || isTrichotomyConjunction;
   return isNegationOrComparison;
 }
 
 bool _sameOperands(String eLeftOperand, String bcLeftOperand,
     String eRightOperand, String bcRightOperand) {
-  final sameOperandsSameOrder =
+  var sameOperandsSameOrder =
       eLeftOperand == bcLeftOperand && eRightOperand == bcRightOperand;
-  final sameOperandsInverted =
+  var sameOperandsInverted =
       eRightOperand == bcLeftOperand && eLeftOperand == bcRightOperand;
   return sameOperandsSameOrder || sameOperandsInverted;
 }
@@ -90,7 +90,7 @@ class TestedExpressions {
 
     var testingExpression = this.testingExpression;
 
-    final binaryExpression =
+    var binaryExpression =
         testingExpression is BinaryExpression ? testingExpression : null;
 
     Iterable<Expression> facts;
@@ -107,7 +107,7 @@ class TestedExpressions {
             : TokenType.AMPERSAND_AMPERSAND);
 
     if (_contradictions?.isEmpty == true) {
-      final set = (binaryExpression != null
+      var set = (binaryExpression != null
           ? _extractComparisons(testingExpression as BinaryExpression)
           : {testingExpression})
         ..addAll(truths.whereType<Expression>())
@@ -128,9 +128,9 @@ class TestedExpressions {
   /// laws https://en.wikipedia.org/wiki/De_Morgan%27s_laws
   LinkedHashSet<ContradictoryComparisons> _findContradictoryComparisons(
       Set<Expression> comparisons, TokenType tokenType) {
-    final Iterable<Expression> binaryExpressions =
+    Iterable<Expression> binaryExpressions =
         comparisons.whereType<BinaryExpression>().toSet();
-    final contradictions = LinkedHashSet<ContradictoryComparisons>.identity();
+    var contradictions = LinkedHashSet<ContradictoryComparisons>.identity();
 
     var testingExpression = this.testingExpression;
     if (testingExpression is SimpleIdentifier) {
@@ -138,7 +138,7 @@ class TestedExpressions {
           n is SimpleIdentifier &&
           testingExpression.staticElement == n.staticElement;
       if (negations.any(sameIdentifier)) {
-        final otherIdentifier =
+        var otherIdentifier =
             negations.firstWhere(sameIdentifier) as SimpleIdentifier?;
         contradictions
             .add(ContradictoryComparisons(otherIdentifier, testingExpression));
@@ -150,10 +150,10 @@ class TestedExpressions {
         return;
       }
 
-      final expression = ex as BinaryExpression;
-      final eLeftOperand = expression.leftOperand.toString();
-      final eRightOperand = expression.rightOperand.toString();
-      final eOperatorType = expression.operator.type;
+      var expression = ex as BinaryExpression;
+      var eLeftOperand = expression.leftOperand.toString();
+      var eRightOperand = expression.rightOperand.toString();
+      var eOperatorType = expression.operator.type;
       comparisons
           .where((comparison) =>
               comparison.offset < expression.offset &&
@@ -163,19 +163,19 @@ class TestedExpressions {
           return;
         }
 
-        final otherExpression = c as BinaryExpression;
+        var otherExpression = c as BinaryExpression;
 
-        final bcLeftOperand = otherExpression.leftOperand.toString();
-        final bcRightOperand = otherExpression.rightOperand.toString();
-        final sameOperands = _sameOperands(
+        var bcLeftOperand = otherExpression.leftOperand.toString();
+        var bcRightOperand = otherExpression.rightOperand.toString();
+        var sameOperands = _sameOperands(
             eLeftOperand, bcLeftOperand, eRightOperand, bcRightOperand);
 
-        final cOperatorType = negations.contains(c)
+        var cOperatorType = negations.contains(c)
             ? BooleanExpressionUtilities
                 .NEGATIONS[otherExpression.operator.type]
             : otherExpression.operator.type;
         if (cOperatorType != null) {
-          final isNegationOrComparison =
+          var isNegationOrComparison =
               _isNegationOrComparison(cOperatorType, eOperatorType, tokenType);
           if (isNegationOrComparison && sameOperands) {
             contradictions
@@ -195,12 +195,12 @@ class TestedExpressions {
   _RecurseCallback _recurseOnChildNodes(
           LinkedHashSet<ContradictoryComparisons> expressions) =>
       (Expression e) {
-        final ex = e as BinaryExpression;
+        var ex = e as BinaryExpression;
         if (ex.operator.type != TokenType.AMPERSAND_AMPERSAND) {
           return;
         }
 
-        final set = _findContradictoryComparisons(
+        var set = _findContradictoryComparisons(
             HashSet.from([ex.leftOperand, ex.rightOperand]), ex.operator.type);
         expressions.addAll(set);
       };

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -40,13 +40,13 @@ DartType? _findIterableTypeArgument(
     return null;
   }
 
-  final predicate = _buildImplementsDefinitionPredicate(definition);
+  var predicate = _buildImplementsDefinitionPredicate(definition);
   if (predicate(type)) {
     return type.typeArguments.first;
   }
 
-  final implementedInterfaces = type.allSupertypes;
-  final interface = implementedInterfaces.firstWhereOrNull(predicate);
+  var implementedInterfaces = type.allSupertypes;
+  var interface = implementedInterfaces.firstWhereOrNull(predicate);
   if (interface != null && interface.typeArguments.isNotEmpty) {
     return interface.typeArguments.first;
   }
@@ -98,7 +98,7 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
     if (target != null) {
       targetType = target.staticType;
     } else {
-      final classDeclaration =
+      var classDeclaration =
           node.thisOrAncestorOfType<ClassOrMixinDeclaration>();
       if (classDeclaration == null) {
         targetType = null;
@@ -108,7 +108,7 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
         targetType = classDeclaration.declaredElement?.thisType;
       }
     }
-    final argument = node.argumentList.arguments.first;
+    var argument = node.argumentList.arguments.first;
 
     // Finally, determine whether the type of the argument is related to the
     // type of the method target.

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -32,7 +32,7 @@ void defineLinterEngineTests() {
           String label, String expected, Function(PrintingReporter r) report) {
         test(label, () {
           String? msg;
-          final reporter = PrintingReporter((m) => msg = m);
+          var reporter = PrintingReporter((m) => msg = m);
           report(reporter);
           expect(msg, expected);
         });
@@ -106,7 +106,7 @@ void defineLinterEngineTests() {
         errorSink = stderr;
       });
       test('smoke', () async {
-        final firstRuleTest =
+        var firstRuleTest =
             Directory(ruleDir).listSync().firstWhere(isDartFile);
         await cli.run([firstRuleTest.path]);
         expect(cli.isLinterErrorCode(exitCode), isFalse);
@@ -126,7 +126,7 @@ void defineLinterEngineTests() {
       });
       test('custom sdk path', () async {
         // Smoke test to ensure a custom sdk path doesn't sink the ship
-        final firstRuleTest =
+        var firstRuleTest =
             Directory(ruleDir).listSync().firstWhere(isDartFile);
         var sdk = getSdkPath();
         await cli.run(['--dart-sdk', sdk, firstRuleTest.path]);
@@ -137,11 +137,11 @@ void defineLinterEngineTests() {
     group('dtos', () {
       group('hyperlink', () {
         test('html', () {
-          final link = Hyperlink('dart', 'http://dart.dev');
+          var link = Hyperlink('dart', 'http://dart.dev');
           expect(link.html, '<a href="http://dart.dev">dart</a>');
         });
         test('html - strong', () {
-          final link = Hyperlink('dart', 'http://dart.dev', bold: true);
+          var link = Hyperlink('dart', 'http://dart.dev', bold: true);
           expect(
               link.html, '<a href="http://dart.dev"><strong>dart</strong></a>');
         });
@@ -160,8 +160,8 @@ void defineLinterEngineTests() {
       group('maturity', () {
         test('comparing', () {
           // Custom
-          final m1 = Maturity('foo', ordinal: 0);
-          final m2 = Maturity('bar', ordinal: 1);
+          var m1 = Maturity('foo', ordinal: 0);
+          var m2 = Maturity('bar', ordinal: 1);
           expect(m1.compareTo(m2), -1);
           // Builtin
           expect(Maturity.stable.compareTo(Maturity.experimental), -1);

--- a/test/experiments_test.dart
+++ b/test/experiments_test.dart
@@ -18,14 +18,14 @@ void main() {
       if (entry is! Directory) continue;
 
       group(p.basename(entry.path), () {
-        final analysisOptionsFile =
+        var analysisOptionsFile =
             File(p.join(entry.path, 'analysis_options.yaml'));
-        final analysisOptions = analysisOptionsFile.readAsStringSync();
-        final ruleTestDir = Directory(p.join(entry.path, 'rules'));
+        var analysisOptions = analysisOptionsFile.readAsStringSync();
+        var ruleTestDir = Directory(p.join(entry.path, 'rules'));
         for (var test in ruleTestDir.listSync()) {
           if (test is! File) continue;
-          final testFile = test;
-          final ruleName = p.basenameWithoutExtension(test.path);
+          var testFile = test;
+          var ruleName = p.basenameWithoutExtension(test.path);
           testRule(ruleName, testFile, analysisOptions: analysisOptions);
         }
       });

--- a/test/integration/always_require_non_null_named_parameters.dart
+++ b/test/integration/always_require_non_null_named_parameters.dart
@@ -13,8 +13,8 @@ import '../mocks.dart';
 
 void main() {
   group('always_require_non_null_named_parameters', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/avoid_private_typedef_functions.dart
+++ b/test/integration/avoid_private_typedef_functions.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('avoid_private_typedef_functions', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
 
     setUp(() {
       exitCode = 0;

--- a/test/integration/avoid_relative_lib_imports.dart
+++ b/test/integration/avoid_relative_lib_imports.dart
@@ -13,8 +13,8 @@ import '../mocks.dart';
 
 void main() {
   group('avoid_relative_lib_imports', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/avoid_renaming_method_parameters.dart
+++ b/test/integration/avoid_renaming_method_parameters.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('avoid_renaming_method_parameters', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
 
     setUp(() {
       exitCode = 0;

--- a/test/integration/avoid_web_libraries_in_flutter.dart
+++ b/test/integration/avoid_web_libraries_in_flutter.dart
@@ -14,8 +14,8 @@ import '../mocks.dart';
 
 void main() {
   group('avoid_web_libraries_in_flutter', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/cancel_subscriptions.dart
+++ b/test/integration/cancel_subscriptions.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('cancel_subscriptions', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/close_sinks.dart
+++ b/test/integration/close_sinks.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('close_sinks', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/directives_ordering.dart
+++ b/test/integration/directives_ordering.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('directives_ordering', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/exhaustive_cases.dart
+++ b/test/integration/exhaustive_cases.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('exhaustive_cases', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() => outSink = collectingOut);
     tearDown(() {
       collectingOut.buffer.clear();

--- a/test/integration/file_names.dart
+++ b/test/integration/file_names.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('file_names', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/flutter_style_todos.dart
+++ b/test/integration/flutter_style_todos.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('flutter_style_todos', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/lines_longer_than_80_chars.dart
+++ b/test/integration/lines_longer_than_80_chars.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('lines_longer_than_80_chars', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/only_throw_errors.dart
+++ b/test/integration/only_throw_errors.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('only_throw_errors', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/overridden_fields.dart
+++ b/test/integration/overridden_fields.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('overridden_fields', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/packages_file_test.dart
+++ b/test/integration/packages_file_test.dart
@@ -14,8 +14,8 @@ import '../mocks.dart';
 
 void main() {
   group('p5', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/prefer_asserts_in_initializer_lists.dart
+++ b/test/integration/prefer_asserts_in_initializer_lists.dart
@@ -13,8 +13,8 @@ import '../mocks.dart';
 
 void main() {
   group('prefer_asserts_in_initializer_lists', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/prefer_const_constructors_in_immutables.dart
+++ b/test/integration/prefer_const_constructors_in_immutables.dart
@@ -13,8 +13,8 @@ import '../mocks.dart';
 
 void main() {
   group('prefer_const_constructors_in_immutables', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/prefer_mixin.dart
+++ b/test/integration/prefer_mixin.dart
@@ -13,8 +13,8 @@ import '../mocks.dart';
 
 void main() {
   group('prefer_mixin', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/prefer_relative_imports.dart
+++ b/test/integration/prefer_relative_imports.dart
@@ -13,8 +13,8 @@ import '../mocks.dart';
 
 void main() {
   group('prefer_relative_imports', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() {
       exitCode = 0;
       outSink = collectingOut;

--- a/test/integration/sort_pub_dependencies.dart
+++ b/test/integration/sort_pub_dependencies.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('sort_pub_dependencies', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
 
     setUp(() {
       exitCode = 0;

--- a/test/integration/unnecessary_lambdas.dart
+++ b/test/integration/unnecessary_lambdas.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('unnecessary_lambdas', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() => outSink = collectingOut);
     tearDown(() {
       collectingOut.buffer.clear();

--- a/test/integration/unnecessary_string_escapes.dart
+++ b/test/integration/unnecessary_string_escapes.dart
@@ -12,8 +12,8 @@ import '../mocks.dart';
 
 void main() {
   group('unnecessary_string_escapes', () {
-    final currentOut = outSink;
-    final collectingOut = CollectingSink();
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
     setUp(() => outSink = collectingOut);
     tearDown(() {
       collectingOut.buffer.clear();

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -57,8 +57,8 @@ void main() {
 void coreTests() {
   group('core', () {
     group('config', () {
-      final currentOut = outSink;
-      final collectingOut = CollectingSink();
+      var currentOut = outSink;
+      var collectingOut = CollectingSink();
       setUp(() {
         exitCode = 0;
         outSink = collectingOut;
@@ -92,8 +92,8 @@ void coreTests() {
     });
 
     group('pubspec', () {
-      final currentOut = outSink;
-      final collectingOut = CollectingSink();
+      var currentOut = outSink;
+      var collectingOut = CollectingSink();
       setUp(() => outSink = collectingOut);
       tearDown(() {
         collectingOut.buffer.clear();
@@ -107,8 +107,8 @@ void coreTests() {
     });
 
     group('canonicalization', () {
-      final currentOut = outSink;
-      final collectingOut = CollectingSink();
+      var currentOut = outSink;
+      var collectingOut = CollectingSink();
       setUp(() => outSink = collectingOut);
       tearDown(() {
         collectingOut.buffer.clear();
@@ -125,9 +125,9 @@ void coreTests() {
 
     group('examples', () {
       test('all.yaml', () {
-        final src = readFile('example/all.yaml');
+        var src = readFile('example/all.yaml');
 
-        final options = _getOptionsFromString(src);
+        var options = _getOptionsFromString(src);
         var configuredLints =
             // ignore: cast_nullable_to_non_nullable
             (options['linter'] as YamlMap)['rules'] as YamlList;
@@ -191,12 +191,12 @@ void ruleTests() {
 
 /// Provide the options found in [optionsSource].
 Map<String, YamlNode> _getOptionsFromString(String? optionsSource) {
-  final options = <String, YamlNode>{};
+  var options = <String, YamlNode>{};
   if (optionsSource == null) {
     return options;
   }
 
-  final doc = loadYamlNode(optionsSource);
+  var doc = loadYamlNode(optionsSource);
 
   // Empty options.
   if (doc is YamlScalar && doc.value == null) {

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -69,7 +69,7 @@ void defineRuleTests() {
       }
     });
     group('format', () {
-      for (final rule in Registry.ruleRegistry.rules) {
+      for (var rule in Registry.ruleRegistry.rules) {
         test('`${rule.name}` description', () {
           expect(rule.description.endsWith('.'), isTrue,
               reason:
@@ -189,8 +189,8 @@ void defineSanityTests() {
   group('reporting', () {
     // https://github.com/dart-lang/linter/issues/193
     group('ignore synthetic nodes', () {
-      final path = p.join('test', '_data', 'synthetic', 'synthetic.dart');
-      final file = File(path);
+      var path = p.join('test', '_data', 'synthetic', 'synthetic.dart');
+      var file = File(path);
       testRule('non_constant_identifier_names', file);
     });
   });
@@ -231,16 +231,16 @@ void testRule(String ruleName, File file,
       ++lineNumber;
     }
 
-    final rule = Registry.ruleRegistry[ruleName];
+    var rule = Registry.ruleRegistry[ruleName];
     if (rule == null) {
       fail('rule `$ruleName` is not registered; unable to test.');
     }
 
-    final driver = buildDriver(rule, file, analysisOptions: analysisOptions);
+    var driver = buildDriver(rule, file, analysisOptions: analysisOptions);
 
-    final lints = await driver.lintFiles([file]);
+    var lints = await driver.lintFiles([file]);
 
-    final actual = <Annotation>[];
+    var actual = <Annotation>[];
     lints.forEach((AnalysisErrorInfo info) {
       info.errors.forEach((AnalysisError error) {
         if (error.errorCode.type == ErrorType.LINT) {
@@ -257,11 +257,11 @@ void testRule(String ruleName, File file,
         // Dump results for debugging purposes.
 
         // AST
-        final optionsProvider = AnalysisOptionsProvider();
-        final optionMap = optionsProvider.getOptionsFromString(analysisOptions);
-        final optionsImpl = AnalysisOptionsImpl();
+        var optionsProvider = AnalysisOptionsProvider();
+        var optionMap = optionsProvider.getOptionsFromString(analysisOptions);
+        var optionsImpl = AnalysisOptionsImpl();
         applyToAnalysisOptions(optionsImpl, optionMap);
-        final featureSet = optionsImpl.contextFeatures;
+        var featureSet = optionsImpl.contextFeatures;
         Spelunker(file.absolute.path, featureSet: featureSet).spelunk();
         print('');
         // Lints.

--- a/test/util/rule_debug.dart
+++ b/test/util/rule_debug.dart
@@ -18,7 +18,7 @@ import '../rule_test.dart';
 ///     dart test -N valid_regexps
 ///
 void main(List<String> args) {
-  final ruleName = args[0];
-  final dir = Directory(ruleDir).absolute;
+  var ruleName = args[0];
+  var dir = Directory(ruleDir).absolute;
   testRule(ruleName, File(p.join(dir.path, '$ruleName.dart')));
 }

--- a/test/validate_format_test.dart
+++ b/test/validate_format_test.dart
@@ -8,9 +8,9 @@ import 'package:test/test.dart';
 
 void main() {
   test('validate source formatting', () async {
-    final result = await Process.run(
+    var result = await Process.run(
         'dart', ['format', '-o', 'none', '--set-exit-if-changed', '.']);
-    final violations = result.stdout.toString().split('\n')
+    var violations = result.stdout.toString().split('\n')
       ..removeWhere(lineIgnored);
     expect(violations, isEmpty, reason: '''Some files need formatting. 
   

--- a/test/validate_headers_test.dart
+++ b/test/validate_headers_test.dart
@@ -18,13 +18,13 @@ void main() {
 }
 
 Future validate(String dir) async {
-  final violations = <String>[];
+  var violations = <String>[];
   await for (FileSystemEntity entity
       in Directory(dir).list(recursive: true, followLinks: false)) {
     if (entity is File && entity.path.endsWith('.dart')) {
-      final file = await entity.open();
+      var file = await entity.open();
       List<int> bytes = await file.read(40);
-      final header = String.fromCharCodes(bytes);
+      var header = String.fromCharCodes(bytes);
       if (!header.startsWith(
           RegExp('// Copyright \\(c\\) 20[0-9][0-9], the Dart project'))) {
         violations.add(entity.path);

--- a/tool/benchmark.dart
+++ b/tool/benchmark.dart
@@ -55,7 +55,7 @@ class DotScanBenchmark extends BaseBenchmark {
   bool hasOneDot(String name) {
     var count = 0;
     for (var i = 0; i < name.length; ++i) {
-      final character = name.codeUnitAt(i);
+      var character = name.codeUnitAt(i);
       count += isDot(character) ? 1 : 0;
       if (count > 1) {
         return false;

--- a/tool/bot/rule_doc_check.dart
+++ b/tool/bot/rule_doc_check.dart
@@ -12,13 +12,13 @@ import '../crawl.dart';
 void main() async {
   print('Getting latest linter package info from pub...');
 
-  final packageInfo =
+  var packageInfo =
       jsonDecode(await getBody('https://pub.dev/api/packages/linter'));
-  final latestVersion = packageInfo['latest']['pubspec']['version'];
+  var latestVersion = packageInfo['latest']['pubspec']['version'];
   print('Found: $latestVersion.');
   if (latestVersion is String) {
-    final minor = latestVersion.split('.').last;
-    final latestRules = await fetchRulesForVersion('0.1.$minor');
+    var minor = latestVersion.split('.').last;
+    var latestRules = await fetchRulesForVersion('0.1.$minor');
     print('Checking to ensure rules have published docs...');
     print('');
 
@@ -27,7 +27,7 @@ void main() async {
         test(rule, () async {
           // todo (pq): consider replacing w/ lintCode.url
           // see: https://github.com/dart-lang/linter/issues/2034
-          final response = await http.head(
+          var response = await http.head(
               Uri.parse('https://dart-lang.github.io/linter/lints/$rule.html'));
           expect(response.statusCode, 200);
         });

--- a/tool/bot/version_check.dart
+++ b/tool/bot/version_check.dart
@@ -9,9 +9,9 @@ import 'package:http/http.dart' as http;
 
 void main() async {
   print('Getting latest linter package info from pub...');
-  final packageInfo =
+  var packageInfo =
       jsonDecode(await getBody('https://pub.dev/api/packages/linter'));
-  final latestVersion = packageInfo['latest']['pubspec']['version'];
+  var latestVersion = packageInfo['latest']['pubspec']['version'];
   print('Found: $latestVersion.');
   print('Checking for a git release tag corresponding to $latestVersion...');
 

--- a/tool/crawl.dart
+++ b/tool/crawl.dart
@@ -181,8 +181,8 @@ Future<String?> _fetchLinterForVersion(String version) async {
 }
 
 Future<List<String>> _fetchSdkTags() async {
-  final github = GitHub();
-  final slug = RepositorySlug('dart-lang', 'sdk');
+  var github = GitHub();
+  var slug = RepositorySlug('dart-lang', 'sdk');
 
   print('list repository tags: $slug');
 
@@ -215,7 +215,7 @@ Future<List<String>> _fetchSdkTags() async {
 
 Future<int> _readLatestMinorVersion() async {
   var contents = await File('pubspec.yaml').readAsString();
-  final pubspec = loadYamlNode(contents) as YamlMap;
+  var pubspec = loadYamlNode(contents) as YamlMap;
   // 0.1.79 or 0.1.79-dev or 0.1.97+1
   return int.parse((pubspec['version'] as String)
       .split('.')

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -159,13 +159,13 @@ Future<void> fetchSinceInfo() async {
 Future<void> generateDocs(String? dir) async {
   var outDir = dir;
   if (outDir != null) {
-    final d = Directory(outDir);
+    var d = Directory(outDir);
     if (!d.existsSync()) {
       print("Directory '${d.path}' does not exist");
       return;
     }
     if (!File('$outDir/options').existsSync()) {
-      final lintsChildDir = Directory('$outDir/lints');
+      var lintsChildDir = Directory('$outDir/lints');
       if (lintsChildDir.existsSync()) {
         outDir = lintsChildDir.path;
       }
@@ -351,7 +351,7 @@ class MarkdownIndexer {
   MarkdownIndexer(this.rules);
 
   void generate({String? filePath}) {
-    final buffer = StringBuffer();
+    var buffer = StringBuffer();
 
     buffer.writeln('# Linter for Dart');
     buffer.writeln();
@@ -440,7 +440,7 @@ class OptionsSample {
   }
 
   String generateOptions() {
-    final sb = StringBuffer('''
+    var sb = StringBuffer('''
 ```
 linter:
   rules:
@@ -520,7 +520,7 @@ class RuleHtmlGenerator {
   String get humanReadableName => rule.name;
 
   String get incompatibleRuleDetails {
-    final sb = StringBuffer();
+    var sb = StringBuffer();
     var incompatibleRules = rule.incompatibleRules;
     if (incompatibleRules.isNotEmpty) {
       sb.writeln('<p>');
@@ -639,7 +639,7 @@ class RuleMarkdownGenerator {
   }
 
   void generate({String? filePath}) {
-    final buffer = StringBuffer();
+    var buffer = StringBuffer();
 
     buffer.writeln('# Rule $name');
     buffer.writeln();
@@ -670,7 +670,7 @@ class RuleMarkdownGenerator {
     buffer.writeln('${details.trim()}');
 
     // incompatible rules
-    final incompatibleRules = rule.incompatibleRules;
+    var incompatibleRules = rule.incompatibleRules;
     if (incompatibleRules.isNotEmpty) {
       buffer.writeln('## Incompatible With');
       buffer.writeln();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -26,8 +26,8 @@ Iterable<FileSystemEntity> get sources => existingSourceDirs.expand((dir) {
 
 @Task('Generate lint rule docs.')
 void docs() {
-  final args = context.invocation.arguments;
-  final dir = args.getOption('dir');
+  var args = context.invocation.arguments;
+  var dir = args.getOption('dir');
   generateDocs(dir);
 }
 
@@ -39,8 +39,8 @@ void format() {
 
 @Task('Generate a lint rule stub.')
 void rule() {
-  final args = context.invocation.arguments;
-  final name = args.getOption('name')!;
+  var args = context.invocation.arguments;
+  var name = args.getOption('name')!;
   generateRule(name, outDir: Directory.current.path);
 }
 

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -9,7 +9,7 @@ import 'package:args/args.dart';
 /// Generates rule and rule test stub files (into `src/rules` and `test/rules`
 /// respectively), as well as the rule index (`rules.dart`).
 void main(List<String> args) {
-  final parser = ArgParser()
+  var parser = ArgParser()
     ..addOption('out', abbr: 'o', help: 'Specifies project root.')
     ..addOption('name',
         abbr: 'n', help: 'Specifies lower_underscore rule name.');
@@ -22,17 +22,17 @@ void main(List<String> args) {
     return;
   }
 
-  final outDir = options['out'];
+  var outDir = options['out'];
 
   if (outDir != null) {
-    final d = Directory(outDir as String);
+    var d = Directory(outDir as String);
     if (!d.existsSync()) {
       print("Directory '${d.path}' does not exist");
       return;
     }
   }
 
-  final ruleName = options['name'];
+  var ruleName = options['name'];
 
   if (ruleName == null) {
     printUsage(parser);
@@ -60,10 +60,10 @@ void generateRule(String ruleName, {String? outDir}) {
 
 void generateStub(String ruleName, String stubPath, _Generator generator,
     {String? outDir}) {
-  final generated = generator(ruleName, toClassName(ruleName));
+  var generated = generator(ruleName, toClassName(ruleName));
   if (outDir != null) {
-    final outPath = '$outDir/$stubPath/$ruleName.dart';
-    final outFile = File(outPath);
+    var outPath = '$outDir/$stubPath/$ruleName.dart';
+    var outFile = File(outPath);
     if (outFile.existsSync()) {
       print('Warning: stub already exists at $outPath; skipping');
       return;
@@ -76,7 +76,7 @@ void generateStub(String ruleName, String stubPath, _Generator generator,
 }
 
 void printUsage(ArgParser parser, [String? error]) {
-  final message = error ?? 'Generates rule stubs.';
+  var message = error ?? 'Generates rule stubs.';
 
   stdout.write('''$message
 Usage: rule
@@ -133,7 +133,7 @@ class $className extends LintRule implements NodeLintRule {
 
   @override
   void registerNodeProcessors(NodeLintRegistry registry, LinterContext context) {
-    final visitor = _Visitor(this);
+    var visitor = _Visitor(this);
     registry.addSimpleIdentifier(this, visitor);
   }
 }

--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -147,7 +147,7 @@ class _AssistCollector extends GeneralizingAstVisitor<void> {
   @override
   void visitNamedExpression(NamedExpression node) {
     if (node.name.toString() == 'associatedErrorCodes:') {
-      final list = node.expression as ListLiteral;
+      var list = node.expression as ListLiteral;
       for (var element in list.elements) {
         var name =
             element.toString().substring(1, element.toString().length - 1);

--- a/tool/since.dart
+++ b/tool/since.dart
@@ -39,7 +39,7 @@ Future<Map<String, SinceInfo>> get sinceMap async =>
 
 Future<Map<String, SinceInfo>> _getSinceInfo() async {
   var linterCache = File('tool/since/linter.yaml').readAsStringSync();
-  final linterVersionCache = loadYamlNode(linterCache) as YamlMap;
+  var linterVersionCache = loadYamlNode(linterCache) as YamlMap;
 
   var sinceMap = <String, SinceInfo>{};
   for (var lint in registeredLints.map((l) => l.name)) {
@@ -64,7 +64,7 @@ Map<String, String>? _dartSdkMap;
 Future<Map<String, String>?> get dartSdkMap async {
   if (_dartSdkMap == null) {
     var dartSdkCache = await File('tool/since/dart_sdk.yaml').readAsString();
-    final yamlMap = loadYamlNode(dartSdkCache) as YamlMap;
+    var yamlMap = loadYamlNode(dartSdkCache) as YamlMap;
     _dartSdkMap = yamlMap.map((k, v) => MapEntry(k.toString(), v.toString()));
 
     var sdks = await sdkTags;
@@ -116,7 +116,7 @@ Future<String?> _sinceSdkForLinter(String? linterVersionString) async {
 Future<String?> _nextLinterVersion(Version linterVersion) async {
   var versions = await linterVersions;
   if (versions != null) {
-    for (final version in versions) {
+    for (var version in versions) {
       if (Version.parse(version).compareTo(linterVersion) > 0) {
         return version;
       }


### PR DESCRIPTION
As per the updated advice in "Effective Dart": https://dart.dev/guides/language/effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables, this enforces an opinion on `var` over `final` for locals.

/cc @bwilkerson
