### PR TITLE
Remove lints without full alignment

### DIFF
--- a/tool/canonical/core.yaml
+++ b/tool/canonical/core.yaml
@@ -22,7 +22,6 @@ linter:
     - prefer_iterable_whereType
     - prefer_typing_uninitialized_variables
     - provide_deprecation_message
-    - unawaited_futures
     - unnecessary_overrides
     - unrelated_type_equality_checks
     - valid_regexps

--- a/tool/canonical/recommend.yaml
+++ b/tool/canonical/recommend.yaml
@@ -18,7 +18,6 @@ linter:
     - library_names
     - library_prefixes
     - null_closures
-    - omit_local_variable_types
     - overridden_fields
     - package_names
     - prefer_adjacent_string_concatenation
@@ -33,7 +32,6 @@ linter:
     - prefer_initializing_formals
     - prefer_inlined_adds
     - prefer_is_not_operator
-    - prefer_mixin
     - prefer_null_aware_operators
     - prefer_spread_collections
     - prefer_void_to_null


### PR DESCRIPTION
As discussed in our meeting today this PR removes the three lints from the `core.yaml` / `recommend.yaml` set for which we don't have full agreement between Flutter and Dart yet.

For details see also https://github.com/flutter/flutter/issues/78432.