### PR TITLE
analyzer 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 - New lint: `eol_at_end_of_file`
+- Update `analyzer` constraint to `>=2.0.0 <3.0.0`.
 
 # 1.7.1
 

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -51,7 +51,7 @@ class DartTypeUtilities {
 
     // And no subclasses in the defining library.
     var compilationUnit = classElement.library.definingCompilationUnit;
-    for (var cls in compilationUnit.types) {
+    for (var cls in compilationUnit.classes) {
       InterfaceType? classType = cls.thisType;
       do {
         classType = classType?.superclass;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=1.7.0 <3.0.0'
+  analyzer: '>=2.0.0 <3.0.0'
   args: ^2.0.0
   collection: ^1.15.0
   glob: ^2.0.0


### PR DESCRIPTION
As there error [here](https://github.com/dart-lang/linter/pull/2771/checks?check_run_id=3078290090), we need to use `CompilationUnitElement`.`classes` instead of `types` and this is not existing in `analyzer` `1.7.0`

Needed for any upcoming PR, including #2771