### PR TITLE
skip factory constructors when checking `prefer_initializing_formals`

### DIFF
--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -122,6 +122,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
+    // Skip factory constructors.
+    // https://github.com/dart-lang/linter/issues/2441
+    if (node.factoryKeyword != null) {
+      return;
+    }
+
     var parameters = _getParameters(node);
     var parametersUsedOnce = <Element?>{};
     var parametersUsedMoreThanOnce = <Element?>{};

--- a/test_data/rules/prefer_initializing_formals.dart
+++ b/test_data/rules/prefer_initializing_formals.dart
@@ -4,6 +4,18 @@
 
 // test w/ `dart test -N prefer_initializing_formals`
 
+class C {
+  String? value;
+  C._();
+
+  /// https://github.com/dart-lang/linter/issues/2441
+  factory C.withValue(String? value) {
+    var c = C._();
+    c.value = value; // OK
+    return c;
+  }
+}
+
 class Foo {
   final bool isBlahEnabled;
   final List<String> whatever;


### PR DESCRIPTION
Fixes #2441

/cc @bwilkerson 