### PR TITLE
relax sort_child_properties_last to accept closures after child

### DIFF
--- a/test_data/rules/sort_child_properties_last.dart
+++ b/test_data/rules/sort_child_properties_last.dart
@@ -94,3 +94,23 @@ nestedChildren() {
     crossAxisAlignment: CrossAxisAlignment.center,
   );
 }
+
+class WithClosure extends Widget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        key: 0,
+        child: Center( // OK
+          child: Column(
+            key: 0,
+            children: [],
+          ),
+        ),
+        onPress: () {
+          // some code
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Related to flutter/flutter#81687

This relax the rule to accept closure after `child` property.
