### PR TITLE
stop visiting simple identifiers in `prefer_void_to_null`

### DIFF
--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -57,7 +57,6 @@ class PreferVoidToNull extends LintRule implements NodeLintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
-    registry.addSimpleIdentifier(this, visitor);
     registry.addTypeName(this, visitor);
   }
 }


### PR DESCRIPTION
Improves perf a bit.

Benchmark runs:

**before:**

    -----------------------------------------------------------------------------
    Timings                                                                    ms
    -----------------------------------------------------------------------------

    prefer_void_to_null [recommended]                                          14

**after:**

    prefer_void_to_null [recommended]                                           7


/cc @bwilkerson 