### PR TITLE
update flutter lint source

### DIFF
--- a/lib/src/util/score_utils.dart
+++ b/lib/src/util/score_utils.dart
@@ -24,6 +24,7 @@ Future<String> get pedanticLatestVersion async {
   return parts[1].split('.yaml')[0];
 }
 
+/// todo(pq): de-duplicate these fetches / URIs
 Future<List<String>> _readFlutterLints() async => _fetchLints(
     'https://raw.githubusercontent.com/flutter/packages/master/packages/flutter_lints/lib/flutter.yaml');
 

--- a/lib/src/util/score_utils.dart
+++ b/lib/src/util/score_utils.dart
@@ -25,8 +25,7 @@ Future<String> get pedanticLatestVersion async {
 }
 
 Future<List<String>> _readFlutterLints() async => _fetchLints(
-// todo(pq):update when landed
-    'https://raw.githubusercontent.com/dart-lang/lints/400c60bf379bbad5b161148f52a29c0e4fd378f6/lib/flutter.yaml');
+    'https://raw.githubusercontent.com/flutter/packages/master/packages/flutter_lints/lib/flutter.yaml');
 
 Future<List<String>> _readRecommendedLints() async => _fetchLints(
     'https://raw.githubusercontent.com/dart-lang/lints/main/lib/recommended.yaml');


### PR DESCRIPTION
Missed in https://github.com/dart-lang/linter/pull/2646.

(I have a TODO to consolidate these two fetch URI paths but that's part of a bigger cleanup; this just gets this aligned in the meantime.)

/cc @bwilkerson @goderbauer 
