### PR TITLE
add noop_primitive_operations

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -88,6 +88,7 @@ linter:
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names
+    - noop_primitive_operations
     - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -90,6 +90,7 @@ import 'rules/no_duplicate_case_values.dart';
 import 'rules/no_logic_in_create_state.dart';
 import 'rules/no_runtimeType_toString.dart';
 import 'rules/non_constant_identifier_names.dart';
+import 'rules/noop_primitive_operations.dart';
 import 'rules/null_check_on_nullable_type_parameter.dart';
 import 'rules/null_closures.dart';
 import 'rules/omit_local_variable_types.dart';
@@ -283,6 +284,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(NoDuplicateCaseValues())
     ..register(NonConstantIdentifierNames())
     ..register(NoLogicInCreateState())
+    ..register(NoopPrimitiveOperations())
     ..register(NoRuntimeTypeToString())
     ..register(NullCheckOnNullableTypeParameter())
     ..register(NullClosures())

--- a/lib/src/rules/noop_primitive_operations.dart
+++ b/lib/src/rules/noop_primitive_operations.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Noop primitive operations.';
+
+const _details = r'''
+
+Some operations on primitive types are idempotent and can be removed.
+
+**BAD:**
+
+```dart
+doubleValue.toDouble();
+
+intValue.toInt();
+intValue.round();
+intValue.ceil();
+intValue.floor();
+intValue.truncate();
+
+string.toString();
+string = 'hello\n'
+    'world\n'
+    ''; // useless empty string
+```
+''';
+
+class NoopPrimitiveOperations extends LintRule implements NodeLintRule {
+  NoopPrimitiveOperations()
+      : super(
+          name: 'noop_primitive_operations',
+          description: _desc,
+          details: _details,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(
+    NodeLintRegistry registry,
+    LinterContext context,
+  ) {
+    var visitor = _Visitor(this, context);
+    registry.addAdjacentStrings(this, visitor);
+    registry.addMethodInvocation(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final LintRule rule;
+  final LinterContext context;
+
+  @override
+  void visitAdjacentStrings(AdjacentStrings node) {
+    for (var literal in node.strings) {
+      if (literal.stringValue?.isEmpty ?? false) {
+        rule.reportLint(literal);
+      }
+    }
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    var type = node.realTarget?.staticType;
+    if (type == null) return;
+
+    // string.toString()
+    if (type.isDartCoreString &&
+        node.methodName.name == 'toString' &&
+        context.typeSystem.isNonNullable(type)) {
+      rule.reportLint(node.methodName);
+      return;
+    }
+
+    // int invariant methods
+    if (type.isDartCoreInt &&
+        ['toInt', 'round', 'ceil', 'floor', 'truncate']
+            .contains(node.methodName.name)) {
+      rule.reportLint(node.methodName);
+      return;
+    }
+
+    // double.toDouble()
+    if (type.isDartCoreDouble && node.methodName.name == 'toDouble') {
+      rule.reportLint(node.methodName);
+      return;
+    }
+  }
+}

--- a/test_data/rules/noop_primitive_operations.dart
+++ b/test_data/rules/noop_primitive_operations.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N noop_primitive_operations`
+
+onString() {
+  String? nullable;
+  String v = 'hello';
+
+  v.toString(); // LINT
+  nullable.toString(); // OK
+
+  v = 'hello\n'
+      'world\n'
+      ''; // LINT
+}
+
+onInt() {
+  int v = 1;
+  v.toInt(); // LINT
+  v.round(); // LINT
+  v.ceil(); // LINT
+  v.floor(); // LINT
+  v.truncate(); // LINT
+}
+
+onDouble() {
+  double v = 1.23;
+  v.toDouble(); // LINT
+}


### PR DESCRIPTION
Follow up on #2618

# Description

Some operations on primitive types are idempotent and can be removed.

**BAD:**

```dart
doubleValue.toDouble();

intValue.toInt();
intValue.round();
intValue.ceil();
intValue.floor();
intValue.truncate();

string.toString();
string = 'hello\n'
    'world\n'
    ''; // useless empty string
```