### PR TITLE
Update use_key_in_widget_constructors.dart

### DIFF
--- a/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/lib/src/rules/use_key_in_widget_constructors.dart
@@ -28,7 +28,7 @@ class MyPublicWidget extends StatelessWidget {
 **GOOD:**
 ```dart
 class MyPublicWidget extends StatelessWidget {
-  MyPublicWidget({Key key}) : super(key: key);
+  MyPublicWidget({Key? key}) : super(key: key);
 }
 ```
 ''';


### PR DESCRIPTION
"The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier."