### PR TITLE
add incompatible rules

### DIFF
--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -37,6 +37,7 @@ String getMachineListing(Iterable<LintRule> ruleRegistry,
         'description': rule.description,
         'group': rule.group.name,
         'maturity': rule.maturity.name,
+        'incompatible': rule.incompatibleRules,
         'sets': [
           if (flutterRules.contains(rule.name)) 'flutter',
           if (pedanticRules.contains(rule.name)) 'pedantic',


### PR DESCRIPTION
Fixes #2627

Example:

```json
...

  {
    "name": "unnecessary_final",
    "description": "Don't use `final` for local variables.",
    "group": "style",
    "maturity": "stable",
    "incompatible": [
      "prefer_final_locals",
      "prefer_final_parameters"
    ],
    "sets": [],
    "details": "**DON'T** use `final` for local variables.\n\n`var` is shorter, and `final` does not change the meaning of the code.\n\n**BAD:**\n```dart\nvoid badMethod() {\n  final label = 'Final or var?';\n  for (final char in ['v', 'a', 'r']) {\n    print(char);\n  }\n}\n```\n\n**GOOD:**\n```dart\nvoid goodMethod() {\n  var label = 'Final or var?';\n  for (var char in ['v', 'a', 'r']) {\n    print(char);\n  }\n}\n```\n"
  },

...
```

/cc @bwilkerson @parlough 