### PR TITLE
`unnecessary_new` tests for constructor tear-offs

### DIFF
--- a/test_data/rules/experiments/constructor_tearoffs/rules/unnecessary_new.dart
+++ b/test_data/rules/experiments/constructor_tearoffs/rules/unnecessary_new.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N unnecessary_new`
+
+class A {
+  const A([o]);
+  A.c1();
+}
+
+main() {
+  const A(); // OK
+  new A(); // LINT
+  A(); // OK
+
+  // Constructor tear-offs.
+  new A.new(); // LINT
+  const A.new(); // OK
+
+  new A.c1(); // LINT
+  A.c1(); // OK
+
+  new A([]); // LINT
+  A([]); // OK
+
+  final v1 = A(); // OK
+  final v2 = new A(); // LINT
+}


### PR DESCRIPTION
See: dart-lang/sdk#58424

Salient content is lines 18-19.

Any cases I'm missing?

/cc @srawlins @bwilkerson
