### PR TITLE
fix depend_on_referenced_packages lint to allow imports of the current package

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -9,13 +9,13 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:analyzer/error/error.dart';
+import 'package:analyzer/src/generated/engine.dart' show AnalysisErrorInfo;
 import 'package:analyzer/src/lint/io.dart' show errorSink;
 import 'package:analyzer/src/lint/linter.dart';
 import 'package:analyzer/src/lint/registry.dart';
 import 'package:analyzer/src/lint/util.dart' as util;
 import 'package:analyzer/src/services/lint.dart' as lint_service;
 
-import 'analyzer.dart';
 import 'version.dart';
 
 export 'package:analyzer/dart/element/type_system.dart';

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/src/lint/config.dart'; // ignore: implementation_imports
 import 'package:analyzer/src/lint/io.dart'; // ignore: implementation_imports
-import 'package:analyzer/src/lint/linter.dart'; // ignore: implementation_imports
 import 'package:analyzer/src/lint/registry.dart'; // ignore: implementation_imports
 import 'package:args/args.dart';
 

--- a/lib/src/rules/depend_on_referenced_packages.dart
+++ b/lib/src/rules/depend_on_referenced_packages.dart
@@ -61,10 +61,13 @@ class DependOnReferencedPackages extends LintRule implements NodeLintRule {
     if (package is! PubWorkspacePackage) return;
     var pubspec = package.pubspec;
     if (pubspec == null) return;
+    var name = pubspec.name?.value.text;
+    if (name == null) return;
 
     var dependencies = pubspec.dependencies;
     var devDependencies = pubspec.devDependencies;
     var availableDeps = [
+      name,
       if (dependencies != null)
         for (var dep in dependencies)
           if (dep.name?.text != null) dep.name!.text!,

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:analyzer/dart/element/type_system.dart';
 import 'package:analyzer/src/dart/element/member.dart'; // ignore: implementation_imports
 
 import '../analyzer.dart';

--- a/test/formatter_test.dart
+++ b/test/formatter_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/src/generated/engine.dart';
-import 'package:analyzer/src/lint/linter.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/formatter.dart';
 import 'package:test/test.dart';

--- a/test/integration/depend_on_referenced_packages.dart
+++ b/test/integration/depend_on_referenced_packages.dart
@@ -26,67 +26,70 @@ void main() {
     });
 
     test('lints files under bin', () async {
-      var packagesFilePath = File('.packages').absolute.path;
       await cli.run([
         '--packages',
-        packagesFilePath,
+        '$integrationTestDir/depend_on_referenced_packages/_packages',
         '$integrationTestDir/depend_on_referenced_packages/bin',
         '--rules=depend_on_referenced_packages'
       ]);
+      var output = collectingOut.trim();
       expect(
-          collectingOut.trim(),
+          output,
           stringContainsInOrder([
             "Depend on referenced packages.",
-            "import 'package:test/test.dart'; // LINT",
+            "import 'package:private_dep/private_dep.dart'; // LINT",
             "Depend on referenced packages.",
-            "import 'package:matcher/matcher.dart'; // LINT",
+            "import 'package:transitive_dep/transitive_dep.dart'; // LINT",
             "Depend on referenced packages.",
-            "export 'package:test/test.dart'; // LINT",
+            "export 'package:private_dep/private_dep.dart'; // LINT",
             "Depend on referenced packages.",
-            "export 'package:matcher/matcher.dart'; // LINT",
+            "export 'package:transitive_dep/transitive_dep.dart'; // LINT",
           ]));
+      expect(output, isNot(contains('// OK')));
       expect(exitCode, 1);
     });
 
     test('lints files under lib', () async {
-      var packagesFilePath = File('.packages').absolute.path;
       await cli.run([
         '--packages',
-        packagesFilePath,
+        '$integrationTestDir/depend_on_referenced_packages/_packages',
         '$integrationTestDir/depend_on_referenced_packages/lib',
         '--rules=depend_on_referenced_packages'
       ]);
+      var output = collectingOut.trim();
       expect(
-          collectingOut.trim(),
+          output,
           stringContainsInOrder([
             "Depend on referenced packages.",
-            "import 'package:test/test.dart'; // LINT",
+            "import 'package:private_dep/private_dep.dart'; // LINT",
             "Depend on referenced packages.",
-            "import 'package:matcher/matcher.dart'; // LINT",
+            "import 'package:transitive_dep/transitive_dep.dart'; // LINT",
             "Depend on referenced packages.",
-            "export 'package:test/test.dart'; // LINT",
+            "export 'package:private_dep/private_dep.dart'; // LINT",
             "Depend on referenced packages.",
-            "export 'package:matcher/matcher.dart'; // LINT",
+            "export 'package:transitive_dep/transitive_dep.dart'; // LINT",
           ]));
+      expect(output, isNot(contains('// OK')));
       expect(exitCode, 1);
     });
 
     test('lints files under test', () async {
-      var packagesFilePath = File('.packages').absolute.path;
       await cli.run([
         '--packages',
-        packagesFilePath,
+        '$integrationTestDir/depend_on_referenced_packages/_packages',
         '$integrationTestDir/depend_on_referenced_packages/test',
         '--rules=depend_on_referenced_packages'
       ]);
+      var output = collectingOut.trim();
       expect(
-          collectingOut.trim(),
+          output,
           stringContainsInOrder([
             "Depend on referenced packages.",
-            "import 'package:matcher/matcher.dart'; // LINT",
+            "import 'package:transitive_dep/transitive_dep.dart'; // LINT",
             "Depend on referenced packages.",
-            "export 'package:matcher/matcher.dart'; // LINT",
+            "export 'package:transitive_dep/transitive_dep.dart'; // LINT",
           ]));
+      expect(output, isNot(contains('// OK')));
       expect(exitCode, 1);
     });
   });

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 
 import 'package:analyzer/src/lint/io.dart';
-import 'package:analyzer/src/lint/linter.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/cli.dart' as cli;
 import 'package:linter/src/rules.dart';

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -11,7 +11,6 @@ import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/lint/linter.dart';
-import 'package:analyzer/src/lint/project.dart';
 import 'package:analyzer/src/lint/pub.dart';
 import 'package:linter/src/analyzer.dart';
 

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/error/error.dart';
 import 'package:analyzer/src/analysis_options/analysis_options_provider.dart';
 import 'package:analyzer/src/generated/engine.dart';
 import 'package:analyzer/src/lint/io.dart';
-import 'package:analyzer/src/lint/linter.dart';
 import 'package:analyzer/src/lint/registry.dart';
 import 'package:analyzer/src/services/lint.dart' as lint_service;
 import 'package:analyzer/src/task/options.dart';

--- a/test/util/test_utils.dart
+++ b/test/util/test_utils.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:matcher/matcher.dart';
 import 'package:test/test.dart';
 
 void testEach<T>(Iterable<T> values, bool Function(T s) f, Matcher m) {

--- a/test_data/integration/depend_on_referenced_packages/_packages
+++ b/test_data/integration/depend_on_referenced_packages/_packages
@@ -1,0 +1,4 @@
+sample_project:lib/
+public_dep:vendor/public_dep/
+private_dep:vendor/private_dep/
+transitive_dep:vendor/transitive_dep/

--- a/test_data/integration/depend_on_referenced_packages/bin/main.dart
+++ b/test_data/integration/depend_on_referenced_packages/bin/main.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart'; // OK
-import 'package:test/test.dart'; // LINT
-import 'package:matcher/matcher.dart'; // LINT
+import 'package:sample_project/sample_project.dart'; // OK
+import 'package:public_dep/public_dep.dart'; // OK
+import 'package:private_dep/private_dep.dart'; // LINT
+import 'package:transitive_dep/transitive_dep.dart'; // LINT
 
-export 'package:meta/meta.dart'; // OK
-export 'package:test/test.dart'; // LINT
-export 'package:matcher/matcher.dart'; // LINT
+export 'package:sample_project/sample_project.dart'; // OK
+export 'package:public_dep/public_dep.dart'; // OK
+export 'package:private_dep/private_dep.dart'; // LINT
+export 'package:transitive_dep/transitive_dep.dart'; // LINT

--- a/test_data/integration/depend_on_referenced_packages/lib/public.dart
+++ b/test_data/integration/depend_on_referenced_packages/lib/public.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart'; // OK
-import 'package:test/test.dart'; // LINT
-import 'package:matcher/matcher.dart'; // LINT
+import 'package:sample_project/sample_project.dart'; // OK
+import 'package:public_dep/public_dep.dart'; // OK
+import 'package:private_dep/private_dep.dart'; // LINT
+import 'package:transitive_dep/transitive_dep.dart'; // LINT
 
-export 'package:meta/meta.dart'; // OK
-export 'package:test/test.dart'; // LINT
-export 'package:matcher/matcher.dart'; // LINT
+export 'package:sample_project/sample_project.dart'; // OK
+export 'package:public_dep/public_dep.dart'; // OK
+export 'package:private_dep/private_dep.dart'; // LINT
+export 'package:transitive_dep/transitive_dep.dart'; // LINT

--- a/test_data/integration/depend_on_referenced_packages/lib/sample_project.dart
+++ b/test_data/integration/depend_on_referenced_packages/lib/sample_project.dart
@@ -1,0 +1,3 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.

--- a/test_data/integration/depend_on_referenced_packages/pubspec.yaml
+++ b/test_data/integration/depend_on_referenced_packages/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sample_project
 dependencies:
-  meta: any
+  public_dep: any
 dev_dependencies:
-  test: any
+  private_dep: any

--- a/test_data/integration/depend_on_referenced_packages/test/private.dart
+++ b/test_data/integration/depend_on_referenced_packages/test/private.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart'; // OK
-import 'package:test/test.dart'; // OK
-import 'package:matcher/matcher.dart'; // LINT
+import 'package:sample_project/sample_project.dart'; // OK
+import 'package:public_dep/public_dep.dart'; // OK
+import 'package:private_dep/private_dep.dart'; // OK
+import 'package:transitive_dep/transitive_dep.dart'; // LINT
 
-export 'package:meta/meta.dart'; // OK
-export 'package:test/test.dart'; // OK
-export 'package:matcher/matcher.dart'; // LINT
+export 'package:sample_project/sample_project.dart'; // OK
+export 'package:public_dep/public_dep.dart'; // OK
+export 'package:private_dep/private_dep.dart'; // OK
+export 'package:transitive_dep/transitive_dep.dart'; // LINT

--- a/test_data/integration/depend_on_referenced_packages/vendor/private_dep/private_dep.dart
+++ b/test_data/integration/depend_on_referenced_packages/vendor/private_dep/private_dep.dart
@@ -1,0 +1,3 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.

--- a/test_data/integration/depend_on_referenced_packages/vendor/public_dep/public_dep.dart
+++ b/test_data/integration/depend_on_referenced_packages/vendor/public_dep/public_dep.dart
@@ -1,0 +1,3 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.

--- a/test_data/integration/depend_on_referenced_packages/vendor/transitive_dep/transitive_dep.dart
+++ b/test_data/integration/depend_on_referenced_packages/vendor/transitive_dep/transitive_dep.dart
@@ -1,0 +1,3 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.


### PR DESCRIPTION
I realized last night this would trigger for the current package as well, which we definitely don't want 🤣 .

This fixes that, and also makes the tests a bit more robust by ensuring we don't lint for any lines with `// OK` in them.

Also fixes some new unnecessary import lints (this lint now triggers for imports that don't expose anything not exposed already by another import).