### PR TITLE
Better lint messages for `avoid_renaming_method_parameters`

### DIFF
--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -62,13 +62,14 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
     var visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
   }
-
-  void _reportLintForNodeWithDescription(AstNode node, String description) {
-    reporter.reportErrorForNode(LintCode(name, description), node);
-  }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
+  static const LintCode parameterCode = LintCode(
+      "avoid_renaming_method_parameters",
+      "The overridden method should have same parameter names as the parent method.",
+      correction:
+          "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.");
   final AvoidRenamingMethodParameters rule;
   final LinterContext context;
 
@@ -112,8 +113,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       var paramIdentifier = parameters[i].identifier;
       if (paramIdentifier != null &&
           paramIdentifier.name != parentParameters[i].name) {
-        rule._reportLintForNodeWithDescription(paramIdentifier,
-            "Don't rename parameter '${parentParameters[i].name}' of the overridden method to '${paramIdentifier.name}'.");
+        rule.reportLint(paramIdentifier,
+            arguments: [parentParameters[i].name, paramIdentifier.name],
+            errorCode: parameterCode);
       }
     }
   }

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -71,7 +71,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       correction:
           "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.");
 
-  final AvoidRenamingMethodParameters rule;
+  final LintRule rule;
 
   _Visitor(this.rule);
 

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -114,7 +114,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (paramIdentifier != null &&
           paramIdentifier.name != parentParameters[i].name) {
         rule.reportLint(paramIdentifier,
-            arguments: [parentParameters[i].name, paramIdentifier.name],
+            arguments: [paramIdentifier.name, parentParameters[i].name],
             errorCode: parameterCode);
       }
     }

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -59,7 +59,7 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
       return;
     }
 
-    var visitor = _Visitor(this, context);
+    var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
   }
 }
@@ -70,10 +70,10 @@ class _Visitor extends SimpleAstVisitor<void> {
       "The overridden method should have same parameter names as the parent method.",
       correction:
           "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.");
-  final AvoidRenamingMethodParameters rule;
-  final LinterContext context;
 
-  _Visitor(this.rule, this.context);
+  final AvoidRenamingMethodParameters rule;
+
+  _Visitor(this.rule);
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -62,10 +62,14 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
     var visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
   }
+
+  void _reportLintForNodeWithDescription(AstNode node, String description) {
+    reporter.reportErrorForNode(LintCode(name, description), node);
+  }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  final LintRule rule;
+  final AvoidRenamingMethodParameters rule;
   final LinterContext context;
 
   _Visitor(this.rule, this.context);
@@ -108,7 +112,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       var paramIdentifier = parameters[i].identifier;
       if (paramIdentifier != null &&
           paramIdentifier.name != parentParameters[i].name) {
-        rule.reportLint(parameters[i].identifier);
+        rule._reportLintForNodeWithDescription(paramIdentifier,
+            "Don't rename parameter '${parentParameters[i].name}' of the overridden method to '${paramIdentifier.name}'.");
       }
     }
   }

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -67,9 +67,8 @@ class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
 class _Visitor extends SimpleAstVisitor<void> {
   static const LintCode parameterCode = LintCode(
       "avoid_renaming_method_parameters",
-      "The overridden method should have same parameter names as the parent method.",
-      correction:
-          "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.");
+      "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.",
+      correction: "Try renaming the parameter.");
 
   final LintRule rule;
 

--- a/test/integration/avoid_renaming_method_parameters.dart
+++ b/test/integration/avoid_renaming_method_parameters.dart
@@ -37,12 +37,12 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'a.dart 29:6 [lint] Don\'t rename parameters of overridden methods.',
-            'a.dart 31:12 [lint] Don\'t rename parameters of overridden methods.',
-            'a.dart 32:9 [lint] Don\'t rename parameters of overridden methods.',
-            'a.dart 34:7 [lint] Don\'t rename parameters of overridden methods.',
-            'a.dart 35:6 [lint] Don\'t rename parameters of overridden methods.',
-            'a.dart 36:6 [lint] Don\'t rename parameters of overridden methods.',
+            "a.dart 29:6 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
+            "a.dart 31:12 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
+            "a.dart 32:9 [lint] Don't rename parameter 'b' of the overridden method to 'bb'.",
+            "a.dart 34:7 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
+            "a.dart 35:6 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
+            "a.dart 36:6 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
             '3 files analyzed, 6 issues found',
           ]));
       expect(exitCode, 1);

--- a/test/integration/avoid_renaming_method_parameters.dart
+++ b/test/integration/avoid_renaming_method_parameters.dart
@@ -37,12 +37,12 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            "a.dart 29:6 [lint] The overridden method should have same parameter names as the parent method.",
-            "a.dart 31:12 [lint] The overridden method should have same parameter names as the parent method.",
-            "a.dart 32:9 [lint] The overridden method should have same parameter names as the parent method.",
-            "a.dart 34:7 [lint] The overridden method should have same parameter names as the parent method.",
-            "a.dart 35:6 [lint] The overridden method should have same parameter names as the parent method.",
-            "a.dart 36:6 [lint] The overridden method should have same parameter names as the parent method.",
+            "a.dart 29:6 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
+            "a.dart 31:12 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
+            "a.dart 32:9 [lint] The parameter 'bb' should have the name 'b' to match the name used in the overridden method.",
+            "a.dart 34:7 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
+            "a.dart 35:6 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
+            "a.dart 36:6 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
             '3 files analyzed, 6 issues found',
           ]));
       expect(exitCode, 1);

--- a/test/integration/avoid_renaming_method_parameters.dart
+++ b/test/integration/avoid_renaming_method_parameters.dart
@@ -37,12 +37,12 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            "a.dart 29:6 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
-            "a.dart 31:12 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
-            "a.dart 32:9 [lint] Don't rename parameter 'b' of the overridden method to 'bb'.",
-            "a.dart 34:7 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
-            "a.dart 35:6 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
-            "a.dart 36:6 [lint] Don't rename parameter 'a' of the overridden method to 'aa'.",
+            "a.dart 29:6 [lint] The overridden method should have same parameter names as the parent method.",
+            "a.dart 31:12 [lint] The overridden method should have same parameter names as the parent method.",
+            "a.dart 32:9 [lint] The overridden method should have same parameter names as the parent method.",
+            "a.dart 34:7 [lint] The overridden method should have same parameter names as the parent method.",
+            "a.dart 35:6 [lint] The overridden method should have same parameter names as the parent method.",
+            "a.dart 36:6 [lint] The overridden method should have same parameter names as the parent method.",
             '3 files analyzed, 6 issues found',
           ]));
       expect(exitCode, 1);


### PR DESCRIPTION
Related to the message description of #2683 

Dart `fix` to be separately handled.