### PR TITLE
Implement `FAILING` tests

### DIFF
--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -225,7 +225,7 @@ void testRule(String ruleName, File file,
     var lineNumber = 1;
     for (var line in file.readAsLinesSync()) {
       var annotation = extractAnnotation(lineNumber, line);
-      if (annotation != null) {
+      if (annotation != null && (!annotation.failing || !annotation.lint)) {
         expected.add(AnnotationMatcher(annotation));
       }
       ++lineNumber;


### PR DESCRIPTION
Fixes #2815 

To test

Select any current rule test, e.g.

```dart
currentlyLinting(); //LINT
currentlyOk(); //OK
```

Change the expectations to the below, and the tests are still green.
```dart
// this is for false positive cases, means it should be ok, but `unfortunately` currently lints
currentlyLinting(); // OK FAILING
// this is for false negative ones, meaning it should lint, but `unfortunately` currently is ok
currentlyOk(); // LINT FAILING
```

If the `FAILING` ones actually pass, there is a message printed about the succession.

```dart
// this fails the build and gives a message that it actually works
currentlyLinting(); // LINT FAILING
// this fails the build and gives a message that it actually works
currentlyOk(); // OK FAILING
```
