### PR TITLE
Make `directives_ordering` match "organize imports" in the analyzer.

### DIFF
--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -359,7 +359,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         var directiveUri = directive.uriContent;
         if (previousUri != null &&
             directiveUri != null &&
-            previousUri.compareTo(directiveUri) > 0) {
+            compareDirectives(previousUri, directiveUri) > 0) {
           reportDirective(directive);
         }
       }
@@ -372,4 +372,18 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   Iterable<ImportDirective> _getImportDirectives(CompilationUnit node) =>
       node.directives.whereType<ImportDirective>();
+}
+
+/// Compares directives by package then file in package.
+///
+/// Package is everything until the first `/`.
+int compareDirectives(String a, String b) {
+  if (!a.contains('/') || !b.contains('/')) {
+    return a.compareTo(b);
+  }
+  var as = a.split('/');
+  var bs = b.split('/');
+  var result = as[0].compareTo(bs[0]);
+  if (result != 0) return result;
+  return as.skip(1).join('/').compareTo(bs.skip(1).join('/'));
 }

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -378,12 +378,10 @@ class _Visitor extends SimpleAstVisitor<void> {
 ///
 /// Package is everything until the first `/`.
 int compareDirectives(String a, String b) {
-  if (!a.contains('/') || !b.contains('/')) {
-    return a.compareTo(b);
-  }
-  var as = a.split('/');
-  var bs = b.split('/');
-  var result = as[0].compareTo(bs[0]);
+  var indexA = a.indexOf('/');
+  var indexB = b.indexOf('/');
+  if (indexA == -1 || indexB == -1) return a.compareTo(b);
+  var result = a.substring(0, indexA).compareTo(b.substring(0, indexB));
   if (result != 0) return result;
-  return as.skip(1).join('/').compareTo(bs.skip(1).join('/'));
+  return a.substring(indexA + 1).compareTo(b.substring(indexB + 1));
 }

--- a/test/integration/directives_ordering.dart
+++ b/test/integration/directives_ordering.dart
@@ -150,5 +150,18 @@ void main() {
           ]));
       expect(exitCode, 1);
     });
+
+    test('match_analyzer_organize_directives', () async {
+      var packagesFilePath = File('.packages').absolute.path;
+      await cli.run([
+        '--packages',
+        packagesFilePath,
+        '$integrationTestDir/directives_ordering/match_analyzer_organize_directives',
+        '--rules=directives_ordering'
+      ]);
+      // There are errors in the file due to missing imports, but no lints
+      // should fire.
+      expect(collectingOut.trim(), isNot(contains('[lint]')));
+    });
   });
 }

--- a/test_data/integration/directives_ordering/match_analyzer_organize_directives/sort.dart
+++ b/test_data/integration/directives_ordering/match_analyzer_organize_directives/sort.dart
@@ -1,0 +1,32 @@
+// From analysis_server/test/services/correction/organize_directives_test.dart
+// test named `sort`.
+library lib;
+
+import 'dart:aaa';
+import 'dart:bbb';
+
+import 'package:aaa/aaa.dart';
+import 'package:bbb/bbb.dart';
+
+import 'http://aaa.com';
+import 'http://bbb.com';
+
+import 'aaa/aaa.dart';
+import 'bbb/bbb.dart';
+
+export 'dart:aaa';
+export 'dart:bbb';
+
+export 'package:aaa/aaa.dart';
+export 'package:bbb/bbb.dart';
+
+export 'http://aaa.com';
+export 'http://bbb.com';
+
+export 'aaa/aaa.dart';
+export 'bbb/bbb.dart';
+
+part 'aaa/aaa.dart';
+part 'bbb/bbb.dart';
+
+main() {}

--- a/test_data/integration/directives_ordering/match_analyzer_organize_directives/sort_imports_package_and_path.dart
+++ b/test_data/integration/directives_ordering/match_analyzer_organize_directives/sort_imports_package_and_path.dart
@@ -1,0 +1,11 @@
+// From analysis_server/test/services/correction/organize_directives_test.dart
+// test named `sort_imports_packageAndPath`.
+
+library lib;
+
+import 'package:product.ui/entity.dart';
+import 'package:product.ui.api/entity1.dart';
+import 'package:product.ui.api/entity2.dart';
+import 'package:product.ui.api.aaa/manager2.dart';
+import 'package:product.ui.api.bbb/manager1.dart';
+import 'package:product2.client/entity.dart';


### PR DESCRIPTION
I added the tests I could find in the analyzer about sort ordering--not enough coverage by itself but it's a start.

Unfortunately it looks like we do need a breaking change to the lint. At least, it's not a _new_ breaking change with the last change to the lint, it was there before :)