### PR TITLE
Remove unnecessary `begin of input` and raw string from `identifierPart`

### DIFF
--- a/lib/src/rules/unnecessary_brace_in_string_interps.dart
+++ b/lib/src/rules/unnecessary_brace_in_string_interps.dart
@@ -29,7 +29,7 @@ print("Hi, ${name}!");
 
 ''';
 
-final RegExp identifierPart = RegExp(r'^[a-zA-Z0-9_]');
+final RegExp identifierPart = RegExp('[a-zA-Z0-9_]');
 
 bool isIdentifierPart(Token? token) =>
     token is StringToken && token.lexeme.startsWith(identifierPart);


### PR DESCRIPTION
In `unnecessary_brace_in_string_interps.dart`, there is an extra `^`, which doesn't add a value, since the `identifierPart` is used only once in `startsWith()`.

This PR removes, as also hinted in https://dart-review.googlesource.com/c/sdk/+/212742/comments/e3e4560f_28eca233

Also, no need to have the starting as `raw`.