### PR TITLE
Report unnecessary_parenthesis when the parent precedence is equal to the expression precedence.

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -122,7 +122,7 @@ class _Visitor extends SimpleAstVisitor<void> {
             parent.parent is ExpressionStatement) return;
       }
 
-      if (parent.precedence < node.expression.precedence) {
+      if (parent.precedence <= node.expression.precedence) {
         rule.reportLint(node);
         return;
       }

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -27,6 +27,10 @@ main() async {
   // than the cascade.
   (true ? [] : [])..add(''); // OK
   (a ?? true) ? true : true; // OK
+  (a.foo).bar; // LINT
+  (a.foo.bar).baz; // LINT
+  (a.foo()).bar(); // LINT
+  (a.foo().bar()).baz(); // LINT
   true ? [] : []
     ..add(''); // OK
   m(p: (1 + 3)); // LINT


### PR DESCRIPTION
The internal presubmit looks green.
https://test.corp.google.com/ui#id=OCL:375864901:BASE:375864817:1622008515263:e0e91d35&include_skipped=true