### PR TITLE
feat: lint when widgets are being returned outside the build method

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -33,6 +33,7 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
+    - avoid_returning_widgets
     - avoid_returning_null
     - avoid_returning_null_for_future
     - avoid_returning_null_for_void

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -33,11 +33,11 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_widgets
     - avoid_returning_null
     - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     - avoid_returning_this
+    - avoid_returning_widgets
     - avoid_setters_without_getters
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -39,6 +39,7 @@ import 'rules/avoid_returning_null.dart';
 import 'rules/avoid_returning_null_for_future.dart';
 import 'rules/avoid_returning_null_for_void.dart';
 import 'rules/avoid_returning_this.dart';
+import 'rules/avoid_returning_widgets.dart';
 import 'rules/avoid_setters_without_getters.dart';
 import 'rules/avoid_shadowing_type_parameters.dart';
 import 'rules/avoid_single_cascade_in_expression_statements.dart';
@@ -232,6 +233,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(AvoidReturningNullForVoid())
     ..register(AvoidReturningThis())
     ..register(AvoidReturnTypesOnSetters())
+    ..register(AvoidReturningWidgets())
     ..register(AvoidSettersWithoutGetters())
     ..register(AvoidShadowingTypeParameters())
     ..register(AvoidSingleCascadeInExpressionStatements())

--- a/lib/src/rules/avoid_returning_widgets.dart
+++ b/lib/src/rules/avoid_returning_widgets.dart
@@ -1,0 +1,112 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+import '../analyzer.dart';
+import '../util/flutter_utils.dart';
+
+const _desc = r'''Don't return a Widget outside the build method of '
+    'a StatelessWidget or a StatefulWidget''';
+
+const _details = r'''
+**DON'T** return a Widget outside the build of a StatelesWidget or a 
+StatefulWidget
+
+It is considered a good practice to create a new class every time you need to 
+reuse a new widget, instead of creating a field, method or function.
+
+**BAD:**
+```dart
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return myWidget();
+  }
+
+  Widget myWidget() => Row(children: [Container()]);
+}
+```
+
+**GOOD:**
+```dart
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return CustomWidget();
+  }
+}
+
+class CustomWidget extends StatelessWidget {  @override
+  Widget build(BuildContext context) {
+    return Row(children: [Container()]);
+  }}
+```
+''';
+
+class AvoidReturningWidgets extends LintRule implements NodeLintRule {
+  AvoidReturningWidgets()
+      : super(
+            name: 'avoid_returning_widgets',
+            description: _desc,
+            details: _details,
+            group: Group.errors);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addMethodDeclaration(this, visitor);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addFieldDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final LintRule rule;
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    if (_isReturningWidget(node.returnType) && !_isBuildMethodOfWidget(node)) {
+      rule.reportLint(node);
+    }
+  }
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    if (_isReturningWidget(node.returnType) &&
+        !_isBuildMethod(node.declaredElement)) {
+      rule.reportLint(node);
+    }
+  }
+
+  bool _isReturningWidget(TypeAnnotation? typeAnnotation) {
+    if (typeAnnotation?.type != null) {
+      return isWidgetType(typeAnnotation!.type);
+    }
+    return false;
+  }
+
+  bool _isBuildMethod(ExecutableElement? element) => element?.name == 'build';
+
+  bool _isBuildMethodOfWidget(MethodDeclaration node) {
+    if (_isBuildMethod(node.declaredElement)) {
+      return _isStatelessWidgetOrState(node);
+    }
+    return false;
+  }
+
+  bool _isStatelessWidgetOrState(MethodDeclaration node) {
+    var parent = node.thisOrAncestorMatching((e) => e is ClassDeclaration);
+    if (parent is ClassDeclaration) {
+      var element = parent.declaredElement;
+      return isStatelessWidget(element) || isState(element);
+    }
+    return false;
+  }
+}

--- a/lib/src/rules/avoid_returning_widgets.dart
+++ b/lib/src/rules/avoid_returning_widgets.dart
@@ -13,7 +13,7 @@ const _desc = r'''Don't return a Widget outside the build method of '
     'a StatelessWidget or a StatefulWidget''';
 
 const _details = r'''
-**DON'T** return a Widget outside the build of a StatelesWidget or a 
+**DON'T** return a Widget outside the build method of a StatelesWidget or a 
 StatefulWidget
 
 It is considered a good practice to create a new class every time you need to 
@@ -40,7 +40,8 @@ class MyWidget extends StatelessWidget {
   }
 }
 
-class CustomWidget extends StatelessWidget {  @override
+class CustomWidget extends StatelessWidget {  
+  @override
   Widget build(BuildContext context) {
     return Row(children: [Container()]);
   }}
@@ -61,7 +62,6 @@ class AvoidReturningWidgets extends LintRule implements NodeLintRule {
     var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
     registry.addFunctionDeclaration(this, visitor);
-    registry.addFieldDeclaration(this, visitor);
   }
 }
 
@@ -79,18 +79,13 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
-    if (_isReturningWidget(node.returnType) &&
-        !_isBuildMethod(node.declaredElement)) {
+    if (_isReturningWidget(node.returnType)) {
       rule.reportLint(node);
     }
   }
 
-  bool _isReturningWidget(TypeAnnotation? typeAnnotation) {
-    if (typeAnnotation?.type != null) {
-      return isWidgetType(typeAnnotation!.type);
-    }
-    return false;
-  }
+  bool _isReturningWidget(TypeAnnotation? typeAnnotation) =>
+      typeAnnotation != null && isWidgetType(typeAnnotation.type);
 
   bool _isBuildMethod(ExecutableElement? element) => element?.name == 'build';
 
@@ -102,11 +97,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _isStatelessWidgetOrState(MethodDeclaration node) {
-    var parent = node.thisOrAncestorMatching((e) => e is ClassDeclaration);
-    if (parent is ClassDeclaration) {
-      var element = parent.declaredElement;
-      return isStatelessWidget(element) || isState(element);
-    }
-    return false;
+    var parent = node.thisOrAncestorOfType<ClassDeclaration>();
+    var element = parent?.declaredElement;
+    return isStatelessWidget(element) || isState(element);
   }
 }

--- a/lib/src/rules/avoid_returning_widgets.dart
+++ b/lib/src/rules/avoid_returning_widgets.dart
@@ -9,12 +9,12 @@ import 'package:analyzer/dart/element/element.dart';
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
 
-const _desc = r'''Don't return a Widget outside the build method of '
-    'a StatelessWidget or a StatefulWidget''';
+const _desc = r"Don't return a Widget outside the build method of "
+    r'a StatelessWidget or a StatefulWidget';
 
 const _details = r'''
-**DON'T** return a Widget outside the build method of a StatelesWidget or a 
-StatefulWidget
+**DON'T** return a Widget outside the build method of a StatelessWidget or a 
+StatefulWidget.
 
 It is considered a good practice to create a new class every time you need to 
 reuse a new widget, instead of creating a field, method or function.

--- a/lib/src/util/flutter_utils.dart
+++ b/lib/src/util/flutter_utils.dart
@@ -34,6 +34,11 @@ bool isExactWidgetTypeContainer(DartType? type) =>
 bool isStatefulWidget(ClassElement? element) =>
     _flutter.isStatefulWidget(element);
 
+bool isStatelessWidget(ClassElement? element) =>
+    _flutter.isStatelessWidget(element);
+
+bool isState(ClassElement? element) => _flutter.isState(element);
+
 bool isWidgetProperty(DartType? type) {
   if (isWidgetType(type)) {
     return true;
@@ -52,6 +57,8 @@ bool isWidgetType(DartType? type) => _flutter.isWidgetType(type);
 class _Flutter {
   static const _nameBuildContext = 'BuildContext';
   static const _nameStatefulWidget = 'StatefulWidget';
+  static const _nameStatelessWidget = 'StatelessWidget';
+  static const _nameState = 'State';
   static const _nameWidget = 'Widget';
   static const _nameContainer = 'Container';
 
@@ -104,6 +111,36 @@ class _Flutter {
     }
     for (var type in element.allSupertypes) {
       if (_isExactWidget(type.element, _nameStatefulWidget, _uriFramework)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool isStatelessWidget(ClassElement? element) {
+    if (element == null) {
+      return false;
+    }
+    if (_isExactWidget(element, _nameStatelessWidget, _uriFramework)) {
+      return true;
+    }
+    for (var type in element.allSupertypes) {
+      if (_isExactWidget(type.element, _nameStatelessWidget, _uriFramework)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool isState(ClassElement? element) {
+    if (element == null) {
+      return false;
+    }
+    if (_isExactWidget(element, _nameState, _uriFramework)) {
+      return true;
+    }
+    for (var type in element.allSupertypes) {
+      if (_isExactWidget(type.element, _nameState, _uriFramework)) {
         return true;
       }
     }

--- a/test/rules/avoid_returning_widgets.dart
+++ b/test/rules/avoid_returning_widgets.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N avoid_returning_widgets`
+
+import 'package:flutter/widgets.dart';
+
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) { // OK
+    return Container();
+  }
+
+  String notImportant() => 'hey'; // OK
+
+  Widget yourWidget() { // LINT
+    return Container();
+  }
+
+  Widget myWidget() => Container(); // LINT
+
+  Widget _myWidget() => Container(); // LINT
+
+  Widget get _aWidget => Container(); // LINT
+
+  Container yourWidget2() { // LINT
+    return Container();
+  }
+
+  Container myWidget2() => Container(); // LINT
+
+  Container _myWidget2() => Container(); // LINT
+
+  Container get _aWidget2 => Container(); // LINT
+}
+
+class OneWidget extends StatefulWidget {
+  @override
+  State createState() => OneWidgetState(); // OK
+
+  Widget build() => Container(); // LINT
+}
+
+class OneWidgetState extends State<OneWidget> {
+  @override
+  Widget build(BuildContext context) { // OK
+    return Container();
+  }
+
+  String notImportant() => 'hey'; // OK
+
+  Widget yourWidget() { // LINT
+    return Container();
+  }
+
+  Widget myWidget() => Container(); // LINT
+
+  Widget _myWidget() => Container(); // LINT
+
+  Widget get _aWidget => Container(); // LINT
+
+  Container yourWidget2() { // LINT
+    return Container();
+  }
+
+  Container myWidget2() => Container(); // LINT
+
+  Container _myWidget2() => Container(); // LINT
+
+  Container get _aWidget2 => Container(); // LINT
+}
+
+class Cat {
+  Widget build() => Container(); // LINT
+}
+
+Widget globalFunction() => Container(); // LINT
+
+Widget get globalField => Container(); // LINT

--- a/test/rules/avoid_returning_widgets.dart
+++ b/test/rules/avoid_returning_widgets.dart
@@ -78,3 +78,10 @@ class Cat {
 Widget globalFunction() => Container(); // LINT
 
 Widget get globalField => Container(); // LINT
+
+mixin M {
+  Widget myWidget() => Container(); // LINT
+}
+extension on Object {
+  Widget myWidget() => Container(); // LINT
+}


### PR DESCRIPTION
# Description

One of the most common questions I have received is why it is preferred to use classes to create widgets in Flutter, as opposed to returning and reusing widgets from fields and methods. 

This SO issue explains really well the issue:

https://stackoverflow.com/questions/53234825/what-is-the-difference-between-functions-and-classes-to-create-reusable-widgets

With this new lint rule, I attempt to highlight cases where a widget is not created properly.

### Fixes

https://github.com/dart-lang/linter/issues/2410
