### PR TITLE
Fix false positive in `use_build_context_synchronously`

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -85,6 +85,12 @@ class _AwaitVisitor extends RecursiveAstVisitor {
   void visitAwaitExpression(AwaitExpression node) {
     hasAwait = true;
   }
+
+  @override
+  visitBlockFunctionBody(BlockFunctionBody node) {
+    // Stop visiting if it's a function body block.
+    // Awaits inside it shouldn't matter
+  }
 }
 
 class _Visitor extends SimpleAstVisitor {

--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -91,6 +91,11 @@ class _AwaitVisitor extends RecursiveAstVisitor {
     // Stop visiting if it's a function body block.
     // Awaits inside it shouldn't matter
   }
+
+  @override
+  visitExpressionFunctionBody(ExpressionFunctionBody node) {
+    // Stopping following the same logic as function body blocks
+  }
 }
 
 class _Visitor extends SimpleAstVisitor {

--- a/test/integration/use_build_context_synchronously.dart
+++ b/test/integration/use_build_context_synchronously.dart
@@ -31,7 +31,7 @@ void main() {
       var out = collectingOut.trim();
       expect(out, contains('1 file analyzed, 1 issue found'));
       expect(out,
-          contains('21:3 [lint] Do not use BuildContexts across async gaps.'));
+          contains('22:3 [lint] Do not use BuildContexts across async gaps.'));
     });
   });
 }

--- a/test_data/integration/use_build_context_synchronously/lib/unmigrated.dart
+++ b/test_data/integration/use_build_context_synchronously/lib/unmigrated.dart
@@ -4,6 +4,7 @@
 
 // @dart=2.9
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'migrated.dart';
@@ -19,4 +20,32 @@ void topLevel(BuildContext context) async {
 
   await Future<void>.delayed(Duration());
   Navigator.of(context).pushNamed('routeName'); // LINT
+}
+
+void anonymousFunction(BuildContext context) async {
+  final anon = () async {
+    await Future<void>.delayed(Duration(seconds: 1));
+  };
+  await Navigator.of(context).pushNamed('routeName'); // OK
+}
+
+void widgetCallbacks(BuildContext context) async {
+  final widget = _Button(
+    onTap: () async {
+      await Future<void>.delayed(Duration());
+    },
+  );
+  // Build complex widget piece by piece...
+  f(context); // OK
+}
+
+class _Button extends StatelessWidget {
+  const _Button({Key key, this.onTap}) : super(key: key);
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
 }

--- a/test_data/integration/use_build_context_synchronously/lib/unmigrated.dart
+++ b/test_data/integration/use_build_context_synchronously/lib/unmigrated.dart
@@ -29,6 +29,11 @@ void anonymousFunction(BuildContext context) async {
   await Navigator.of(context).pushNamed('routeName'); // OK
 }
 
+void anonymousExpressionFunction(BuildContext context) async {
+  final anon = () async => await Future<void>.delayed(Duration());
+  await Navigator.of(context).pushNamed('routeName'); // OK
+}
+
 void widgetCallbacks(BuildContext context) async {
   final widget = _Button(
     onTap: () async {


### PR DESCRIPTION
# Description

There are false positives when writing awaits inside anonymous functions defined above.

Fixes #2878

PS: First time contributing to the linter so I may be taking wrong assumptions here, but this works for the false positive cases I've encountered.
