### PR TITLE
fix `unnecessary_parenthesis` false positive for function expressions

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -70,7 +70,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // https://github.com/dart-lang/linter/issues/2944
     // (() => foo()).bar();
-    if (expression is FunctionExpression) {
+    if (expression is FunctionExpression && parent is MethodInvocation) {
       return;
     }
 

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -69,9 +69,13 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     // https://github.com/dart-lang/linter/issues/2944
-    // (() => foo()).bar();
-    if (expression is FunctionExpression && parent is MethodInvocation) {
-      return;
+    if (expression is FunctionExpression) {
+      if (parent is MethodInvocation ||
+          parent is PropertyAccess ||
+          parent is BinaryExpression ||
+          parent is IndexExpression) {
+        return;
+      }
     }
 
     if (expression is ConstructorReference) {

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -68,6 +68,12 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
+    // https://github.com/dart-lang/linter/issues/2944
+    // (() => foo()).bar();
+    if (expression is FunctionExpression) {
+      return;
+    }
+
     if (expression is ConstructorReference) {
       if (parent is! FunctionExpressionInvocation ||
           parent.typeArguments == null) {

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -20,6 +20,8 @@ extension A on void Function() {
   };
 }
 
+var func = (() => null); // LINT
+
 class D {
   D.d([int? x, int? y]);
 }

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -6,6 +6,20 @@
 
 import 'dart:async';
 
+
+/// https://github.com/dart-lang/linter/issues/2944
+void foo() {
+  final items = [];
+  (() => [].add('something')).compose(() {}); // OK
+}
+
+extension A on void Function() {
+  void Function() compose(void Function() other) => () {
+    this();
+    other();
+  };
+}
+
 class D {
   D.d([int? x, int? y]);
 }

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -11,6 +11,10 @@ import 'dart:async';
 void foo() {
   final items = [];
   (() => [].add('something')).compose(() {}); // OK
+  (() => '').hashCode; // OK
+  (() => '').f = 1; // OK
+  (() => '') +  1; // OK
+  (() => '')[0]; // OK
 }
 
 extension A on void Function() {
@@ -18,6 +22,10 @@ extension A on void Function() {
     this();
     other();
   };
+
+  set f(int f) {}
+  operator+(int x) {}
+  int operator[](int i) => 0;
 }
 
 var func = (() => null); // LINT


### PR DESCRIPTION
Fixes #https://github.com/dart-lang/linter/issues/2944

/cc @bwilkerson @srawlins 
