### PR TITLE
1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.11.0
+
+- added support for constructor tear-offs to `avoid_redundant_argument_values`, 
+  `unnecessary_lambdas`, and `unnecessary_parenthesis`
+- new lint: `unnecessary_constructor_name` to flag unnecessary uses of `.new`
+
 # 1.10.0
 
 - improved regular expression parsing performance for common checks 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.10.0';
+const String version = '1.11.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.10.0
+version: 1.11.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.11.0

- added support for constructor tear-offs to `avoid_redundant_argument_values`, 
  `unnecessary_lambdas`, and `unnecessary_parenthesis`
- new lint: `unnecessary_constructor_name` to flag unnecessary uses of `.new`

/cc @bwilkerson @srawlins 
