### PR TITLE
Fix false negative in `prefer_is_empty`

### DIFF
--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -81,15 +81,13 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
-    // todo(pq): not evaluating constants deliberately but we *should*.
-    // see: https://github.com/dart-lang/linter/issues/2818
-    var value = getIntValue(node.rightOperand, null);
+    var value = getIntValue(node.rightOperand, context);
     if (value != null) {
       if (_isLengthAccess(node.leftOperand)) {
         _check(node, value, constantOnRight: true);
       }
     } else {
-      value = getIntValue(node.leftOperand, null);
+      value = getIntValue(node.leftOperand, context);
       // ignore: invariant_booleans
       if (value != null) {
         if (_isLengthAccess(node.rightOperand)) {

--- a/test_data/rules/prefer_is_empty.dart
+++ b/test_data/rules/prefer_is_empty.dart
@@ -57,8 +57,8 @@ bool le = list.length > 0; //LINT
 bool le2 = [].length > 0; //LINT
 bool le3 = ([].length as int) > 0; //LINT
 bool le4 = 0 < list.length; //LINT
-bool le5 = [].length < zero;
-bool le6 = zero < [].length;
+bool le5 = [].length < zero; //LINT
+bool le6 = zero < [].length; //LINT
 bool me = (map.length) == 0; //LINT
 bool ie = iterable.length != 0; //LINT
 bool ce = a()().length == 0; //LINT


### PR DESCRIPTION
Fixes #2818 

I hope it is fine to do this change, since `not evaluating constants deliberately` in the old TODO, I guess it was added to retain the old behavior in the other PR.