### PR TITLE
Fix `directives_ordering` for non-pub packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.1
+
+- `directives_ordering` now checks ordering of `package:` imports in code
+  outside pub packages
+
 # 1.3.0
 
 - `non_constant_identifier_names` updated to check local variables, for-loop
@@ -22,7 +27,7 @@
 
 - fixed `prefer_mixin` to properly make exceptions for `dart.collection` legacy
   mixins
-- improved formatting of source examples in docs  
+- improved formatting of source examples in docs
 - new lint: `use_build_context_synchronously` (experimental)
 - new lint: `avoid_multiple_declarations_per_line`
 

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -271,7 +271,14 @@ class _Visitor extends SimpleAstVisitor<void> {
     _checkSectionInOrder(lintedNodes, relativeExports);
 
     var projectName = project?.name;
-    if (projectName != null) {
+    if (projectName == null) {
+      // Not a pub package. Package directives should be sorted in one block.
+      var packageImports = importDirectives.where(_isPackageDirective);
+      var packageExports = exportDirectives.where(_isPackageDirective);
+
+      _checkSectionInOrder(lintedNodes, packageImports);
+      _checkSectionInOrder(lintedNodes, packageExports);
+    } else {
       var packageBox = _PackageBox(projectName);
 
       var thirdPartyPackageImports =


### PR DESCRIPTION
`directives_ordering` had a gap for google3 because those don't count as pub packages; this seems to do the job.