### PR TITLE
missing words in the document

### DIFF
--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -19,7 +19,7 @@ From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
 
 In Java and C#, it's common to hide all fields behind getters and setters (or
 properties in C#), even if the implementation just forwards to the field.  That
-way, if you ever need to do more work in those members, you can without needing
+way, if you ever need to do more work in those members, you can do it without needing
 to touch the callsites.  This is because calling a getter method is different
 than accessing a field in Java, and accessing a property isn't binary-compatible
 with accessing a raw field in C#.


### PR DESCRIPTION
The sentence is incomplete or confusing before, I assume what the writer mean in the first place and add the missing words.

# Description

the rule is `unnecessary_getters_setters`, I discovered it when reading from the lint [rule online doc](https://dart-lang.github.io/linter/lints/unnecessary_getters_setters.html):
![image](https://user-images.githubusercontent.com/13610283/114667702-63030500-9d32-11eb-9d47-a006bfd5085f.png)


