### PR TITLE
Fixed false positive use_full_hex_values_for_flutter_colors

### DIFF
--- a/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
+++ b/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
@@ -61,7 +61,7 @@ class _Visitor extends SimpleAstVisitor {
       if (arguments.isNotEmpty) {
         var argument = arguments.first;
         if (argument is IntegerLiteral) {
-          var value = argument.literal.lexeme;
+          var value = argument.literal.lexeme.toLowerCase();
           if (!value.startsWith('0x') || value.length != 10) {
             rule.reportLint(argument);
           }

--- a/test_data/rules/use_full_hex_values_for_flutter_colors.dart
+++ b/test_data/rules/use_full_hex_values_for_flutter_colors.dart
@@ -17,5 +17,7 @@ m() {
   Color(1); // LINT
   Color(0x000000); // LINT
   Color(0x00000000); // OK
+  Color(0X000000); // LINT
+  Color(0X00000000); // OK
   Color(a); // OK
 }


### PR DESCRIPTION
If you use an uppercase 'X' in the hexadecimal prefix, it gives a false positive.