### PR TITLE
prefer_interpolation_to_compose_strings should apply only for String.+

### DIFF
--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -75,8 +75,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (leftOperand is StringLiteral && rightOperand is StringLiteral) {
         return;
       }
-      if ((leftOperand.staticType?.isDartCoreString ?? false) ||
-          (rightOperand.staticType?.isDartCoreString ?? false)) {
+      if (leftOperand.staticType?.isDartCoreString ?? false) {
         DartTypeUtilities.traverseNodesInDFS(node).forEach(skippedNodes.add);
         rule.reportLint(node);
       }

--- a/test_data/rules/prefer_interpolation_to_compose_strings.dart
+++ b/test_data/rules/prefer_interpolation_to_compose_strings.dart
@@ -31,3 +31,10 @@ issue2490() {
   final String foo = 'Hello';
   final String bar = foo + r' /world\'; // OK
 }
+
+class Issue792 {
+  Issue792 operator +(String other) => this;
+  f() {
+    var a = this + ' '; // OK
+  }
+}


### PR DESCRIPTION
# Description

`prefer_interpolation_to_compose_strings` should apply only if the left operand has a `String` type.

Fixes #792
