### PR TITLE
1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 1.9.0
+
+- marked `avoid_dynamic_calls` stable
+- (internal) removed unused `MockPubVisitor` and `MockRule` classes
+- fixed `prefer_void_to_null` false positive w/ overridden properties
+- (internal) removed references to `NodeLintRule` in lint rule declarations
+- fixed `prefer_void_to_null` false positive on overriding returns
+- fixed `prefer_generic_function_type_aliases` false positive w/ incomplete statements
+- fixed false positive for `prefer_initializing_formals` with factory constructors
+- fixed `void_checks` false positives with incomplete source
+- updated `unnecessary_getters_setters` to only flag the getter
+- improved messages for `avoid_renaming_method_parameters`
+- fixed false positive in `prefer_void_to_null`
+- fixed false positive in `omit_local_variable_types`
+- fixed false positive in `use_rethrow_when_possible`
+- performance improvements for `annotate_overrides`, `prefer_contains`, and `prefer_void_to_null`
+
 # 1.8.0
 
 - performance improvements for `prefer_is_not_empty`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.8.0';
+const String version = '1.9.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.8.0
+version: 1.9.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.9.0

- marked `avoid_dynamic_calls` stable
- (internal) removed unused `MockPubVisitor` and `MockRule` classes
- fixed `prefer_void_to_null` false positive w/ overridden properties
- (internal) removed references to `NodeLintRule` in lint rule declarations
- fixed `prefer_void_to_null` false positive on overriding returns
- fixed `prefer_generic_function_type_aliases` false positive w/ incomplete statements
- fixed false positive for `prefer_initializing_formals` with factory constructors
- fixed `void_checks` false positives with incomplete source
- updated `unnecessary_getters_setters` to only flag the getter
- improved messages for `avoid_renaming_method_parameters`
- fixed false positive in `prefer_void_to_null`
- fixed false positive in `omit_local_variable_types`
- fixed false positive in `use_rethrow_when_possible`
- performance improvements for `annotate_overrides`, `prefer_contains`, and `prefer_void_to_null`

---

Try running: https://dart-review.googlesource.com/c/sdk/+/209765

/cc @bwilkerson 
