### PR TITLE
Ignore unnecessary cast warning.

### DIFF
--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -231,8 +231,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
     if (root is CompoundAssignmentExpression) {
-      // Not promoted by "is" since the type would lose capabilities.
-      var rootAsAssignment = root as CompoundAssignmentExpression;
+      // Not guaranteed to be promoted by "is" since in older analyzers,
+      // CompoundAssignmentExpression didn't implement Expression (so the
+      // promotion would lose capabilities).  TODO(paulberry): in the future,
+      // when we depend on a version of the analyzer in which
+      // CompoundAssignmentExpression is guaranteed to implement Expression,
+      // remove the cast.
+      var rootAsAssignment = root as CompoundAssignmentExpression; // ignore: unnecessary_cast
       if (rootAsAssignment.readType?.isDynamic ?? false) {
         // An assignment expression can only be a dynamic call if it is a
         // "compound assignment" (i.e. such as `x += 1`); so if `readType` is

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -237,7 +237,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       // when we depend on a version of the analyzer in which
       // CompoundAssignmentExpression is guaranteed to implement Expression,
       // remove the cast.
-      var rootAsAssignment = root as CompoundAssignmentExpression; // ignore: unnecessary_cast
+      var rootAsAssignment =
+          root as CompoundAssignmentExpression; // ignore: unnecessary_cast
       if (rootAsAssignment.readType?.isDynamic ?? false) {
         // An assignment expression can only be a dynamic call if it is a
         // "compound assignment" (i.e. such as `x += 1`); so if `readType` is


### PR DESCRIPTION
https://dart-review.googlesource.com/c/sdk/+/207360 improved the
analyzer by making CompoundAssignmentExpression a subtype of
Expression; this means that once a version of the analyzer is
published with this improvement, and the linter can depend on that
version, it will be possible to promote from Expression to
CompoundAssignmentExpression (and the linter will be able to remove a
cast).  Until then, the cast is still required to work with older
analyzers, but will trigger an "unnecessary cast" warning when
analyzing against the newest analyzer.

So for now we ignore the "unnecessary cast" warning.  Once the linter
depends on a later version of the analyzer, we'll be able to clean
this up.
