### PR TITLE
test updates for `always_specify_types` w/ constructor tear-offs

### DIFF
--- a/test_data/rules/experiments/constructor_tearoffs/rules/always_specify_types.dart
+++ b/test_data/rules/experiments/constructor_tearoffs/rules/always_specify_types.dart
@@ -10,8 +10,11 @@ import 'package:meta/meta.dart';
 
 /// Constructor tear-offs
 void constructorTearOffs() {
-  List.filled; // LINT
   List<List>.filled; // LINT
+  // todo(pq): should be OK.
+  // List<E> Function<E>(int, E) filledList = List.filled; // OK - generic function
+  filledList<int>(3, 3); // OK
+  filledList(3, 3); // todo(pq): LINT? -- https://github.com/dart-lang/linter/issues/2914
 }
 
 Map<String, String> map = {}; //LINT


### PR DESCRIPTION
Follow-up from #2693.

See also: #2914.

(FWIW: waiting to address TODOs until a new push of analyzer since ASTs are in flux.)

/cc @bwilkerson @srawlins 