### PR TITLE
Add TODO to remove an `ignore` once an issue is fixed

### DIFF
--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -251,6 +251,8 @@ void testRule(String ruleName, File file,
     actual.sort();
     try {
       expect(actual, unorderedMatches(expected));
+      // TODO (asashour): to be removed after fixing
+      // https://github.com/dart-lang/linter/issues/909
       // ignore: avoid_catches_without_on_clauses
     } catch (_) {
       if (debug) {


### PR DESCRIPTION
Since #909 is accepted as a bug, then the `ignore` should be removed once the issue is fixed.