### PR TITLE
Report use_setters_to_change_properties on the method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master
+
+- update `use_setters_to_change_properties` to only highlight a method name,
+  not the entire body and doc comment.
+
 # 1.6.1
 
 - reverted relaxation of `sort_child_properties_last` to allow for a 

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -61,7 +61,8 @@ class _Visitor extends SimpleAstVisitor<void> {
         node.returnType?.type?.isVoid != true) {
       return;
     }
-    void _visitExpression(Expression expression) {
+
+    void visitExpression(Expression expression) {
       if (expression is AssignmentExpression &&
           expression.operator.type == TokenType.EQ) {
         var leftOperand =
@@ -70,7 +71,7 @@ class _Visitor extends SimpleAstVisitor<void> {
             expression.rightHandSide);
         var parameterElement = node.declaredElement?.parameters.first;
         if (rightOperand == parameterElement && leftOperand is FieldElement) {
-          rule.reportLint(node);
+          rule.reportLint(node.name);
         }
       }
     }
@@ -80,11 +81,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (body.block.statements.length == 1) {
         var statement = body.block.statements.first;
         if (statement is ExpressionStatement) {
-          _visitExpression(statement.expression);
+          visitExpression(statement.expression);
         }
       }
     } else if (body is ExpressionFunctionBody) {
-      _visitExpression(body.expression);
+      visitExpression(body.expression);
     }
   }
 }

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -62,7 +62,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    void visitExpression(Expression expression) {
+    void checkExpression(Expression expression) {
       if (expression is AssignmentExpression &&
           expression.operator.type == TokenType.EQ) {
         var leftOperand =
@@ -81,11 +81,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (body.block.statements.length == 1) {
         var statement = body.block.statements.first;
         if (statement is ExpressionStatement) {
-          visitExpression(statement.expression);
+          checkExpression(statement.expression);
         }
       }
     } else if (body is ExpressionFunctionBody) {
-      visitExpression(body.expression);
+      checkExpression(body.expression);
     }
   }
 }


### PR DESCRIPTION
# Description

Fixes #2430 by reporting lint on the method name, not the entire method node including its doc comment and body.

Also tidy up by renaming a _local_ function to not start with an underscore, as per Effective Dart.
