### PR TITLE
introduce test constants

### DIFF
--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -18,7 +18,7 @@ import 'package:linter/src/utils.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
-import 'rule_test.dart' show ruleDir;
+import 'test_constants.dart';
 
 void main() {
   defineLinterEngineTests();
@@ -107,7 +107,7 @@ void defineLinterEngineTests() {
       });
       test('smoke', () async {
         var firstRuleTest =
-            Directory(ruleDir).listSync().firstWhere(isDartFile);
+            Directory(ruleTestDir).listSync().firstWhere(isDartFile);
         await cli.run([firstRuleTest.path]);
         expect(cli.isLinterErrorCode(exitCode), isFalse);
       });
@@ -127,7 +127,7 @@ void defineLinterEngineTests() {
       test('custom sdk path', () async {
         // Smoke test to ensure a custom sdk path doesn't sink the ship
         var firstRuleTest =
-            Directory(ruleDir).listSync().firstWhere(isDartFile);
+            Directory(ruleTestDir).listSync().firstWhere(isDartFile);
         var sdk = getSdkPath();
         await cli.run(['--dart-sdk', sdk, firstRuleTest.path]);
         expect(cli.isLinterErrorCode(exitCode), isFalse);

--- a/test/experiments_test.dart
+++ b/test/experiments_test.dart
@@ -9,12 +9,14 @@ import 'package:test/test.dart';
 
 import 'rule_test.dart';
 import 'rules/experiments/experiments.dart';
+import 'test_constants.dart';
 
 void main() {
   group('experiments', () {
     registerLintRuleExperiments();
 
-    for (var entry in Directory(p.join(ruleDir, 'experiments')).listSync()) {
+    for (var entry
+        in Directory(p.join(ruleTestDir, 'experiments')).listSync()) {
       if (entry is! Directory) continue;
 
       group(p.basename(entry.path), () {

--- a/test/integration/always_require_non_null_named_parameters.dart
+++ b/test/integration/always_require_non_null_named_parameters.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('always_require_non_null_named_parameters', () {
@@ -27,7 +28,7 @@ void main() {
 
     test('only throw errors', () async {
       await cli.runLinter([
-        'test_data/integration/always_require_non_null_named_parameters',
+        '$integrationTestDir/always_require_non_null_named_parameters',
         '--rules=always_require_non_null_named_parameters',
         '--packages',
         'test/rules/.mock_packages',

--- a/test/integration/avoid_private_typedef_functions.dart
+++ b/test/integration/avoid_private_typedef_functions.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('avoid_private_typedef_functions', () {
@@ -28,8 +29,8 @@ void main() {
 
     test('handles parts', () async {
       await cli.run([
-        'test_data/integration/avoid_private_typedef_functions/lib.dart',
-        'test_data/integration/avoid_private_typedef_functions/part.dart',
+        '$integrationTestDir/avoid_private_typedef_functions/lib.dart',
+        '$integrationTestDir/avoid_private_typedef_functions/part.dart',
         '--rules=avoid_private_typedef_functions'
       ]);
       expect(

--- a/test/integration/avoid_relative_lib_imports.dart
+++ b/test/integration/avoid_relative_lib_imports.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('avoid_relative_lib_imports', () {
@@ -27,10 +28,10 @@ void main() {
 
     test('avoid relative lib imports', () async {
       await cli.runLinter([
-        'test_data/integration/avoid_relative_lib_imports',
+        '$integrationTestDir/avoid_relative_lib_imports',
         '--rules=avoid_relative_lib_imports',
         '--packages',
-        'test_data/integration/avoid_relative_lib_imports/_packages'
+        '$integrationTestDir/avoid_relative_lib_imports/_packages'
       ], LinterOptions());
       expect(
           collectingOut.trim(),

--- a/test/integration/avoid_renaming_method_parameters.dart
+++ b/test/integration/avoid_renaming_method_parameters.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('avoid_renaming_method_parameters', () {
@@ -29,8 +30,8 @@ void main() {
     test('lint lib/ sources and non-lib/ sources', () async {
       await cli.run([
         '--packages',
-        'test_data/integration/avoid_renaming_method_parameters/_packages',
-        'test_data/integration/avoid_renaming_method_parameters',
+        '$integrationTestDir/avoid_renaming_method_parameters/_packages',
+        '$integrationTestDir/avoid_renaming_method_parameters',
         '--rules=avoid_renaming_method_parameters'
       ]);
       expect(

--- a/test/integration/avoid_web_libraries_in_flutter.dart
+++ b/test/integration/avoid_web_libraries_in_flutter.dart
@@ -11,6 +11,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('avoid_web_libraries_in_flutter', () {
@@ -28,7 +29,7 @@ void main() {
 
     test('no pubspec', () async {
       await cli.runLinter([
-        'test_data/integration/avoid_web_libraries_in_flutter/no_pubspec',
+        '$integrationTestDir/avoid_web_libraries_in_flutter/no_pubspec',
         '--rules=avoid_web_libraries_in_flutter',
       ], LinterOptions());
       expect(collectingOut.trim(),
@@ -38,7 +39,7 @@ void main() {
 
     test('non flutter app', () async {
       await cli.runLinter([
-        'test_data/integration/avoid_web_libraries_in_flutter/non_flutter_app',
+        '$integrationTestDir/avoid_web_libraries_in_flutter/non_flutter_app',
         '--rules=avoid_web_libraries_in_flutter',
       ], LinterOptions());
       expect(collectingOut.trim(),
@@ -48,7 +49,7 @@ void main() {
 
     test('non web app', () async {
       await cli.runLinter([
-        'test_data/integration/avoid_web_libraries_in_flutter/non_web_app',
+        '$integrationTestDir/avoid_web_libraries_in_flutter/non_web_app',
         '--rules=avoid_web_libraries_in_flutter',
       ], LinterOptions());
       expect(collectingOut.trim(),
@@ -58,7 +59,7 @@ void main() {
 
     test('web app', () async {
       await cli.runLinter([
-        'test_data/integration/avoid_web_libraries_in_flutter/web_app',
+        '$integrationTestDir/avoid_web_libraries_in_flutter/web_app',
         '--rules=avoid_web_libraries_in_flutter',
       ], LinterOptions());
       expect(collectingOut.trim(),
@@ -68,7 +69,7 @@ void main() {
 
     test('web plugin', () async {
       await cli.runLinter([
-        'test_data/integration/avoid_web_libraries_in_flutter/web_plugin',
+        '$integrationTestDir/avoid_web_libraries_in_flutter/web_plugin',
         '--rules=avoid_web_libraries_in_flutter',
       ], LinterOptions());
       expect(collectingOut.trim(),

--- a/test/integration/cancel_subscriptions.dart
+++ b/test/integration/cancel_subscriptions.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('cancel_subscriptions', () {
@@ -26,7 +27,7 @@ void main() {
 
     test('cancel subscriptions', () async {
       await cli.run([
-        'test_data/integration/cancel_subscriptions',
+        '$integrationTestDir/cancel_subscriptions',
         '--rules=cancel_subscriptions'
       ]);
       expect(

--- a/test/integration/close_sinks.dart
+++ b/test/integration/close_sinks.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('close_sinks', () {
@@ -29,7 +30,7 @@ void main() {
       await cli.run([
         '--packages',
         packagesFilePath,
-        'test_data/integration/close_sinks',
+        '$integrationTestDir/close_sinks',
         '--rules=close_sinks'
       ]);
       expect(

--- a/test/integration/directives_ordering.dart
+++ b/test/integration/directives_ordering.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('directives_ordering', () {
@@ -29,7 +30,7 @@ void main() {
       await cli.run([
         '--packages',
         packagesFilePath,
-        'test_data/integration/directives_ordering/dart_directives_go_first',
+        '$integrationTestDir/directives_ordering/dart_directives_go_first',
         '--rules=directives_ordering'
       ]);
       expect(
@@ -53,7 +54,7 @@ void main() {
       await cli.run([
         '--packages',
         packagesFilePath,
-        'test_data/integration/directives_ordering/package_directives_before_relative',
+        '$integrationTestDir/directives_ordering/package_directives_before_relative',
         '--rules=directives_ordering'
       ]);
       expect(
@@ -77,7 +78,7 @@ void main() {
       await cli.run([
         '--packages',
         packagesFilePath,
-        'test_data/integration/directives_ordering/export_directives_after_import_directives',
+        '$integrationTestDir/directives_ordering/export_directives_after_import_directives',
         '--rules=directives_ordering'
       ]);
       expect(
@@ -97,7 +98,7 @@ void main() {
       await cli.run([
         '--packages',
         packagesFilePath,
-        'test_data/integration/directives_ordering/sort_directive_sections_alphabetically',
+        '$integrationTestDir/directives_ordering/sort_directive_sections_alphabetically',
         '--rules=directives_ordering'
       ]);
       expect(
@@ -137,7 +138,7 @@ void main() {
       await cli.run([
         '--packages',
         packagesFilePath,
-        'test_data/integration/directives_ordering/lint_one_node_no_more_than_once',
+        '$integrationTestDir/directives_ordering/lint_one_node_no_more_than_once',
         '--rules=directives_ordering'
       ]);
       expect(

--- a/test/integration/exhaustive_cases.dart
+++ b/test/integration/exhaustive_cases.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('exhaustive_cases', () {
@@ -21,7 +22,7 @@ void main() {
     });
     test('exhaustive_cases', () async {
       await cli.runLinter([
-        'test_data/integration/exhaustive_cases',
+        '$integrationTestDir/exhaustive_cases',
         '--rules=exhaustive_cases',
       ], LinterOptions());
       expect(collectingOut.trim(),

--- a/test/integration/file_names.dart
+++ b/test/integration/file_names.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('file_names', () {
@@ -26,7 +27,7 @@ void main() {
 
     test('bad', () async {
       await cli.run(
-          ['test_data/integration/file_names/a-b.dart', '--rules=file_names']);
+          ['$integrationTestDir/file_names/a-b.dart', '--rules=file_names']);
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
@@ -37,7 +38,7 @@ void main() {
 
     test('ok', () async {
       await cli.run([
-        'test_data/integration/file_names/non-strict.css.dart',
+        '$integrationTestDir/file_names/non-strict.css.dart',
         '--rules=file_names'
       ]);
       expect(exitCode, 0);

--- a/test/integration/flutter_style_todos.dart
+++ b/test/integration/flutter_style_todos.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('flutter_style_todos', () {
@@ -26,7 +27,7 @@ void main() {
 
     test('on bad TODOs', () async {
       await cli.run([
-        'test_data/integration/flutter_style_todos',
+        '$integrationTestDir/flutter_style_todos',
         '--rules=flutter_style_todos'
       ]);
       expect(

--- a/test/integration/lines_longer_than_80_chars.dart
+++ b/test/integration/lines_longer_than_80_chars.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('lines_longer_than_80_chars', () {
@@ -26,7 +27,7 @@ void main() {
 
     test('ignores can exceed 80', () async {
       await cli.run([
-        'test_data/integration/lines_longer_than_80_chars',
+        '$integrationTestDir/lines_longer_than_80_chars',
         '--rules=lines_longer_than_80_chars'
       ]);
       expect(

--- a/test/integration/only_throw_errors.dart
+++ b/test/integration/only_throw_errors.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('only_throw_errors', () {
@@ -26,7 +27,7 @@ void main() {
 
     test('only throw errors', () async {
       await cli.run([
-        'test_data/integration/only_throw_errors',
+        '$integrationTestDir/only_throw_errors',
         '--rules=only_throw_errors'
       ]);
       expect(

--- a/test/integration/overridden_fields.dart
+++ b/test/integration/overridden_fields.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('overridden_fields', () {
@@ -27,7 +28,7 @@ void main() {
     // https://github.com/dart-lang/linter/issues/246
     test('overrides across libraries', () async {
       await cli.run([
-        'test_data/integration/overridden_fields',
+        '$integrationTestDir/overridden_fields',
         '--rules',
         'overridden_fields'
       ]);

--- a/test/integration/packages_file_test.dart
+++ b/test/integration/packages_file_test.dart
@@ -11,6 +11,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('p5', () {
@@ -29,9 +30,9 @@ void main() {
       test('basic', () async {
         // Requires .packages to analyze cleanly.
         await cli.runLinter([
-          'test_data/integration/p5',
+          '$integrationTestDir/p5',
           '--packages',
-          'test_data/integration/p5/_packages'
+          '$integrationTestDir/p5/_packages'
         ], LinterOptions([]));
         // Should have 0 issues.
         expect(exitCode, 0);

--- a/test/integration/prefer_asserts_in_initializer_lists.dart
+++ b/test/integration/prefer_asserts_in_initializer_lists.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('prefer_asserts_in_initializer_lists', () {
@@ -27,7 +28,7 @@ void main() {
 
     test('only throw errors', () async {
       await cli.runLinter([
-        'test_data/integration/prefer_asserts_in_initializer_lists',
+        '$integrationTestDir/prefer_asserts_in_initializer_lists',
         '--rules=prefer_asserts_in_initializer_lists'
       ], LinterOptions());
       expect(

--- a/test/integration/prefer_const_constructors_in_immutables.dart
+++ b/test/integration/prefer_const_constructors_in_immutables.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('prefer_const_constructors_in_immutables', () {
@@ -27,7 +28,7 @@ void main() {
 
     test('only throw errors', () async {
       await cli.runLinter([
-        'test_data/integration/prefer_const_constructors_in_immutables',
+        '$integrationTestDir/prefer_const_constructors_in_immutables',
         '--rules=prefer_const_constructors_in_immutables',
         '--packages',
         'test/rules/.mock_packages',

--- a/test/integration/prefer_mixin.dart
+++ b/test/integration/prefer_mixin.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('prefer_mixin', () {
@@ -27,7 +28,7 @@ void main() {
 
     test('analysis', () async {
       await cli.runLinter([
-        'test_data/integration/prefer_mixin',
+        '$integrationTestDir/prefer_mixin',
         '--rules=prefer_mixin',
         '--packages',
         'test/rules/.mock_packages',

--- a/test/integration/prefer_relative_imports.dart
+++ b/test/integration/prefer_relative_imports.dart
@@ -10,6 +10,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('prefer_relative_imports', () {
@@ -27,10 +28,10 @@ void main() {
 
     test('prefer relative imports', () async {
       await cli.runLinter([
-        'test_data/integration/prefer_relative_imports',
+        '$integrationTestDir/prefer_relative_imports',
         '--rules=prefer_relative_imports',
         '--packages',
-        'test_data/integration/prefer_relative_imports/_packages'
+        '$integrationTestDir/prefer_relative_imports/_packages'
       ], LinterOptions());
       expect(
           collectingOut.trim(),

--- a/test/integration/public_member_api_docs.dart
+++ b/test/integration/public_member_api_docs.dart
@@ -6,6 +6,8 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
+import '../test_constants.dart';
+
 void main() {
   group('public_member_api_docs', () {
     test('lint lib/ sources and non-lib/ sources', () async {
@@ -15,12 +17,12 @@ void main() {
             'pub',
             'get',
           ],
-          workingDirectory: 'test_data/integration/public_member_api_docs');
+          workingDirectory: '$integrationTestDir/public_member_api_docs');
       expect(pubResult.exitCode, 0);
 
       var result = Process.runSync(
         'dart',
-        ['analyze', 'test_data/integration/public_member_api_docs'],
+        ['analyze', '$integrationTestDir/public_member_api_docs'],
       );
       expect(
           result.stdout.trim(),

--- a/test/integration/sort_pub_dependencies.dart
+++ b/test/integration/sort_pub_dependencies.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('sort_pub_dependencies', () {
@@ -28,7 +29,7 @@ void main() {
 
     test('check order', () async {
       await cli.run([
-        'test_data/integration/sort_pub_dependencies',
+        '$integrationTestDir/sort_pub_dependencies',
         '--rules=sort_pub_dependencies',
       ]);
       expect(

--- a/test/integration/unnecessary_lambdas.dart
+++ b/test/integration/unnecessary_lambdas.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('unnecessary_lambdas', () {
@@ -21,7 +22,7 @@ void main() {
     });
     test('deferred import', () async {
       await cli.runLinter([
-        'test_data/integration/unnecessary_lambdas',
+        '$integrationTestDir/unnecessary_lambdas',
         '--rules=unnecessary_lambdas',
       ], LinterOptions());
       expect(collectingOut.trim(), contains('2 files analyzed, 1 issue found'));

--- a/test/integration/unnecessary_string_escapes.dart
+++ b/test/integration/unnecessary_string_escapes.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('unnecessary_string_escapes', () {
@@ -21,7 +22,7 @@ void main() {
     });
     test('no_closing_quote', () async {
       await cli.runLinter([
-        'test_data/integration/unnecessary_string_escapes/no_closing_quote.dart',
+        '$integrationTestDir/unnecessary_string_escapes/no_closing_quote.dart',
         '--rules=unnecessary_string_escapes',
       ], LinterOptions());
       // No exception.

--- a/test/integration/use_build_context_synchronously.dart
+++ b/test/integration/use_build_context_synchronously.dart
@@ -9,6 +9,7 @@ import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
 import '../mocks.dart';
+import '../test_constants.dart';
 
 void main() {
   group('use_build_context_synchronously', () {
@@ -22,7 +23,7 @@ void main() {
     //https://github.com/dart-lang/linter/issues/2572
     test('mixed_mode', () async {
       await cli.runLinter([
-        'test_data/integration/use_build_context_synchronously/lib/unmigrated.dart',
+        '$integrationTestDir/use_build_context_synchronously/lib/unmigrated.dart',
         '--packages',
         'test/rules/.mock_packages',
         '--rules=use_build_context_synchronously',

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -48,6 +48,7 @@ import 'integration/use_build_context_synchronously.dart'
     as use_build_context_synchronously;
 import 'mocks.dart';
 import 'rules/experiments/experiments.dart';
+import 'test_constants.dart';
 
 void main() {
   group('integration', () {
@@ -72,9 +73,9 @@ void coreTests() {
       });
       test('excludes', () async {
         await cli.run([
-          'test_data/integration/p2',
+          '$integrationTestDir/p2',
           '-c',
-          'test_data/integration/p2/lintconfig.yaml'
+          '$integrationTestDir/p2/lintconfig.yaml'
         ]);
         expect(
             collectingOut.trim(),
@@ -84,16 +85,16 @@ void coreTests() {
       });
       test('overrides', () async {
         await cli.run([
-          'test_data/integration/p2',
+          '$integrationTestDir/p2',
           '-c',
-          'test_data/integration/p2/lintconfig2.yaml'
+          '$integrationTestDir/p2/lintconfig2.yaml'
         ]);
         expect(collectingOut.trim(),
             stringContainsInOrder(['4 files analyzed, 0 issues found, in']));
         expect(exitCode, 0);
       });
       test('default', () async {
-        await cli.run(['test_data/integration/p2']);
+        await cli.run(['$integrationTestDir/p2']);
         expect(collectingOut.trim(),
             stringContainsInOrder(['4 files analyzed, 3 issues found, in']));
         expect(exitCode, 1);
@@ -110,8 +111,8 @@ void coreTests() {
       });
       test('bad pubspec', () async {
         await cli.run([
-          'test_data/integration/p3',
-          'test_data/integration/p3/_pubpspec.yaml'
+          '$integrationTestDir/p3',
+          '$integrationTestDir/p3/_pubpspec.yaml'
         ]);
         expect(collectingOut.trim(),
             startsWith('1 file analyzed, 0 issues found, in'));
@@ -128,9 +129,9 @@ void coreTests() {
       });
       test('no warnings due to bad canonicalization', () async {
         var packagesFilePath =
-            File('test_data/integration/p4/_packages').absolute.path;
+            File('$integrationTestDir/p4/_packages').absolute.path;
         await cli.runLinter(
-            ['--packages', packagesFilePath, 'test_data/integration/p4'],
+            ['--packages', packagesFilePath, '$integrationTestDir/p4'],
             LinterOptions([]));
         expect(collectingOut.trim(),
             startsWith('3 files analyzed, 0 issues found, in'));

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -25,6 +25,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'experiments_test.dart' as experiment_tests;
+import 'test_constants.dart';
 import 'util/annotation_matcher.dart';
 import 'util/test_utils.dart';
 
@@ -35,15 +36,12 @@ void main() {
   defineRuleUnitTests();
 }
 
-final String ruleDir = p.join('test', 'rules');
-final String testConfigDir = p.join('test', 'configs');
-
 /// Rule tests
 void defineRuleTests() {
   group('rule', () {
     group('dart', () {
       // Rule tests run with default analysis options.
-      testRules(ruleDir);
+      testRules(ruleTestDir);
 
       // Rule tests run against specific configurations.
       for (var entry in Directory(testConfigDir).listSync()) {
@@ -52,12 +50,12 @@ void defineRuleTests() {
           var analysisOptionsFile =
               File(p.join(entry.path, 'analysis_options.yaml'));
           var analysisOptions = analysisOptionsFile.readAsStringSync();
-          testRules(ruleDir, analysisOptions: analysisOptions);
+          testRules(ruleTestDir, analysisOptions: analysisOptions);
         });
       }
     });
     group('pub', () {
-      for (var entry in Directory(p.join(ruleDir, 'pub')).listSync()) {
+      for (var entry in Directory(p.join(ruleTestDir, 'pub')).listSync()) {
         if (entry is Directory) {
           for (var child in entry.listSync()) {
             if (child is File && isPubspecFile(child)) {
@@ -203,7 +201,7 @@ void defineSanityTests() {
 
 /// Handy for debugging.
 void defineSoloRuleTest(String ruleToTest) {
-  for (var entry in Directory(ruleDir).listSync()) {
+  for (var entry in Directory(ruleTestDir).listSync()) {
     if (entry is! File || !isDartFile(entry)) continue;
     var ruleName = p.basenameWithoutExtension(entry.path);
     if (ruleName == ruleToTest) {

--- a/test/test_constants.dart
+++ b/test/test_constants.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as path;
+
+final String integrationTestDir = path.join('test_data', 'integration');
+final String ruleTestDir = path.join('test', 'rules');
+final String testConfigDir = path.join('test', 'configs');

--- a/test/util/rule_debug.dart
+++ b/test/util/rule_debug.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 
 import '../rule_test.dart';
+import '../test_constants.dart';
 
 /// Solo rule test runner.  Handy for debugging until `dart test` supports
 /// VM debugging (https://github.com/dart-lang/test/issues/50).
@@ -19,6 +20,6 @@ import '../rule_test.dart';
 ///
 void main(List<String> args) {
   var ruleName = args[0];
-  var dir = Directory(ruleDir).absolute;
+  var dir = Directory(ruleTestDir).absolute;
   testRule(ruleName, File(p.join(dir.path, '$ruleName.dart')));
 }


### PR DESCRIPTION
Some constant corralling to prepare for moving rule test data out of `test/` (#2595).

/cc @bwilkerson 
