### PR TITLE
Fix missing_whitespace_between_adjacent_strings handling of no-whitespace strings

### DIFF
--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -95,44 +95,34 @@ class _Visitor extends RecursiveAstVisitor<void> {
 }
 
 extension on StringLiteral {
-  /// Returns whether this ends with whitespace, where any
+  /// Returns whether this ends with whitespace, where an initial
   /// [InterpolationExpression] counts as whitespace.
   bool get endsWithWhitespace {
-    if (this is SimpleStringLiteral) {
-      return (this as SimpleStringLiteral).value.endsWithWhitespace;
-    } else if (this is StringInterpolation) {
-      var last = (this as StringInterpolation).elements.last;
-      if (last is InterpolationExpression) {
-        // Treat an interpolation expression as containing whitespace so as to
-        // avoid over-reporting strings that end with an interpolation
-        // expression.
-        return true;
-      } else if (last is InterpolationString) {
-        return last.value.endsWithWhitespace;
-      }
+    var self = this;
+    if (self is SimpleStringLiteral) {
+      return self.value.endsWithWhitespace;
+    } else if (self is StringInterpolation) {
+      var last = self.elements.last as InterpolationString;
+      return last.value.isEmpty || last.value.endsWithWhitespace;
     }
     throw ArgumentError(
-        'Expected SimpleStringLiteral or StringInterpolation, got $runtimeType');
+        'Expected SimpleStringLiteral or StringInterpolation, but got '
+        '$runtimeType');
   }
 
-  /// Returns whether this starts with whitespace, where any
+  /// Returns whether this starts with whitespace, where an initial
   /// [InterpolationExpression] counts as whitespace.
   bool get startsWithWhitespace {
-    if (this is SimpleStringLiteral) {
-      return (this as SimpleStringLiteral).value.startsWithWhitespace;
-    } else if (this is StringInterpolation) {
-      var first = (this as StringInterpolation).elements.first;
-      if (first is InterpolationExpression) {
-        // Treat an interpolation expression as containing whitespace so as to
-        // avoid over-reporting strings that start with an interpolation
-        // expression.
-        return true;
-      } else if (first is InterpolationString) {
-        return first.value.endsWithWhitespace;
-      }
+    var self = this;
+    if (self is SimpleStringLiteral) {
+      return self.value.startsWithWhitespace;
+    } else if (self is StringInterpolation) {
+      var first = self.elements.first as InterpolationString;
+      return first.value.isEmpty || first.value.endsWithWhitespace;
     }
     throw ArgumentError(
-        'Expected SimpleStringLiteral or StringInterpolation, got $runtimeType');
+        'Expected SimpleStringLiteral or StringInterpolation, but got '
+        '$runtimeType');
   }
 
   /// Returns whether this contains whitespace, where any

--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -73,11 +73,10 @@ class _Visitor extends RecursiveAstVisitor<void> {
     for (var i = 0; i < node.strings.length - 1; i++) {
       var current = node.strings[i];
       var next = node.strings[i + 1];
-      if (_visit(current, (l) => l.last.endsWithWhitespace) ||
-          _visit(next, (l) => l.first.startsWithWhitespace)) {
+      if (current.endsWithWhitespace || next.startsWithWhitespace) {
         continue;
       }
-      if (!_visit(current, (l) => l.any((e) => e.hasWhitespace))) {
+      if (!current.hasWhitespace) {
         continue;
       }
       rule.reportLint(current);
@@ -86,34 +85,65 @@ class _Visitor extends RecursiveAstVisitor<void> {
     return super.visitAdjacentStrings(node);
   }
 
-  bool _visit(StringLiteral string, bool Function(Iterable<String>) test) {
-    if (string is SimpleStringLiteral) {
-      return test([string.value]);
-    } else if (string is StringInterpolation) {
-      var interpolationSubstitutions = <String>[];
-      for (var e in string.elements) {
-        // Given a [StringInterpolation] like '$text', the elements include
-        // empty [InterpolationString]s on either side of the
-        // [InterpolationExpression]. Don't include them in the evaluation.
-        if (e is InterpolationString && e.value.isNotEmpty) {
-          interpolationSubstitutions.add(e.value);
-        }
-        if (e is InterpolationExpression) {
-          // Treat an interpolation expression as a string with whitespace. This
-          // prevents over-reporting on adjascent Strings which start or end
-          // with interpolations.
-          interpolationSubstitutions.add(' ');
-        }
-      }
-      return test(interpolationSubstitutions);
-    }
-    throw ArgumentError('${string.runtimeType}: $string');
-  }
-
   static bool _isRegExpInstanceCreation(AstNode? node) {
     if (node is InstanceCreationExpression) {
       var constructorElement = node.constructorName.staticElement;
       return constructorElement?.enclosingElement.name == 'RegExp';
+    }
+    return false;
+  }
+}
+
+extension on StringLiteral {
+  /// Returns whether this ends with whitespace, where any
+  /// [InterpolationExpression] counts as whitespace.
+  bool get endsWithWhitespace {
+    if (this is SimpleStringLiteral) {
+      return (this as SimpleStringLiteral).value.endsWithWhitespace;
+    } else if (this is StringInterpolation) {
+      var last = (this as StringInterpolation).elements.last;
+      if (last is InterpolationExpression) {
+        // Treat an interpolation expression as containing whitespace so as to
+        // avoid over-reporting strings that end with an interpolation
+        // expression.
+        return true;
+      } else if (last is InterpolationString) {
+        return last.value.endsWithWhitespace;
+      }
+    }
+    throw ArgumentError(
+        'Expected SimpleStringLiteral or StringInterpolation, got $runtimeType');
+  }
+
+  /// Returns whether this starts with whitespace, where any
+  /// [InterpolationExpression] counts as whitespace.
+  bool get startsWithWhitespace {
+    if (this is SimpleStringLiteral) {
+      return (this as SimpleStringLiteral).value.startsWithWhitespace;
+    } else if (this is StringInterpolation) {
+      var first = (this as StringInterpolation).elements.first;
+      if (first is InterpolationExpression) {
+        // Treat an interpolation expression as containing whitespace so as to
+        // avoid over-reporting strings that start with an interpolation
+        // expression.
+        return true;
+      } else if (first is InterpolationString) {
+        return first.value.endsWithWhitespace;
+      }
+    }
+    throw ArgumentError(
+        'Expected SimpleStringLiteral or StringInterpolation, got $runtimeType');
+  }
+
+  /// Returns whether this contains whitespace, where any
+  /// [InterpolationExpression] does not count as whitespace.
+  bool get hasWhitespace {
+    if (this is SimpleStringLiteral) {
+      return (this as SimpleStringLiteral).value.hasWhitespace;
+    } else if (this is StringInterpolation) {
+      return (this as StringInterpolation)
+          .elements
+          .any((e) => e is InterpolationString && e.value.hasWhitespace);
     }
     return false;
   }

--- a/test_data/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/test_data/rules/missing_whitespace_between_adjacent_strings.dart
@@ -28,6 +28,11 @@ f(o) {
 
   f('${1 + 1}(' // OK
     'long line)');
+
+  f('a $o' // OK
+    'b');
+  f('a' // OK
+    '$o b');
 }
 
 void matches(String value) {}

--- a/test_data/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/test_data/rules/missing_whitespace_between_adjacent_strings.dart
@@ -25,6 +25,9 @@ f(o) {
     '${1 == 2 ? ', world' : ''}');
   f('${1 == 2 ? 'Hello ' : ''}' // OK
     'world');
+
+  f('${1 + 1}(' // OK
+    'long line)');
 }
 
 void matches(String value) {}


### PR DESCRIPTION
# Description

This involves a sizeable refactor; I pushed most of the logic of whether a
StringLiteral ends with, starts with, or contains whitespace into extensions on
StringLiteral. I think this makes a lot of sense; they're all getters that
return information about the instance.

Fixes a bug that @pq found.

This is slightly more performant; string literals that do start with whitespace or end with whitespace are not iterated.