### PR TITLE
Update unnecessary_getters_setters to allow for non-basic assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   and setters with annotations.
 - update `missing_whitespace_between_adjacent_strings` to allow String
   interpolations at the beginning and end of String literals.
+- update `unnecessary_getters_setters` to allow for setters with non-basic
+  assignments (for example, `??=` or `+=`).
 
 # 1.6.1
 

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -162,11 +162,17 @@ bool isPublicMethod(ClassMember m) {
 ///
 /// A simple getter takes one of these basic forms:
 ///
-///     get x => _simpleIdentifier;
+/// ```dart
+/// get x => _simpleIdentifier;
+/// ```
+///
 /// or
-///     get x {
-///       return _simpleIdentifier;
-///     }
+///
+/// ```dart
+/// get x {
+///   return _simpleIdentifier;
+/// }
+/// ```
 bool isSimpleGetter(MethodDeclaration declaration) {
   if (!declaration.isGetter) {
     return false;
@@ -190,14 +196,18 @@ bool isSimpleGetter(MethodDeclaration declaration) {
 ///
 /// A simple setter takes this basic form:
 ///
-///     var _x;
-///     set(x) {
-///       _x = x;
-///     }
+/// ```dart
+/// var _x;
+/// set(x) {
+///   _x = x;
+/// }
+/// ```
 ///
 /// or:
 ///
-///     set(x) => _x = x;
+/// ```dart
+/// set(x) => _x = x;
+/// ```
 ///
 /// where the static type of the left and right hand sides must be the same.
 bool isSimpleSetter(MethodDeclaration setter) {
@@ -274,18 +284,20 @@ bool _checkForSimpleSetter(MethodDeclaration setter, Expression expression) {
   if (expression is! AssignmentExpression) {
     return false;
   }
-  var assignment = expression;
+  if (expression.operator.type != TokenType.EQ) {
+    return false;
+  }
 
-  var leftHandSide = assignment.leftHandSide;
-  var rightHandSide = assignment.rightHandSide;
+  var leftHandSide = expression.leftHandSide;
+  var rightHandSide = expression.rightHandSide;
   if (leftHandSide is SimpleIdentifier && rightHandSide is SimpleIdentifier) {
-    var leftElement = assignment.writeElement;
+    var leftElement = expression.writeElement;
     if (leftElement is! PropertyAccessorElement || !leftElement.isSynthetic) {
       return false;
     }
 
     // To guard against setters used as type constraints
-    if (assignment.writeType != rightHandSide.staticType) {
+    if (expression.writeType != rightHandSide.staticType) {
       return false;
     }
 

--- a/test_data/rules/unnecessary_getters_setters.dart
+++ b/test_data/rules/unnecessary_getters_setters.dart
@@ -74,6 +74,14 @@ class Box7 {
   }
 }
 
+class Box8 {
+  var _contents;
+  get contents => _contents; //OK (setter uses `??=`)
+  set contents(value) {
+    _contents ??= value;
+  }
+}
+
 class LowerCase {
   var _contents;
   get contents => _contents;


### PR DESCRIPTION
# Description

Assignments other than `=` are allowable in setters, like `??=` or `+=`.

Fixes #2402 

Also updates related doc comments to use Markdown code blocks with language tags; dartdoc started warning about code blocks which don't use language tags recently.