### PR TITLE
fix `prefer_void_to_null` false positive on overriding returns

### DIFF
--- a/test_data/rules/prefer_void_to_null.dart
+++ b/test_data/rules/prefer_void_to_null.dart
@@ -11,6 +11,34 @@ import 'dart:async';
 import 'dart:core';
 import 'dart:core' as core;
 
+/// https://github.com/dart-lang/linter/issues/2792
+class A<T> {
+  Future<T>? something() {}
+}
+
+class B<T> implements A<T> {
+  @override
+  Null something() {}  // OK
+}
+
+class C {
+  FutureOr<void>? something() {}
+}
+
+class D implements C {
+  @override
+  Null something() {}  // LINT
+}
+
+class E {
+  Never? something() {} // LINT
+}
+
+class F implements E {
+  @override
+  Null something() {}  // OK
+}
+
 void void_; // OK
 Null null_; // LINT
 core.Null core_null; // LINT


### PR DESCRIPTION
Fixes #https://github.com/dart-lang/linter/issues/2792


/cc @bwilkerson 