### PR TITLE
allow keywords for dart package_names

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -62,8 +62,7 @@ bool isValidLibraryPrefix(String libraryPrefix) =>
 
 /// Returns true if this [id] is a valid package name.
 bool isValidPackageName(String id) =>
-    _lowerCaseUnderScoreWithLeadingUnderscores.hasMatch(id) &&
-    isValidDartIdentifier(id);
+    _lowerCaseUnderScoreWithLeadingUnderscores.hasMatch(id) && isIdentifier(id);
 
 class CamelCaseString {
   static final _camelCaseMatcher = RegExp(r'[A-Z][a-z]*');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'ast.dart';
-
 final _identifier = RegExp(r'^([(_|$)a-zA-Z]+([_a-zA-Z0-9])*)$');
 
 final _lowerCamelCase = RegExp(

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -22,6 +22,7 @@ void main() {
       'foo',
       '_foo',
       '__foo',
+      'async',
     ], isValidPackageName, isTrue);
     testEach([
       'fOO',


### PR DESCRIPTION
Fixes #2790

`isValidDartIdentifier` rejects keywords too which is too restrictive for package names.


/cc @natebosch @bwilkerson 