### PR TITLE
Revert "relax sort_child_properties_last to accept other widget afterward"

### DIFF
--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -11,7 +11,7 @@ import '../util/flutter_utils.dart';
 const _desc = r'Sort child properties last in widget instance creations.';
 
 const _details = r'''
-Sort arguments to end with a Widget in widget instance creations.  This improves
+Sort child properties last in widget instance creations.  This improves
 readability and plays nicest with UI as Code visualization in IDEs with UI as
 Code Guides in editors (such as IntelliJ) where Properties in the correct order
 appear clearly associated with the constructor call and separated from the
@@ -75,8 +75,9 @@ return Scaffold(
 );
 ```
 
-Exception: It's allowed to have function expression arguments after the last
-Widget argument.
+Exception: It's allowed to have parameter with a function expression after the
+`child` property.
+
 ''';
 
 class SortChildPropertiesLast extends LintRule implements NodeLintRule {
@@ -107,25 +108,31 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     var arguments = node.argumentList.arguments;
-    if (arguments.length < 2 || isWidgetProperty(arguments.last.staticType)) {
+    if (arguments.length < 2 ||
+        isChildArg(arguments.last) ||
+        arguments.where(isChildArg).length != 1) {
       return;
     }
 
-    var lastWidgetIndex =
-        arguments.lastIndexWhere((e) => isWidgetProperty(e.staticType));
-
-    // no widget argument
-    if (lastWidgetIndex == -1) {
-      return;
-    }
-
-    var onlyClosuresAfterLastWidget = arguments
-        .skip(lastWidgetIndex + 1)
-        .where(
-            (e) => e is NamedExpression && e.expression is! FunctionExpression)
+    var onlyClosuresAfterChild = arguments.reversed
+        .takeWhile((argument) => !isChildArg(argument))
+        .toList()
+        .reversed
+        .where((element) =>
+            element is NamedExpression &&
+            element.expression is! FunctionExpression)
         .isEmpty;
-    if (!onlyClosuresAfterLastWidget) {
-      rule.reportLint(arguments[lastWidgetIndex]);
+    if (!onlyClosuresAfterChild) {
+      rule.reportLint(arguments.firstWhere(isChildArg));
     }
+  }
+
+  static bool isChildArg(Expression e) {
+    if (e is NamedExpression) {
+      var name = e.name.label.name;
+      return (name == 'child' || name == 'children') &&
+          isWidgetProperty(e.staticType);
+    }
+    return false;
   }
 }

--- a/test_data/mock_packages/flutter/lib/src/widgets/basic.dart
+++ b/test_data/mock_packages/flutter/lib/src/widgets/basic.dart
@@ -56,10 +56,6 @@ class AspectRatio extends SingleChildRenderObjectWidget {
   });
 }
 
-class Text extends StatelessWidget {
-  const Text(String data, {Key key});
-}
-
 class Center extends StatelessWidget {
   const Center({Key key, double heightFactor, Widget child});
 }

--- a/test_data/rules/sort_child_properties_last.dart
+++ b/test_data/rules/sort_child_properties_last.dart
@@ -114,35 +114,3 @@ class WithClosure extends Widget {
     );
   }
 }
-
-class WithSeveralWidgetCreation extends Widget {
-  WithSeveralWidgetCreation({
-    this.header,
-    this.child,
-    this.boldFooter,
-    this.onFooterClick,
-    this.footer,
-  });
-  final Widget? header;
-  final Widget? child;
-  final bool? boldFooter;
-  final void Function()? onFooterClick;
-  final Widget? footer;
-
-  @override
-  Widget build(BuildContext context) {
-    WithSeveralWidgetCreation(
-      header: Text('a'),
-      child: Text('b'), // OK
-      footer: Text('c'), // LINT
-      boldFooter: true,
-    );
-    WithSeveralWidgetCreation(
-      header: Text('a'),
-      child: Text('b'), // OK
-      footer: Text('c'), // OK
-      onFooterClick: (){},
-    );
-    return null;
-  }
-}


### PR DESCRIPTION
Reverts dart-lang/linter#2648

This change is flagging a number of new violations internally and needs to be investigated (https://github.com/dart-lang/linter/issues/2713).  This revert will unblock the other changes that we want to roll.

/cc @bwilkerson @a14n @jacob314 