### PR TITLE
Handle block comments in `rule_test`

### DIFF
--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -223,10 +223,19 @@ void testRule(String ruleName, File file,
     var expected = <AnnotationMatcher>[];
 
     var lineNumber = 1;
+    var inComment = false;
     for (var line in file.readAsLinesSync()) {
-      var annotation = extractAnnotation(lineNumber, line);
-      if (annotation != null) {
-        expected.add(AnnotationMatcher(annotation));
+      if (!inComment && line.contains('/*') && !line.contains('/**')) {
+        inComment = true;
+      }
+      if (inComment && line.contains('*/')) {
+        inComment = false;
+      }
+      if (!inComment) {
+        var annotation = extractAnnotation(lineNumber, line);
+        if (annotation != null) {
+          expected.add(AnnotationMatcher(annotation));
+        }
       }
       ++lineNumber;
     }


### PR DESCRIPTION
During testing a new case in an existing file with `rule_test`, one is tempted to use the block comment `/* */` to comment cases which are not relevant, to focus and debug the new case only.

It seems `rule_test` reads the lines and lints regardless of whether they are in block comment or not.

This PR adds a primitive way to consider inside comment or outside comment.

Test scenario:

- Put a block comment around all code of a particular rule test
- Run `dart test -N <specific_rule_name>`

Expected: successful test and 0 lints
Actual: triggered lints are 0, however the expectations is always more than 0.
