### PR TITLE
1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
   underscore
 - fixed false negative in `prefer_final_parameters` where first parameter
   is final
-- improved `directives_ordering` sorting of directives with dot-separated 
-  package names
+- improved `directives_ordering` sorting of directives with dot paths and 
+  dot-separated package names
 - relaxed `sort_child_properties_last` to allow for a trailing Widget in
   instance creations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.6.0
+
+- relaxed `non_constant_identifier_names` to allow for a trailing
+  underscore
+- fixed false negative in `prefer_final_parameters` where first parameter
+  is final
+- improved `directives_ordering` sorting of directives with dot-separated 
+  package names
+- relaxed `sort_child_properties_last` to allow for a trailing Widget in
+  instance creations
+
 # 1.5.0
 
 - (internal) migrated to `SecurityLintCode` instead of deprecated 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.5.0';
+const String version = '1.6.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.5.0
+version: 1.6.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.6.0

- relaxed `non_constant_identifier_names` to allow for a trailing
  underscore
- fixed false negative in `prefer_final_parameters` where first parameter
  is final
- improved `directives_ordering` sorting of directives with dot-separated 
  package names
- relaxed `sort_child_properties_last` to allow for a trailing Widget in
  instance creations

/cc @bwilkerson @a14n @srawlins 
