### PR TITLE
Enable `prefer_single_quotes`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -63,6 +63,7 @@ linter:
 #    - prefer_mixin
     - prefer_null_aware_method_calls
     - prefer_relative_imports
+    - prefer_single_quotes
 #    - public_member_api_docs
 #    - sort_constructors_first
     - sort_pub_dependencies

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -68,8 +68,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   static const LintCode parameterCode = LintCode(
       "avoid_renaming_method_parameters",  // ignore: prefer_single_quotes
       "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.",
-      correction: "Try renaming the parameter."  // ignore: prefer_single_quotes
-  );
+      correction: "Try renaming the parameter.");  // ignore: prefer_single_quotes
 
   final LintRule rule;
 

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -66,9 +66,10 @@ class AvoidRenamingMethodParameters extends LintRule {
 
 class _Visitor extends SimpleAstVisitor<void> {
   static const LintCode parameterCode = LintCode(
-      "avoid_renaming_method_parameters",
+      "avoid_renaming_method_parameters",  // ignore: prefer_single_quotes
       "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.",
-      correction: "Try renaming the parameter.");
+      correction: "Try renaming the parameter."  // ignore: prefer_single_quotes
+  );
 
   final LintRule rule;
 

--- a/lib/src/rules/avoid_renaming_method_parameters.dart
+++ b/lib/src/rules/avoid_renaming_method_parameters.dart
@@ -66,9 +66,10 @@ class AvoidRenamingMethodParameters extends LintRule {
 
 class _Visitor extends SimpleAstVisitor<void> {
   static const LintCode parameterCode = LintCode(
-      "avoid_renaming_method_parameters",  // ignore: prefer_single_quotes
+      "avoid_renaming_method_parameters", // ignore: prefer_single_quotes
       "The parameter '{0}' should have the name '{1}' to match the name used in the overridden method.",
-      correction: "Try renaming the parameter.");  // ignore: prefer_single_quotes
+      correction:
+          "Try renaming the parameter."); // ignore: prefer_single_quotes
 
   final LintRule rule;
 

--- a/lib/src/util/ascii_utils.dart
+++ b/lib/src/util/ascii_utils.dart
@@ -8,7 +8,7 @@
 /// See: https://github.com/dart-lang/linter/issues/1828
 library ascii_utils;
 
-import "charcodes.dart";
+import 'charcodes.dart';
 
 /// Return `true` if the given [character] is the ASCII '.' character.
 bool isDot(int character) => character == $dot;

--- a/test/integration/depend_on_referenced_packages.dart
+++ b/test/integration/depend_on_referenced_packages.dart
@@ -36,13 +36,13 @@ void main() {
       expect(
           output,
           stringContainsInOrder([
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "import 'package:private_dep/private_dep.dart'; // LINT",
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "import 'package:transitive_dep/transitive_dep.dart'; // LINT",
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "export 'package:private_dep/private_dep.dart'; // LINT",
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "export 'package:transitive_dep/transitive_dep.dart'; // LINT",
           ]));
       expect(output, isNot(contains('// OK')));
@@ -60,13 +60,13 @@ void main() {
       expect(
           output,
           stringContainsInOrder([
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "import 'package:private_dep/private_dep.dart'; // LINT",
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "import 'package:transitive_dep/transitive_dep.dart'; // LINT",
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "export 'package:private_dep/private_dep.dart'; // LINT",
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "export 'package:transitive_dep/transitive_dep.dart'; // LINT",
           ]));
       expect(output, isNot(contains('// OK')));
@@ -84,9 +84,9 @@ void main() {
       expect(
           output,
           stringContainsInOrder([
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "import 'package:transitive_dep/transitive_dep.dart'; // LINT",
-            "Depend on referenced packages.",
+            'Depend on referenced packages.',
             "export 'package:transitive_dep/transitive_dep.dart'; // LINT",
           ]));
       expect(output, isNot(contains('// OK')));


### PR DESCRIPTION
~~No need to ignore `prefer_single_quotes`. It is not part of the checked lints in the project.~~

Enable `prefer_single_quotes`, as per the below feedback.