### PR TITLE
Allow interpolations on adjacent strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master
+
+- update `missing_whitespace_between_adjacent_strings` to allow String
+  interpolations at the beginning and end of String literals.
+
 # 1.6.1
 
 - reverted relaxation of `sort_child_properties_last` to allow for a 

--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -57,7 +57,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitAdjacentStrings(AdjacentStrings node) {
-    // skip regexp
+    // Skip strings passed to `RegExp()` or any method named `matches`.
     var parent = node.parent;
     if (parent is ArgumentList) {
       var parentParent = parent.parent;
@@ -73,11 +73,11 @@ class _Visitor extends RecursiveAstVisitor<void> {
     for (var i = 0; i < node.strings.length - 1; i++) {
       var current = node.strings[i];
       var next = node.strings[i + 1];
-      if (_visit(current, (l) => _endsWithWhitespace(l.last)) ||
-          _visit(next, (l) => _startsWithWhitespace(l.first))) {
+      if (_visit(current, (l) => l.last.endsWithWhitespace) ||
+          _visit(next, (l) => l.first.startsWithWhitespace)) {
         continue;
       }
-      if (!_visit(current, (l) => l.any(_hasWhitespace))) {
+      if (!_visit(current, (l) => l.any((e) => e.hasWhitespace))) {
         continue;
       }
       rule.reportLint(current);
@@ -90,27 +90,39 @@ class _Visitor extends RecursiveAstVisitor<void> {
     if (string is SimpleStringLiteral) {
       return test([string.value]);
     } else if (string is StringInterpolation) {
-      return test(string.elements.map((e) {
-        if (e is InterpolationString) return e.value;
-        return '';
-      }));
+      var interpolationSubstitutions = <String>[];
+      for (var e in string.elements) {
+        // Given a [StringInterpolation] like '$text', the elements include
+        // empty [InterpolationString]s on either side of the
+        // [InterpolationExpression]. Don't include them in the evaluation.
+        if (e is InterpolationString && e.value.isNotEmpty) {
+          interpolationSubstitutions.add(e.value);
+        }
+        if (e is InterpolationExpression) {
+          // Treat an interpolation expression as a string with whitespace. This
+          // prevents over-reporting on adjascent Strings which start or end
+          // with interpolations.
+          interpolationSubstitutions.add(' ');
+        }
+      }
+      return test(interpolationSubstitutions);
     }
     throw ArgumentError('${string.runtimeType}: $string');
   }
 
-  bool _hasWhitespace(String value) => _whitespaces.any(value.contains);
-  bool _endsWithWhitespace(String value) => _whitespaces.any(value.endsWith);
-  bool _startsWithWhitespace(String value) =>
-      _whitespaces.any(value.startsWith);
-
   static bool _isRegExpInstanceCreation(AstNode? node) {
     if (node is InstanceCreationExpression) {
       var constructorElement = node.constructorName.staticElement;
-      return constructorElement != null &&
-          constructorElement.enclosingElement.name == 'RegExp';
+      return constructorElement?.enclosingElement.name == 'RegExp';
     }
     return false;
   }
+}
+
+extension on String {
+  bool get hasWhitespace => _whitespaces.any(contains);
+  bool get endsWithWhitespace => _whitespaces.any(endsWith);
+  bool get startsWithWhitespace => _whitespaces.any(startsWith);
 }
 
 const _whitespaces = [' ', '\n', '\r', '\t'];

--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -120,9 +120,9 @@ class _Visitor extends RecursiveAstVisitor<void> {
 }
 
 extension on String {
-  bool get hasWhitespace => _whitespaces.any(contains);
-  bool get endsWithWhitespace => _whitespaces.any(endsWith);
-  bool get startsWithWhitespace => _whitespaces.any(startsWith);
-}
+  bool get hasWhitespace => whitespaces.any(contains);
+  bool get endsWithWhitespace => whitespaces.any(endsWith);
+  bool get startsWithWhitespace => whitespaces.any(startsWith);
 
-const _whitespaces = [' ', '\n', '\r', '\t'];
+  static const whitespaces = [' ', '\n', '\r', '\t'];
+}

--- a/test_data/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/test_data/rules/missing_whitespace_between_adjacent_strings.dart
@@ -20,6 +20,11 @@ f(o) {
   f(RegExp('(\n)+' '(\n)+' '(\n)+')); // OK
   new Unresolved('aaa' 'bbb'); // OK
   matches('(\n)+' '(\n)+' '(\n)+'); // OK
+
+  f('Hello' // OK
+    '${1 == 2 ? ', world' : ''}');
+  f('${1 == 2 ? 'Hello ' : ''}' // OK
+    'world');
 }
 
-void matches(String value){}
+void matches(String value) {}


### PR DESCRIPTION
# Description

This lint rule was too strict on adjacent strings that start or end with interpolations. Since it cannot know anything about string interpolations, it should treat them as "valid" (containing whitespace).

Fixes #2489 

Also:

* change helper functions to extension methods; let me know if this is undesirable
* update comments to format like sentences, as per [Effective Dart](https://dart.dev/guides/language/effective-dart/documentation#do-format-comments-like-sentences).