### PR TITLE
Remove a word from documentation.

### DIFF
--- a/doc/WritingLints.MD
+++ b/doc/WritingLints.MD
@@ -72,7 +72,7 @@ generates lint and test stubs in `lib/src/rules` and `test_data/rules`.
 
 The linter has a close relationship with the `analyzer` package and at times reaches into non-public APIs.  For the most part, we have isolated these references in an [analyzer.dart utility library](https://github.com/dart-lang/linter/blob/master/lib/src/analyzer.dart).  *Whereever possible please use this library to access analyzer internals.*  
 
-  * If `analyzer.dart` is missing something please consider either opening an issue where we can discuss how best to add it. 
+  * If `analyzer.dart` is missing something please consider opening an issue where we can discuss how best to add it. 
   * If you find yourself tempted to make references to analyzer [implementation classes](https://dart-lang.github.io/linter/lints/implementation_imports.html) also consider opening an issue so that we can see how best to manage the new dependency.
   
 Thanks!


### PR DESCRIPTION
Correct a sentence in `WritingLints`.

`either` is usually followed by `or`, and it seems the sentence is better without it.