### PR TITLE
Fix false positive in `use_rethrow_when_possible`

### DIFF
--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -62,7 +62,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitThrowExpression(ThrowExpression node) {
-    if (node.parent is ConditionalExpression) return;
+    if (node.parent is Expression || node.parent is ArgumentList) return;
 
     var element =
         DartTypeUtilities.getCanonicalElementFromIdentifier(node.expression);

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -62,6 +62,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitThrowExpression(ThrowExpression node) {
+    if (node.parent is ConditionalExpression) return;
+
     var element =
         DartTypeUtilities.getCanonicalElementFromIdentifier(node.expression);
     if (element != null) {

--- a/test_data/rules/use_rethrow_when_possible.dart
+++ b/test_data/rules/use_rethrow_when_possible.dart
@@ -41,4 +41,8 @@ void bug2789() {
   try {} catch (e) {
     e != null ? e.toString() : throw e; // OK
   }
+
+  try {} catch (e) {
+    print(throw e); // OK
+  }
 }

--- a/test_data/rules/use_rethrow_when_possible.dart
+++ b/test_data/rules/use_rethrow_when_possible.dart
@@ -36,3 +36,9 @@ void good3() {
     }
   }
 }
+
+void bug2789() {
+  try {} catch (e) {
+    e != null ? e.toString() : throw e; // OK
+  }
+}


### PR DESCRIPTION
Fixes #2789

I don't know how to have a compilable case with `return i ?? throw e;`