### PR TITLE
1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.1
+
+- reverted relaxation of `sort_child_properties_last` to allow for a 
+  trailing Widget in instance creations
+
 # 1.6.0
 
 - relaxed `non_constant_identifier_names` to allow for a trailing

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.6.0';
+const String version = '1.6.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.6.0
+version: 1.6.1
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.6.1

- reverted relaxation of `sort_child_properties_last` to allow for a 
  trailing Widget in instance creations

/cc @bwilkerson 
