### PR TITLE
`unnecessary_const` tests for constructor tear-offs

### DIFF
--- a/test_data/rules/experiments/constructor_tearoffs/rules/unnecessary_const.dart
+++ b/test_data/rules/experiments/constructor_tearoffs/rules/unnecessary_const.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N unnecessary_const`
+
+//ignore_for_file: unused_local_variable
+
+class A {
+  const A([o]);
+}
+
+main() {
+  const A(); // OK
+  A(); // OK
+
+  A.new(); // OK
+  const A.new(); // OK
+
+  const A([]); // OK
+  A([]); // OK
+  A(const []); // OK
+
+  const A(A()); // OK
+  A(const A()); // OK
+  A(A()); // OK
+
+  final v1 = A(); // OK
+  const v3 = const A(); // LINT
+  const v4 = A(); // OK
+  final v5 = const A([]); // OK
+  const v6 = const A([]); // LINT
+  const v7 = A([]); // OK
+  final v8 = A(const []); // OK
+  final v9 = const A(const []); // LINT
+  final v10 = const A([]); // OK
+  final v11 = const A(const {}); // LINT
+  final v12 = const A({}); // OK
+
+  const v13 = const A.new(); // LINT
+  final v14 = A.new(const []); // OK
+  final v15 = const A.new(const []); // LINT
+}


### PR DESCRIPTION
See: dart-lang/sdk#58424

Salient content is lines 17-18, 40-42.

Any cases I'm missing?

/cc @srawlins @bwilkerson
