### PR TITLE
Correct typo in missing_whitespace_between_adjacent_strings

### DIFF
--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -118,7 +118,7 @@ extension on StringLiteral {
       return self.value.startsWithWhitespace;
     } else if (self is StringInterpolation) {
       var first = self.elements.first as InterpolationString;
-      return first.value.isEmpty || first.value.endsWithWhitespace;
+      return first.value.isEmpty || first.value.startsWithWhitespace;
     }
     throw ArgumentError(
         'Expected SimpleStringLiteral or StringInterpolation, but got '

--- a/test_data/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/test_data/rules/missing_whitespace_between_adjacent_strings.dart
@@ -33,6 +33,8 @@ f(o) {
     'b');
   f('a' // OK
     '$o b');
+  f("a $o b" // OK
+    " c$o");
 }
 
 void matches(String value) {}


### PR DESCRIPTION
# Description

Fix a typo in missing_whitespace_between_adjacent_strings which causes false positives.

Fixes an issue that @pq found.
