### PR TITLE
Add new lint prefixed_integer_literals

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -141,6 +141,7 @@ linter:
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables
     - prefer_void_to_null
+    - prefixed_integer_literals
     - provide_deprecation_message
     - public_member_api_docs
     - recursive_getters

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -143,6 +143,7 @@ import 'rules/prefer_single_quotes.dart';
 import 'rules/prefer_spread_collections.dart';
 import 'rules/prefer_typing_uninitialized_variables.dart';
 import 'rules/prefer_void_to_null.dart';
+import 'rules/prefixed_integer_literals.dart';
 import 'rules/provide_deprecation_message.dart';
 import 'rules/pub/package_names.dart';
 import 'rules/pub/sort_pub_dependencies.dart';
@@ -341,6 +342,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(PreferSpreadCollections())
     ..register(PreferTypingUninitializedVariables())
     ..register(PreferVoidToNull())
+    ..register(PrefixedIntegerLiterals())
     ..register(ProvideDeprecationMessage())
     ..register(PublicMemberApiDocs())
     ..register(PubPackageNames())

--- a/lib/src/rules/prefixed_integer_literals.dart
+++ b/lib/src/rules/prefixed_integer_literals.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Prefer a lowercase prefix and an uppercase value.';
+
+const _details = r'''
+
+Prefer a lowercase prefix and an uppercase value when using an integer literal
+that contains a prefix indicating the base.
+
+**BAD:**
+```dart
+int a = 0xffffffff;
+int b = 0XFFFFFFFF;
+```
+
+**GOOD:**
+```dart
+int a = 0xFFFFFFFF;
+int b = 0x12345678;
+```
+
+''';
+
+class PrefixedIntegerLiterals extends LintRule implements NodeLintRule {
+  PrefixedIntegerLiterals()
+      : super(
+            name: 'prefixed_integer_literals',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addIntegerLiteral(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  visitIntegerLiteral(IntegerLiteral node) {
+    var lexeme = node.literal.lexeme;
+    if (lexeme.startsWith(RegExp('0[a-zA-Z]'))) {
+      var prefix = lexeme.substring(0, 2);
+      var value = lexeme.substring(3);
+      if (prefix != prefix.toLowerCase() || value != value.toUpperCase()) {
+        rule.reportLint(node);
+      }
+    }
+  }
+}

--- a/test_data/rules/prefixed_integer_literals.dart
+++ b/test_data/rules/prefixed_integer_literals.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N prefixed_integer_literals`
+
+var a = 0xFFFFFF00; // OK
+var b = 0x00000000; // OK
+var c = 0xffffffff; // LINT
+var d = 0xABCDEf01; // LINT
+var e = 0Xffffffff; // LINT
+var f = 0XFFFFFFFF; // LINT


### PR DESCRIPTION
Prefer a lowercase prefix and an uppercase value when using an integer literal that contains a prefix indicating the base.

**BAD:**
```dart
int a = 0xffffffff;
int b = 0XFFFFFFFF;
```

**GOOD:**
```dart
int a = 0xFFFFFFFF;
int b = 0x12345678;
```