### PR TITLE
Fix doc typo "enabled"

### DIFF
--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -66,7 +66,7 @@ the following will not generate a lint:
 class Point {
   bool isEnabled;
   Point({bool enabled}) {
-    this.isEnabled = enable; // OK
+    this.isEnabled = enabled; // OK
   }
 }
 ```


### PR DESCRIPTION
# Fix documentation typo for prefer_initializing_formals code sample
