### PR TITLE
1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.3.0
+
+- `non_constant_identifier_names` updated to check local variables, for-loop
+  initializers and catch clauses
+- error range of `lines_longer_than_80_chars` updated to start at 80 (to make)
+  splitting easier
+- new lint: `require_trailing_commas`
+- new lint: `prefer_null_aware_method_calls`
+
 # 1.2.1
 
 - fix: adjusted SDK lower bound to 2.12.0-0 (from 2.13.0-0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - `non_constant_identifier_names` updated to check local variables, for-loop
   initializers and catch clauses
-- error range of `lines_longer_than_80_chars` updated to start at 80 (to make)
+- error range of `lines_longer_than_80_chars` updated to start at 80 to make
   splitting easier
 - new lint: `require_trailing_commas`
 - new lint: `prefer_null_aware_method_calls`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.2.1';
+const String version = '1.3.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.2.1
+version: 1.3.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.3.0

- `non_constant_identifier_names` updated to check local variables, for-loop
  initializers and catch clauses
- error range of `lines_longer_than_80_chars` updated to start at 80 (to make)
  splitting easier
- new lint: `require_trailing_commas`
- new lint: `prefer_null_aware_method_calls`


/cc @bwilkerson 
