### PR TITLE
add lint always_depend_on_packages_you_use

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -43,9 +43,11 @@ export 'package:analyzer/src/lint/linter.dart'
         NodeLintRule;
 export 'package:analyzer/src/lint/project.dart'
     show DartProject, ProjectVisitor;
-export 'package:analyzer/src/lint/pub.dart' show PubspecVisitor, PSEntry;
+export 'package:analyzer/src/lint/pub.dart'
+    show PubspecVisitor, PSEntry, Pubspec;
 export 'package:analyzer/src/lint/util.dart' show Spelunker;
 export 'package:analyzer/src/services/lint.dart' show lintRegistry;
+export 'package:analyzer/src/workspace/pub.dart' show PubWorkspacePackage;
 
 const loggedAnalyzerErrorExitCode = 63;
 

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -129,6 +129,18 @@ bool isInLibDir(CompilationUnit node, WorkspacePackage? package) {
   return path.isWithin(libDir, cuPath);
 }
 
+/// Return true if this compilation unit [node] is declared within a public
+/// directory in the given [package]'s directory tree. Public dirs are the
+/// `lib` and `bin` dirs.
+bool isInPublicDir(CompilationUnit node, WorkspacePackage? package) {
+  if (package == null) return false;
+  var cuPath = node.declaredElement?.library.source.fullName;
+  if (cuPath == null) return false;
+  var libDir = path.join(package.root, 'lib');
+  var binDir = path.join(package.root, 'bin');
+  return path.isWithin(libDir, cuPath) || path.isWithin(binDir, cuPath);
+}
+
 /// Returns `true` if the keyword associated with the given [token] matches
 /// [keyword].
 bool isKeyword(Token token, Keyword keyword) =>

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -4,6 +4,7 @@
 
 import 'analyzer.dart';
 import 'rules/always_declare_return_types.dart';
+import 'rules/always_depend_on_packages_you_use.dart';
 import 'rules/always_put_control_body_on_new_line.dart';
 import 'rules/always_put_required_named_parameters_first.dart';
 import 'rules/always_require_non_null_named_parameters.dart';
@@ -200,6 +201,7 @@ void registerLintRules({bool inTestMode = false}) {
   Analyzer.facade.cacheLinterVersion();
   Analyzer.facade
     ..register(AlwaysDeclareReturnTypes())
+    ..register(AlwaysDependOnPackagesYouUse())
     ..register(AlwaysPutControlBodyOnNewLine())
     ..register(AlwaysPutRequiredNamedParametersFirst())
     ..register(AlwaysRequireNonNullNamedParameters())

--- a/lib/src/rules/always_depend_on_packages_you_use.dart
+++ b/lib/src/rules/always_depend_on_packages_you_use.dart
@@ -1,0 +1,112 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import '../ast.dart';
+
+const _desc = r'Depend on packages you use.';
+
+const _details = r'''
+
+**DO** depend on packages you use.
+
+When importing a package, *always* add a dependency on it to your pubspec.
+
+Depending explicitly on packages that you use ensures they will always exist
+and allows you to put a dependency constraint on them to guard you against
+breaking changes.
+
+Whether this should be a regular dependency or dev_dependency depends on if it
+is imported from a public file (one under either `lib` or `bin`), or some other
+file.
+
+**BAD:**
+```dart
+import 'package:a/a.dart';
+import 'package:b/b.dart';
+```
+
+```yaml
+dependencies:
+  a: ^1.0.0
+```
+
+**GOOD:**
+```dart
+import 'package:a/a.dart';
+import 'package:b/b.dart';
+```
+
+```yaml
+dependencies:
+  a: ^1.0.0
+  b: ^1.0.0
+```
+
+''';
+
+class AlwaysDependOnPackagesYouUse extends LintRule implements NodeLintRule {
+  AlwaysDependOnPackagesYouUse()
+      : super(
+            name: 'always_depend_on_packages_you_use',
+            description: _desc,
+            details: _details,
+            group: Group.pub);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    // Only lint if we have a pubspec.
+    var package = context.package;
+    if (package is! PubWorkspacePackage) return;
+    var pubspec = package.pubspec;
+    if (pubspec == null) return;
+
+    var visitor = _Visitor(this, context, pubspec,
+        isPublicFile: isInPublicDir(context.currentUnit.unit, context.package));
+    registry.addImportDirective(this, visitor);
+    registry.addExportDirective(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final AlwaysDependOnPackagesYouUse rule;
+  final LinterContext context;
+  final Pubspec pubspec;
+  final bool isPublicFile;
+  late final availableDeps = [
+    if (pubspec.dependencies != null)
+      for (var dep in pubspec.dependencies!)
+        if (dep.name?.text != null) dep.name!.text!,
+    if (!isPublicFile && pubspec.devDependencies != null)
+      for (var dep in pubspec.devDependencies!)
+        if (dep.name?.text != null) dep.name!.text!
+  ];
+
+  _Visitor(this.rule, this.context, this.pubspec, {required this.isPublicFile});
+
+  void _checkDirective(UriBasedDirective node) {
+    // Is it a package: import?
+    var importUriContent = node.uriContent;
+    if (importUriContent == null) return;
+    if (!importUriContent.startsWith('package:')) return;
+
+    try {
+      var importUri = Uri.parse(importUriContent);
+      if (importUri.pathSegments.isEmpty) return;
+      var packageName = importUri.pathSegments.first;
+      if (availableDeps.contains(packageName)) return;
+      rule.reportLint(node.uri);
+    } on FormatException catch (_) {}
+  }
+
+  @override
+  void visitImportDirective(ImportDirective node) => _checkDirective(node);
+
+  @override
+  void visitExportDirective(ExportDirective node) => _checkDirective(node);
+}

--- a/test/integration/always_depend_on_packages_you_use.dart
+++ b/test/integration/always_depend_on_packages_you_use.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:analyzer/src/lint/io.dart';
+import 'package:linter/src/cli.dart' as cli;
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+import '../test_constants.dart';
+
+void main() {
+  group('always depend on packages you use', () {
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
+    setUp(() {
+      exitCode = 0;
+      outSink = collectingOut;
+    });
+    tearDown(() {
+      collectingOut.buffer.clear();
+      outSink = currentOut;
+      exitCode = 0;
+    });
+
+    test('lints files under bin', () async {
+      var packagesFilePath = File('.packages').absolute.path;
+      await cli.run([
+        '--packages',
+        packagesFilePath,
+        '$integrationTestDir/always_depend_on_packages_you_use/bin',
+        '--rules=always_depend_on_packages_you_use'
+      ]);
+      expect(
+          collectingOut.trim(),
+          stringContainsInOrder([
+            "Depend on packages you use.",
+            "import 'package:test/test.dart'; // LINT",
+            "Depend on packages you use.",
+            "import 'package:matcher/matcher.dart'; // LINT",
+            "Depend on packages you use.",
+            "export 'package:test/test.dart'; // LINT",
+            "Depend on packages you use.",
+            "export 'package:matcher/matcher.dart'; // LINT",
+          ]));
+      expect(exitCode, 1);
+    });
+
+    test('lints files under lib', () async {
+      var packagesFilePath = File('.packages').absolute.path;
+      await cli.run([
+        '--packages',
+        packagesFilePath,
+        '$integrationTestDir/always_depend_on_packages_you_use/lib',
+        '--rules=always_depend_on_packages_you_use'
+      ]);
+      expect(
+          collectingOut.trim(),
+          stringContainsInOrder([
+            "Depend on packages you use.",
+            "import 'package:test/test.dart'; // LINT",
+            "Depend on packages you use.",
+            "import 'package:matcher/matcher.dart'; // LINT",
+            "Depend on packages you use.",
+            "export 'package:test/test.dart'; // LINT",
+            "Depend on packages you use.",
+            "export 'package:matcher/matcher.dart'; // LINT",
+          ]));
+      expect(exitCode, 1);
+    });
+
+    test('lints files under test', () async {
+      var packagesFilePath = File('.packages').absolute.path;
+      await cli.run([
+        '--packages',
+        packagesFilePath,
+        '$integrationTestDir/always_depend_on_packages_you_use/test',
+        '--rules=always_depend_on_packages_you_use'
+      ]);
+      expect(
+          collectingOut.trim(),
+          stringContainsInOrder([
+            "Depend on packages you use.",
+            "import 'package:matcher/matcher.dart'; // LINT",
+            "Depend on packages you use.",
+            "export 'package:matcher/matcher.dart'; // LINT",
+          ]));
+      expect(exitCode, 1);
+    });
+  });
+}

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -13,6 +13,8 @@ import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
 import '../test_data/rules/experiments/experiments.dart';
+import 'integration/always_depend_on_packages_you_use.dart'
+    as always_depend_on_packages_you_use;
 import 'integration/always_require_non_null_named_parameters.dart'
     as always_require_non_null_named_parameters;
 import 'integration/avoid_private_typedef_functions.dart'
@@ -190,6 +192,7 @@ void ruleTests() {
     flutter_style_todos.main();
     lines_longer_than_80_chars.main();
     only_throw_errors.main();
+    always_depend_on_packages_you_use.main();
     always_require_non_null_named_parameters.main();
     prefer_asserts_in_initializer_lists.main();
     prefer_const_constructors_in_immutables.main();

--- a/test_data/integration/always_depend_on_packages_you_use/bin/main.dart
+++ b/test_data/integration/always_depend_on_packages_you_use/bin/main.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart'; // OK
+import 'package:test/test.dart'; // LINT
+import 'package:matcher/matcher.dart'; // LINT
+
+export 'package:meta/meta.dart'; // OK
+export 'package:test/test.dart'; // LINT
+export 'package:matcher/matcher.dart'; // LINT

--- a/test_data/integration/always_depend_on_packages_you_use/lib/public.dart
+++ b/test_data/integration/always_depend_on_packages_you_use/lib/public.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart'; // OK
+import 'package:test/test.dart'; // LINT
+import 'package:matcher/matcher.dart'; // LINT
+
+export 'package:meta/meta.dart'; // OK
+export 'package:test/test.dart'; // LINT
+export 'package:matcher/matcher.dart'; // LINT

--- a/test_data/integration/always_depend_on_packages_you_use/pubspec.yaml
+++ b/test_data/integration/always_depend_on_packages_you_use/pubspec.yaml
@@ -1,0 +1,5 @@
+name: sample_project
+dependencies:
+  meta: any
+dev_dependencies:
+  test: any

--- a/test_data/integration/always_depend_on_packages_you_use/test/private.dart
+++ b/test_data/integration/always_depend_on_packages_you_use/test/private.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart'; // OK
+import 'package:test/test.dart'; // OK
+import 'package:matcher/matcher.dart'; // LINT
+
+export 'package:meta/meta.dart'; // OK
+export 'package:test/test.dart'; // OK
+export 'package:matcher/matcher.dart'; // LINT


### PR DESCRIPTION
# Description

Adds a new lint, `always_depend_on_packages_you_use`. This applies to all imports and exports.

For files under the `lib` or `bin` dir, only packages in the `dependencies` section may be referenced. For all other files any package listed in `dev_dependencies` is also allowed.

Fixes #29 
