### PR TITLE
Add prefer_final_parameters lint

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -115,6 +115,7 @@ linter:
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
+    - prefer_final_parameters
     - prefer_for_elements_to_map_fromIterable
     - prefer_foreach
     - prefer_function_declarations_over_variables

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:linter/src/rules/prefer_final_parameters.dart';
-
 import 'analyzer.dart';
 import 'rules/always_declare_return_types.dart';
 import 'rules/always_put_control_body_on_new_line.dart';
@@ -119,6 +117,7 @@ import 'rules/prefer_expression_function_bodies.dart';
 import 'rules/prefer_final_fields.dart';
 import 'rules/prefer_final_in_for_each.dart';
 import 'rules/prefer_final_locals.dart';
+import 'rules/prefer_final_parameters.dart';
 import 'rules/prefer_for_elements_to_map_fromIterable.dart';
 import 'rules/prefer_foreach.dart';
 import 'rules/prefer_function_declarations_over_variables.dart';

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:linter/src/rules/prefer_final_parameters.dart';
+
 import 'analyzer.dart';
 import 'rules/always_declare_return_types.dart';
 import 'rules/always_put_control_body_on_new_line.dart';
@@ -310,6 +312,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(PreferFinalFields())
     ..register(PreferFinalInForEach())
     ..register(PreferFinalLocals())
+    ..register(PreferFinalParameters())
     ..register(PreferForeach())
     ..register(PreferForElementsToMapFromIterable())
     ..register(PreferFunctionDeclarationsOverVariables())

--- a/lib/src/rules/prefer_final_parameters.dart
+++ b/lib/src/rules/prefer_final_parameters.dart
@@ -84,14 +84,14 @@ class _Visitor extends SimpleAstVisitor<void> {
   void _reportApplicableParameters(
       FormalParameterList? parameters, FunctionBody body) {
     if (parameters != null) {
-      parameters.parameters.forEach((e) {
-        if (e.isFinal || e.isConst || e is FieldFormalParameter) {
+      parameters.parameters.forEach((param) {
+        if (param.isFinal || param.isConst || param is FieldFormalParameter) {
           return;
         }
-        var declaredElement = e.declaredElement;
+        var declaredElement = param.declaredElement;
         if (declaredElement != null &&
             !body.isPotentiallyMutatedInScope(declaredElement)) {
-          rule.reportLint(e);
+          rule.reportLint(param);
         }
       });
     }

--- a/lib/src/rules/prefer_final_parameters.dart
+++ b/lib/src/rules/prefer_final_parameters.dart
@@ -68,9 +68,9 @@ class PreferFinalParameters extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
-    registry.addFunctionDeclaration(this, visitor);
-    registry.addMethodDeclaration(this, visitor);
+    registry.addConstructorDeclaration(this, visitor);
     registry.addFunctionExpression(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
   }
 }
 
@@ -85,7 +85,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       FormalParameterList? parameters, FunctionBody body) {
     if (parameters != null) {
       parameters.parameters.forEach((e) {
-        if (e.isFinal || e.isConst) {
+        if (e.isFinal || e.isConst || e is FieldFormalParameter) {
           return;
         }
         var declaredElement = e.declaredElement;
@@ -98,21 +98,14 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   @override
-  void visitFunctionExpression(FunctionExpression node) {
-    var parameters = node.parameters;
-    _reportApplicableParameters(parameters, node.body);
-  }
+  void visitConstructorDeclaration(ConstructorDeclaration node) =>
+      _reportApplicableParameters(node.parameters, node.body);
 
   @override
-  void visitFunctionDeclaration(FunctionDeclaration node) {
-    var functionExpression = node.functionExpression;
-    var parameters = functionExpression.parameters;
-    _reportApplicableParameters(parameters, functionExpression.body);
-  }
+  void visitFunctionExpression(FunctionExpression node) =>
+      _reportApplicableParameters(node.parameters, node.body);
 
   @override
-  void visitMethodDeclaration(MethodDeclaration node) {
-    var parameters = node.parameters;
-    _reportApplicableParameters(parameters, node.body);
-  }
+  void visitMethodDeclaration(MethodDeclaration node) =>
+      _reportApplicableParameters(node.parameters, node.body);
 }

--- a/lib/src/rules/prefer_final_parameters.dart
+++ b/lib/src/rules/prefer_final_parameters.dart
@@ -42,6 +42,16 @@ void badExpression(int value) => print(value); // LINT
 void goodExpression(final int value) => print(value); // OK
 ```
 
+**BAD:**
+```dart
+[1, 4, 6, 8].forEach((value) => print(value + 2)); // LINT
+```
+
+**GOOD:**
+```dart
+[1, 4, 6, 8].forEach((final value) => print(value + 2)); // OK
+```
+
 **GOOD:**
 ```dart
 void mutableParameter(String label) { // OK

--- a/lib/src/rules/prefer_final_parameters.dart
+++ b/lib/src/rules/prefer_final_parameters.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc =
+    r'Prefer final for parameter declarations if they are not reassigned.';
+
+const _details = r'''
+
+**DO** prefer declaring parameters as final if they are not reassigned in
+the function body.
+
+Declaring parameters as final when possible is a good practice because it helps
+avoid accidental reassignments.
+
+**BAD:**
+```dart
+void badParameter(String label) { // LINT
+  print(label);
+}
+```
+
+**GOOD:**
+```dart
+void goodParameter(final String label) { // OK
+  print(label);
+}
+```
+
+**BAD:**
+```dart
+void badExpression(int value) => print(value); // LINT
+```
+
+**GOOD:**
+```dart
+void goodExpression(final int value) => print(value); // OK
+```
+
+**GOOD:**
+```dart
+void mutableParameter(String label) { // OK
+  print(label);
+  label = 'Hello Linter!';
+  print(label);
+}
+```
+
+''';
+
+class PreferFinalParameters extends LintRule implements NodeLintRule {
+  PreferFinalParameters()
+      : super(
+            name: 'prefer_final_parameters',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  List<String> get incompatibleRules => const ['unnecessary_final'];
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addMethodDeclaration(this, visitor);
+    registry.addFunctionExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  /// Report the lint for parameters in the [parameters] list that are not
+  /// const or final already and not potentially mutated in the function [body].
+  void _reportApplicableParameters(
+      FormalParameterList? parameters, FunctionBody body) {
+    if (parameters != null) {
+      parameters.parameters.forEach((e) {
+        if (e.isFinal || e.isConst) {
+          return;
+        }
+        var declaredElement = e.declaredElement;
+        if (declaredElement != null &&
+            !body.isPotentiallyMutatedInScope(declaredElement)) {
+          rule.reportLint(e);
+        }
+      });
+    }
+  }
+
+  @override
+  void visitFunctionExpression(FunctionExpression node) {
+    var parameters = node.parameters;
+    _reportApplicableParameters(parameters, node.body);
+  }
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    var functionExpression = node.functionExpression;
+    var parameters = functionExpression.parameters;
+    _reportApplicableParameters(parameters, functionExpression.body);
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    var parameters = node.parameters;
+    _reportApplicableParameters(parameters, node.body);
+  }
+}

--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -44,7 +44,8 @@ class UnnecessaryFinal extends LintRule implements NodeLintRule {
             group: Group.style);
 
   @override
-  List<String> get incompatibleRules => const ['prefer_final_locals'];
+  List<String> get incompatibleRules =>
+      const ['prefer_final_locals', 'prefer_final_parameters'];
 
   @override
   void registerNodeProcessors(

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -4,11 +4,35 @@
 
 // test w/ `dart test -N prefer_final_parameters`
 
-void badFunction(String label) { // LINT
+void badRequiredPositional(String label) { // LINT
   print(label);
 }
 
-void goodFunction(final String label) { // OK
+void goodRequiredPositional(final String label) { // OK
+  print(label);
+}
+
+void badOptionalPosition([String? label]) { // LINT
+  print(label);
+}
+
+void goodOptionalPosition([final String? label]) { // OK
+  print(label);
+}
+
+void badRequiredNamed({required String label}) { // LINT
+  print(label);
+}
+
+void goodRequiredNamed({required final String label}) { // OK
+  print(label);
+}
+
+void badOptionalNamed({String? label}) { // LINT
+  print(label);
+}
+
+void goodOptionalNamed({final String? label}) { // OK
   print(label);
 }
 

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -4,7 +4,7 @@
 
 // test w/ `dart test -N prefer_final_parameters`
 
-void badMethod(String label) { // LINT
+void badFunction(String label) { // LINT
   print(label);
 }
 
@@ -19,11 +19,11 @@ bool _testingVariable;
 
 void set badSet(bool setting) => _testingVariable = setting; // LINT
 
-var badCallback = (Object random) { // LINT
+var badClosure = (Object random) { // LINT
   print(random);
 };
 
-void goodMethod(final String label) { // OK
+void goodFunction(final String label) { // OK
   print(label);
 }
 
@@ -36,7 +36,7 @@ void goodMultiple(final String bad, final String good) { // OK
 
 void set goodSet(final bool setting) => _testingVariable = setting; // OK
 
-var goodCallback = (final Object random) { // OK
+var goodClosure = (final Object random) { // OK
   print(random);
 };
 

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N prefer_final_parameters`
+
+void badMethod(String label) { // LINT
+  print(label);
+}
+
+void badExpression(int value) => print(value); // LINT
+
+void badMixed(String bad, final String good) { // LINT
+  print(bad);
+  print(good);
+}
+
+bool _testingVariable;
+
+void set badSet(bool setting) => _testingVariable = setting; // LINT
+
+var badCallback = (Object random) { // LINT
+  print(random);
+};
+
+void goodMethod(final String label) { // OK
+  print(label);
+}
+
+void goodExpression(final int value) => print(value); // OK
+
+void goodMultiple(final String bad, final String good) { // OK
+  print(bad);
+  print(good);
+}
+
+void set goodSet(final bool setting) => _testingVariable = setting; // OK
+
+var goodCallback = (final Object random) { // OK
+  print(random);
+};
+
+void mutableCase(String label) { // OK
+  print(label);
+  label = 'Lint away!';
+  print(label);
+}
+
+void mutableExpression(int value) => value = 3; // OK

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -8,37 +8,37 @@ void badFunction(String label) { // LINT
   print(label);
 }
 
+void goodFunction(final String label) { // OK
+  print(label);
+}
+
 void badExpression(int value) => print(value); // LINT
+
+void goodExpression(final int value) => print(value); // OK
+
+bool _testingVariable;
+
+void set badSet(bool setting) => _testingVariable = setting; // LINT
+
+void set goodSet(final bool setting) => _testingVariable = setting; // OK
+
+var badClosure = (Object random) { // LINT
+  print(random);
+};
+
+var goodClosure = (final Object random) { // OK
+  print(random);
+};
 
 void badMixed(String bad, final String good) { // LINT
   print(bad);
   print(good);
 }
 
-bool _testingVariable;
-
-void set badSet(bool setting) => _testingVariable = setting; // LINT
-
-var badClosure = (Object random) { // LINT
-  print(random);
-};
-
-void goodFunction(final String label) { // OK
-  print(label);
-}
-
-void goodExpression(final int value) => print(value); // OK
-
 void goodMultiple(final String bad, final String good) { // OK
   print(bad);
   print(good);
 }
-
-void set goodSet(final bool setting) => _testingVariable = setting; // OK
-
-var goodClosure = (final Object random) { // OK
-  print(random);
-};
 
 void mutableCase(String label) { // OK
   print(label);
@@ -60,9 +60,9 @@ class C {
 
   C.good(final int contents): _contents = contents; // OK
 
-  factory C.theValue(this.value); // OK
+  factory C.theValueGood(this.value); // OK
 
-  factory C.theValue(String value): this.value = value; // LINT
+  factory C.theValueBad(String value): this.value = value; // LINT
 
   void set badContents(int contents) => _contents = setting; // LINT
   void set goodContents(final int contents) => _contents = setting; // OK

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -47,3 +47,38 @@ void mutableCase(String label) { // OK
 }
 
 void mutableExpression(int value) => value = 3; // OK
+
+class C {
+  int _contents = 0;
+
+  C(String content) { // LINT
+    _contents = content.length;
+  }
+
+  C.bad(int contents): _contents = contents; // LINT
+
+  C.good(final int contents): _contents = contents; // OK
+
+  void set badContents(int contents) => _contents = setting; // LINT
+  void set goodContents(final int contents) => _contents = setting; // OK
+
+  int get contentValue => _contents + 4; // OK
+
+  void badMethod(String bad) { // LINT
+    print(bad);
+  }
+
+  void goodMethod(final String good) { // OK
+    print(good);
+  }
+
+  @override
+  C operator +(C other) { // LINT
+    return C.good(contentValue + other.contentValue);
+  }
+
+  @override
+  C operator -(final C other) { // OK
+    return C.good(contentValue + other.contentValue);
+  }
+}

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -49,6 +49,7 @@ void mutableCase(String label) { // OK
 void mutableExpression(int value) => value = 3; // OK
 
 class C {
+  String value = '';
   int _contents = 0;
 
   C(String content) { // LINT
@@ -58,6 +59,10 @@ class C {
   C.bad(int contents): _contents = contents; // LINT
 
   C.good(final int contents): _contents = contents; // OK
+
+  factory C.theValue(this.value); // OK
+
+  factory C.theValue(String value): this.value = value; // LINT
 
   void set badContents(int contents) => _contents = setting; // LINT
   void set goodContents(final int contents) => _contents = setting; // OK

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -40,7 +40,7 @@ void badExpression(int value) => print(value); // LINT
 
 void goodExpression(final int value) => print(value); // OK
 
-bool _testingVariable;
+bool? _testingVariable;
 
 void set badSet(bool setting) => _testingVariable = setting; // LINT
 
@@ -53,6 +53,20 @@ var badClosure = (Object random) { // LINT
 var goodClosure = (final Object random) { // OK
   print(random);
 };
+
+var _testingList = [1, 7, 15, 20];
+
+void useBadClosureArgument() {
+  _testingList.forEach((element) => print(element + 4)); // LINT
+}
+
+void useGoodClosureArgument() {
+  _testingList.forEach((final element) => print(element + 4)); // OK
+}
+
+void useGoodTypedClosureArgument() {
+  _testingList.forEach((final int element) => print(element + 4)); // OK
+}
 
 void badMixed(String bad, final String good) { // LINT
   print(bad);
@@ -84,9 +98,17 @@ class C {
 
   C.good(final int contents): _contents = contents; // OK
 
-  factory C.theValueGood(this.value); // OK
+  C.badValue(String value): this.value = value; // LINT
 
-  factory C.theValueBad(String value): this.value = value; // LINT
+  C.goodValue(this.value); // OK
+
+  factory C.goodFactory(final String value) { // OK
+    return C(value);
+  }
+
+  factory C.badFactory(String value) { // LINT
+    return C(value);
+  }
 
   void set badContents(int contents) => _contents = setting; // LINT
   void set goodContents(final int contents) => _contents = setting; // OK


### PR DESCRIPTION
I know this one doesn't fit everyone's style, but it's how I instinctively write my code and goes well along with `prefer_final_locals`. It's strange to have your locals be `final` but not your parameters which are similar to locally declared variables.

It also goes well with `parameter_assignments` as once they removal those assignments, then this lint can trigger. Then they won't trigger the `parameter_assignments` lint again.

Fixes #1914
