### PR TITLE
1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # 1.5.0
 
-- fixed `unnecessary_parenthesis` to report when the parent precedence
-  is equal to the expression precedence
 - (internal) migrated to `SecurityLintCode` instead of deprecated 
   `SecurityLintCodeWithUniqueName`
 - (internal) fixed `avoid_types_as_parameter_names` to skip field formal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 1.5.0
+
+- fixed `unnecessary_parenthesis` to report when the parent precedence
+  is equal to the expression precedence
+- (internal) migrated to `SecurityLintCode` instead of deprecated 
+  `SecurityLintCodeWithUniqueName`
+- (internal) fixed `avoid_types_as_parameter_names` to skip field formal
+  parameters
+- fixed false positives in `prefer_interpolation_to_compose_strings` where
+  the left operand is not a String
+- fixed false positives in `only_throw_errors` for misidentified type
+  variables
+- new lint: `depend_on_referenced_packages`
+- update `avoid_returning_null_for_future` to skip checks for null-safe
+  libraries
+- new lint: `use_test_throws_matchers`
+- relax `sort_child_properties_last` to accept closures after child
+- performance improvements for `prefer_contains` and `prefer_is_empty`
+- new lint: `noop_primitive_operations`
+- mark `avoid_web_libraries_in_flutter` as stable
+- new lint: `prefer_final_parameters`
+- update `prefer_initializing_formals` to allow assignments where identifier
+  names don't match
+
 # 1.4.0
 
 - `directives_ordering` now checks ordering of `package:` imports in code

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.4.0';
+const String version = '1.5.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.4.0
+version: 1.5.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.5.0

- (internal) migrated to `SecurityLintCode` instead of deprecated 
  `SecurityLintCodeWithUniqueName`
- (internal) fixed `avoid_types_as_parameter_names` to skip field formal
  parameters
- fixed false positives in `prefer_interpolation_to_compose_strings` where
  the left operand is not a String
- fixed false positives in `only_throw_errors` for misidentified type
  variables
- new lint: `depend_on_referenced_packages`
- update `avoid_returning_null_for_future` to skip checks for null-safe
  libraries
- new lint: `use_test_throws_matchers`
- relax `sort_child_properties_last` to accept closures after child
- performance improvements for `prefer_contains` and `prefer_is_empty`
- new lint: `noop_primitive_operations`
- mark `avoid_web_libraries_in_flutter` as stable
- new lint: `prefer_final_parameters`
- update `prefer_initializing_formals` to allow assignments where identifier
  names don't match


/cc @bwilkerson @scheglov @srawlins 