### PR TITLE
Fix `void_checks` for a compiler error case

### DIFF
--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -135,6 +135,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (expectedType == null || type == null) {
       return;
     }
+    if (expectedType.isVoid && !type.isDynamic && node is ReturnStatement) {
+      return;
+    }
     if (expectedType.isVoid && !isTypeAcceptableWhenExpectingVoid(type)) {
       rule.reportLint(node);
     } else if (expectedType.isDartAsyncFutureOr &&

--- a/test_data/rules/void_checks.dart
+++ b/test_data/rules/void_checks.dart
@@ -213,3 +213,7 @@ missing_parameter_for_argument() {
 void emptyFunctionExpressionReturningFutureOrVoid(FutureOr<void> Function() f) {
   f = () {}; // OK
 }
+
+void bug2813() {
+  return 1; //OK this gives compiler error
+}


### PR DESCRIPTION
Fixes #2813

I feel it may need further refactoring, since the condition is very similar to the one next:

```dart
if (expectedType.isVoid && !isTypeAcceptableWhenExpectingVoid(type)) {
```

but I am not sure.