### PR TITLE
Revert "allow overrides with a doc comment only if they are abstract"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
   interpolations at the beginning and end of String literals.
 - update `unnecessary_getters_setters` to allow for setters with non-basic
   assignments (for example, `??=` or `+=`).
-- update `unnecessary_overrides` to allow overrides with a doc comment only if
-  they are abstract.
 
 # 1.6.1
 

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -39,11 +39,10 @@ class A extends B {
 
 It's valid to override a member in the following cases:
 
-* if a return type or a parameter type is not the exact same type as the
-  super method,
+* if a type (return type or a parameter type) is not the exactly the same as the
+super method,
 * if the `covariant` keyword is added to one of the parameters,
-* if a documentation comment is present on the member, and the member is
-  abstract,
+* if documentation comments are present on the member,
 * if the member has annotations other than `@override`.
 
 `noSuchMethod` is a special method and is not checked by this rule.
@@ -100,12 +99,11 @@ abstract class _AbstractUnnecessaryOverrideVisitor extends SimpleAstVisitor {
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    // `noSuchMethod` is mandatory to proxify.
+    // noSuchMethod is mandatory to proxify
     if (node.name.name == 'noSuchMethod') return;
 
-    // It's ok to override a method with an abstract declaration, in order to
-    // have better documentation.
-    if (node.documentationComment != null && node.isAbstract) return;
+    // it's ok to override to have better documentation
+    if (node.documentationComment != null) return;
 
     inheritedMethod = getInheritedElement(node);
     declaration = node;

--- a/test_data/rules/unnecessary_overrides.dart
+++ b/test_data/rules/unnecessary_overrides.dart
@@ -20,7 +20,7 @@ class Base {
   int m2({int a, int b}) => 0;
   int m3({int a, int b}) => 0;
   int operator +(other) => 0;
-  Base operator ~() => null;
+  Base operator ~()=> null;
   @override
   int get hashCode => 13;
 }
@@ -53,7 +53,7 @@ class Parent extends Base {
   int operator +(other) => super + other; // LINT
 
   @override
-  Base operator ~() => ~super; // LINT
+  Base operator ~()=> ~super; // LINT
 
   @override
   @myAnnotation
@@ -195,11 +195,7 @@ class D implements C {
 }
 
 class E extends C {
-  /// Overridden for documentation, but has a body.
+  /// it's ok to override to provide better documentation
   @override
-  num get g => super.g; // LINT
-
-  /// Overridden for documentation, without a body.
-  @override
-  num m(int v); // OK
+  num get g => super.g; // OK
 }


### PR DESCRIPTION
Reverts dart-lang/linter#2723

This flags a bunch of new places in flutter which suggests some more ecosystem impact.  The rub is that the message should indicate the rationale from https://github.com/dart-lang/linter/issues/2277 and the remedy (make the method abstract).  We should also consider updating the quick-fix to make methods abstract where appropriate.

/cc @bwilkerson @srawlins 