### PR TITLE
fix `avoid_classes_with_only_static_members` to flag classes with only methods

### DIFF
--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -79,10 +79,14 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitClassDeclaration(ClassDeclaration node) {
     var declaredElement = node.declaredElement;
-    if (declaredElement != null &&
-        node.members.isNotEmpty &&
+    if (declaredElement == null) {
+      return;
+    }
+
+    if (node.members.isNotEmpty &&
         node.members.every(_isStaticMember) &&
-        declaredElement.fields.any(_isNonConst)) {
+        (declaredElement.methods.isNotEmpty ||
+            declaredElement.fields.any(_isNonConst))) {
       rule.reportLint(node);
     }
   }

--- a/test_data/rules/avoid_classes_with_only_static_members.dart
+++ b/test_data/rules/avoid_classes_with_only_static_members.dart
@@ -4,36 +4,50 @@
 
 // test w/ `dart test -N avoid_classes_with_only_static_members`
 
-class Bad { // LINT
+class Bad // LINT
+{
   static int a;
 
   static foo() {}
 }
 
-class Bad2 extends Good1 { // LINT
+class Bad2 extends Good1 // LINT
+{
   static int staticInt;
 
   static foo() {}
 }
 
-class Bad3 {} // OK
+class Bad3 // OK
+{}
 
-class Good1 { // OK
+class Good1 // OK
+{
   int a = 0;
 }
 
-class Good2 { // OK
+class Good2 // OK
+{
   void foo() {}
 }
 
-class Good3 { // OK
+class Good3 // OK
+{
   Good3();
 }
 
-class Color { // OK
+class Color // OK
+{
   static const red = '#f00';
   static const green = '#0f0';
   static const blue = '#00f';
   static const black = '#000';
   static const white = '#fff';
+}
+
+class DateUtils // LINT
+{
+  static DateTime mostRecent(List<DateTime> dates) {
+    return dates.reduce((a, b) => a.isAfter(b) ? a : b);
+  }
 }


### PR DESCRIPTION
Fixes #2731

/cc @bwilkerson 