### PR TITLE
remove uneeded `NodeLintRule` reference

### DIFF
--- a/lib/src/rules/always_declare_return_types.dart
+++ b/lib/src/rules/always_declare_return_types.dart
@@ -45,7 +45,7 @@ typedef predicate = bool Function(Object o);
 
 ''';
 
-class AlwaysDeclareReturnTypes extends LintRule implements NodeLintRule {
+class AlwaysDeclareReturnTypes extends LintRule {
   AlwaysDeclareReturnTypes()
       : super(
             name: 'always_declare_return_types',

--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -46,7 +46,7 @@ while (condition) i += 1;
 
 ''';
 
-class AlwaysPutControlBodyOnNewLine extends LintRule implements NodeLintRule {
+class AlwaysPutControlBodyOnNewLine extends LintRule {
   AlwaysPutControlBodyOnNewLine()
       : super(
             name: 'always_put_control_body_on_new_line',

--- a/lib/src/rules/always_put_required_named_parameters_first.dart
+++ b/lib/src/rules/always_put_required_named_parameters_first.dart
@@ -35,8 +35,7 @@ m({b, c, @required a}) ;
 
 ''';
 
-class AlwaysPutRequiredNamedParametersFirst extends LintRule
-    implements NodeLintRule {
+class AlwaysPutRequiredNamedParametersFirst extends LintRule {
   AlwaysPutRequiredNamedParametersFirst()
       : super(
             name: 'always_put_required_named_parameters_first',

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -39,8 +39,7 @@ NOTE: Only asserts at the start of the bodies will be taken into account.
 
 ''';
 
-class AlwaysRequireNonNullNamedParameters extends LintRule
-    implements NodeLintRule {
+class AlwaysRequireNonNullNamedParameters extends LintRule {
   AlwaysRequireNonNullNamedParameters()
       : super(
             name: 'always_require_non_null_named_parameters',

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -76,7 +76,7 @@ bool _isOptionalTypeArgs(Element? element) =>
     element.name == _optionalTypeArgsVarName &&
     element.library.name == _metaLibName;
 
-class AlwaysSpecifyTypes extends LintRule implements NodeLintRule {
+class AlwaysSpecifyTypes extends LintRule {
   AlwaysSpecifyTypes()
       : super(
             name: 'always_specify_types',

--- a/lib/src/rules/always_use_package_imports.dart
+++ b/lib/src/rules/always_use_package_imports.dart
@@ -46,7 +46,7 @@ import '../lib/baz.dart';
 
 ''';
 
-class AlwaysUsePackageImports extends LintRule implements NodeLintRule {
+class AlwaysUsePackageImports extends LintRule {
   AlwaysUsePackageImports()
       : super(
             name: 'always_use_package_imports',

--- a/lib/src/rules/annotate_overrides.dart
+++ b/lib/src/rules/annotate_overrides.dart
@@ -45,7 +45,7 @@ class Lucky extends Cat {
 
 ''';
 
-class AnnotateOverrides extends LintRule implements NodeLintRule {
+class AnnotateOverrides extends LintRule {
   AnnotateOverrides()
       : super(
             name: 'annotate_overrides',

--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -36,7 +36,7 @@ lookUpOrDefault(String name, Map map, defaultValue) {
 
 ''';
 
-class AvoidAnnotatingWithDynamic extends LintRule implements NodeLintRule {
+class AvoidAnnotatingWithDynamic extends LintRule {
   AvoidAnnotatingWithDynamic()
       : super(
             name: 'avoid_annotating_with_dynamic',

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -52,7 +52,7 @@ HasScrollDirection scrollable = renderObject as dynamic;
 The rule will be removed in a future Linter release.
 ''';
 
-class AvoidAs extends LintRule implements NodeLintRule {
+class AvoidAs extends LintRule {
   AvoidAs()
       : super(
           name: 'avoid_as',

--- a/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
+++ b/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
@@ -31,8 +31,7 @@ condition && boolExpression
 
 ''';
 
-class AvoidBoolLiteralsInConditionalExpressions extends LintRule
-    implements NodeLintRule {
+class AvoidBoolLiteralsInConditionalExpressions extends LintRule {
   AvoidBoolLiteralsInConditionalExpressions()
       : super(
             name: 'avoid_bool_literals_in_conditional_expressions',

--- a/lib/src/rules/avoid_catches_without_on_clauses.dart
+++ b/lib/src/rules/avoid_catches_without_on_clauses.dart
@@ -38,7 +38,7 @@ on Exception catch(e) {
 
 ''';
 
-class AvoidCatchesWithoutOnClauses extends LintRule implements NodeLintRule {
+class AvoidCatchesWithoutOnClauses extends LintRule {
   AvoidCatchesWithoutOnClauses()
       : super(
             name: 'avoid_catches_without_on_clauses',

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -37,7 +37,7 @@ try {
 
 ''';
 
-class AvoidCatchingErrors extends LintRule implements NodeLintRule {
+class AvoidCatchingErrors extends LintRule {
   AvoidCatchingErrors()
       : super(
             name: 'avoid_catching_errors',

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -54,8 +54,7 @@ bool _isStaticMember(ClassMember classMember) {
   return false;
 }
 
-class AvoidClassesWithOnlyStaticMembers extends LintRule
-    implements NodeLintRule {
+class AvoidClassesWithOnlyStaticMembers extends LintRule {
   AvoidClassesWithOnlyStaticMembers()
       : super(
             name: 'avoid_classes_with_only_static_members',

--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -42,7 +42,7 @@ f(dynamic x) {
 
 ''';
 
-class AvoidDoubleAndIntChecks extends LintRule implements NodeLintRule {
+class AvoidDoubleAndIntChecks extends LintRule {
   AvoidDoubleAndIntChecks()
       : super(
             name: 'avoid_double_and_int_checks',

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -91,7 +91,7 @@ void functionTypeWithParameters(Function() function) {
 
 ''';
 
-class AvoidDynamicCalls extends LintRule implements NodeLintRule {
+class AvoidDynamicCalls extends LintRule {
   AvoidDynamicCalls()
       : super(
           name: 'avoid_dynamic_calls',

--- a/lib/src/rules/avoid_empty_else.dart
+++ b/lib/src/rules/avoid_empty_else.dart
@@ -23,7 +23,7 @@ else ;
 
 ''';
 
-class AvoidEmptyElse extends LintRule implements NodeLintRule {
+class AvoidEmptyElse extends LintRule {
   AvoidEmptyElse()
       : super(
             name: 'avoid_empty_else',

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -75,8 +75,7 @@ bool _isImmutable(Element? element) =>
     element.name == _immutableVarName &&
     element.library.name == _metaLibName;
 
-class AvoidOperatorEqualsOnMutableClasses extends LintRule
-    implements NodeLintRule {
+class AvoidOperatorEqualsOnMutableClasses extends LintRule {
   AvoidOperatorEqualsOnMutableClasses()
       : super(
             name: 'avoid_equals_and_hash_code_on_mutable_classes',

--- a/lib/src/rules/avoid_escaping_inner_quotes.dart
+++ b/lib/src/rules/avoid_escaping_inner_quotes.dart
@@ -25,7 +25,7 @@ var s = "It's not fun";
 
 ''';
 
-class AvoidEscapingInnerQuotes extends LintRule implements NodeLintRule {
+class AvoidEscapingInnerQuotes extends LintRule {
   AvoidEscapingInnerQuotes()
       : super(
             name: 'avoid_escaping_inner_quotes',

--- a/lib/src/rules/avoid_field_initializers_in_const_classes.dart
+++ b/lib/src/rules/avoid_field_initializers_in_const_classes.dart
@@ -36,8 +36,7 @@ class A {
 
 ''';
 
-class AvoidFieldInitializersInConstClasses extends LintRule
-    implements NodeLintRule {
+class AvoidFieldInitializersInConstClasses extends LintRule {
   AvoidFieldInitializersInConstClasses()
       : super(
             name: 'avoid_field_initializers_in_const_classes',

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -54,8 +54,7 @@ bool _isNonNullableIterable(DartType? type) =>
     type.nullabilitySuffix != NullabilitySuffix.question &&
     DartTypeUtilities.implementsInterface(type, 'Iterable', 'dart.core');
 
-class AvoidFunctionLiteralInForeachMethod extends LintRule
-    implements NodeLintRule {
+class AvoidFunctionLiteralInForeachMethod extends LintRule {
   AvoidFunctionLiteralInForeachMethod()
       : super(
             name: 'avoid_function_literals_in_foreach_calls',

--- a/lib/src/rules/avoid_implementing_value_types.dart
+++ b/lib/src/rules/avoid_implementing_value_types.dart
@@ -86,7 +86,7 @@ void main() {
 
 ''';
 
-class AvoidImplementingValueTypes extends LintRule implements NodeLintRule {
+class AvoidImplementingValueTypes extends LintRule {
   AvoidImplementingValueTypes()
       : super(
             name: 'avoid_implementing_value_types',

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -57,7 +57,7 @@ class LazyId {
 
 ''';
 
-class AvoidInitToNull extends LintRule implements NodeLintRule {
+class AvoidInitToNull extends LintRule {
   AvoidInitToNull()
       : super(
             name: 'avoid_init_to_null',

--- a/lib/src/rules/avoid_js_rounded_ints.dart
+++ b/lib/src/rules/avoid_js_rounded_ints.dart
@@ -33,7 +33,7 @@ BigInt value = BigInt.parse('9007199254740995');
 
 ''';
 
-class AvoidJsRoundedInts extends LintRule implements NodeLintRule {
+class AvoidJsRoundedInts extends LintRule {
   AvoidJsRoundedInts()
       : super(
             name: 'avoid_js_rounded_ints',

--- a/lib/src/rules/avoid_multiple_declarations_per_line.dart
+++ b/lib/src/rules/avoid_multiple_declarations_per_line.dart
@@ -27,8 +27,7 @@ String? baz;
 
 ''';
 
-class AvoidMultipleDeclarationsPerLine extends LintRule
-    implements NodeLintRule {
+class AvoidMultipleDeclarationsPerLine extends LintRule {
   AvoidMultipleDeclarationsPerLine()
       : super(
             name: 'avoid_multiple_declarations_per_line',

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -71,8 +71,7 @@ bool _isParameterWithQuestionQuestion(
     node.operator.type == TokenType.QUESTION_QUESTION &&
     _isParameter(node.leftOperand, parameter);
 
-class AvoidNullChecksInEqualityOperators extends LintRule
-    implements NodeLintRule {
+class AvoidNullChecksInEqualityOperators extends LintRule {
   AvoidNullChecksInEqualityOperators()
       : super(
             name: 'avoid_null_checks_in_equality_operators',

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -37,8 +37,7 @@ Button(ButtonState.enabled);
 
 ''';
 
-class AvoidPositionalBooleanParameters extends LintRule
-    implements NodeLintRule {
+class AvoidPositionalBooleanParameters extends LintRule {
   AvoidPositionalBooleanParameters()
       : super(
             name: 'avoid_positional_boolean_parameters',

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -22,7 +22,7 @@ void f(int x) {
 ```
 ''';
 
-class AvoidPrint extends LintRule implements NodeLintRule {
+class AvoidPrint extends LintRule {
   AvoidPrint()
       : super(
             name: 'avoid_print',

--- a/lib/src/rules/avoid_private_typedef_functions.dart
+++ b/lib/src/rules/avoid_private_typedef_functions.dart
@@ -27,7 +27,7 @@ m(void Function() f);
 
 ''';
 
-class AvoidPrivateTypedefFunctions extends LintRule implements NodeLintRule {
+class AvoidPrivateTypedefFunctions extends LintRule {
   AvoidPrivateTypedefFunctions()
       : super(
             name: 'avoid_private_typedef_functions',

--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -38,7 +38,7 @@ void main() {
 ```
 ''';
 
-class AvoidRedundantArgumentValues extends LintRule implements NodeLintRule {
+class AvoidRedundantArgumentValues extends LintRule {
   AvoidRedundantArgumentValues()
       : super(
             name: 'avoid_redundant_argument_values',

--- a/lib/src/rules/avoid_relative_lib_imports.dart
+++ b/lib/src/rules/avoid_relative_lib_imports.dart
@@ -38,7 +38,7 @@ import '../lib/baz.dart';
 
 ''';
 
-class AvoidRelativeLibImports extends LintRule implements NodeLintRule {
+class AvoidRelativeLibImports extends LintRule {
   AvoidRelativeLibImports()
       : super(
             name: 'avoid_relative_lib_imports',

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -44,7 +44,7 @@ abstract class B extends A {
 
 ''';
 
-class AvoidRenamingMethodParameters extends LintRule implements NodeLintRule {
+class AvoidRenamingMethodParameters extends LintRule {
   AvoidRenamingMethodParameters()
       : super(
             name: 'avoid_renaming_method_parameters',

--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -27,7 +27,7 @@ void set speed(int ms);
 
 ''';
 
-class AvoidReturnTypesOnSetters extends LintRule implements NodeLintRule {
+class AvoidReturnTypesOnSetters extends LintRule {
   AvoidReturnTypesOnSetters()
       : super(
             name: 'avoid_return_types_on_setters',

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -52,7 +52,7 @@ bool _isPrimitiveType(DartType type) =>
 bool _isReturnNull(AstNode node) =>
     node is ReturnStatement && DartTypeUtilities.isNullLiteral(node.expression);
 
-class AvoidReturningNull extends LintRule implements NodeLintRule {
+class AvoidReturningNull extends LintRule {
   AvoidReturningNull()
       : super(
             name: 'avoid_returning_null',

--- a/lib/src/rules/avoid_returning_null_for_future.dart
+++ b/lib/src/rules/avoid_returning_null_for_future.dart
@@ -20,7 +20,7 @@ developer simply forgot to put an `async` keyword on the function.
 
 ''';
 
-class AvoidReturningNullForFuture extends LintRule implements NodeLintRule {
+class AvoidReturningNullForFuture extends LintRule {
   AvoidReturningNullForFuture()
       : super(
             name: 'avoid_returning_null_for_future',

--- a/lib/src/rules/avoid_returning_null_for_void.dart
+++ b/lib/src/rules/avoid_returning_null_for_void.dart
@@ -42,7 +42,7 @@ Future<void> f2() async {
 
 ''';
 
-class AvoidReturningNullForVoid extends LintRule implements NodeLintRule {
+class AvoidReturningNullForVoid extends LintRule {
   AvoidReturningNullForVoid()
       : super(
             name: 'avoid_returning_null_for_void',

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -51,7 +51,7 @@ bool _isReturnStatement(AstNode node) => node is ReturnStatement;
 bool _returnsThis(AstNode node) =>
     (node as ReturnStatement).expression is ThisExpression;
 
-class AvoidReturningThis extends LintRule implements NodeLintRule {
+class AvoidReturningThis extends LintRule {
   AvoidReturningThis()
       : super(
             name: 'avoid_returning_this',

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -50,7 +50,7 @@ bool _hasGetter(MethodDeclaration node) =>
 bool _hasInheritedSetter(MethodDeclaration node) =>
     DartTypeUtilities.lookUpInheritedConcreteSetter(node) != null;
 
-class AvoidSettersWithoutGetters extends LintRule implements NodeLintRule {
+class AvoidSettersWithoutGetters extends LintRule {
   AvoidSettersWithoutGetters()
       : super(
             name: 'avoid_setters_without_getters',

--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -29,7 +29,7 @@ class A<T> {
 
 ''';
 
-class AvoidShadowingTypeParameters extends LintRule implements NodeLintRule {
+class AvoidShadowingTypeParameters extends LintRule {
   AvoidShadowingTypeParameters()
       : super(
             name: 'avoid_shadowing_type_parameters',

--- a/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
+++ b/lib/src/rules/avoid_single_cascade_in_expression_statements.dart
@@ -25,8 +25,7 @@ o.m();
 
 ''';
 
-class AvoidSingleCascadeInExpressionStatements extends LintRule
-    implements NodeLintRule {
+class AvoidSingleCascadeInExpressionStatements extends LintRule {
   AvoidSingleCascadeInExpressionStatements()
       : super(
             name: 'avoid_single_cascade_in_expression_statements',

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -69,7 +69,7 @@ const List<String> _fileSystemEntityMethodNames = <String>[
   'type',
 ];
 
-class AvoidSlowAsyncIo extends LintRule implements NodeLintRule {
+class AvoidSlowAsyncIo extends LintRule {
   AvoidSlowAsyncIo()
       : super(
             name: 'avoid_slow_async_io',

--- a/lib/src/rules/avoid_type_to_string.dart
+++ b/lib/src/rules/avoid_type_to_string.dart
@@ -51,7 +51,7 @@ Object baz(Thing myThing) {
 
 ''';
 
-class AvoidTypeToString extends LintRule implements NodeLintRule {
+class AvoidTypeToString extends LintRule {
   AvoidTypeToString()
       : super(
             name: 'avoid_type_to_string',

--- a/lib/src/rules/avoid_types_as_parameter_names.dart
+++ b/lib/src/rules/avoid_types_as_parameter_names.dart
@@ -26,7 +26,7 @@ m(f(int v));
 
 ''';
 
-class AvoidTypesAsParameterNames extends LintRule implements NodeLintRule {
+class AvoidTypesAsParameterNames extends LintRule {
   AvoidTypesAsParameterNames()
       : super(
             name: 'avoid_types_as_parameter_names',

--- a/lib/src/rules/avoid_types_on_closure_parameters.dart
+++ b/lib/src/rules/avoid_types_on_closure_parameters.dart
@@ -29,7 +29,7 @@ var names = people.map((person) => person.name);
 
 ''';
 
-class AvoidTypesOnClosureParameters extends LintRule implements NodeLintRule {
+class AvoidTypesOnClosureParameters extends LintRule {
   AvoidTypesOnClosureParameters()
       : super(
             name: 'avoid_types_on_closure_parameters',

--- a/lib/src/rules/avoid_unnecessary_containers.dart
+++ b/lib/src/rules/avoid_unnecessary_containers.dart
@@ -46,7 +46,7 @@ Widget buildRow() {
 ```
 ''';
 
-class AvoidUnnecessaryContainers extends LintRule implements NodeLintRule {
+class AvoidUnnecessaryContainers extends LintRule {
   AvoidUnnecessaryContainers()
       : super(
             name: 'avoid_unnecessary_containers',

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -32,8 +32,7 @@ class BadTwo {
 
 ''';
 
-class AvoidUnusedConstructorParameters extends LintRule
-    implements NodeLintRule {
+class AvoidUnusedConstructorParameters extends LintRule {
   AvoidUnusedConstructorParameters()
       : super(
             name: 'avoid_unused_constructor_parameters',

--- a/lib/src/rules/avoid_void_async.dart
+++ b/lib/src/rules/avoid_void_async.dart
@@ -31,7 +31,7 @@ Future<void> f2() async => null;
 
 ''';
 
-class AvoidVoidAsync extends LintRule implements NodeLintRule {
+class AvoidVoidAsync extends LintRule {
   AvoidVoidAsync()
       : super(
             name: 'avoid_void_async',

--- a/lib/src/rules/avoid_web_libraries_in_flutter.dart
+++ b/lib/src/rules/avoid_web_libraries_in_flutter.dart
@@ -40,7 +40,7 @@ YamlMap _parseYaml(String content) {
   return YamlMap();
 }
 
-class AvoidWebLibrariesInFlutter extends LintRule implements NodeLintRule {
+class AvoidWebLibrariesInFlutter extends LintRule {
   /// Cache of most recent analysis root to parsed "hasFlutter" state.
   static final Map<String, bool> _rootHasFlutterCache = {};
 

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -34,7 +34,7 @@ main() async {
 ```
 ''';
 
-class AwaitOnlyFutures extends LintRule implements NodeLintRule {
+class AwaitOnlyFutures extends LintRule {
   AwaitOnlyFutures()
       : super(
             name: 'await_only_futures',

--- a/lib/src/rules/camel_case_extensions.dart
+++ b/lib/src/rules/camel_case_extensions.dart
@@ -31,7 +31,7 @@ extension SmartIterable<T> on Iterable<T> {
 ```
 ''';
 
-class CamelCaseExtensions extends LintRule implements NodeLintRule {
+class CamelCaseExtensions extends LintRule {
   CamelCaseExtensions()
       : super(
             name: 'camel_case_extensions',

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -34,7 +34,7 @@ typedef num Adder(num x, num y);
 
 ''';
 
-class CamelCaseTypes extends LintRule implements NodeLintRule {
+class CamelCaseTypes extends LintRule {
   CamelCaseTypes()
       : super(
             name: 'camel_case_types',

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -61,7 +61,7 @@ void someFunctionOK() {
 bool _isSubscription(DartType type) => DartTypeUtilities.implementsInterface(
     type, 'StreamSubscription', 'dart.async');
 
-class CancelSubscriptions extends LintRule implements NodeLintRule {
+class CancelSubscriptions extends LintRule {
   CancelSubscriptions()
       : super(
             name: 'cancel_subscriptions',

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -108,7 +108,7 @@ bool _isInvokedWithoutNullAwareOperator(Token? token) =>
 
 /// Rule to lint consecutive invocations of methods or getters on the same
 /// reference that could be done with the cascade operator.
-class CascadeInvocations extends LintRule implements NodeLintRule {
+class CascadeInvocations extends LintRule {
   /// Default constructor.
   CascadeInvocations()
       : super(

--- a/lib/src/rules/cast_nullable_to_non_nullable.dart
+++ b/lib/src/rules/cast_nullable_to_non_nullable.dart
@@ -37,7 +37,7 @@ var v = a!;
 
 ''';
 
-class CastNullableToNonNullable extends LintRule implements NodeLintRule {
+class CastNullableToNonNullable extends LintRule {
   CastNullableToNonNullable()
       : super(
           name: 'cast_nullable_to_non_nullable',

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -63,7 +63,7 @@ bool _isSink(DartType type) =>
 bool _isSocket(DartType type) =>
     DartTypeUtilities.implementsInterface(type, 'Socket', 'dart.io');
 
-class CloseSinks extends LintRule implements NodeLintRule {
+class CloseSinks extends LintRule {
   CloseSinks()
       : super(
             name: 'close_sinks',

--- a/lib/src/rules/comment_references.dart
+++ b/lib/src/rules/comment_references.dart
@@ -46,7 +46,7 @@ references within square brackets can consist of either
 
 ''';
 
-class CommentReferences extends LintRule implements NodeLintRule {
+class CommentReferences extends LintRule {
   CommentReferences()
       : super(
             name: 'comment_references',

--- a/lib/src/rules/constant_identifier_names.dart
+++ b/lib/src/rules/constant_identifier_names.dart
@@ -44,7 +44,7 @@ class Dice {
 
 ''';
 
-class ConstantIdentifierNames extends LintRule implements NodeLintRule {
+class ConstantIdentifierNames extends LintRule {
   ConstantIdentifierNames()
       : super(
             name: 'constant_identifier_names',

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -84,7 +84,7 @@ class BadBreak {
 
 ''';
 
-class ControlFlowInFinally extends LintRule implements NodeLintRule {
+class ControlFlowInFinally extends LintRule {
   ControlFlowInFinally()
       : super(
             name: 'control_flow_in_finally',

--- a/lib/src/rules/curly_braces_in_flow_control_structures.dart
+++ b/lib/src/rules/curly_braces_in_flow_control_structures.dart
@@ -50,8 +50,7 @@ if (overflowChars != other.overflowChars)
 ```
 ''';
 
-class CurlyBracesInFlowControlStructures extends LintRule
-    implements NodeLintRule {
+class CurlyBracesInFlowControlStructures extends LintRule {
   CurlyBracesInFlowControlStructures()
       : super(
             name: 'curly_braces_in_flow_control_structures',

--- a/lib/src/rules/depend_on_referenced_packages.dart
+++ b/lib/src/rules/depend_on_referenced_packages.dart
@@ -45,7 +45,7 @@ dependencies:
 
 ''';
 
-class DependOnReferencedPackages extends LintRule implements NodeLintRule {
+class DependOnReferencedPackages extends LintRule {
   DependOnReferencedPackages()
       : super(
             name: 'depend_on_referenced_packages',

--- a/lib/src/rules/deprecated_consistency.dart
+++ b/lib/src/rules/deprecated_consistency.dart
@@ -49,7 +49,7 @@ class B {
 
 ''';
 
-class DeprecatedConsistency extends LintRule implements NodeLintRule {
+class DeprecatedConsistency extends LintRule {
   DeprecatedConsistency()
       : super(
           name: 'deprecated_consistency',

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -65,8 +65,7 @@ class Absorber extends Widget {
 ```
 ''';
 
-class DiagnosticsDescribeAllProperties extends LintRule
-    implements NodeLintRule {
+class DiagnosticsDescribeAllProperties extends LintRule {
   DiagnosticsDescribeAllProperties()
       : super(
           name: 'diagnostic_describe_all_properties',

--- a/lib/src/rules/do_not_use_environment.dart
+++ b/lib/src/rules/do_not_use_environment.dart
@@ -22,7 +22,7 @@ const loggingLevel =
 ```
 ''';
 
-class DoNotUseEnvironment extends LintRule implements NodeLintRule {
+class DoNotUseEnvironment extends LintRule {
   DoNotUseEnvironment()
       : super(
             name: 'do_not_use_environment',

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -49,7 +49,7 @@ try {
 
 ''';
 
-class EmptyCatches extends LintRule implements NodeLintRule {
+class EmptyCatches extends LintRule {
   EmptyCatches()
       : super(
             name: 'empty_catches',

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -37,7 +37,7 @@ class Point {
 
 ''';
 
-class EmptyConstructorBodies extends LintRule implements NodeLintRule {
+class EmptyConstructorBodies extends LintRule {
   EmptyConstructorBodies()
       : super(
             name: 'empty_constructor_bodies',

--- a/lib/src/rules/empty_statements.dart
+++ b/lib/src/rules/empty_statements.dart
@@ -41,7 +41,7 @@ if (complicated.expression.foo())
 
 ''';
 
-class EmptyStatements extends LintRule implements NodeLintRule {
+class EmptyStatements extends LintRule {
   EmptyStatements()
       : super(
             name: 'empty_statements',

--- a/lib/src/rules/eol_at_end_of_file.dart
+++ b/lib/src/rules/eol_at_end_of_file.dart
@@ -27,7 +27,7 @@ b {
 ```    
 ''';
 
-class EolAtEndOfFile extends LintRule implements NodeLintRule {
+class EolAtEndOfFile extends LintRule {
   EolAtEndOfFile()
       : super(
             name: 'eol_at_end_of_file',

--- a/lib/src/rules/exhaustive_cases.dart
+++ b/lib/src/rules/exhaustive_cases.dart
@@ -74,7 +74,7 @@ void ok(EnumLike e) {
 ```
 ''';
 
-class ExhaustiveCases extends LintRule implements NodeLintRule {
+class ExhaustiveCases extends LintRule {
   ExhaustiveCases()
       : super(
             name: 'exhaustive_cases',

--- a/lib/src/rules/file_names.dart
+++ b/lib/src/rules/file_names.dart
@@ -43,7 +43,7 @@ library.
 
 ''';
 
-class FileNames extends LintRule implements NodeLintRule {
+class FileNames extends LintRule {
   FileNames()
       : super(
             name: 'file_names',

--- a/lib/src/rules/flutter_style_todos.dart
+++ b/lib/src/rules/flutter_style_todos.dart
@@ -27,7 +27,7 @@ From the [Flutter docs](https://github.com/flutter/flutter/wiki/Style-guide-for-
 
 ''';
 
-class FlutterStyleTodos extends LintRule implements NodeLintRule {
+class FlutterStyleTodos extends LintRule {
   FlutterStyleTodos()
       : super(
             name: 'flutter_style_todos',

--- a/lib/src/rules/hash_and_equals.dart
+++ b/lib/src/rules/hash_and_equals.dart
@@ -47,7 +47,7 @@ class Better {
 ```
 ''';
 
-class HashAndEquals extends LintRule implements NodeLintRule {
+class HashAndEquals extends LintRule {
   HashAndEquals()
       : super(
             name: 'hash_and_equals',

--- a/lib/src/rules/implementation_imports.dart
+++ b/lib/src/rules/implementation_imports.dart
@@ -59,7 +59,7 @@ bool samePackage(Uri? uri1, Uri? uri2) {
   return segments1[0] == segments2[0];
 }
 
-class ImplementationImports extends LintRule implements NodeLintRule {
+class ImplementationImports extends LintRule {
   ImplementationImports()
       : super(
             name: 'implementation_imports',

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -103,7 +103,7 @@ Iterable<Element?> _getElementsInExpression(Expression node) =>
         .map(DartTypeUtilities.getCanonicalElementFromIdentifier)
         .where((e) => e != null);
 
-class InvariantBooleans extends LintRule implements NodeLintRule {
+class InvariantBooleans extends LintRule {
   InvariantBooleans()
       : super(
             name: 'invariant_booleans',

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -119,7 +119,7 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 
 ''';
 
-class IterableContainsUnrelatedType extends LintRule implements NodeLintRule {
+class IterableContainsUnrelatedType extends LintRule {
   IterableContainsUnrelatedType()
       : super(
             name: 'iterable_contains_unrelated_type',

--- a/lib/src/rules/join_return_with_assignment.dart
+++ b/lib/src/rules/join_return_with_assignment.dart
@@ -44,7 +44,7 @@ Expression? _getExpressionFromAssignmentStatement(Statement node) {
 Expression? _getExpressionFromReturnStatement(Statement node) =>
     node is ReturnStatement ? node.expression : null;
 
-class JoinReturnWithAssignment extends LintRule implements NodeLintRule {
+class JoinReturnWithAssignment extends LintRule {
   JoinReturnWithAssignment()
       : super(
             name: 'join_return_with_assignment',

--- a/lib/src/rules/leading_newlines_in_multiline_strings.dart
+++ b/lib/src/rules/leading_newlines_in_multiline_strings.dart
@@ -34,8 +34,7 @@ var s2 = '''This one-liner multiline string is ok. It usually allows to escape b
 
 """;
 
-class LeadingNewlinesInMultilineStrings extends LintRule
-    implements NodeLintRule {
+class LeadingNewlinesInMultilineStrings extends LintRule {
   LeadingNewlinesInMultilineStrings()
       : super(
             name: 'leading_newlines_in_multiline_strings',

--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -35,7 +35,7 @@ file.
 
 ''';
 
-class LibraryNames extends LintRule implements NodeLintRule {
+class LibraryNames extends LintRule {
   LibraryNames()
       : super(
             name: 'library_names',

--- a/lib/src/rules/library_prefixes.dart
+++ b/lib/src/rules/library_prefixes.dart
@@ -33,7 +33,7 @@ import 'package:javascript_utils/javascript_utils.dart' as jsUtils;
 
 ''';
 
-class LibraryPrefixes extends LintRule implements NodeLintRule {
+class LibraryPrefixes extends LintRule {
   LibraryPrefixes()
       : super(
             name: 'library_prefixes',

--- a/lib/src/rules/library_private_types_in_public_api.dart
+++ b/lib/src/rules/library_private_types_in_public_api.dart
@@ -40,7 +40,7 @@ class _Private {}
 
 ''';
 
-class LibraryPrivateTypesInPublicAPI extends LintRule implements NodeLintRule {
+class LibraryPrivateTypesInPublicAPI extends LintRule {
   LibraryPrivateTypesInPublicAPI()
       : super(
             name: 'library_private_types_in_public_api',

--- a/lib/src/rules/lines_longer_than_80_chars.dart
+++ b/lib/src/rules/lines_longer_than_80_chars.dart
@@ -42,7 +42,7 @@ const _lf = '\n';
 final _uriRegExp = RegExp(r'[/\\]');
 bool _looksLikeUriOrPath(String value) => _uriRegExp.hasMatch(value);
 
-class LinesLongerThan80Chars extends LintRule implements NodeLintRule {
+class LinesLongerThan80Chars extends LintRule {
   LinesLongerThan80Chars()
       : super(
             name: 'lines_longer_than_80_chars',

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -119,7 +119,7 @@ class DerivedClass3 extends ClassBase implements Mixin {}
 
 ''';
 
-class ListRemoveUnrelatedType extends LintRule implements NodeLintRule {
+class ListRemoveUnrelatedType extends LintRule {
   ListRemoveUnrelatedType()
       : super(
             name: 'list_remove_unrelated_type',

--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -99,7 +99,7 @@ bool _onlyLiterals(Expression? rawExpression) {
   return false;
 }
 
-class LiteralOnlyBooleanExpressions extends LintRule implements NodeLintRule {
+class LiteralOnlyBooleanExpressions extends LintRule {
   LiteralOnlyBooleanExpressions()
       : super(
             name: 'literal_only_boolean_expressions',

--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -33,8 +33,7 @@ var s =
 
 ''';
 
-class MissingWhitespaceBetweenAdjacentStrings extends LintRule
-    implements NodeLintRule {
+class MissingWhitespaceBetweenAdjacentStrings extends LintRule {
   MissingWhitespaceBetweenAdjacentStrings()
       : super(
             name: 'missing_whitespace_between_adjacent_strings',

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -35,7 +35,7 @@ List<String> list = <String>[
 
 ''';
 
-class NoAdjacentStringsInList extends LintRule implements NodeLintRule {
+class NoAdjacentStringsInList extends LintRule {
   NoAdjacentStringsInList()
       : super(
             name: 'no_adjacent_strings_in_list',

--- a/lib/src/rules/no_default_cases.dart
+++ b/lib/src/rules/no_default_cases.dart
@@ -47,7 +47,7 @@ Enum-like classes are defined as concrete (non-abstract) classes that have:
 ```
 ''';
 
-class NoDefaultCases extends LintRule implements NodeLintRule {
+class NoDefaultCases extends LintRule {
   NoDefaultCases()
       : super(
             name: 'no_default_cases',

--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -41,7 +41,7 @@ switch (v) {
 String message(String value1, String value2) =>
     'Do not use more than one case with same value ($value1 and $value2)';
 
-class NoDuplicateCaseValues extends LintRule implements NodeLintRule {
+class NoDuplicateCaseValues extends LintRule {
   NoDuplicateCaseValues()
       : super(
             name: 'no_duplicate_case_values',

--- a/lib/src/rules/no_logic_in_create_state.dart
+++ b/lib/src/rules/no_logic_in_create_state.dart
@@ -58,7 +58,7 @@ class MyStateful extends StatefulWidget {
 ```
 ''';
 
-class NoLogicInCreateState extends LintRule implements NodeLintRule {
+class NoLogicInCreateState extends LintRule {
   NoLogicInCreateState()
       : super(
             name: 'no_logic_in_create_state',

--- a/lib/src/rules/no_runtimeType_toString.dart
+++ b/lib/src/rules/no_runtimeType_toString.dart
@@ -41,7 +41,7 @@ type information is more important than performance:
 
 ''';
 
-class NoRuntimeTypeToString extends LintRule implements NodeLintRule {
+class NoRuntimeTypeToString extends LintRule {
   NoRuntimeTypeToString()
       : super(
             name: 'no_runtimeType_toString',

--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -31,7 +31,7 @@ align(clearItems) {
 
 ''';
 
-class NonConstantIdentifierNames extends LintRule implements NodeLintRule {
+class NonConstantIdentifierNames extends LintRule {
   NonConstantIdentifierNames()
       : super(
             name: 'non_constant_identifier_names',

--- a/lib/src/rules/noop_primitive_operations.dart
+++ b/lib/src/rules/noop_primitive_operations.dart
@@ -31,7 +31,7 @@ string = 'hello\n'
 ```
 ''';
 
-class NoopPrimitiveOperations extends LintRule implements NodeLintRule {
+class NoopPrimitiveOperations extends LintRule {
   NoopPrimitiveOperations()
       : super(
           name: 'noop_primitive_operations',

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -44,8 +44,7 @@ T run<T>(T callback()) {
 
 ''';
 
-class NullCheckOnNullableTypeParameter extends LintRule
-    implements NodeLintRule {
+class NullCheckOnNullableTypeParameter extends LintRule {
   NullCheckOnNullableTypeParameter()
       : super(
           name: 'null_check_on_nullable_type_parameter',

--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -206,7 +206,7 @@ class NonNullableFunction {
       other is NonNullableFunction && other.hashCode == hashCode;
 }
 
-class NullClosures extends LintRule implements NodeLintRule {
+class NullClosures extends LintRule {
   NullClosures()
       : super(
             name: 'null_closures',

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -44,7 +44,7 @@ Map<int, List<Person>> groupByZip(Iterable<Person> people) {
 
 ''';
 
-class OmitLocalVariableTypes extends LintRule implements NodeLintRule {
+class OmitLocalVariableTypes extends LintRule {
   OmitLocalVariableTypes()
       : super(
             name: 'omit_local_variable_types',

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -36,7 +36,7 @@ abstract class Predicate {
 
 ''';
 
-class OneMemberAbstracts extends LintRule implements NodeLintRule {
+class OneMemberAbstracts extends LintRule {
   OneMemberAbstracts()
       : super(
             name: 'one_member_abstracts',

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -60,7 +60,7 @@ bool _isThrowable(DartType? type) {
           typeForInterfaceCheck, _interfaceDefinitions);
 }
 
-class OnlyThrowErrors extends LintRule implements NodeLintRule {
+class OnlyThrowErrors extends LintRule {
   OnlyThrowErrors()
       : super(
             name: 'only_throw_errors',

--- a/lib/src/rules/overridden_fields.dart
+++ b/lib/src/rules/overridden_fields.dart
@@ -97,7 +97,7 @@ Iterable<InterfaceType> _findAllSupertypesInMixin(ClassElement classElement) {
   return supertypes;
 }
 
-class OverriddenFields extends LintRule implements NodeLintRule {
+class OverriddenFields extends LintRule {
   OverriddenFields()
       : super(
             name: 'overridden_fields',

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -108,7 +108,7 @@ bool _preOrPostFixExpressionMutation(FormalParameter parameter, AstNode n) =>
         (n.operand as SimpleIdentifier).staticElement ==
             parameter.declaredElement;
 
-class ParameterAssignments extends LintRule implements NodeLintRule {
+class ParameterAssignments extends LintRule {
   ParameterAssignments()
       : super(
             name: 'parameter_assignments',

--- a/lib/src/rules/prefer_adjacent_string_concatenation.dart
+++ b/lib/src/rules/prefer_adjacent_string_concatenation.dart
@@ -29,8 +29,7 @@ raiseAlarm(
 
 ''';
 
-class PreferAdjacentStringConcatenation extends LintRule
-    implements NodeLintRule {
+class PreferAdjacentStringConcatenation extends LintRule {
   PreferAdjacentStringConcatenation()
       : super(
             name: 'prefer_adjacent_string_concatenation',

--- a/lib/src/rules/prefer_asserts_in_initializer_lists.dart
+++ b/lib/src/rules/prefer_asserts_in_initializer_lists.dart
@@ -33,7 +33,7 @@ class A {
 
 ''';
 
-class PreferAssertsInInitializerLists extends LintRule implements NodeLintRule {
+class PreferAssertsInInitializerLists extends LintRule {
   PreferAssertsInInitializerLists()
       : super(
             name: 'prefer_asserts_in_initializer_lists',

--- a/lib/src/rules/prefer_asserts_with_message.dart
+++ b/lib/src/rules/prefer_asserts_with_message.dart
@@ -38,7 +38,7 @@ class A {
 
 ''';
 
-class PreferAssertsWithMessage extends LintRule implements NodeLintRule {
+class PreferAssertsWithMessage extends LintRule {
   PreferAssertsWithMessage()
       : super(
             name: 'prefer_asserts_with_message',

--- a/lib/src/rules/prefer_bool_in_asserts.dart
+++ b/lib/src/rules/prefer_bool_in_asserts.dart
@@ -40,7 +40,7 @@ necessary.
 The rule will be removed in a future Linter release.
 ''';
 
-class PreferBoolInAsserts extends LintRule implements NodeLintRule {
+class PreferBoolInAsserts extends LintRule {
   PreferBoolInAsserts()
       : super(
             name: 'prefer_bool_in_asserts',

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -57,7 +57,7 @@ void printHashMap(LinkedHashMap map) => printMap(map);
 ```
 ''';
 
-class PreferCollectionLiterals extends LintRule implements NodeLintRule {
+class PreferCollectionLiterals extends LintRule {
   PreferCollectionLiterals()
       : super(
             name: 'prefer_collection_literals',

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -66,7 +66,7 @@ Expression? _getExpressionCondition(Expression rawExpression) {
   return null;
 }
 
-class PreferConditionalAssignment extends LintRule implements NodeLintRule {
+class PreferConditionalAssignment extends LintRule {
   PreferConditionalAssignment()
       : super(
             name: 'prefer_conditional_assignment',

--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -51,7 +51,7 @@ void accessA() {
 
 ''';
 
-class PreferConstConstructors extends LintRule implements NodeLintRule {
+class PreferConstConstructors extends LintRule {
   PreferConstConstructors()
       : super(
             name: 'prefer_const_constructors',

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -49,8 +49,7 @@ bool _isImmutable(Element? element) =>
     element.name == _immutableVarName &&
     element.library.name == _metaLibName;
 
-class PreferConstConstructorsInImmutables extends LintRule
-    implements NodeLintRule {
+class PreferConstConstructorsInImmutables extends LintRule {
   PreferConstConstructorsInImmutables()
       : super(
             name: 'prefer_const_constructors_in_immutables',

--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -38,7 +38,7 @@ class A {
 
 ''';
 
-class PreferConstDeclarations extends LintRule implements NodeLintRule {
+class PreferConstDeclarations extends LintRule {
   PreferConstDeclarations()
       : super(
             name: 'prefer_const_declarations',

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -48,8 +48,7 @@ bool _isImmutable(Element? element) =>
     element.name == _immutableVarName &&
     element.library.name == _metaLibName;
 
-class PreferConstLiteralsToCreateImmutables extends LintRule
-    implements NodeLintRule {
+class PreferConstLiteralsToCreateImmutables extends LintRule {
   PreferConstLiteralsToCreateImmutables()
       : super(
             name: 'prefer_const_literals_to_create_immutables',

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -51,8 +51,7 @@ bool _hasNewInvocation(DartType returnType, FunctionBody body) {
       .any(_isInstanceCreationExpression);
 }
 
-class PreferConstructorsInsteadOfStaticMethods extends LintRule
-    implements NodeLintRule {
+class PreferConstructorsInsteadOfStaticMethods extends LintRule {
   PreferConstructorsInsteadOfStaticMethods()
       : super(
             name: 'prefer_constructors_over_static_methods',

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -37,7 +37,7 @@ if (lunchBox.indexOf('sandwich') == -1) return 'so hungry...';
 
 ''';
 
-class PreferContainsOverIndexOf extends LintRule implements NodeLintRule {
+class PreferContainsOverIndexOf extends LintRule {
   PreferContainsOverIndexOf()
       : super(
             name: 'prefer_contains',

--- a/lib/src/rules/prefer_double_quotes.dart
+++ b/lib/src/rules/prefer_double_quotes.dart
@@ -42,7 +42,7 @@ useStrings(
 
 ''';
 
-class PreferDoubleQuotes extends LintRule implements NodeLintRule {
+class PreferDoubleQuotes extends LintRule {
   PreferDoubleQuotes()
       : super(
             name: 'prefer_double_quotes',

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -28,7 +28,7 @@ m({a = 1})
 
 ''';
 
-class PreferEqualForDefaultValues extends LintRule implements NodeLintRule {
+class PreferEqualForDefaultValues extends LintRule {
   PreferEqualForDefaultValues()
       : super(
             name: 'prefer_equal_for_default_values',

--- a/lib/src/rules/prefer_expression_function_bodies.dart
+++ b/lib/src/rules/prefer_expression_function_bodies.dart
@@ -52,7 +52,7 @@ containsValue(String value) => getValues().contains(value);
 
 ''';
 
-class PreferExpressionFunctionBodies extends LintRule implements NodeLintRule {
+class PreferExpressionFunctionBodies extends LintRule {
   PreferExpressionFunctionBodies()
       : super(
             name: 'prefer_expression_function_bodies',

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -97,7 +97,7 @@ bool _containedInInitializer(
             initializer.fieldName) ==
         element;
 
-class PreferFinalFields extends LintRule implements NodeLintRule {
+class PreferFinalFields extends LintRule {
   PreferFinalFields()
       : super(
             name: 'prefer_final_fields',

--- a/lib/src/rules/prefer_final_in_for_each.dart
+++ b/lib/src/rules/prefer_final_in_for_each.dart
@@ -43,7 +43,7 @@ for (var element in elements) {
 
 ''';
 
-class PreferFinalInForEach extends LintRule implements NodeLintRule {
+class PreferFinalInForEach extends LintRule {
   PreferFinalInForEach()
       : super(
             name: 'prefer_final_in_for_each',

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -46,7 +46,7 @@ void mutableCase() {
 
 ''';
 
-class PreferFinalLocals extends LintRule implements NodeLintRule {
+class PreferFinalLocals extends LintRule {
   PreferFinalLocals()
       : super(
             name: 'prefer_final_locals',

--- a/lib/src/rules/prefer_final_parameters.dart
+++ b/lib/src/rules/prefer_final_parameters.dart
@@ -63,7 +63,7 @@ void mutableParameter(String label) { // OK
 
 ''';
 
-class PreferFinalParameters extends LintRule implements NodeLintRule {
+class PreferFinalParameters extends LintRule {
   PreferFinalParameters()
       : super(
             name: 'prefer_final_parameters',

--- a/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
+++ b/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
@@ -32,8 +32,7 @@ return {
 ```
 ''';
 
-class PreferForElementsToMapFromIterable extends LintRule
-    implements NodeLintRule {
+class PreferForElementsToMapFromIterable extends LintRule {
   PreferForElementsToMapFromIterable()
       : super(
             name: 'prefer_for_elements_to_map_fromIterable',

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -44,7 +44,7 @@ myList.forEach(foo().f); // But this one invokes foo() just once.
 
 ''';
 
-class PreferForeach extends LintRule implements NodeLintRule {
+class PreferForeach extends LintRule {
   PreferForeach()
       : super(
             name: 'prefer_foreach',

--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -36,8 +36,7 @@ void main() {
 
 ''';
 
-class PreferFunctionDeclarationsOverVariables extends LintRule
-    implements NodeLintRule {
+class PreferFunctionDeclarationsOverVariables extends LintRule {
   PreferFunctionDeclarationsOverVariables()
       : super(
             name: 'prefer_function_declarations_over_variables',

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -33,8 +33,7 @@ typedef F = void Function();
 
 ''';
 
-class PreferGenericFunctionTypeAliases extends LintRule
-    implements NodeLintRule {
+class PreferGenericFunctionTypeAliases extends LintRule {
   PreferGenericFunctionTypeAliases()
       : super(
             name: 'prefer_generic_function_type_aliases',

--- a/lib/src/rules/prefer_if_elements_to_conditional_expressions.dart
+++ b/lib/src/rules/prefer_if_elements_to_conditional_expressions.dart
@@ -40,8 +40,7 @@ Widget build(BuildContext context) {
 ```
 ''';
 
-class PreferIfElementsToConditionalExpressions extends LintRule
-    implements NodeLintRule {
+class PreferIfElementsToConditionalExpressions extends LintRule {
   PreferIfElementsToConditionalExpressions()
       : super(
             name: 'prefer_if_elements_to_conditional_expressions',

--- a/lib/src/rules/prefer_if_null_operators.dart
+++ b/lib/src/rules/prefer_if_null_operators.dart
@@ -27,7 +27,7 @@ v = a ?? b;
 
 ''';
 
-class PreferIfNullOperators extends LintRule implements NodeLintRule {
+class PreferIfNullOperators extends LintRule {
   PreferIfNullOperators()
       : super(
             name: 'prefer_if_null_operators',

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -99,7 +99,7 @@ Element? _getRightElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElementFromIdentifier(
         assignment.rightHandSide);
 
-class PreferInitializingFormals extends LintRule implements NodeLintRule {
+class PreferInitializingFormals extends LintRule {
   PreferInitializingFormals()
       : super(
             name: 'prefer_initializing_formals',

--- a/lib/src/rules/prefer_inlined_adds.dart
+++ b/lib/src/rules/prefer_inlined_adds.dart
@@ -27,7 +27,7 @@ var 2 = ['a', 'b', 'c'];
 ```
 ''';
 
-class PreferInlinedAdds extends LintRule implements NodeLintRule {
+class PreferInlinedAdds extends LintRule {
   PreferInlinedAdds()
       : super(
             name: 'prefer_inlined_adds',

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -34,7 +34,7 @@ main() {
 
 ''';
 
-class PreferIntLiterals extends LintRule implements NodeLintRule {
+class PreferIntLiterals extends LintRule {
   PreferIntLiterals()
       : super(
             name: 'prefer_int_literals',

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -30,8 +30,7 @@ and read than concatenation.
 
 ''';
 
-class PreferInterpolationToComposeStrings extends LintRule
-    implements NodeLintRule {
+class PreferInterpolationToComposeStrings extends LintRule {
   PreferInterpolationToComposeStrings()
       : super(
             name: 'prefer_interpolation_to_compose_strings',

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -43,7 +43,7 @@ if (words.length != 0) return words.join(' ');
 
 ''';
 
-class PreferIsEmpty extends LintRule implements NodeLintRule {
+class PreferIsEmpty extends LintRule {
   PreferIsEmpty()
       : super(
             name: 'prefer_is_empty',

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -35,7 +35,7 @@ if (!sources.isEmpty) {
 
 ''';
 
-class PreferIsNotEmpty extends LintRule implements NodeLintRule {
+class PreferIsNotEmpty extends LintRule {
   PreferIsNotEmpty()
       : super(
             name: 'prefer_is_not_empty',

--- a/lib/src/rules/prefer_is_not_operator.dart
+++ b/lib/src/rules/prefer_is_not_operator.dart
@@ -29,7 +29,7 @@ if (foo is! Foo) {
 
 ''';
 
-class PreferIsNotOperator extends LintRule implements NodeLintRule {
+class PreferIsNotOperator extends LintRule {
   PreferIsNotOperator()
       : super(
             name: 'prefer_is_not_operator',

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -27,7 +27,7 @@ iterable.whereType<MyClass>()
 
 ''';
 
-class PreferIterableWhereType extends LintRule implements NodeLintRule {
+class PreferIterableWhereType extends LintRule {
   PreferIterableWhereType()
       : super(
             name: 'prefer_iterable_whereType',

--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -41,7 +41,7 @@ const _mapMixinName = 'MapMixin';
 const _setMixinName = 'SetMixin';
 const _stringConversionSinkName = 'StringConversionSinkMixin';
 
-class PreferMixin extends LintRule implements NodeLintRule {
+class PreferMixin extends LintRule {
   PreferMixin()
       : super(
             name: 'prefer_mixin',

--- a/lib/src/rules/prefer_null_aware_method_calls.dart
+++ b/lib/src/rules/prefer_null_aware_method_calls.dart
@@ -27,7 +27,7 @@ f?.call();
 
 ''';
 
-class PreferNullAwareMethodCalls extends LintRule implements NodeLintRule {
+class PreferNullAwareMethodCalls extends LintRule {
   PreferNullAwareMethodCalls()
       : super(
           name: 'prefer_null_aware_method_calls',

--- a/lib/src/rules/prefer_null_aware_operators.dart
+++ b/lib/src/rules/prefer_null_aware_operators.dart
@@ -27,7 +27,7 @@ v = a?.b;
 
 ''';
 
-class PreferNullAwareOperators extends LintRule implements NodeLintRule {
+class PreferNullAwareOperators extends LintRule {
   PreferNullAwareOperators()
       : super(
             name: 'prefer_null_aware_operators',

--- a/lib/src/rules/prefer_relative_imports.dart
+++ b/lib/src/rules/prefer_relative_imports.dart
@@ -33,7 +33,7 @@ import 'package:my_package/bar.dart';
 
 ''';
 
-class PreferRelativeImports extends LintRule implements NodeLintRule {
+class PreferRelativeImports extends LintRule {
   PreferRelativeImports()
       : super(
             name: 'prefer_relative_imports',

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -43,7 +43,7 @@ useStrings(
 
 ''';
 
-class PreferSingleQuotes extends LintRule implements NodeLintRule {
+class PreferSingleQuotes extends LintRule {
   PreferSingleQuotes()
       : super(
             name: 'prefer_single_quotes',

--- a/lib/src/rules/prefer_spread_collections.dart
+++ b/lib/src/rules/prefer_spread_collections.dart
@@ -69,7 +69,7 @@ var l = ['a', ...?things];
 ```
 ''';
 
-class PreferSpreadCollections extends LintRule implements NodeLintRule {
+class PreferSpreadCollections extends LintRule {
   PreferSpreadCollections()
       : super(
             name: 'prefer_spread_collections',

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -56,8 +56,7 @@ class GoodClass {
 
 ''';
 
-class PreferTypingUninitializedVariables extends LintRule
-    implements NodeLintRule {
+class PreferTypingUninitializedVariables extends LintRule {
   PreferTypingUninitializedVariables()
       : super(
             name: 'prefer_typing_uninitialized_variables',

--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -45,7 +45,7 @@ for any type of map or list:
 ```
 ''';
 
-class PreferVoidToNull extends LintRule implements NodeLintRule {
+class PreferVoidToNull extends LintRule {
   PreferVoidToNull()
       : super(
             name: 'prefer_void_to_null',

--- a/lib/src/rules/provide_deprecation_message.dart
+++ b/lib/src/rules/provide_deprecation_message.dart
@@ -32,7 +32,7 @@ void oldFunction(arg1, arg2) {}
 
 ''';
 
-class ProvideDeprecationMessage extends LintRule implements NodeLintRule {
+class ProvideDeprecationMessage extends LintRule {
   ProvideDeprecationMessage()
       : super(
             name: 'provide_deprecation_message',

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -67,7 +67,7 @@ setters inherit the docs from the getters.
 // of the actual API surface area of a package - including that defined by
 // exports - and linting against that.
 
-class PublicMemberApiDocs extends LintRule implements NodeLintRule {
+class PublicMemberApiDocs extends LintRule {
   PublicMemberApiDocs()
       : super(
             name: 'public_member_api_docs',

--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -37,7 +37,7 @@ int get field => _field;
 
 ''';
 
-class RecursiveGetters extends LintRule implements NodeLintRule {
+class RecursiveGetters extends LintRule {
   RecursiveGetters()
       : super(
             name: 'recursive_getters',

--- a/lib/src/rules/require_trailing_commas.dart
+++ b/lib/src/rules/require_trailing_commas.dart
@@ -44,7 +44,7 @@ produce false positives until that has happened.
 
 ''';
 
-class RequireTrailingCommas extends LintRule implements NodeLintRule {
+class RequireTrailingCommas extends LintRule {
   RequireTrailingCommas()
       : super(
           name: 'require_trailing_commas',

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -46,7 +46,7 @@ Widget buildRow() {
 ```
 ''';
 
-class SizedBoxForWhitespace extends LintRule implements NodeLintRule {
+class SizedBoxForWhitespace extends LintRule {
   SizedBoxForWhitespace()
       : super(
             name: 'sized_box_for_whitespace',

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -43,7 +43,7 @@ bool isJavaStyle(Comment comment) {
   return comment.tokens[0].lexeme.startsWith('/**');
 }
 
-class SlashForDocComments extends LintRule implements NodeLintRule {
+class SlashForDocComments extends LintRule {
   SlashForDocComments()
       : super(
             name: 'slash_for_doc_comments',

--- a/lib/src/rules/sort_child_properties_last.dart
+++ b/lib/src/rules/sort_child_properties_last.dart
@@ -80,7 +80,7 @@ Exception: It's allowed to have parameter with a function expression after the
 
 ''';
 
-class SortChildPropertiesLast extends LintRule implements NodeLintRule {
+class SortChildPropertiesLast extends LintRule {
   SortChildPropertiesLast()
       : super(
             name: 'sort_child_properties_last',

--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -33,7 +33,7 @@ abstract class Visitor {
 
 ''';
 
-class SortConstructorsFirst extends LintRule implements NodeLintRule {
+class SortConstructorsFirst extends LintRule {
   SortConstructorsFirst()
       : super(
             name: 'sort_constructors_first',

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -33,7 +33,7 @@ class _PriorityItem {
 
 ''';
 
-class SortUnnamedConstructorsFirst extends LintRule implements NodeLintRule {
+class SortUnnamedConstructorsFirst extends LintRule {
   SortUnnamedConstructorsFirst()
       : super(
             name: 'sort_unnamed_constructors_first',

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -52,7 +52,7 @@ necessary.
 The rule will be removed in a future Linter release.
 ''';
 
-class SuperGoesLast extends LintRule implements NodeLintRule {
+class SuperGoesLast extends LintRule {
   SuperGoesLast()
       : super(
             name: 'super_goes_last',

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -68,7 +68,7 @@ class Bad {
 
 ''';
 
-class TestTypesInEquals extends LintRule implements NodeLintRule {
+class TestTypesInEquals extends LintRule {
   TestTypesInEquals()
       : super(
             name: 'test_types_in_equals',

--- a/lib/src/rules/throw_in_finally.dart
+++ b/lib/src/rules/throw_in_finally.dart
@@ -49,7 +49,7 @@ class BadThrow {
 
 ''';
 
-class ThrowInFinally extends LintRule implements NodeLintRule {
+class ThrowInFinally extends LintRule {
   ThrowInFinally()
       : super(
             name: 'throw_in_finally',

--- a/lib/src/rules/tighten_type_of_initializing_formals.dart
+++ b/lib/src/rules/tighten_type_of_initializing_formals.dart
@@ -37,8 +37,7 @@ class A {
 
 ''';
 
-class TightenTypeOfInitializingFormals extends LintRule
-    implements NodeLintRule {
+class TightenTypeOfInitializingFormals extends LintRule {
   TightenTypeOfInitializingFormals()
       : super(
           name: 'tighten_type_of_initializing_formals',

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -49,7 +49,7 @@ With types, all of this is clarified.
 
 ''';
 
-class TypeAnnotatePublicApis extends LintRule implements NodeLintRule {
+class TypeAnnotatePublicApis extends LintRule {
   TypeAnnotatePublicApis()
       : super(
             name: 'type_annotate_public_apis',

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -36,7 +36,7 @@ class Point {
 
 ''';
 
-class TypeInitFormals extends LintRule implements NodeLintRule {
+class TypeInitFormals extends LintRule {
   TypeInitFormals()
       : super(
             name: 'type_init_formals',

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -43,7 +43,7 @@ void main() async {
 
 ''';
 
-class UnawaitedFutures extends LintRule implements NodeLintRule {
+class UnawaitedFutures extends LintRule {
   UnawaitedFutures()
       : super(
             name: 'unawaited_futures',

--- a/lib/src/rules/unnecessary_await_in_return.dart
+++ b/lib/src/rules/unnecessary_await_in_return.dart
@@ -36,7 +36,7 @@ Future<int> f2() {
 
 ''';
 
-class UnnecessaryAwaitInReturn extends LintRule implements NodeLintRule {
+class UnnecessaryAwaitInReturn extends LintRule {
   UnnecessaryAwaitInReturn()
       : super(
             name: 'unnecessary_await_in_return',

--- a/lib/src/rules/unnecessary_brace_in_string_interps.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interps.dart
@@ -34,7 +34,7 @@ final RegExp identifierPart = RegExp(r'^[a-zA-Z0-9_]');
 bool isIdentifierPart(Token? token) =>
     token is StringToken && token.lexeme.startsWith(identifierPart);
 
-class UnnecessaryBraceInStringInterps extends LintRule implements NodeLintRule {
+class UnnecessaryBraceInStringInterps extends LintRule {
   UnnecessaryBraceInStringInterps()
       : super(
             name: 'unnecessary_brace_in_string_interps',

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -34,7 +34,7 @@ m(){
 
 ''';
 
-class UnnecessaryConst extends LintRule implements NodeLintRule {
+class UnnecessaryConst extends LintRule {
   UnnecessaryConst()
       : super(
             name: 'unnecessary_const',

--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -35,7 +35,7 @@ void goodMethod() {
 ```
 ''';
 
-class UnnecessaryFinal extends LintRule implements NodeLintRule {
+class UnnecessaryFinal extends LintRule {
   UnnecessaryFinal()
       : super(
             name: 'unnecessary_final',

--- a/lib/src/rules/unnecessary_getters.dart
+++ b/lib/src/rules/unnecessary_getters.dart
@@ -40,7 +40,7 @@ class Box {
 
 ''';
 
-class UnnecessaryGetters extends LintRule implements NodeLintRule {
+class UnnecessaryGetters extends LintRule {
   UnnecessaryGetters()
       : super(
             name: 'unnecessary_getters',

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -50,7 +50,7 @@ class Box {
 
 ''';
 
-class UnnecessaryGettersSetters extends LintRule implements NodeLintRule {
+class UnnecessaryGettersSetters extends LintRule {
   UnnecessaryGettersSetters()
       : super(
             name: 'unnecessary_getters_setters',

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -46,7 +46,7 @@ Iterable<Element?> _extractElementsOfSimpleIdentifiers(AstNode node) =>
         .whereType<SimpleIdentifier>()
         .map((e) => e.staticElement);
 
-class UnnecessaryLambdas extends LintRule implements NodeLintRule {
+class UnnecessaryLambdas extends LintRule {
   UnnecessaryLambdas()
       : super(
             name: 'unnecessary_lambdas',

--- a/lib/src/rules/unnecessary_new.dart
+++ b/lib/src/rules/unnecessary_new.dart
@@ -32,7 +32,7 @@ m(){
 
 ''';
 
-class UnnecessaryNew extends LintRule implements NodeLintRule {
+class UnnecessaryNew extends LintRule {
   UnnecessaryNew()
       : super(
             name: 'unnecessary_new',

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -32,7 +32,7 @@ x ??= null;
 
 ''';
 
-class UnnecessaryNullAwareAssignments extends LintRule implements NodeLintRule {
+class UnnecessaryNullAwareAssignments extends LintRule {
   UnnecessaryNullAwareAssignments()
       : super(
             name: 'unnecessary_null_aware_assignments',

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -82,7 +82,7 @@ DartType? getExpectedType(PostfixExpression node) {
   return null;
 }
 
-class UnnecessaryNullChecks extends LintRule implements NodeLintRule {
+class UnnecessaryNullChecks extends LintRule {
   UnnecessaryNullChecks()
       : super(
             name: 'unnecessary_null_checks',

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -31,8 +31,7 @@ var y = null ?? 1;
 
 ''';
 
-class UnnecessaryNullInIfNullOperators extends LintRule
-    implements NodeLintRule {
+class UnnecessaryNullInIfNullOperators extends LintRule {
   UnnecessaryNullInIfNullOperators()
       : super(
             name: 'unnecessary_null_in_if_null_operators',

--- a/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
+++ b/lib/src/rules/unnecessary_nullable_for_final_variable_declarations.dart
@@ -28,8 +28,7 @@ final int i = 1;
 
 ''';
 
-class UnnecessaryNullableForFinalVariableDeclarations extends LintRule
-    implements NodeLintRule {
+class UnnecessaryNullableForFinalVariableDeclarations extends LintRule {
   UnnecessaryNullableForFinalVariableDeclarations()
       : super(
             name: 'unnecessary_nullable_for_final_variable_declarations',

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -49,7 +49,7 @@ super method,
 
 ''';
 
-class UnnecessaryOverrides extends LintRule implements NodeLintRule {
+class UnnecessaryOverrides extends LintRule {
   UnnecessaryOverrides()
       : super(
             name: 'unnecessary_overrides',

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -25,7 +25,7 @@ a = (b);
 
 ''';
 
-class UnnecessaryParenthesis extends LintRule implements NodeLintRule {
+class UnnecessaryParenthesis extends LintRule {
   UnnecessaryParenthesis()
       : super(
             name: 'unnecessary_parenthesis',

--- a/lib/src/rules/unnecessary_raw_strings.dart
+++ b/lib/src/rules/unnecessary_raw_strings.dart
@@ -27,7 +27,7 @@ var s3 = r'\a';
 
 ''';
 
-class UnnecessaryRawStrings extends LintRule implements NodeLintRule {
+class UnnecessaryRawStrings extends LintRule {
   UnnecessaryRawStrings()
       : super(
             name: 'unnecessary_raw_strings',

--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -46,7 +46,7 @@ return myvar;
 
 ''';
 
-class UnnecessaryStatements extends LintRule implements NodeLintRule {
+class UnnecessaryStatements extends LintRule {
   UnnecessaryStatements()
       : super(
             name: 'unnecessary_statements',

--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -28,7 +28,7 @@ Remove unnecessary backslashes in strings.
 
 ''';
 
-class UnnecessaryStringEscapes extends LintRule implements NodeLintRule {
+class UnnecessaryStringEscapes extends LintRule {
   UnnecessaryStringEscapes()
       : super(
             name: 'unnecessary_string_escapes',

--- a/lib/src/rules/unnecessary_string_interpolations.dart
+++ b/lib/src/rules/unnecessary_string_interpolations.dart
@@ -28,7 +28,7 @@ String o = message;
 
 ''';
 
-class UnnecessaryStringInterpolations extends LintRule implements NodeLintRule {
+class UnnecessaryStringInterpolations extends LintRule {
   UnnecessaryStringInterpolations()
       : super(
             name: 'unnecessary_string_interpolations',

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -49,7 +49,7 @@ class Box {
 
 ''';
 
-class UnnecessaryThis extends LintRule implements NodeLintRule {
+class UnnecessaryThis extends LintRule {
   UnnecessaryThis()
       : super(
             name: 'unnecessary_this',

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -156,7 +156,7 @@ bool _isFixNumIntX(DartType type) {
       element.library?.name == 'fixnum';
 }
 
-class UnrelatedTypeEqualityChecks extends LintRule implements NodeLintRule {
+class UnrelatedTypeEqualityChecks extends LintRule {
   UnrelatedTypeEqualityChecks()
       : super(
             name: 'unrelated_type_equality_checks',

--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -40,7 +40,7 @@ extension on DartType? {
       DartTypeUtilities.extendsClass(this, className, 'dart.dom.html');
 }
 
-class UnsafeHtml extends LintRule implements NodeLintRule {
+class UnsafeHtml extends LintRule {
   UnsafeHtml()
       : super(
             name: 'unsafe_html',

--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -53,7 +53,7 @@ class _MyWidgetState extends State<MyWidget> {
 ```
 ''';
 
-class UseBuildContextSynchronously extends LintRule implements NodeLintRule {
+class UseBuildContextSynchronously extends LintRule {
   /// Flag to short-circuit `inTestDir` checking when running tests.
   final bool inTestMode;
 

--- a/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
+++ b/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
@@ -30,8 +30,7 @@ Color(0x00000001);
 
 ''';
 
-class UseFullHexValuesForFlutterColors extends LintRule
-    implements NodeLintRule {
+class UseFullHexValuesForFlutterColors extends LintRule {
   UseFullHexValuesForFlutterColors()
       : super(
             name: 'use_full_hex_values_for_flutter_colors',

--- a/lib/src/rules/use_function_type_syntax_for_parameters.dart
+++ b/lib/src/rules/use_function_type_syntax_for_parameters.dart
@@ -25,8 +25,7 @@ Iterable<T> where(bool Function(T) predicate) {}
 
 ''';
 
-class UseFunctionTypeSyntaxForParameters extends LintRule
-    implements NodeLintRule {
+class UseFunctionTypeSyntaxForParameters extends LintRule {
   UseFunctionTypeSyntaxForParameters()
       : super(
             name: 'use_function_type_syntax_for_parameters',

--- a/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
+++ b/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
@@ -34,7 +34,7 @@ if (nullableBool ?? true) {
 
 ''';
 
-class UseIfNullToConvertNullsToBools extends LintRule implements NodeLintRule {
+class UseIfNullToConvertNullsToBools extends LintRule {
   UseIfNullToConvertNullsToBools()
       : super(
           name: 'use_if_null_to_convert_nulls_to_bools',

--- a/lib/src/rules/use_is_even_rather_than_modulo.dart
+++ b/lib/src/rules/use_is_even_rather_than_modulo.dart
@@ -29,7 +29,7 @@ bool isOdd = 13.isOdd;
 
 ''';
 
-class UseIsEvenRatherThanModuloCheck extends LintRule implements NodeLintRule {
+class UseIsEvenRatherThanModuloCheck extends LintRule {
   UseIsEvenRatherThanModuloCheck()
       : super(
             name: 'use_is_even_rather_than_modulo',

--- a/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/lib/src/rules/use_key_in_widget_constructors.dart
@@ -33,7 +33,7 @@ class MyPublicWidget extends StatelessWidget {
 ```
 ''';
 
-class UseKeyInWidgetConstructors extends LintRule implements NodeLintRule {
+class UseKeyInWidgetConstructors extends LintRule {
   UseKeyInWidgetConstructors()
       : super(
             name: 'use_key_in_widget_constructors',

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -46,8 +46,7 @@ bool _isPrivateExtension(AstNode parent) {
   return parentName == null || Identifier.isPrivateName(parentName);
 }
 
-class UseLateForPrivateFieldsAndVariables extends LintRule
-    implements NodeLintRule {
+class UseLateForPrivateFieldsAndVariables extends LintRule {
   UseLateForPrivateFieldsAndVariables()
       : super(
           name: 'use_late_for_private_fields_and_variables',

--- a/lib/src/rules/use_named_constants.dart
+++ b/lib/src/rules/use_named_constants.dart
@@ -27,7 +27,7 @@ Duration.zero;
 ''';
 const lintName = 'use_named_constants';
 
-class UseNamedConstants extends LintRule implements NodeLintRule {
+class UseNamedConstants extends LintRule {
   UseNamedConstants()
       : super(
           name: lintName,

--- a/lib/src/rules/use_raw_strings.dart
+++ b/lib/src/rules/use_raw_strings.dart
@@ -25,7 +25,7 @@ var s = r'A string with only \ and $';
 
 ''';
 
-class UseRawStrings extends LintRule implements NodeLintRule {
+class UseRawStrings extends LintRule {
   UseRawStrings()
       : super(
             name: 'use_raw_strings',

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -39,7 +39,7 @@ try {
 
 ''';
 
-class UseRethrowWhenPossible extends LintRule implements NodeLintRule {
+class UseRethrowWhenPossible extends LintRule {
   UseRethrowWhenPossible()
       : super(
             name: 'use_rethrow_when_possible',

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -31,7 +31,7 @@ button.visible = false;
 
 ''';
 
-class UseSettersToChangeAProperty extends LintRule implements NodeLintRule {
+class UseSettersToChangeAProperty extends LintRule {
   UseSettersToChangeAProperty()
       : super(
             name: 'use_setters_to_change_properties',

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -52,7 +52,7 @@ bool _isEmptyInterpolationString(AstNode node) =>
 /// step it creates an auxiliary String that takes O(amount of chars) to be
 /// computed, in otherwise using a StringBuffer the order is reduced to O(~N)
 /// so the bad case is N times slower than the good case.
-class UseStringBuffers extends LintRule implements NodeLintRule {
+class UseStringBuffers extends LintRule {
   UseStringBuffers()
       : super(
             name: 'use_string_buffers',

--- a/lib/src/rules/use_test_throws_matchers.dart
+++ b/lib/src/rules/use_test_throws_matchers.dart
@@ -51,7 +51,7 @@ await expectLater(
 
 ''';
 
-class UseTestThrowsMatchers extends LintRule implements NodeLintRule {
+class UseTestThrowsMatchers extends LintRule {
   UseTestThrowsMatchers()
       : super(
           name: 'use_test_throws_matchers',

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -56,7 +56,7 @@ bool _beginsWithAsOrTo(String name) {
 bool _isVoid(TypeAnnotation? returnType) =>
     returnType is TypeName && returnType.name.name == 'void';
 
-class UseToAndAsIfApplicable extends LintRule implements NodeLintRule {
+class UseToAndAsIfApplicable extends LintRule {
   UseToAndAsIfApplicable()
       : super(
             name: 'use_to_and_as_if_applicable',

--- a/lib/src/rules/valid_regexps.dart
+++ b/lib/src/rules/valid_regexps.dart
@@ -29,7 +29,7 @@ print(RegExp(r'\(').hasMatch('foo()'));
 
 ''';
 
-class ValidRegExps extends LintRule implements NodeLintRule {
+class ValidRegExps extends LintRule {
   ValidRegExps()
       : super(
             name: 'valid_regexps',

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -30,7 +30,7 @@ void main() {
 ```
 ''';
 
-class VoidChecks extends LintRule implements NodeLintRule {
+class VoidChecks extends LintRule {
   VoidChecks()
       : super(
             name: 'void_checks',

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -127,7 +127,7 @@ const _details = r'''
 
 ''';
 
-class $className extends LintRule implements NodeLintRule {
+class $className extends LintRule {
   $className()
       : super(
             name: '$ruleName',


### PR DESCRIPTION
The common `LintRule` base class implements `NodeLintRule` so we no longer need to explicitly implement it.

/cc @bwilkerson 
