### PR TITLE
add use_test_throws_matchers

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -187,6 +187,7 @@ linter:
     - use_rethrow_when_possible
     - use_setters_to_change_properties
     - use_string_buffers
+    - use_test_throws_matchers
     - use_to_and_as_if_applicable
     - valid_regexps
     - void_checks

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -191,6 +191,7 @@ import 'rules/use_raw_strings.dart';
 import 'rules/use_rethrow_when_possible.dart';
 import 'rules/use_setters_to_change_properties.dart';
 import 'rules/use_string_buffers.dart';
+import 'rules/use_test_throws_matchers.dart';
 import 'rules/use_to_and_as_if_applicable.dart';
 import 'rules/valid_regexps.dart';
 import 'rules/void_checks.dart';
@@ -388,6 +389,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(UseRawStrings())
     ..register(UseSettersToChangeAProperty())
     ..register(UseStringBuffers())
+    ..register(UseTestThrowsMatchers())
     ..register(UseToAndAsIfApplicable())
     ..register(ValidRegExps())
     ..register(VoidChecks());

--- a/lib/src/rules/use_test_throws_matchers.dart
+++ b/lib/src/rules/use_test_throws_matchers.dart
@@ -81,7 +81,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     if (isTestInvocation(lastBodyStatement, 'fail') &&
         node.finallyBlock == null) {
-      rule.reportLint(node);
+      rule.reportLint(lastBodyStatement);
     }
   }
 

--- a/lib/src/rules/use_test_throws_matchers.dart
+++ b/lib/src/rules/use_test_throws_matchers.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Use throwsA matcher instead of fail().';
+
+const _details = r'''
+
+Use the `throwsA` matcher instead of try-catch with `fail()`.
+
+**BAD:**
+
+```dart
+// sync code
+try {
+  someSyncFunctionThatThrows();
+  fail('expected Error');
+} on Error catch (error) {
+  expect(error.message, contains('some message'));
+}
+
+// async code
+try {
+  await someAsyncFunctionThatThrows();
+  fail('expected Error');
+} on Error catch (error) {
+  expect(error.message, contains('some message'));
+}
+```
+
+**GOOD:**
+```dart
+// sync code
+expect(
+  () => someSyncFunctionThatThrows(),
+  throwsA(isA<Error>().having((Error error) => error.message, 'message', contains('some message'))),
+);
+
+// async code
+await expectLater(
+  () => someAsyncFunctionThatThrows(),
+  throwsA(isA<Error>().having((Error error) => error.message, 'message', contains('some message'))),
+);
+```
+
+''';
+
+class UseTestThrowsMatchers extends LintRule implements NodeLintRule {
+  UseTestThrowsMatchers()
+      : super(
+          name: 'use_test_throws_matchers',
+          description: _desc,
+          details: _details,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addTryStatement(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitTryStatement(TryStatement node) {
+    if (node.catchClauses.length != 1 || node.body.statements.isEmpty) return;
+
+    var lastBodyStatement = node.body.statements.last;
+
+    if (isTestInvocation(lastBodyStatement, 'fail') &&
+        node.finallyBlock == null) {
+      rule.reportLint(node);
+    }
+  }
+
+  bool isTestInvocation(Statement statement, String functionName) {
+    if (statement is! ExpressionStatement) return false;
+    var expression = statement.expression;
+    if (expression is! MethodInvocation) return false;
+    var element = expression.methodName.staticElement;
+    return element is FunctionElement &&
+        element.source.uri ==
+            Uri.parse('package:test_api/src/frontend/expect.dart') &&
+        element.name == functionName;
+  }
+}

--- a/test_data/mock_packages/test_api/lib/src/frontend/expect.dart
+++ b/test_data/mock_packages/test_api/lib/src/frontend/expect.dart
@@ -1,0 +1,2 @@
+void expect(actual, matcher) {}
+Never fail(String message) {}

--- a/test_data/mock_packages/test_api/lib/test_api.dart
+++ b/test_data/mock_packages/test_api/lib/test_api.dart
@@ -1,0 +1,3 @@
+library test_api;
+
+export 'src/frontend/expect.dart';

--- a/test_data/mock_packages/test_api/pubspec.yaml
+++ b/test_data/mock_packages/test_api/pubspec.yaml
@@ -1,0 +1,4 @@
+name: test_api
+
+environment:
+  sdk: '>=2.2.2 <3.0.0'

--- a/test_data/rules/.mock_packages
+++ b/test_data/rules/.mock_packages
@@ -1,3 +1,4 @@
 fixnum:../mock_packages/fixnum/lib/
 flutter:../mock_packages/flutter/lib/
 meta:../mock_packages/meta/lib/
+test_api:../mock_packages/test_api/lib/

--- a/test_data/rules/use_test_throws_matchers.dart
+++ b/test_data/rules/use_test_throws_matchers.dart
@@ -7,31 +7,27 @@
 import 'package:test_api/test_api.dart';
 
 f() {
-  try // LINT
-  {
+  try {
     f();
-    fail('fail');
+    fail('fail'); // LINT
   } catch (e) {}
 
-  try // OK
-  {
+  try {
     f();
   } catch (e) {}
 
-  try // OK
-  {
+  try {
     f();
-    fail('fail');
+    fail('fail'); // OK
   } catch (e) {
     expect(e, null);
   } finally {
     print('hello');
   }
 
-  try // OK
-  {
+  try {
     f();
-    fail('fail');
+    fail('fail'); // OK
   } on Exception catch (e) {
     expect(e, null);
   } catch (e) {

--- a/test_data/rules/use_test_throws_matchers.dart
+++ b/test_data/rules/use_test_throws_matchers.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N use_test_throws_matchers`
+
+import 'package:test_api/test_api.dart';
+
+f() {
+  try // LINT
+  {
+    f();
+    fail('fail');
+  } catch (e) {}
+
+  try // OK
+  {
+    f();
+  } catch (e) {}
+
+  try // OK
+  {
+    f();
+    fail('fail');
+  } catch (e) {
+    expect(e, null);
+  } finally {
+    print('hello');
+  }
+
+  try // OK
+  {
+    f();
+    fail('fail');
+  } on Exception catch (e) {
+    expect(e, null);
+  } catch (e) {
+    expect(e, null);
+  }
+}


### PR DESCRIPTION
Use the `throwsA` matcher instead of try-catch with `fail()`.

**BAD:**

```dart
// sync code
try {
  someSyncFunctionThatThrows();
  fail('expected Error');
} on Error catch (error) {
  expect(error.message, contains('some message'));
}
// async code
try {
  await someAsyncFunctionThatThrows();
  fail('expected Error');
} on Error catch (error) {
  expect(error.message, contains('some message'));
}
```

**GOOD:**

```dart
// sync code
expect(
  () => someSyncFunctionThatThrows(),
  throwsA(isA<Error>().having((Error error) => error.message, 'message', contains('some message'))),
);
// async code
await expectLater(
  () => someAsyncFunctionThatThrows(),
  throwsA(isA<Error>().having((Error error) => error.message, 'message', contains('some message'))),
);
```