### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# 1.3.1
+# 1.4.0
 
 - `directives_ordering` now checks ordering of `package:` imports in code
   outside pub packages
+- simple reachability analysis added to `use_build_context_synchronously` to
+  short-circuit await-discovery in terminating blocks
+- `use_build_context_synchronously` updated to recognize nullable types when
+  accessed from legacy libraries
 
 # 1.3.0
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.3.0';
+const String version = '1.4.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.3.0
+version: 1.4.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.4.0

- `directives_ordering` now checks ordering of `package:` imports in code
  outside pub packages
- simple reachability analysis added to `use_build_context_synchronously` to
  short-circuit await-discovery in terminating blocks
- `use_build_context_synchronously` updated to recognize nullable types when
  accessed from legacy libraries

/cc @bwilkerson 

/fyi @davidmorgan 
