### PR TITLE
Use SecurityLintCode instead of deprecated SecurityLintCodeWithUniqueName

### DIFF
--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -71,21 +71,21 @@ class _Visitor extends SimpleAstVisitor<void> {
   // single-quotes to match the convention in the analyzer and linter packages.
   // This requires some coordination within Google, as various allow-lists are
   // keyed on the exact text of the LintCode message.
-  // ignore: deprecated_member_use
-  static const unsafeAttributeCode = SecurityLintCodeWithUniqueName(
-      'unsafe_html',
-      'LintCode.unsafe_html_attribute',
-      '$_descPrefix (assigning "{0}" attribute).');
-  // ignore: deprecated_member_use
-  static const unsafeMethodCode = SecurityLintCodeWithUniqueName(
-      'unsafe_html',
-      'LintCode.unsafe_html_method',
-      "$_descPrefix (calling the '{0}' method of {1}).");
-  // ignore: deprecated_member_use
-  static const unsafeConstructorCode = SecurityLintCodeWithUniqueName(
-      'unsafe_html',
-      'LintCode.unsafe_html_constructor',
-      "$_descPrefix (calling the '{0}' constructor of {1}).");
+  static const unsafeAttributeCode = SecurityLintCode(
+    'unsafe_html',
+    '$_descPrefix (assigning "{0}" attribute).',
+    uniqueName: 'LintCode.unsafe_html_attribute',
+  );
+  static const unsafeMethodCode = SecurityLintCode(
+    'unsafe_html',
+    "$_descPrefix (calling the '{0}' method of {1}).",
+    uniqueName: 'LintCode.unsafe_html_method',
+  );
+  static const unsafeConstructorCode = SecurityLintCode(
+    'unsafe_html',
+    "$_descPrefix (calling the '{0}' constructor of {1}).",
+    uniqueName: 'LintCode.unsafe_html_constructor',
+  );
 
   final LintRule rule;
 


### PR DESCRIPTION
I want to remove `SecurityLintCodeWithUniqueName`.