### PR TITLE
Fix false positive case in `invariant_booleans`

### DIFF
--- a/lib/src/util/boolean_expression_utilities.dart
+++ b/lib/src/util/boolean_expression_utilities.dart
@@ -31,6 +31,15 @@ class BooleanExpressionUtilities {
     TokenType.LT_EQ: TokenType.GT,
   });
 
+  static HashMap<TokenType, TokenType> INVERSIONS = HashMap.from(const {
+    TokenType.EQ_EQ: TokenType.EQ_EQ,
+    TokenType.BANG_EQ: TokenType.BANG_EQ,
+    TokenType.GT: TokenType.LT,
+    TokenType.GT_EQ: TokenType.LT_EQ,
+    TokenType.LT: TokenType.GT,
+    TokenType.LT_EQ: TokenType.GT_EQ,
+  });
+
   static HashSet<TokenType> TRICHOTOMY_OPERATORS =
       HashSet.from(const [TokenType.EQ_EQ, TokenType.LT, TokenType.GT]);
 

--- a/test_data/rules/invariant_booleans.dart
+++ b/test_data/rules/invariant_booleans.dart
@@ -478,3 +478,17 @@ void bug811_2() {
 
   if (bar < foo) {} // LINT
 }
+
+void bug2478() {
+  var i = 0;
+  var j = 0;
+
+  if (i < j) {
+    i++;
+  } else if (j < i) { // OK
+    j++;
+  } else {
+    i++;
+    j++;
+  }
+}


### PR DESCRIPTION
Fixes #2478

Changes:

1. `_sameOperands` treated operands in the same order similar to the inverted one. This is now split into `_sameOperandsSameOrder` and `_sameOperandsInverted`
1.1. If `_sameOperandsSameOrder`, then same behavior as before
1.2. If `_sameOperandsInverted`, we need to `invert` the `operator`, e.g. `a > b` becomes `b < a`
1.3 If none of the above, then `return`. This is the same as the previous logic, with a little performance improvement since we now `return` earlier.
2. `cOperatorType` is now not-nullable (I think we have all cases in `BooleanExpressionUtilities.NEGATIONS` and `INVERSIONS`, but we can revert this change.