### PR TITLE
1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
-# master
+# 1.7.0
 
-- update `use_setters_to_change_properties` to only highlight a method name,
-  not the entire body and doc comment.
-- update `unnecessary_getters_setters` to allow otherwise "unnecessary" getters
-  and setters with annotations.
-- update `missing_whitespace_between_adjacent_strings` to allow String
-  interpolations at the beginning and end of String literals.
-- update `unnecessary_getters_setters` to allow for setters with non-basic
-  assignments (for example, `??=` or `+=`).
-- update `unnecessary_overrides` to allow overrides with a doc comment only if
-  they are abstract.
+- improved try-block and switch statement flow analysis for 
+  `use_build_context_synchronously`
+- updated `use_setters_to_change_properties` to only highlight a method name,
+  not the entire body and doc comment
+- updated `unnecessary_getters_setters` to allow otherwise "unnecessary" getters
+  and setters with annotations
+- updated `missing_whitespace_between_adjacent_strings` to allow String
+  interpolations at the beginning and end of String literals
+- updated `unnecessary_getters_setters` to allow for setters with non-basic
+  assignments (for example, `??=` or `+=`)
+- updated `unnecessary_overrides` to allow overrides with a doc comment only if
+  they are abstract
 
 # 1.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.7.0
 
+- fixed case-sensitive false positive in `use_full_hex_values_for_flutter_colors`
 - improved try-block and switch statement flow analysis for 
   `use_build_context_synchronously`
 - updated `use_setters_to_change_properties` to only highlight a method name,
@@ -10,8 +11,6 @@
   interpolations at the beginning and end of String literals
 - updated `unnecessary_getters_setters` to allow for setters with non-basic
   assignments (for example, `??=` or `+=`)
-- updated `unnecessary_overrides` to allow overrides with a doc comment only if
-  they are abstract
 
 # 1.6.1
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.6.1';
+const String version = '1.7.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.6.1
+version: 1.7.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.7.0

- fixed case-sensitive false positive in `use_full_hex_values_for_flutter_colors`
- improved try-block and switch statement flow analysis for 
  `use_build_context_synchronously`
- updated `use_setters_to_change_properties` to only highlight a method name,
  not the entire body and doc comment
- updated `unnecessary_getters_setters` to allow otherwise "unnecessary" getters
  and setters with annotations
- updated `missing_whitespace_between_adjacent_strings` to allow String
  interpolations at the beginning and end of String literals
- updated `unnecessary_getters_setters` to allow for setters with non-basic
  assignments (for example, `??=` or `+=`)


/cc @bwilkerson @srawlins 