### PR TITLE
Reduce lines_longer_than_80_chars range to only the offending part of the line

### DIFF
--- a/lib/src/rules/lines_longer_than_80_chars.dart
+++ b/lib/src/rules/lines_longer_than_80_chars.dart
@@ -198,7 +198,10 @@ class _Visitor extends SimpleAstVisitor {
       }
       var length = end - start;
       if (length > 80) {
-        var line = _LineInfo(index: i, offset: start, end: end);
+        // Use 80 as the start of the range so that navigating to the lint
+        // will place the caret at exactly the location where the line needs
+        // to wrap.
+        var line = _LineInfo(index: i, offset: start + 80, end: end);
         longLines.add(line);
       }
     }

--- a/test/integration/lines_longer_than_80_chars.dart
+++ b/test/integration/lines_longer_than_80_chars.dart
@@ -32,10 +32,10 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'a.dart 7:1 [lint] Avoid lines longer than 80 characters.',
-            'a.dart 11:1 [lint] Avoid lines longer than 80 characters.',
-            'a.dart 20:1 [lint] Avoid lines longer than 80 characters.',
-            'a.dart 25:1 [lint] Avoid lines longer than 80 characters.',
+            'a.dart 7:81 [lint] Avoid lines longer than 80 characters.',
+            'a.dart 11:81 [lint] Avoid lines longer than 80 characters.',
+            'a.dart 20:81 [lint] Avoid lines longer than 80 characters.',
+            'a.dart 25:81 [lint] Avoid lines longer than 80 characters.',
             "a.dart 32:40 [hint] The diagnostic 'lines_longer_than_80_chars' doesn't need to be ignored here because it's already being ignored.",
             "a.dart 32:68 [hint] The diagnostic 'lines_longer_than_80_chars' doesn't need to be ignored here because it's already being ignored.",
             '1 file analyzed, 6 issues found, in'


### PR DESCRIPTION
This came up at https://github.com/Dart-Code/Dart-Code/issues/3263 / https://github.com/dart-lang/linter/issues/2570. Previously the entire line would be included in the range which means clicking the lint would place the caret at the start of the line and not in the area where you need to make the modification. Jumping to 80 saves time time - especially if using a screenreader as the original reporter.

![Screenshot showing long lines of code with only the characters past 80 squiggled](https://user-images.githubusercontent.com/1078012/114316755-cf94be80-9afc-11eb-914c-c9418f900660.png)

Fixes #2570.
