### PR TITLE
Allow unnecessary getters and setters with annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - update `use_setters_to_change_properties` to only highlight a method name,
   not the entire body and doc comment.
+- update `unnecessary_getters_setters` to allow otherwise "unnecessary" getters
+  and setters with annotations.
 
 # 1.6.1
 

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -98,12 +98,6 @@ bool inPrivateMember(AstNode node) {
   return false;
 }
 
-/// Returns `true` if the given [declaration] is annotated `@deprecated`.
-bool isDeprecated(Declaration declaration) {
-  var declaredElement = declaration.declaredElement;
-  return declaredElement != null && declaredElement.hasDeprecated;
-}
-
 /// Returns `true` if this element is the `==` method declaration.
 bool isEquals(ClassMember element) =>
     element is MethodDeclaration && element.name.name == '==';
@@ -157,10 +151,6 @@ bool isMethod(ClassMember m) => m is MethodDeclaration;
 /// Check if the given identifier has a private name.
 bool isPrivate(SimpleIdentifier? identifier) =>
     identifier != null ? Identifier.isPrivateName(identifier.name) : false;
-
-/// Returns `true` if the given [declaration] is annotated `@protected`.
-bool isProtected(Declaration declaration) =>
-    declaration.metadata.any((Annotation a) => a.name.name == 'protected');
 
 /// Returns `true` if the given [ClassMember] is a public method.
 bool isPublicMethod(ClassMember m) {

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -91,13 +91,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Only select getters with setter pairs
     for (var id in getters.keys.where((id) => setters.keys.contains(id))) {
-      _visitGetterSetter(getters[id], setters[id]);
+      _visitGetterSetter(getters[id]!, setters[id]!);
     }
   }
 
-  void _visitGetterSetter(
-      MethodDeclaration? getter, MethodDeclaration? setter) {
-    if (getter == null || setter == null) return;
+  void _visitGetterSetter(MethodDeclaration getter, MethodDeclaration setter) {
     var getterElement = getter.declaredElement;
     var setterElement = setter.declaredElement;
     if (getterElement == null || setterElement == null) return;

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../ast.dart';
@@ -89,21 +90,21 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // Only select getters with setter pairs
-    getters.keys
-        .where((id) => setters.keys.contains(id))
-        .forEach((id) => _visitGetterSetter(getters[id], setters[id]));
+    for (var id in getters.keys.where((id) => setters.keys.contains(id))) {
+      _visitGetterSetter(getters[id], setters[id]);
+    }
   }
 
   void _visitGetterSetter(
       MethodDeclaration? getter, MethodDeclaration? setter) {
-    if (getter != null &&
-        setter != null &&
-        isSimpleSetter(setter) &&
+    if (getter == null || setter == null) return;
+    var getterElement = getter.declaredElement;
+    var setterElement = setter.declaredElement;
+    if (getterElement == null || setterElement == null) return;
+    if (isSimpleSetter(setter) &&
         isSimpleGetter(getter) &&
-        !isProtected(getter) &&
-        !isProtected(setter) &&
-        !isDeprecated(getter) &&
-        !isDeprecated(setter)) {
+        getterElement.metadata.isEmpty &&
+        setterElement.metadata.isEmpty) {
       rule..reportLint(getter.name)..reportLint(setter.name);
     }
   }

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../ast.dart';

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -90,12 +90,13 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // Only select getters with setter pairs
-    for (var id in getters.keys.where((id) => setters.keys.contains(id))) {
-      _visitGetterSetter(getters[id]!, setters[id]!);
+    for (var id in getters.keys) {
+      _visitGetterSetter(getters[id]!, setters[id]);
     }
   }
 
-  void _visitGetterSetter(MethodDeclaration getter, MethodDeclaration setter) {
+  void _visitGetterSetter(MethodDeclaration getter, MethodDeclaration? setter) {
+    if (setter == null) return;
     var getterElement = getter.declaredElement;
     var setterElement = setter.declaredElement;
     if (getterElement == null || setterElement == null) return;

--- a/test_data/rules/unnecessary_getters_setters.dart
+++ b/test_data/rules/unnecessary_getters_setters.dart
@@ -65,6 +65,15 @@ class Box6 {
   }
 }
 
+class Box7 {
+  var _contents;
+  @visibleForTesting
+  get contents => _contents; //OK (annotation)
+  set contents(value) {
+    _contents = value;
+  }
+}
+
 class LowerCase {
   var _contents;
   get contents => _contents;


### PR DESCRIPTION
# Description

A getter or setter which is otherwise unnecessary, but has an annotation should be allowed; the annotation may carry meaning to humans, static analyzers, or code generators

Fixes #2706 
