### PR TITLE
`annotate_overrides` perf fixes

### DIFF
--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -7,7 +7,6 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../ast.dart';
 
 const _desc = r'Annotate overridden members.';
 
@@ -100,7 +99,6 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isStatic) return;
 
     for (var field in node.fields.variables) {
-      if (isPrivate(field.name)) continue;
 
       check(field.declaredElement, field);
     }
@@ -109,7 +107,6 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
     if (node.isStatic) return;
-    if (isPrivate(node.name)) return;
 
     check(node.declaredElement, node.name);
   }

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -5,9 +5,9 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:linter/src/ast.dart';
 
 import '../analyzer.dart';
+import '../ast.dart';
 
 const _desc = r'Annotate overridden members.';
 

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:linter/src/ast.dart';
 
 import '../analyzer.dart';
 
@@ -57,7 +58,6 @@ class AnnotateOverrides extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this, context);
-    registry.addCompilationUnit(this, visitor);
     registry.addFieldDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);
   }
@@ -68,6 +68,15 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LinterContext context;
 
   _Visitor(this.rule, this.context);
+
+  void check(Element? element, AstNode target) {
+    if (element == null || element.hasOverride) return;
+
+    var member = getOverriddenMember(element);
+    if (member != null) {
+      rule.reportLint(target);
+    }
+  }
 
   Element? getOverriddenMember(Element member) {
     var classElement = member.thisOrAncestorOfType<ClassElement>();
@@ -88,25 +97,20 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
+    if (node.isStatic) return;
+
     for (var field in node.fields.variables) {
-      var element = field.declaredElement;
-      if (element != null && !element.hasOverride) {
-        var member = getOverriddenMember(element);
-        if (member != null) {
-          rule.reportLint(field);
-        }
-      }
+      if (isPrivate(field.name)) continue;
+
+      check(field.declaredElement, field);
     }
   }
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
-    var element = node.declaredElement;
-    if (element != null && !element.hasOverride) {
-      var member = getOverriddenMember(element);
-      if (member != null) {
-        rule.reportLint(node.name);
-      }
-    }
+    if (node.isStatic) return;
+    if (isPrivate(node.name)) return;
+
+    check(node.declaredElement, node.name);
   }
 }

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -99,7 +99,6 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isStatic) return;
 
     for (var field in node.fields.variables) {
-
       check(field.declaredElement, field);
     }
   }


### PR DESCRIPTION
* avoid unnecessary calls to `getOverriddenMember`
* remove unused node visit registration

/cc @bwilkerson 
