### PR TITLE
Prepare const static function tearoff test for analyzer roll

### DIFF
--- a/test_data/rules/prefer_const_declarations.dart
+++ b/test_data/rules/prefer_const_declarations.dart
@@ -25,7 +25,7 @@ void constructorTearOffStaticTests<T>() {
   // todo: consider cases -- https://github.com/dart-lang/linter/issues/2911
   // final c2 = C.m<int>; // LINT
   final C<int> Function() c3 = C.m; // LINT
-  final c4 = C.m<T>; // OK --  not constant (only with ....)
+  final c4 = C.m<T>; // LINT
   // final C<T> Function() c5 = C.m; // OK -- not constant
 }
 


### PR DESCRIPTION
# Description

The next analyzer release will allow for top-level and static function tearoffs to be const. This means this test data file has one new LINT inside, where indicated.

Instead of merging this PR by itself, the diff can just be used in a PR which bumps analyzer.