### PR TITLE
Report adjacent strings in if-elements and for-elements

### DIFF
--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -11,9 +11,9 @@ const _desc = r"Don't use adjacent strings in list.";
 
 const _details = r'''
 
-**DON'T** use adjacent strings in list.
+**DON'T** use adjacent strings in a list.
 
-This can be sign of forgotten comma.
+This can indicate a forgotten comma.
 
 **GOOD:**
 ```dart
@@ -47,6 +47,8 @@ class NoAdjacentStringsInList extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
+    registry.addForElement(this, visitor);
+    registry.addIfElement(this, visitor);
     registry.addListLiteral(this, visitor);
   }
 }
@@ -55,6 +57,20 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
+
+  @override
+  void visitForElement(ForElement node) {
+    if (node.body is AdjacentStrings) {
+      rule.reportLint(node.body);
+    }
+  }
+
+  @override
+  void visitIfElement(IfElement node) {
+    if (node.thenElement is AdjacentStrings) {
+      rule.reportLint(node.thenElement);
+    }
+  }
 
   @override
   void visitListLiteral(ListLiteral node) {

--- a/test_data/rules/no_adjacent_strings_in_list.dart
+++ b/test_data/rules/no_adjacent_strings_in_list.dart
@@ -5,21 +5,31 @@
 // test w/ `dart test -N no_adjacent_strings_in_list`
 
 void bad() {
-  List<String> list = <String>[
+  var list = [
     'a' // LINT
     'b',
     'c',
   ];
 
-  List<String> list2 = <String>[
+  var list2 = [
     'a' // LINT
     'b'
     'c'
   ];
+
+  var list3 = [
+    if (1 == 2) 'a' // LINT
+    'b'
+  ];
+
+  var list4 = [
+    for (var v in []) 'a' // LINT
+    'b'
+  ];
 }
 
 void good() {
-  List<String> list = <String>[
+  var list = [
     'a' + // OK
     'b',
     'c',


### PR DESCRIPTION
# Description

This enhances no_adjacent_string_in_list to include if-elements and for-elements (see tests for examples).

Note that this will trigger on if-elements and for-elements in sets as well 😲 . The lint broadly does not cover sets. Should it? New lint rule? Deprecate this one and make a new lint rule for collection literals and collection elements?

Fixes #2343

Also fixes some grammar in the docs, and makes the test code more idiomatic.
