### PR TITLE
Fix unclosed code block in directives_ordering details

### DIFF
--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -13,7 +13,7 @@ const _details = r'''
 **DO** follow the conventions in the 
 [Effective Dart Guide](https://dart.dev/guides/language/effective-dart/style#ordering)
 
-**DO** place “dart:” imports before other imports.
+**DO** place `dart:` imports before other imports.
 
 **BAD:**
 ```dart
@@ -42,7 +42,7 @@ import 'package:bar/bar.dart';
 import 'package:foo/foo.dart';
 ```
 
-**DO** place “package:” imports before relative imports.
+**DO** place `package:` imports before relative imports.
 
 **BAD:**
 ```dart
@@ -106,7 +106,7 @@ import 'package:foo/bar.dart'; // OK
 
 import 'a.dart'; // OK
 import 'a/b.dart'; // OK
-
+```
 ''';
 const _directiveSectionOrderedAlphabetically =
     'Sort directive sections alphabetically.';


### PR DESCRIPTION
Also switches import mentions from quotes to inline code blocks

Codeblock issue discovered here: https://github.com/dart-lang/site-www/pull/3372

@pq Can you regenerate gh-pages after this change makes it in? Thanks!
