### PR TITLE
Don't report avoid_types_as_parameter_names for FieldFormalParameterElement.

### DIFF
--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -65,8 +65,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       var declaredElement = parameter.declaredElement;
       var identifier = parameter.identifier;
       if (declaredElement != null &&
-          identifier != null &&
+          declaredElement is! FieldFormalParameterElement &&
           declaredElement.hasImplicitType &&
+          identifier != null &&
           _isTypeName(node, identifier)) {
         rule.reportLint(identifier);
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.4.0
+  analyzer: ^1.7.0
   args: ^2.0.0
   charcode: ^1.2.0
   collection: ^1.15.0

--- a/test_data/rules/avoid_types_as_parameter_names.dart
+++ b/test_data/rules/avoid_types_as_parameter_names.dart
@@ -42,3 +42,9 @@ m9(f7) => null; // LINT
 m10(m1) => null; // OK
 
 final void Function(Object, [StackTrace]) onError = null; // OK
+
+/// Naming the field `num` is significant - should be the name of a class.
+class FieldFormalParameter {
+  final int num;
+  FieldFormalParameter(this.num); // OK
+}


### PR DESCRIPTION
See https://buganizer.corp.google.com/issues/188405800 for the full context.
Once this lands everywhere, I will able to revert https://dart-review.googlesource.com/c/sdk/+/200280.