### PR TITLE
Include new rule sets in the machine generated rules file

### DIFF
--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -16,11 +16,14 @@ import 'doc.dart';
 void main(List<String> args) async {
   var parser = ArgParser()
     ..addFlag('pretty',
-        abbr: 'p', help: 'Pretty-print output.', defaultsTo: true);
+        abbr: 'p', help: 'Pretty-print output.', defaultsTo: true)
+    ..addFlag('sets', abbr: 's', help: 'Include rule sets', defaultsTo: true);
   var options = parser.parse(args);
 
   registerLintRules();
-  await fetchBadgeInfo();
+  if (options['sets'] == true) {
+    await fetchBadgeInfo();
+  }
   var json = getMachineListing(Registry.ruleRegistry,
       pretty: options['pretty'] == true);
   print(json);

--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -13,13 +13,14 @@ import 'doc.dart';
 
 /// Generates a list of lint rules in machine format suitable for consumption by
 /// other tools.
-void main(List<String> args) {
+void main(List<String> args) async {
   var parser = ArgParser()
     ..addFlag('pretty',
         abbr: 'p', help: 'Pretty-print output.', defaultsTo: true);
   var options = parser.parse(args);
 
   registerLintRules();
+  await fetchBadgeInfo();
   var json = getMachineListing(Registry.ruleRegistry,
       pretty: options['pretty'] == true);
   print(json);
@@ -39,8 +40,11 @@ String getMachineListing(Iterable<LintRule> ruleRegistry,
         'maturity': rule.maturity.name,
         'incompatible': rule.incompatibleRules,
         'sets': [
+          if (coreRules.contains(rule.name)) 'core',
+          if (recommendedRules.contains(rule.name)) 'recommended',
           if (flutterRules.contains(rule.name)) 'flutter',
           if (pedanticRules.contains(rule.name)) 'pedantic',
+          if (effectiveDartRules.contains(rule.name)) 'effective_dart',
         ],
         'details': rule.details,
       }


### PR DESCRIPTION
Includes `core`, `recommended`, and `effective_dart` in the machine generated JSON file. I'm heavily open to suggestions on alternative names for these :)

Also fetches the badge info in the `main` method in-case this tool is run standalone to make sure the sets are retrieved.

Fixes #2611
