### PR TITLE
Fix cancel_subscriptions for nullable field

### DIFF
--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -111,6 +111,8 @@ Iterable<AstNode> _findNodesInvokingMethodOnVariable(
           ((_hasMatch(predicates, declaredElement.type, n.methodName.name) &&
                   (_isSimpleIdentifierElementEqualToVariable(
                           n.realTarget, variable) ||
+                      _isPostfixExpressionOperandEqualToVariable(
+                          n.realTarget, variable) ||
                       _isPropertyAccessThroughThis(n.realTarget, variable) ||
                       (n.thisOrAncestorMatching((a) => a == variable) !=
                           null))) ||
@@ -187,6 +189,16 @@ bool _isSimpleIdentifierElementEqualToVariable(
         AstNode? n, VariableDeclaration variable) =>
     n is SimpleIdentifier &&
     _isElementEqualToVariable(n.staticElement, variable);
+
+bool _isPostfixExpressionOperandEqualToVariable(
+    AstNode? n, VariableDeclaration variable) {
+  if (n is PostfixExpression) {
+    var operand = n.operand;
+    return operand is SimpleIdentifier &&
+        _isElementEqualToVariable(operand.staticElement, variable);
+  }
+  return false;
+}
 
 typedef DartTypePredicate = bool Function(DartType type);
 

--- a/test/integration/cancel_subscriptions.dart
+++ b/test/integration/cancel_subscriptions.dart
@@ -35,7 +35,7 @@ void main() {
           stringContainsInOrder([
             'StreamSubscription _subscriptionA; // LINT',
             'StreamSubscription _subscriptionF; // LINT',
-            '1 file analyzed, 3 issues found, in'
+            '2 files analyzed, 3 issues found, in'
           ]));
       expect(exitCode, 1);
     });

--- a/test_data/integration/cancel_subscriptions/cancel_subscriptions_null_safety.dart
+++ b/test_data/integration/cancel_subscriptions/cancel_subscriptions_null_safety.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+class D {
+  StreamSubscription? _subscriptionD; // OK
+  void init(Stream stream) {
+    _subscriptionD = stream.listen((_) {});
+  }
+  void _cancel() {
+    if (_subscriptionD != null) {
+      _subscriptionD!.cancel();
+      _subscriptionD = null;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2338

This changes the `LeakDetectorVisitor` to handle `PostFixExpression.operand` similar to the `SimpleIdentifierElement`.

A new test file with Null Safety was introduced to verify the nullable field.
