### PR TITLE
stop calculating SDK "since" info

### DIFF
--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -592,10 +592,12 @@ class RuleHtmlGenerator {
 
   String get since {
     var info = sinceInfo[name]!;
-    var version = info.sinceDartSdk != null
-        ? '>= ${info.sinceDartSdk}'
-        : '<strong>unreleased</strong>';
-    return 'Dart SDK: $version • <small>(Linter v${info.sinceLinter})</small>';
+    // See: https://github.com/dart-lang/linter/issues/2824
+    // var version = info.sinceDartSdk != null
+    //     ? '>= ${info.sinceDartSdk}'
+    //     : '<strong>unreleased</strong>';
+    //return 'Dart SDK: $version • <small>(Linter v${info.sinceLinter})</small>';
+    return 'Linter v${info.sinceLinter}';
   }
 
   void generate([String? filePath]) {
@@ -669,10 +671,12 @@ class RuleMarkdownGenerator {
 
   String get since {
     var info = sinceInfo[name]!;
-    var version = info.sinceDartSdk != null
-        ? '>= ${info.sinceDartSdk}'
-        : '**unreleased**';
-    return 'Dart SDK: $version • (Linter v${info.sinceLinter})';
+    // See: https://github.com/dart-lang/linter/issues/2824
+    // var version = info.sinceDartSdk != null
+    //     ? '>= ${info.sinceDartSdk}'
+    //     : '**unreleased**';
+    // return 'Dart SDK: $version • (Linter v${info.sinceLinter})';
+    return 'Linter v${info.sinceLinter}';
   }
 
   void generate({String? filePath}) {

--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -173,7 +173,9 @@ class LintScore {
           sb.write(' ${since!.sinceLinter} |');
           break;
         case Detail.sdk:
-          sb.write(' ${since!.sinceDartSdk} |');
+          // See: https://github.com/dart-lang/linter/issues/2824
+          //sb.write(' ${since!.sinceDartSdk} |');
+          sb.write('*untracked*');
           break;
         case Detail.fix:
           sb.write('${hasFix! ? " $bulb" : ""} |');

--- a/tool/since.dart
+++ b/tool/since.dart
@@ -92,8 +92,10 @@ Future<Map<String, SinceInfo>> _getSinceInfo(Authentication? auth) async {
       }
     }
     sinceMap[lint] = SinceInfo(
-        sinceLinter: linterVersion ?? await findSinceLinter(lint),
-        sinceDartSdk: await _sinceSdkForLinter(linterVersion, auth));
+      sinceLinter: linterVersion ?? await findSinceLinter(lint),
+      // See: https://github.com/dart-lang/linter/issues/2824
+      //sinceDartSdk: await _sinceSdkForLinter(linterVersion, auth),
+    );
   }
   return sinceMap;
 }
@@ -110,8 +112,9 @@ Future<String?> _nextLinterVersion(Version linterVersion) async {
   return null;
 }
 
-Future<String?> _sinceSdkForLinter(
-    String? linterVersionString, Authentication? auth) async {
+@Deprecated('See: https://github.com/dart-lang/linter/issues/2824')
+Future<String?> _sinceSdkForLinter // ignore: unused_element
+    (String? linterVersionString, Authentication? auth) async {
   if (linterVersionString == null) {
     return null;
   }
@@ -145,9 +148,12 @@ Future<String?> _sinceSdkForLinter(
 
 class SinceInfo {
   final String? sinceLinter;
-  final String? sinceDartSdk;
-  SinceInfo({this.sinceLinter, this.sinceDartSdk});
+  // See: https://github.com/dart-lang/linter/issues/2824
+  //final String? sinceDartSdk;
+  SinceInfo({this.sinceLinter});
 
   @override
-  String toString() => 'linter: $sinceLinter | sdk: $sinceDartSdk';
+  String toString() => 'linter: $sinceLinter';
+  // See: https://github.com/dart-lang/linter/issues/2824
+  // 'linter: $sinceLinter | sdk: $sinceDartSdk';
 }


### PR DESCRIPTION
(Temporarily) stop calculating and documenting SDK since info.  

It's currently invalid and needs re-work.

See dart-lang/sdk#58472

/cc @bwilkerson 
