### PR TITLE
add support for asserting diagnostics && migrate `overridden_fields`

### DIFF
--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -63,9 +63,6 @@ class AnalysisOptionsFileConfig {
 
 /// A description of a diagnostic that is expected to be reported.
 class ExpectedDiagnostic {
-  /// An empty array of diagnostic descriptors used when no errors are expected.
-  static List<ExpectedDiagnostic> noDiagnostics = <ExpectedDiagnostic>[];
-
   final DiagnosticMatcher diagnosticMatcher;
 
   /// The offset of the beginning of the diagnostic's region.

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -13,11 +13,23 @@ import 'package:analyzer/src/test_utilities/mock_packages.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:analyzer/src/test_utilities/package_config_file_builder.dart';
 import 'package:analyzer/src/test_utilities/resource_provider_mixin.dart';
+import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules.dart';
 import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 
+export 'package:analyzer/src/error/codes.dart';
 export 'package:analyzer/src/test_utilities/package_config_file_builder.dart';
+
+ExpectedError error(ErrorCode code, int offset, int length,
+        {Pattern? messageContains}) =>
+    ExpectedError(code, offset, length, messageContains: messageContains);
+
+ExpectedLint lint(String lintName, int offset, int length,
+        {Pattern? messageContains}) =>
+    ExpectedLint(lintName, offset, length, messageContains: messageContains);
+
+typedef DiagnosticMatcher = bool Function(AnalysisError error);
 
 class AnalysisOptionsFileConfig {
   final List<String> experiments;
@@ -49,12 +61,164 @@ class AnalysisOptionsFileConfig {
   }
 }
 
+/// A description of a diagnostic that is expected to be reported.
+class ExpectedDiagnostic {
+  /// An empty array of diagnostic descriptors used when no errors are expected.
+  static List<ExpectedDiagnostic> noDiagnostics = <ExpectedDiagnostic>[];
+
+  final DiagnosticMatcher diagnosticMatcher;
+
+  /// The offset of the beginning of the diagnostic's region.
+  final int offset;
+
+  /// The offset of the beginning of the diagnostic's region.
+  final int length;
+
+  /// A pattern that should be contained in the diagnostic message or `null` if
+  /// the message contents should not be checked.
+  final Pattern? messageContains;
+
+  /// Initialize a newly created diagnostic description.
+  ExpectedDiagnostic(this.diagnosticMatcher, this.offset, this.length,
+      {this.messageContains});
+
+  /// Return `true` if the [error] matches this description of what it's
+  /// expected to be.
+  bool matches(AnalysisError error) {
+    if (!diagnosticMatcher(error)) return false;
+    if (error.offset != offset) return false;
+    if (error.length != length) return false;
+    if (messageContains != null && error.message.contains(messageContains!)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+class ExpectedError extends ExpectedDiagnostic {
+  final ErrorCode code;
+
+  /// Initialize a newly created error description.
+  ExpectedError(this.code, int offset, int length, {Pattern? messageContains})
+      : super((AnalysisError error) => error.errorCode == code, offset, length,
+            messageContains: messageContains);
+}
+
+class ExpectedLint extends ExpectedDiagnostic {
+  final String lintName;
+
+  /// Initialize a newly created lint description.
+  ExpectedLint(this.lintName, int offset, int length,
+      {Pattern? messageContains})
+      : super((AnalysisError error) => error.errorCode.name == lintName, offset,
+            length,
+            messageContains: messageContains);
+}
+
 abstract class LintRuleTest extends PubPackageResolutionTest {
   String? get lintRule;
 
   @override
   List<String> get _lintRules => [if (lintRule != null) lintRule!];
 
+  /// Assert that the number of diagnostics that have been gathered matches the
+  /// number of [expectedDiagnostics] and that they have the expected error
+  /// descriptions and locations. The order in which the diagnostics were
+  /// gathered is ignored.
+  Future<void> assertDiagnostics(
+      String code, List<ExpectedDiagnostic> expectedDiagnostics) async {
+    addTestFile(code);
+    await resolveTestFile();
+
+    //
+    // Match actual diagnostics to expected diagnostics.
+    //
+    var unmatchedActual = errors.toList();
+    var unmatchedExpected = expectedDiagnostics.toList();
+    var actualIndex = 0;
+    while (actualIndex < unmatchedActual.length) {
+      var matchFound = false;
+      var expectedIndex = 0;
+      while (expectedIndex < unmatchedExpected.length) {
+        if (unmatchedExpected[expectedIndex]
+            .matches(unmatchedActual[actualIndex])) {
+          matchFound = true;
+          unmatchedActual.removeAt(actualIndex);
+          unmatchedExpected.removeAt(expectedIndex);
+          break;
+        }
+        expectedIndex++;
+      }
+      if (!matchFound) {
+        actualIndex++;
+      }
+    }
+    //
+    // Write the results.
+    //
+    var buffer = StringBuffer();
+    if (unmatchedExpected.isNotEmpty) {
+      buffer.writeln('Expected but did not find:');
+      for (var expected in unmatchedExpected) {
+        buffer.write('  ');
+        if (expected is ExpectedError) {
+          buffer.write(expected.code);
+        }
+        if (expected is ExpectedLint) {
+          buffer.write(expected.lintName);
+        }
+        buffer.write(' [');
+        buffer.write(expected.offset);
+        buffer.write(', ');
+        buffer.write(expected.length);
+        buffer.writeln(']');
+      }
+    }
+    if (unmatchedActual.isNotEmpty) {
+      if (buffer.isNotEmpty) {
+        buffer.writeln();
+      }
+      buffer.writeln('Found but did not expect:');
+      for (var actual in unmatchedActual) {
+        buffer.write('  ');
+        buffer.write(actual.errorCode);
+        buffer.write(' [');
+        buffer.write(actual.offset);
+        buffer.write(', ');
+        buffer.write(actual.length);
+        buffer.write(', ');
+        buffer.write(actual.message);
+        buffer.writeln(']');
+      }
+    }
+    if (buffer.isNotEmpty) {
+      errors.sort((first, second) => first.offset.compareTo(second.offset));
+      buffer.writeln();
+      buffer.writeln('To accept the current state, expect:');
+      for (var actual in errors) {
+        late String diagnosticKind;
+        late Object description;
+        if (actual.errorCode is LintCode) {
+          diagnosticKind = 'lint';
+          description = "'${actual.errorCode.name}'";
+        } else {
+          diagnosticKind = 'error';
+          description = actual.errorCode;
+        }
+        buffer.write('  $diagnosticKind(');
+        buffer.write(description);
+        buffer.write(', ');
+        buffer.write(actual.offset);
+        buffer.write(', ');
+        buffer.write(actual.length);
+        buffer.writeln('),');
+      }
+      fail(buffer.toString());
+    }
+  }
+
+  /// todo(pq): consider migrating all calls to assertDiagnostics
   Future<void> assertLint(String code) async {
     addTestFile(code);
     await resolveTestFile();
@@ -68,6 +232,7 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
     fail('Expected: $lintRule, found none');
   }
 
+  /// todo(pq): consider migrating all calls to assertDiagnostics
   Future<void> assertNoLint(String code) async {
     addTestFile(code);
     await resolveTestFile();

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -5,6 +5,7 @@
 import 'avoid_function_literals_in_foreach_calls.dart'
     as avoid_function_literals_in_foreach_calls;
 import 'avoid_init_to_null.dart' as avoid_init_to_null;
+import 'overridden_fields.dart' as overridden_fields;
 import 'prefer_asserts_in_initializer_lists.dart'
     as prefer_asserts_in_initializer_lists;
 import 'prefer_const_constructors_in_immutables.dart'
@@ -16,6 +17,7 @@ import 'void_checks.dart' as void_checks;
 void main() {
   avoid_function_literals_in_foreach_calls.main();
   avoid_init_to_null.main();
+  overridden_fields.main();
   prefer_asserts_in_initializer_lists.main();
   prefer_const_constructors_in_immutables.main();
   prefer_contains.main();

--- a/test/rules/overridden_fields.dart
+++ b/test/rules/overridden_fields.dart
@@ -58,73 +58,73 @@ class Bad1 extends Base {
 
 class GC11 extends Bad1 {
   @override
-  Object something = 'done'; // LINT
+  Object something = 'done';
 
   Object gc33 = 'gc33';
 }
 
 class GC13 extends Object with Bad1 {
   @override
-  Object something = 'done'; // OK
+  Object something = 'done';
 
   @override
-  Object field = 'lint'; // LINT
+  Object field = 'lint';
 }
 
 abstract class GC21 extends GC11 {
   @override
-  Object something = 'done'; // LINT
+  Object something = 'done';
 }
 
 class GC23 extends Object with GC13 {
   @override
-  Object something = 'done'; // LINT
+  Object something = 'done';
 
   @override
-  Object field = 'lint'; // LINT
+  Object field = 'lint';
 }
 
 abstract class GC31 extends GC13 {
   @override
-  Object something = 'done'; // LINT
+  Object something = 'done';
 }
 
 abstract class GC32 implements GC13 {
   @override
-  Object something = 'done'; // OK
+  Object something = 'done';
 }
 
 class GC33 extends GC21 with GC13 {
   @override
-  Object something = 'done'; // LINT
+  Object something = 'done';
 
   @override
-  Object gc33 = 'yada'; // LINT
+  Object gc33 = 'yada';
 }
 
 class GC34 extends GC33 {
   @override
-  var x = 3; // LINT
+  var x = 3;
 
   @override
-  Object gc33 = 'yada'; // LINT
+  Object gc33 = 'yada';
 }
 ''', [
       error(HintCode.OVERRIDE_ON_NON_OVERRIDING_FIELD, 120, 1),
       lint('overridden_fields', 127, 5),
       lint('overridden_fields', 202, 9),
-      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 289, 4),
-      lint('overridden_fields', 365, 5),
-      lint('overridden_fields', 448, 9),
-      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 510, 4),
-      lint('overridden_fields', 538, 9),
-      lint('overridden_fields', 588, 5),
-      lint('overridden_fields', 671, 9),
-      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 819, 4),
-      lint('overridden_fields', 847, 9),
-      lint('overridden_fields', 897, 4),
-      lint('overridden_fields', 967, 1),
-      lint('overridden_fields', 1004, 4),
+      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 281, 4),
+      lint('overridden_fields', 351, 5),
+      lint('overridden_fields', 426, 9),
+      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 480, 4),
+      lint('overridden_fields', 508, 9),
+      lint('overridden_fields', 550, 5),
+      lint('overridden_fields', 625, 9),
+      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 759, 4),
+      lint('overridden_fields', 787, 9),
+      lint('overridden_fields', 829, 4),
+      lint('overridden_fields', 891, 1),
+      lint('overridden_fields', 920, 4),
     ]);
   }
 }

--- a/test/rules/overridden_fields.dart
+++ b/test/rules/overridden_fields.dart
@@ -109,8 +109,7 @@ class GC34 extends GC33 {
   @override
   Object gc33 = 'yada'; // LINT
 }
-''',
-    [
+''', [
       error(HintCode.OVERRIDE_ON_NON_OVERRIDING_FIELD, 120, 1),
       lint('overridden_fields', 127, 5),
       lint('overridden_fields', 202, 9),
@@ -128,7 +127,4 @@ class GC34 extends GC33 {
       lint('overridden_fields', 1004, 4),
     ]);
   }
-
 }
-
-

--- a/test/rules/overridden_fields.dart
+++ b/test/rules/overridden_fields.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(OverriddenFieldsTest);
+  });
+}
+
+@reflectiveTest
+class OverriddenFieldsTest extends LintRuleTest {
+  @override
+  String get lintRule => 'overridden_fields';
+
+  /// https://github.com/dart-lang/linter/issues/2874
+  test_conflictingStaticAndInstance() async {
+    await assertNoLint(r'''
+class A {
+  static final String field = 'value';
+}
+
+class B extends A {
+  String field = 'otherValue';
+}
+''');
+  }
+
+  test_recursiveInterfaceInheritance() async {
+    // Produces a recursive_interface_inheritance diagnostic.
+    await assertNoLint(r'''
+class A extends B {}
+class B extends A {
+  int field = 0;
+}
+''');
+  }
+
+  test_mixinInheritsFromNotObject() async {
+    // See: https://github.com/dart-lang/linter/issues/2969
+    // Preserves existing testing logic but has so many misuses of mixins that
+    // that it's hard to know how much tested logic is intentional.
+    await assertDiagnostics(r'''
+class Base {
+  Object field = 'lorem';
+
+  Object something = 'change';
+}
+
+class Bad1 extends Base {
+  @override
+  final x = 1, field = 'ipsum'; // LINT
+}
+
+class GC11 extends Bad1 {
+  @override
+  Object something = 'done'; // LINT
+
+  Object gc33 = 'gc33';
+}
+
+class GC13 extends Object with Bad1 {
+  @override
+  Object something = 'done'; // OK
+
+  @override
+  Object field = 'lint'; // LINT
+}
+
+abstract class GC21 extends GC11 {
+  @override
+  Object something = 'done'; // LINT
+}
+
+class GC23 extends Object with GC13 {
+  @override
+  Object something = 'done'; // LINT
+
+  @override
+  Object field = 'lint'; // LINT
+}
+
+abstract class GC31 extends GC13 {
+  @override
+  Object something = 'done'; // LINT
+}
+
+abstract class GC32 implements GC13 {
+  @override
+  Object something = 'done'; // OK
+}
+
+class GC33 extends GC21 with GC13 {
+  @override
+  Object something = 'done'; // LINT
+
+  @override
+  Object gc33 = 'yada'; // LINT
+}
+
+class GC34 extends GC33 {
+  @override
+  var x = 3; // LINT
+
+  @override
+  Object gc33 = 'yada'; // LINT
+}
+''',
+    [
+      error(HintCode.OVERRIDE_ON_NON_OVERRIDING_FIELD, 120, 1),
+      lint('overridden_fields', 127, 5),
+      lint('overridden_fields', 202, 9),
+      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 289, 4),
+      lint('overridden_fields', 365, 5),
+      lint('overridden_fields', 448, 9),
+      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 510, 4),
+      lint('overridden_fields', 538, 9),
+      lint('overridden_fields', 588, 5),
+      lint('overridden_fields', 671, 9),
+      error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 819, 4),
+      lint('overridden_fields', 847, 9),
+      lint('overridden_fields', 897, 4),
+      lint('overridden_fields', 967, 1),
+      lint('overridden_fields', 1004, 4),
+    ]);
+  }
+
+}
+
+

--- a/test_data/rules/overridden_fields.dart
+++ b/test_data/rules/overridden_fields.dart
@@ -4,16 +4,6 @@
 
 // test w/ `dart test -N overridden_fields`
 
-class A {
-  static final String f = 'value';
-  String f2 = '';
-}
-class B extends A {
-  /// https://github.com/dart-lang/linter/issues/2874
-  String f = 'otherValue'; //OK
-  static String f2 = ''; //OK
-}
-
 class Base {
   Object field = 'lorem';
 
@@ -21,7 +11,6 @@ class Base {
 }
 
 class Bad1 extends Base {
-  @override
   final x = 1, field = 'ipsum'; // LINT
 }
 
@@ -36,7 +25,7 @@ class Bad3 extends Object with Base {
 }
 
 class Ok extends Base {
-  Object newField; // OK
+  Object newField = 0; // OK
 
   final Object newFinal = 'ignore'; // OK
 }
@@ -46,7 +35,7 @@ class OK2 implements Base {
   Object something = 'done'; // OK
 
   @override
-  Object field;
+  Object field = 0;
 }
 
 abstract class OK3 implements Base {
@@ -66,89 +55,36 @@ abstract class GC12 implements Bad1 {
   Object something = 'done'; // OK
 }
 
-class GC13 extends Object with Bad1 {
-  @override
-  Object something = 'done'; // OK
-
-  @override
-  Object field = 'lint'; // LINT
-}
-
-abstract class GC21 extends GC11 {
-  @override
-  Object something = 'done'; // LINT
-}
-
 abstract class GC22 implements GC11 {
   @override
   Object something = 'done'; // OK
 }
 
-class GC23 extends Object with GC13 {
-  @override
-  Object something = 'done'; // LINT
-
-  @override
-  Object field = 'lint'; // LINT
-}
-
-class GC23_2 extends GC13 {
-  @override
-  var x = 7; // LINT
-}
-
-abstract class GC31 extends GC13 {
-  @override
-  Object something = 'done'; // LINT
-}
-
-abstract class GC32 implements GC13 {
-  @override
-  Object something = 'done'; // OK
-}
-
-class GC33 extends GC21 with GC13 {
-  @override
-  Object something = 'done'; // LINT
-
-  @override
-  Object gc33 = 'yada'; // LINT
-}
-
-class GC33_2 extends GC33 {
-  @override
-  var x = 3; // LINT
-
-  @override
-  Object gc33 = 'yada'; // LINT
-}
-
 class Super1 {}
 
 class Sub1 extends Super1 {
-  @override
-  int y;
+  int y = 0;
 }
 
 class Super2 {
-  int x, y;
+  int x = 0, y = 0;
 }
 
 class Sub2 extends Super2 {
   @override
-  int y; // LINT
+  int y = 0; // LINT
 }
 
 class Super3 {
-  int x;
+  int x = 0;
 }
 
 class Sub3 extends Super3 {
-  int x; // LINT
+  int x = 0; // LINT
 }
 
 class A1 {
-  int f;
+  int f = 0;
 }
 
 class B1 extends A1 {}
@@ -157,25 +93,20 @@ abstract class C1 implements A1 {}
 
 class D1 extends B1 implements C1 {
   @override
-  int f; // LINT
-}
-
-class A extends B {}
-class B extends A {
-  int field;
+  int f = 0; // LINT
 }
 
 class StaticsNo {
-  static int a;
+  static int a = 0;
 }
 
 class VerifyStatic extends StaticsNo {
-  static int a;
+  static int a = 0;
 }
 
 mixin M on A1 {
   @override
-  int f; // LINT
+  int f = 0; // LINT
 
-  int g; // OK
+  int g = 0; // OK
 }


### PR DESCRIPTION
See: #2969

Diagnostics matching API can evolve and certainly the air-lifted test source should be revisited at some point...  (So many errors -- all the more value in this work!)

/cc @bwilkerson 
