### PR TITLE
Replace "Github" with "GitHub"

### DIFF
--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -350,7 +350,7 @@ class HtmlIndexer {
       </div>
       <footer>
          <p>Maintained by the <a href="https://dart.dev/">Dart Team</a></p>
-         <p>Visit us on <a href="https://github.com/dart-lang/linter">Github</a></p>
+         <p>Visit us on <a href="https://github.com/dart-lang/linter">GitHub</a></p>
       </footer>
    </body>
 </html>
@@ -538,7 +538,7 @@ linter:
       </div>
       <footer>
          <p>Maintained by the <a href="https://dart.dev/">Dart Team</a></p>
-         <p>Visit us on <a href="https://github.com/dart-lang/linter">Github</a></p>
+         <p>Visit us on <a href="https://github.com/dart-lang/linter">GitHub</a></p>
       </footer>
    </body>
 </html>
@@ -647,7 +647,7 @@ class RuleHtmlGenerator {
       </div>
       <footer>
          <p>Maintained by the <a href="https://dart.dev/">Dart Team</a></p>
-         <p>Visit us on <a href="https://github.com/dart-lang/linter">Github</a></p>
+         <p>Visit us on <a href="https://github.com/dart-lang/linter">GitHub</a></p>
       </footer>
    </body>
 </html>


### PR DESCRIPTION
# Description

Hello🙂  This is just a small fix to capitalize "h" in the word "Github" on the page footer.

# Screenshot 

<img width="1065" alt="Screen Shot 2021-08-27 at 9 16 50" src="https://user-images.githubusercontent.com/1425259/131068616-24d96920-0693-4f39-930b-fbe387d3519c.png">
