### PR TITLE
Revert unnecessary parenthesis equal precedence

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -122,7 +122,7 @@ class _Visitor extends SimpleAstVisitor<void> {
             parent.parent is ExpressionStatement) return;
       }
 
-      if (parent.precedence <= node.expression.precedence) {
+      if (parent.precedence < node.expression.precedence) {
         rule.reportLint(node);
         return;
       }

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -27,10 +27,6 @@ main() async {
   // than the cascade.
   (true ? [] : [])..add(''); // OK
   (a ?? true) ? true : true; // OK
-  (a.foo).bar; // LINT
-  (a.foo.bar).baz; // LINT
-  (a.foo()).bar(); // LINT
-  (a.foo().bar()).baz(); // LINT
   true ? [] : []
     ..add(''); // OK
   m(p: (1 + 3)); // LINT

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -30,6 +30,7 @@ main() async {
   true ? [] : []
     ..add(''); // OK
   m(p: (1 + 3)); // LINT
+  (a++).toString(); // OK
 
   // OK because it is unobvious where cascades fall in precedence.
   a..b = (c..d); // OK


### PR DESCRIPTION
There were failures in https://dart-review.googlesource.com/c/sdk/+/201163

I suspect that this means that precedence in analyzer might be not quite correct, and `(foo.bar).baz` is still something we would like to report. But for now we should just revert, and get back to it later.