### PR TITLE
add prefer_null_aware_method_calls

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -130,6 +130,7 @@ linter:
     - prefer_is_not_operator
     - prefer_iterable_whereType
     - prefer_mixin
+    - prefer_null_aware_method_calls
     - prefer_null_aware_operators
     - prefer_relative_imports
     - prefer_single_quotes

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -132,6 +132,7 @@ import 'rules/prefer_is_not_empty.dart';
 import 'rules/prefer_is_not_operator.dart';
 import 'rules/prefer_iterable_whereType.dart';
 import 'rules/prefer_mixin.dart';
+import 'rules/prefer_null_aware_method_calls.dart';
 import 'rules/prefer_null_aware_operators.dart';
 import 'rules/prefer_relative_imports.dart';
 import 'rules/prefer_single_quotes.dart';
@@ -324,6 +325,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(PreferIterableWhereType())
     ..register(PreferMixin())
     ..register(PreferNullAwareOperators())
+    ..register(PreferNullAwareMethodCalls())
     ..register(PreferRelativeImports())
     ..register(PreferSingleQuotes())
     ..register(PreferSpreadCollections())

--- a/lib/src/rules/prefer_null_aware_method_calls.dart
+++ b/lib/src/rules/prefer_null_aware_method_calls.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Prefer null aware method call.';
+
+const _details = r'''
+
+Instead of checking nullability of a function/method `f` before calling it you
+can use `f?.call()`.
+
+**BAD:**
+```
+if (f != null) f!();
+```
+
+**GOOD:**
+```
+f?.call();
+```
+
+''';
+
+class PreferNullAwareMethodCalls extends LintRule implements NodeLintRule {
+  PreferNullAwareMethodCalls()
+      : super(
+          name: 'prefer_null_aware_method_calls',
+          description: _desc,
+          details: _details,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addIfStatement(this, visitor);
+    registry.addConditionalExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitIfStatement(IfStatement node) {
+    var condition = node.condition;
+    if (condition is BinaryExpression &&
+        condition.operator.type == TokenType.BANG_EQ &&
+        condition.rightOperand is NullLiteral &&
+        node.elseKeyword == null) {
+      var then = node.thenStatement;
+      if (then is Block) {
+        if (then.statements.length != 1) {
+          return;
+        }
+        then = then.statements.first;
+      }
+      if (then is ExpressionStatement) {
+        _check(then.expression, condition);
+      }
+    }
+  }
+
+  @override
+  void visitConditionalExpression(ConditionalExpression node) {
+    var condition = node.condition;
+    if (condition is BinaryExpression &&
+        condition.operator.type == TokenType.BANG_EQ &&
+        condition.rightOperand is NullLiteral &&
+        node.elseExpression is NullLiteral) {
+      _check(node.thenExpression, condition);
+    }
+  }
+
+  void _check(Expression expression, BinaryExpression condition) {
+    if (expression is FunctionExpressionInvocation) {
+      var target = expression.function;
+      if (target is PostfixExpression &&
+          target.operator.type == TokenType.BANG &&
+          target.operand.toString() == condition.leftOperand.toString()) {
+        rule.reportLint(expression);
+      }
+    }
+  }
+}

--- a/lib/src/rules/prefer_null_aware_method_calls.dart
+++ b/lib/src/rules/prefer_null_aware_method_calls.dart
@@ -86,7 +86,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       var target = expression.function;
       if (target is PostfixExpression &&
           target.operator.type == TokenType.BANG &&
-          target.operand.toString() == condition.leftOperand.toString()) {
+          target.operand.toSource() == condition.leftOperand.toSource()) {
         rule.reportLint(expression);
       }
     }

--- a/lib/src/rules/prefer_null_aware_method_calls.dart
+++ b/lib/src/rules/prefer_null_aware_method_calls.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer null aware method call.';
+const _desc = r'Prefer null aware method calls.';
 
 const _details = r'''
 

--- a/test/rules/prefer_null_aware_method_calls.dart
+++ b/test/rules/prefer_null_aware_method_calls.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N prefer_null_aware_method_calls`
+
+var o;
+m() {
+  if (o != null) o!(); // LINT
+
+  if (o != null) {
+    o!(); // LINT
+  }
+
+  if (o.m != null) {
+    o.m!(); // LINT
+  }
+
+  if (o.a != null) {
+    o.m!(); // OK
+  }
+
+  o != null ? o!() : null; // LINT
+  o.m != null ? o.m!() : null; // LINT
+  o.a != null ? o.m!() : null; // OK
+}

--- a/test/rules/prefer_null_aware_method_calls.dart
+++ b/test/rules/prefer_null_aware_method_calls.dart
@@ -5,6 +5,8 @@
 // test w/ `dart test -N prefer_null_aware_method_calls`
 
 var o;
+var f, g;
+
 m() {
   if (o != null) o!(); // LINT
 
@@ -23,4 +25,7 @@ m() {
   o != null ? o!() : null; // LINT
   o.m != null ? o.m!() : null; // LINT
   o.a != null ? o.m!() : null; // OK
+
+  if (f != null) g!(); // OK
+  f != null ? g!() : null; // OK
 }


### PR DESCRIPTION
# Description

Instead of checking nullability of a function/method `f` before calling it you
can use `f?.call()`.

**BAD:**

```
if (f != null) f!();
```

**GOOD:**

```
f?.call();
```

Requested by https://github.com/flutter/flutter/pull/79003#issuecomment-806156141