### PR TITLE
Don't stop identifying non-final parameters once a final one is found

### DIFF
--- a/lib/src/rules/prefer_final_parameters.dart
+++ b/lib/src/rules/prefer_final_parameters.dart
@@ -96,7 +96,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (parameters != null) {
       for (var param in parameters.parameters) {
         if (param.isFinal || param.isConst || param is FieldFormalParameter) {
-          return;
+          continue;
         }
         var declaredElement = param.declaredElement;
         if (declaredElement != null &&

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -68,9 +68,21 @@ void useGoodTypedClosureArgument() {
   _testingList.forEach((final int element) => print(element + 4)); // OK
 }
 
-void badMixed(String bad, final String good) { // LINT
+void badMixedLast(String bad, final String good) { // LINT
   print(bad);
   print(good);
+}
+
+void badMixedFirst(final String goodFirst, String badSecond) { // LINT
+  print(goodFirst);
+  print(badSecond);
+}
+
+// LINT [+1]
+void badMixedMiddle(String goodFirst, final String badSecond, String badThird) { // LINT
+  print(goodFirst);
+  print(badSecond);
+  print(badThird);
 }
 
 void goodMultiple(final String bad, final String good) { // OK
@@ -110,8 +122,8 @@ class C {
     return C(value);
   }
 
-  void set badContents(int contents) => _contents = setting; // LINT
-  void set goodContents(final int contents) => _contents = setting; // OK
+  void set badContents(int contents) => _contents = contents; // LINT
+  void set goodContents(final int contents) => _contents = contents; // OK
 
   int get contentValue => _contents + 4; // OK
 

--- a/test_data/rules/prefer_final_parameters.dart
+++ b/test_data/rules/prefer_final_parameters.dart
@@ -79,9 +79,9 @@ void badMixedFirst(final String goodFirst, String badSecond) { // LINT
 }
 
 // LINT [+1]
-void badMixedMiddle(String goodFirst, final String badSecond, String badThird) { // LINT
-  print(goodFirst);
-  print(badSecond);
+void badMixedMiddle(String badFirst, final String goodSecond, String badThird) { // LINT
+  print(badFirst);
+  print(goodSecond);
   print(badThird);
 }
 


### PR DESCRIPTION
This rule stopped looking for non-final parameters if it found a `final` one causing lints to not be triggered when they should have been. This modification only skips that parameter instead of stopping processing completely.

Fixes #2700
