### PR TITLE
prefer `alias` over `aliasElement`

### DIFF
--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -127,7 +127,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitNamedType(NamedType namedType) {
     var type = namedType.type;
     if (type is InterfaceType) {
-      var element = type.aliasElement ?? type.element;
+      var element = type.alias?.element ?? type.element;
       if (element.typeParameters.isNotEmpty &&
           namedType.typeArguments == null &&
           namedType.parent is! IsExpression &&


### PR DESCRIPTION
Migrate from deprecated `aliasElement`.

/cc @bwilkerson @scheglov 