### PR TITLE
add noop_string_calls

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -88,6 +88,7 @@ linter:
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names
+    - noop_string_calls
     - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -90,6 +90,7 @@ import 'rules/no_duplicate_case_values.dart';
 import 'rules/no_logic_in_create_state.dart';
 import 'rules/no_runtimeType_toString.dart';
 import 'rules/non_constant_identifier_names.dart';
+import 'rules/noop_string_calls.dart';
 import 'rules/null_check_on_nullable_type_parameter.dart';
 import 'rules/null_closures.dart';
 import 'rules/omit_local_variable_types.dart';
@@ -283,6 +284,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(NoDuplicateCaseValues())
     ..register(NonConstantIdentifierNames())
     ..register(NoLogicInCreateState())
+    ..register(NoopStringCalls())
     ..register(NoRuntimeTypeToString())
     ..register(NullCheckOnNullableTypeParameter())
     ..register(NullClosures())

--- a/lib/src/rules/noop_string_calls.dart
+++ b/lib/src/rules/noop_string_calls.dart
@@ -44,6 +44,7 @@ class NoopStringCalls extends LintRule implements NodeLintRule {
     LinterContext context,
   ) {
     var visitor = _Visitor(this, context);
+    registry.addAdjacentStrings(this, visitor);
     registry.addBinaryExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
@@ -54,6 +55,15 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   final LintRule rule;
   final LinterContext context;
+
+  @override
+  void visitAdjacentStrings(AdjacentStrings node) {
+    for (var literal in node.strings) {
+      if (literal.stringValue?.isEmpty ?? false) {
+        rule.reportLint(literal);
+      }
+    }
+  }
 
   @override
   void visitBinaryExpression(BinaryExpression node) {

--- a/lib/src/rules/noop_string_calls.dart
+++ b/lib/src/rules/noop_string_calls.dart
@@ -61,31 +61,31 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     var right = node.rightOperand;
 
-    // string.toString()
+    // string + ''
     if (node.operator.type == TokenType.PLUS &&
         right is StringLiteral &&
-        right.stringValue == '') {
-      rule.reportLint(node);
+        (right.stringValue?.isEmpty ?? false)) {
+      rule.reportLintForToken(node.operator);
       return;
     }
 
-    // string.toString()
+    // string * 1
     if (node.operator.type == TokenType.STAR &&
         right is IntegerLiteral &&
         right.value == 1) {
-      rule.reportLint(node);
+      rule.reportLintForToken(node.operator);
       return;
     }
   }
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    if (!(node.target?.staticType?.isDartCoreString ?? false)) return;
+    if (!(node.realTarget?.staticType?.isDartCoreString ?? false)) return;
 
     // string.toString()
     if (node.methodName.name == 'toString' &&
         context.typeSystem.isNonNullable(node.target!.staticType!)) {
-      rule.reportLint(node);
+      rule.reportLint(node.methodName);
       return;
     }
 
@@ -94,7 +94,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         node.argumentList.arguments.length == 1) {
       var arg = node.argumentList.arguments.first;
       if (arg is IntegerLiteral && arg.value == 0) {
-        rule.reportLint(node);
+        rule.reportLint(node.methodName);
         return;
       }
     }
@@ -103,7 +103,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (['padLeft', 'padRight'].contains(node.methodName.name)) {
       var firstArg = node.argumentList.arguments.first;
       if (firstArg is IntegerLiteral && firstArg.value == 0) {
-        rule.reportLint(node);
+        rule.reportLint(node.methodName);
         return;
       }
     }

--- a/lib/src/rules/noop_string_calls.dart
+++ b/lib/src/rules/noop_string_calls.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Noop string calls.';
+
+const _details = r'''
+
+Some operation on String are idempotent and return the same string.
+
+**BAD:**
+
+```dart
+f() {
+  var s = 'hello';
+  s + '';
+  s * 1;
+  s.toString();
+  s.substring(0);
+  s.padLeft(0);
+  s.padRight(0);
+}
+```
+''';
+
+class NoopStringCalls extends LintRule implements NodeLintRule {
+  NoopStringCalls()
+      : super(
+          name: 'noop_string_calls',
+          description: _desc,
+          details: _details,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(
+    NodeLintRegistry registry,
+    LinterContext context,
+  ) {
+    var visitor = _Visitor(this, context);
+    registry.addBinaryExpression(this, visitor);
+    registry.addMethodInvocation(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final LintRule rule;
+  final LinterContext context;
+
+  @override
+  void visitBinaryExpression(BinaryExpression node) {
+    if (!(node.leftOperand.staticType?.isDartCoreString ?? false)) return;
+
+    var right = node.rightOperand;
+
+    // string.toString()
+    if (node.operator.type == TokenType.PLUS &&
+        right is StringLiteral &&
+        right.stringValue == '') {
+      rule.reportLint(node);
+      return;
+    }
+
+    // string.toString()
+    if (node.operator.type == TokenType.STAR &&
+        right is IntegerLiteral &&
+        right.value == 1) {
+      rule.reportLint(node);
+      return;
+    }
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!(node.target?.staticType?.isDartCoreString ?? false)) return;
+
+    // string.toString()
+    if (node.methodName.name == 'toString' &&
+        context.typeSystem.isNonNullable(node.target!.staticType!)) {
+      rule.reportLint(node);
+      return;
+    }
+
+    // string.substring(0)
+    if (node.methodName.name == 'substring' &&
+        node.argumentList.arguments.length == 1) {
+      var arg = node.argumentList.arguments.first;
+      if (arg is IntegerLiteral && arg.value == 0) {
+        rule.reportLint(node);
+        return;
+      }
+    }
+
+    // string.padLeft(0,*) or string.padRight(0,*)
+    if (['padLeft', 'padRight'].contains(node.methodName.name)) {
+      var firstArg = node.argumentList.arguments.first;
+      if (firstArg is IntegerLiteral && firstArg.value == 0) {
+        rule.reportLint(node);
+        return;
+      }
+    }
+  }
+}

--- a/test_data/rules/noop_string_calls.dart
+++ b/test_data/rules/noop_string_calls.dart
@@ -25,4 +25,8 @@ f() {
   s.padLeft(1); // OK
   s.padRight(0); // LINT
   s.padRight(1); // OK
+
+  s = 'hello'
+      '' // LINT
+      'world';
 }

--- a/test_data/rules/noop_string_calls.dart
+++ b/test_data/rules/noop_string_calls.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N noop_string_calls`
+
+f() {
+  String? nullable;
+  String s = 'hello';
+  s + ''; // LINT
+  s + 'a'; // OK
+
+  s * 0; // OK
+  s * 1; // LINT
+  s * 2; // OK
+
+  s.toString(); // LINT
+  nullable.toString(); // OK
+
+  s.substring(0); // LINT
+  s.substring(1); // OK
+  s.substring(0, 1); // OK
+
+  s.padLeft(0); // LINT
+  s.padLeft(1); // OK
+  s.padRight(0); // LINT
+  s.padRight(1); // OK
+}


### PR DESCRIPTION
Some operation on String are idempotent and return the same string.

**BAD:**

```dart
f() {
  var s = 'hello';
  s + '';
  s * 1;
  s.toString();
  s.substring(0);
  s.padLeft(0);
  s.padRight(0);
}
```