### PR TITLE
relax require_trailing_commas

### DIFF
--- a/lib/src/rules/require_trailing_commas.dart
+++ b/lib/src/rules/require_trailing_commas.dart
@@ -208,6 +208,7 @@ class _ArgVisitor extends GeneralizingAstVisitor<void> {
   @override
   void visitListLiteral(ListLiteral node) {
     if (currentLine == lineOf(node.leftBracket.offset) &&
+        node.elements.isNotEmpty &&
         node.elements.last.endToken.next?.type == TokenType.COMMA) {
       currentLine = lineOf(node.end);
       return;
@@ -219,6 +220,7 @@ class _ArgVisitor extends GeneralizingAstVisitor<void> {
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
     if (currentLine == lineOf(node.leftBracket.offset) &&
+        node.elements.isNotEmpty &&
         node.elements.last.endToken.next?.type == TokenType.COMMA) {
       currentLine = lineOf(node.end);
       return;

--- a/lib/src/rules/require_trailing_commas.dart
+++ b/lib/src/rules/require_trailing_commas.dart
@@ -34,10 +34,10 @@ void run() {
 }
 ```
 
-**Exception:** If the final parameter/argument is positional (vs named) and is
-either a function literal implemented using curly braces, a literal map, a
-literal set or a literal array. This exception only applies if the final
-parameter does not fit entirely on one line.
+**Exception:** If a parameter/argument is either a function literal
+implemented using curly braces, a literal map, a literal set or a literal array
+then any line break will be ignore and the expression will be treated as a
+single line expression.
 
 **Note:** This lint rule assumes `dartfmt` has been run over the code and may
 produce false positives until that has happened.
@@ -208,8 +208,7 @@ class _ArgVisitor extends GeneralizingAstVisitor<void> {
   @override
   void visitListLiteral(ListLiteral node) {
     if (currentLine == lineOf(node.leftBracket.offset) &&
-        node.elements.isNotEmpty &&
-        node.elements.last.endToken.next?.type == TokenType.COMMA) {
+        node.elements.isNotEmpty) {
       currentLine = lineOf(node.end);
       return;
     }
@@ -220,8 +219,7 @@ class _ArgVisitor extends GeneralizingAstVisitor<void> {
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
     if (currentLine == lineOf(node.leftBracket.offset) &&
-        node.elements.isNotEmpty &&
-        node.elements.last.endToken.next?.type == TokenType.COMMA) {
+        node.elements.isNotEmpty) {
       currentLine = lineOf(node.end);
       return;
     }

--- a/test_data/rules/require_trailing_commas.dart
+++ b/test_data/rules/require_trailing_commas.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// test w/ `dart test -N require_trailing_commas`
+
 class RequireTrailingCommasExample {
   RequireTrailingCommasExample.constructor1(Object param1, Object param2);
 
@@ -146,6 +148,11 @@ class RequireTrailingCommasExample {
       'two',
     }, 'set literal'); // OK
 
+    test([
+      'one',
+      'two'
+    ]);
+
     test('list literal', [
       'one',
       'two',
@@ -240,16 +247,19 @@ class RequireTrailingCommasExample {
     o(o.map(() {
       return '';
     }).join()); // OK
+
+    // flutter codebase style (do not use dartfmt on it)
     o(o.map(() => A(
       a: '',
     )).join()); // OK
     o(o ?? () {
       return '';
     }); // OK
+    // end of flutter
 
     assert(true);
 
-    assert((){
+    assert(() {
       return true;
     }()); // OK
 
@@ -274,7 +284,7 @@ class RequireTrailingCommasExample {
     '''); // OK
 
     print(''
-    ''); // LINT
+        ''); // LINT
   }
 }
 

--- a/test_data/rules/require_trailing_commas.dart
+++ b/test_data/rules/require_trailing_commas.dart
@@ -93,7 +93,7 @@ class RequireTrailingCommasExample {
 
     test('test', () {
       // Function literal implemented using curly braces.
-    }, param3: 'test'); // LINT
+    }, param3: 'test'); // OK
 
     test(
       'test',
@@ -105,7 +105,7 @@ class RequireTrailingCommasExample {
 
     test('test', 'test', param3: () {
       // Function literal implemented using curly braces.
-    }); // LINT
+    }); // OK
 
     test(
       'test',
@@ -124,7 +124,7 @@ class RequireTrailingCommasExample {
 
     test(() {
       // Function literal implemented using curly braces.
-    }, 'test'); // LINT
+    }, 'test'); // OK
 
     test('map literal', {
       'one': 'test',
@@ -134,7 +134,7 @@ class RequireTrailingCommasExample {
     test({
       'one': 'test',
       'two': 'test',
-    }, 'map literal'); // LINT
+    }, 'map literal'); // OK
 
     test('set literal', {
       'one',
@@ -144,7 +144,7 @@ class RequireTrailingCommasExample {
     test({
       'one',
       'two',
-    }, 'set literal'); // LINT
+    }, 'set literal'); // OK
 
     test('list literal', [
       'one',
@@ -154,7 +154,7 @@ class RequireTrailingCommasExample {
     test([
       'one',
       'two',
-    ], 'list literal'); // LINT
+    ], 'list literal'); // OK
 
     (a, b) {
       // Self-executing closure.
@@ -182,7 +182,7 @@ class RequireTrailingCommasExample {
     });
 
     test('exception for set literal as it spans multiple lines', const <
-        AnExtremelyLongClassNameOneTwoThreeFourFiveSixSevenEightNineTen>{});
+        AnExtremelyLongClassNameOneTwoThreeFourFiveSixSevenEightNineTen>{}); // LINT
 
     test(
       'no exception for array literal as it fits entirely on 1 line',
@@ -199,7 +199,7 @@ class RequireTrailingCommasExample {
     ]);
 
     test('exception for array literal as it spans multiple lines', const <
-        AnExtremelyLongClassNameOneTwoThreeFourFiveSixSevenEightNineTen>[]);
+        AnExtremelyLongClassNameOneTwoThreeFourFiveSixSevenEightNineTen>[]); // LINT
 
     test(
       'no exception for map literal as it fits entirely on 1 line',
@@ -216,7 +216,7 @@ class RequireTrailingCommasExample {
     });
 
     test('exception for map literal as it spans multiple lines', const <String,
-        AnExtremelyLongClassNameOneTwoThreeFourFiveSixSevenEightNineTen>{});
+        AnExtremelyLongClassNameOneTwoThreeFourFiveSixSevenEightNineTen>{}); // LINT
 
     test(
       'no exception for function literal as it fits entirely on 1 line',
@@ -226,7 +226,32 @@ class RequireTrailingCommasExample {
     test('no exception for function literal as it fits entirely on 1 line',
         () {}); // LINT
 
+    test(A(
+      a: '',
+      b: '',
+      c: '',
+    )); // OK
+    test(method1(
+      '',
+      '',
+      param3: '',
+    )); // OK
+    var o;
+    o(o.map(() {
+      return '';
+    }).join()); // OK
+    o(o.map(() => A(
+      a: '',
+    )).join()); // OK
+    o(o ?? () {
+      return '';
+    }); // OK
+
     assert(true);
+
+    assert((){
+      return true;
+    }()); // OK
 
     assert('a very very very very very very very very very long string'
         .isNotEmpty); // LINT
@@ -244,7 +269,17 @@ class RequireTrailingCommasExample {
       false,
       'a very very very very very very very very very long string',
     );
+
+    print('''
+    '''); // OK
+
+    print(''
+    ''); // LINT
   }
 }
 
 class AnExtremelyLongClassNameOneTwoThreeFourFiveSixSevenEightNineTen {}
+
+class A {
+  A({a, b, c});
+}


### PR DESCRIPTION
This PR relaxes a lint `require_trailing_commas` to ignore some line splits and allow patterns reported in https://github.com/dart-lang/linter/pull/2557#issuecomment-808406867 and https://github.com/dart-lang/linter/pull/2557#issuecomment-810554136
