### PR TITLE
skip nullable iterables in `avoid_function_literals_in_foreach_calls`

### DIFF
--- a/test_data/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/test_data/rules/avoid_function_literals_in_foreach_calls.dart
@@ -4,6 +4,8 @@
 
 // test w/ `dart test -N avoid_function_literals_in_foreach_calls`
 
+void f(dynamic iter) => iter?.forEach(...); // OK
+
 class Person {
   Iterable<Person> children;
 }

--- a/test_data/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/test_data/rules/avoid_function_literals_in_foreach_calls.dart
@@ -9,12 +9,14 @@ class Person {
 }
 
 void main() {
-  Iterable<String> people;
+  Iterable<String> people = [];
 
-  for (var person in people) { // OK
+  for (var person in people) {
+    // OK
     print('$person!');
   }
-  people.forEach((person) { // LINT
+  people.forEach((person) // LINT
+      {
     print('$person!');
   });
 
@@ -45,4 +47,7 @@ void main() {
       .first
       .children
       .forEach((person) => print('$person!')); // LINT
+
+  Iterable<String>? nullables;
+  nullables?.forEach((n) => print(n)); // OK
 }


### PR DESCRIPTION
Fixes #https://github.com/dart-lang/linter/issues/2751

/cc @bwilkerson 