### PR TITLE
1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.12.0
+
+- fixed `unnecessary_lambdas` false positive for const constructor invocations
+- updated `avoid_print` to allow `kDebugMode`-wrapped print calls
+- fixed handling of initializing formals in `prefer_final_parameters`
+- fixed `unnecessary_parenthesis` false positive with function expressions
+
 # 1.11.0
 
 - added support for constructor tear-offs to `avoid_redundant_argument_values`, 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.11.0';
+const String version = '1.12.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.11.0
+version: 1.12.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.12.0

- fixed `unnecessary_lambdas` false positive for const constructor invocations
- updated `avoid_print` to allow `kDebugMode`-wrapped print calls
- fixed handling of initializing formals in `prefer_final_parameters`
- fixed `unnecessary_parenthesis` false positive with function expressions

/cc @bwilkerson 