### PR TITLE
gh label query tool

### DIFF
--- a/tool/canonical/gh_labels.dart
+++ b/tool/canonical/gh_labels.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:args/args.dart';
+import 'package:github/github.dart';
+import 'package:http/http.dart' as http;
+
+import '../github.dart';
+
+/// Outputs a list of issues whose GH issue tags need updating.
+Future<void> main(List<String> args) async {
+  var parser = ArgParser()
+    ..addOption('token', abbr: 't', help: 'Specifies a github auth token.');
+  ArgResults options;
+  try {
+    options = parser.parse(args);
+  } on FormatException catch (err) {
+    printUsage(parser, err.message);
+    return;
+  }
+
+  var client = http.Client();
+  var req = await client.get(
+      Uri.parse('https://dart-lang.github.io/linter/lints/machine/rules.json'));
+
+  var token = options['token'];
+  var auth = token is String ? Authentication.withToken(token) : null;
+
+  var machine = json.decode(req.body) as List;
+  var rules = machine
+      .map((e) => MapEntry(e['name'] as String, e['sets'] as List))
+      .toList();
+
+  var issues = await getLinterIssues(auth: auth);
+  for (var issue in issues) {
+    var title = issue.title;
+    for (var rule in rules) {
+      if (title.contains(rule.key)) {
+        var sets = rule.value;
+        for (var set in sets) {
+          if (!issue.labels.any((label) => label.name.startsWith('set: '))) {
+            print('${issue.htmlUrl} => set: $set');
+          }
+        }
+      }
+    }
+  }
+
+  //   for (var entry in machine) {
+  //     if (entry['name'] == rule) {
+  //       print('https://dart-lang.github.io/linter/lints/$rule.html');
+  //       print('');
+  //       print('contained in: ${entry["sets"]}');
+  //       var issues = await getLinterIssues(auth: auth);
+  //       for (var issue in issues) {
+  //         var title = issue.title;
+  //         if (title.contains(rule)) {
+  //           print('issue: ${issue.title}');
+  //           print('labels: ${issue.labels.map((e) => e.name).join(", ")}');
+  //           print(issue.htmlUrl);
+  //           print('');
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
+}
+
+void printUsage(ArgParser parser, [String? error]) {
+  var message = error ??
+      'Query lint rules for containing rule sets and relevant GH issues.';
+
+  print('''$message
+Usage: query.dart rule_name
+${parser.usage}
+''');
+}

--- a/tool/canonical/gh_labels.dart
+++ b/tool/canonical/gh_labels.dart
@@ -48,25 +48,6 @@ Future<void> main(List<String> args) async {
       }
     }
   }
-
-  //   for (var entry in machine) {
-  //     if (entry['name'] == rule) {
-  //       print('https://dart-lang.github.io/linter/lints/$rule.html');
-  //       print('');
-  //       print('contained in: ${entry["sets"]}');
-  //       var issues = await getLinterIssues(auth: auth);
-  //       for (var issue in issues) {
-  //         var title = issue.title;
-  //         if (title.contains(rule)) {
-  //           print('issue: ${issue.title}');
-  //           print('labels: ${issue.labels.map((e) => e.name).join(", ")}');
-  //           print(issue.htmlUrl);
-  //           print('');
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
 }
 
 void printUsage(ArgParser parser, [String? error]) {

--- a/tool/canonical/readme.md
+++ b/tool/canonical/readme.md
@@ -1,5 +1,8 @@
 Tools related to Dart and Flutter lints.
 
+* `gh_labels` - emits a list of open github issues that reference
+  lints in lint sets but are missing `set: ...` issue labels.
+
 See: 
 
 * https://github.com/dart-lang/lints


### PR DESCRIPTION
A tool I wrote to help shore up unlabeled github issues.

Emits output like:

```
https://github.com/dart-lang/linter/issues/2732 => set: effective_dart
https://github.com/dart-lang/linter/issues/2731 => set: effective_dart
https://github.com/dart-lang/linter/issues/2713 => set: pedantic
https://github.com/dart-lang/linter/issues/2708 => set: pedantic
https://github.com/dart-lang/linter/issues/2708 => set: effective_dart
https://github.com/dart-lang/linter/issues/2678 => set: effective_dart
https://github.com/dart-lang/linter/issues/2673 => set: effective_dart
https://github.com/dart-lang/linter/issues/2670 => set: effective_dart
https://github.com/dart-lang/linter/issues/2636 => set: effective_dart
https://github.com/dart-lang/linter/issues/2626 => set: pedantic
https://github.com/dart-lang/linter/issues/2626 => set: effective_dart
https://github.com/dart-lang/linter/issues/2616 => set: flutter

...
```

/cc @bwilkerson 