### PR TITLE
in-memory reflective test harness

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,3 +32,4 @@ dev_dependencies:
   matcher: ^0.12.10
   pub_semver: ^2.0.0
   test: ^1.16.1
+  test_reflective_loader: ^0.2.0

--- a/test/all.dart
+++ b/test/all.dart
@@ -10,6 +10,7 @@ import 'formatter_test.dart' as formatter_test;
 import 'integration_test.dart' as integration_test;
 import 'mocks.dart';
 import 'rule_test.dart' as rule_test;
+import 'rules/all.dart' as reflective_rule_tests;
 import 'utils_test.dart' as utils_test;
 import 'validate_format_test.dart' as validate_format;
 import 'validate_headers_test.dart' as validate_headers;
@@ -25,6 +26,7 @@ void main() {
   formatter_test.main();
   integration_test.main();
   rule_test.main();
+  reflective_rule_tests.main();
   utils_test.main();
   validate_format.main();
   validate_headers.main();

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -31,10 +31,12 @@ class AnalysisOptionsFileConfig {
   String toContent() {
     var buffer = StringBuffer();
 
-    buffer.writeln('analyzer:');
-    buffer.writeln('  enable-experiment:');
-    for (var experiment in experiments) {
-      buffer.writeln('    - $experiment');
+    if (experiments.isNotEmpty) {
+      buffer.writeln('analyzer:');
+      buffer.writeln('  enable-experiment:');
+      for (var experiment in experiments) {
+        buffer.writeln('    - $experiment');
+      }
     }
 
     buffer.writeln('linter:');
@@ -53,7 +55,7 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
   @override
   List<String> get _lintRules => [if (lintRule != null) lintRule!];
 
-  Future<void> assertHasLint(String code) async {
+  Future<void> assertLint(String code) async {
     addTestFile(code);
     await resolveTestFile();
 
@@ -66,7 +68,7 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
     fail('Expected: $lintRule, found none');
   }
 
-  Future<void> assertHasNoLint(String code) async {
+  Future<void> assertNoLint(String code) async {
     addTestFile(code);
     await resolveTestFile();
 

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -1,0 +1,306 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/error/error.dart';
+import 'package:analyzer/file_system/file_system.dart';
+import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/src/dart/analysis/byte_store.dart';
+import 'package:analyzer/src/dart/analysis/driver_based_analysis_context.dart';
+import 'package:analyzer/src/dart/analysis/experiments.dart';
+import 'package:analyzer/src/test_utilities/mock_packages.dart';
+import 'package:analyzer/src/test_utilities/mock_sdk.dart';
+import 'package:analyzer/src/test_utilities/package_config_file_builder.dart';
+import 'package:analyzer/src/test_utilities/resource_provider_mixin.dart';
+import 'package:linter/src/rules.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+export 'package:analyzer/src/test_utilities/package_config_file_builder.dart';
+
+class AnalysisOptionsFileConfig {
+  final List<String> experiments;
+  final List<String> lints;
+
+  AnalysisOptionsFileConfig({
+    this.experiments = const [],
+    this.lints = const [],
+  });
+
+  String toContent() {
+    var buffer = StringBuffer();
+
+    buffer.writeln('analyzer:');
+    buffer.writeln('  enable-experiment:');
+    for (var experiment in experiments) {
+      buffer.writeln('    - $experiment');
+    }
+
+    buffer.writeln('linter:');
+    buffer.writeln('  rules:');
+    for (var lint in lints) {
+      buffer.writeln('    - $lint');
+    }
+
+    return buffer.toString();
+  }
+}
+
+abstract class LintRuleTest extends PubPackageResolutionTest {
+  String? get lintRule;
+
+  @override
+  List<String> get _lintRules => [if (lintRule != null) lintRule!];
+
+  Future<void> assertHasLint(String code) async {
+    addTestFile(code);
+    await resolveTestFile();
+
+    for (var error in errors) {
+      if (error.errorCode.name == lintRule) {
+        return;
+      }
+    }
+
+    fail('Expected: $lintRule, found none');
+  }
+
+  Future<void> assertHasNoLint(String code) async {
+    addTestFile(code);
+    await resolveTestFile();
+
+    for (var error in errors) {
+      if (error.errorCode.name == lintRule) {
+        fail(error.message);
+      }
+    }
+  }
+}
+
+class PubPackageResolutionTest extends _ContextResolutionTest {
+  final List<String> _lintRules = const [];
+
+  @override
+  List<String> get collectionIncludedPaths => [workspaceRootPath];
+
+  List<String> get experiments => [
+        EnableString.constructor_tearoffs,
+      ];
+
+  /// The path that is not in [workspaceRootPath], contains external packages.
+  String get packagesRootPath => '/packages';
+
+  @override
+  String get testFilePath => '$testPackageLibPath/test.dart';
+
+  String? get testPackageLanguageVersion => null;
+
+  String get testPackageLibPath => '$testPackageRootPath/lib';
+
+  String get testPackageRootPath => '$workspaceRootPath/test';
+
+  String get workspaceRootPath => '/home';
+
+  @override
+  @mustCallSuper
+  void setUp() {
+    super.setUp();
+
+    writeTestPackageAnalysisOptionsFile(
+      AnalysisOptionsFileConfig(
+        experiments: experiments,
+        lints: _lintRules,
+      ),
+    );
+    writeTestPackageConfig(
+      PackageConfigFileBuilder(),
+    );
+  }
+
+  void writePackageConfig(String path, PackageConfigFileBuilder config) {
+    newFile(
+      path,
+      content: config.toContent(
+        toUriStr: toUriStr,
+      ),
+    );
+  }
+
+  void writeTestPackageAnalysisOptionsFile(AnalysisOptionsFileConfig config) {
+    newAnalysisOptionsYamlFile(
+      testPackageRootPath,
+      content: config.toContent(),
+    );
+  }
+
+  void writeTestPackageConfig(
+    PackageConfigFileBuilder config, {
+    String? languageVersion,
+    bool js = false,
+    bool meta = false,
+  }) {
+    var configCopy = config.copy();
+
+    configCopy.add(
+      name: 'test',
+      rootPath: testPackageRootPath,
+      languageVersion: languageVersion ?? testPackageLanguageVersion,
+    );
+
+    if (js) {
+      var jsPath = '/packages/js';
+      MockPackages.addJsPackageFiles(
+        getFolder(jsPath),
+      );
+      configCopy.add(name: 'js', rootPath: jsPath);
+    }
+
+    if (meta) {
+      var metaPath = '/packages/meta';
+      MockPackages.addMetaPackageFiles(
+        getFolder(metaPath),
+      );
+      configCopy.add(name: 'meta', rootPath: metaPath);
+    }
+
+    var path = '$testPackageRootPath/.dart_tool/package_config.json';
+    writePackageConfig(path, configCopy);
+  }
+
+  void writeTestPackageConfigWithMeta() {
+    writeTestPackageConfig(PackageConfigFileBuilder(), meta: true);
+  }
+
+  void writeTestPackagePubspecYamlFile(PubspecYamlFileConfig config) {
+    newPubspecYamlFile(testPackageRootPath, config.toContent());
+  }
+}
+
+class PubspecYamlFileConfig {
+  final String? name;
+  final String? sdkVersion;
+  final List<PubspecYamlFileDependency> dependencies;
+
+  PubspecYamlFileConfig({
+    this.name,
+    this.sdkVersion,
+    this.dependencies = const [],
+  });
+
+  String toContent() {
+    var buffer = StringBuffer();
+
+    if (name != null) {
+      buffer.writeln('name: $name');
+    }
+
+    if (sdkVersion != null) {
+      buffer.writeln('environment:');
+      buffer.writeln("  sdk: '$sdkVersion'");
+    }
+
+    if (dependencies.isNotEmpty) {
+      buffer.writeln('dependencies:');
+      for (var dependency in dependencies) {
+        buffer.writeln('  ${dependency.name}: ${dependency.version}');
+      }
+    }
+
+    return buffer.toString();
+  }
+}
+
+class PubspecYamlFileDependency {
+  final String name;
+  final String version;
+
+  PubspecYamlFileDependency({
+    required this.name,
+    this.version = 'any',
+  });
+}
+
+abstract class _ContextResolutionTest with ResourceProviderMixin {
+  static bool _lintRulesAreRegistered = false;
+
+  final ByteStore _byteStore = MemoryByteStore();
+
+  AnalysisContextCollectionImpl? _analysisContextCollection;
+
+  late ResolvedUnitResult result;
+
+  List<MockSdkLibrary> get additionalMockSdkLibraries => [];
+
+  List<String> get collectionIncludedPaths;
+
+  /// The analysis errors that were computed during analysis.
+  List<AnalysisError> get errors => result.errors;
+
+  String get testFilePath => '/test/lib/test.dart';
+
+  void addTestFile(String content) {
+    newFile(testFilePath, content: content);
+  }
+
+  @override
+  File newFile(String path, {String content = ''}) {
+    if (_analysisContextCollection != null && !path.endsWith('.dart')) {
+      throw StateError('Only dart files can be changed after analysis.');
+    }
+
+    return super.newFile(path, content: content);
+  }
+
+  Future<ResolvedUnitResult> resolveFile(String path) async {
+    var analysisContext = _contextFor(path);
+    var session = analysisContext.currentSession;
+    return await session.getResolvedUnit(path) as ResolvedUnitResult;
+  }
+
+  Future<void> resolveTestFile() => _resolveFile(testFilePath);
+
+  @mustCallSuper
+  void setUp() {
+    if (!_lintRulesAreRegistered) {
+      registerLintRules();
+      _lintRulesAreRegistered = true;
+    }
+
+    MockSdk(
+      resourceProvider: resourceProvider,
+      additionalLibraries: additionalMockSdkLibraries,
+    );
+  }
+
+  DriverBasedAnalysisContext _contextFor(String path) {
+    _createAnalysisContexts();
+
+    var convertedPath = convertPath(path);
+    return _analysisContextCollection!.contextFor(convertedPath);
+  }
+
+  /// Create all analysis contexts in [collectionIncludedPaths].
+  void _createAnalysisContexts() {
+    if (_analysisContextCollection != null) {
+      return;
+    }
+
+    _analysisContextCollection = AnalysisContextCollectionImpl(
+      byteStore: _byteStore,
+      declaredVariables: {},
+      enableIndex: true,
+      includedPaths: collectionIncludedPaths.map(convertPath).toList(),
+      resourceProvider: resourceProvider,
+      sdkPath: convertPath('/sdk'),
+    );
+  }
+
+  /// Resolve the file with the [path] into [result].
+  Future<void> _resolveFile(String path) async {
+    var convertedPath = convertPath(path);
+
+    result = await resolveFile(convertedPath);
+    expect(result.state, ResultState.VALID);
+  }
+}

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'avoid_init_to_null.dart' as avoid_init_to_null;
+
+void main() {
+  avoid_init_to_null.main();
+}

--- a/test/rules/analysis_options.yaml
+++ b/test/rules/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../../analysis_options.yaml
+
+linter:
+  rules:
+    # For reflective test naming
+    non_constant_identifier_names: false

--- a/test/rules/avoid_init_to_null.dart
+++ b/test/rules/avoid_init_to_null.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AvoidInitToNullTest);
+  });
+}
+
+@reflectiveTest
+class AvoidInitToNullTest extends LintRuleTest {
+  @override
+  String get lintRule => 'avoid_init_to_null';
+
+  test_lintOnNullable() async {
+    await assertHasLint(r'''
+int? ii = null;
+''');
+  }
+
+  test_NoLintOnInvalidAssignment_field() async {
+    // Produces an invalid_assignment compilation error.
+    await assertHasNoLint(r'''
+class X {
+  int x = null;
+}
+''');
+  }
+
+  test_NoLintOnInvalidAssignment_parameter() async {
+    // Produces an invalid_assignment compilation error.
+    await assertHasNoLint(r'''
+class X {
+  X({int a: null});
+}
+''');
+  }
+
+  test_NoLintOnInvalidAssignment_parameter2() async {
+    // Produces an invalid_assignment compilation error.
+    await assertHasNoLint(r'''
+class X {
+  int x;
+  X({this.x: null});
+}
+''');
+  }
+
+  test_NoLintOnInvalidAssignment_topLevel() async {
+    // Produces an invalid_assignment compilation error.
+    await assertHasNoLint(r'''
+int i = null;
+''');
+  }
+}

--- a/test/rules/avoid_init_to_null.dart
+++ b/test/rules/avoid_init_to_null.dart
@@ -17,33 +17,27 @@ class AvoidInitToNullTest extends LintRuleTest {
   @override
   String get lintRule => 'avoid_init_to_null';
 
-  test_lintOnNullable() async {
-    await assertHasLint(r'''
-int? ii = null;
-''');
-  }
-
-  test_NoLintOnInvalidAssignment_field() async {
+  test_invalidAssignment_field() async {
     // Produces an invalid_assignment compilation error.
-    await assertHasNoLint(r'''
+    await assertNoLint(r'''
 class X {
   int x = null;
 }
 ''');
   }
 
-  test_NoLintOnInvalidAssignment_parameter() async {
+  test_invalidAssignment_namedParameter() async {
     // Produces an invalid_assignment compilation error.
-    await assertHasNoLint(r'''
+    await assertNoLint(r'''
 class X {
   X({int a: null});
 }
 ''');
   }
 
-  test_NoLintOnInvalidAssignment_parameter2() async {
+  test_invalidAssignment_namedParameter_fieldFormal() async {
     // Produces an invalid_assignment compilation error.
-    await assertHasNoLint(r'''
+    await assertNoLint(r'''
 class X {
   int x;
   X({this.x: null});
@@ -51,10 +45,16 @@ class X {
 ''');
   }
 
-  test_NoLintOnInvalidAssignment_topLevel() async {
+  test_invalidAssignment_topLevelVariable() async {
     // Produces an invalid_assignment compilation error.
-    await assertHasNoLint(r'''
+    await assertNoLint(r'''
 int i = null;
+''');
+  }
+
+  test_nullable_topLevelVariable() async {
+    await assertLint(r'''
+int? ii = null;
 ''');
   }
 }

--- a/test_data/rules/experiments/nnbd/rules/avoid_init_to_null.dart
+++ b/test_data/rules/experiments/nnbd/rules/avoid_init_to_null.dart
@@ -4,7 +4,6 @@
 
 // test w/ `dart test -N avoid_init_to_null`
 
-int i = null; //OK (compilation error)
 int? ii = null; //LINT
 dynamic iii = null; //LINT
 
@@ -23,21 +22,12 @@ class X {
   final nil2 = null; //OK
 
   // TODO(pq): ints are not nullable so we'll want to update the lint here
-  // since it will produce a compilation error.
-  int x = null; //OK (compilation error)
   int? xx = null; //LINT
   int y; //OK
   int z; //OK
 
-  X({int a: null}) //OK (compilation error)
-    : y = 1, z = 1;
-
-  X.b({this.z: null}) //OK (compilation error)
-    : y = 1;
-
   X.c({this.xx: null}) //LINT
       : y = 1, z = 1;
-
 
   fooNamed({
     p: null, //LINT


### PR DESCRIPTION
Fixes #2974

Extracts a set of tests with diagnostics (`avoid_init_to_null` -- see: #2969).

/cc @bwilkerson 