### PR TITLE
unawaited is present in dart:async

### DIFF
--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -10,7 +10,7 @@ import '../analyzer.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'`Future` results in `async` function bodies must be '
-    '`await`ed or marked `unawaited` using `package:pedantic`.';
+    '`await`ed or marked `unawaited` using `dart:async`.';
 
 const _details = r'''
 
@@ -20,7 +20,7 @@ It's easy to forget await in async methods as naming conventions usually don't
 tell us if a method is sync or async (except for some in `dart:io`).
 
 When you really _do_ want to start a fire-and-forget `Future`, the recommended
-way is to use `unawaited` from `package:pedantic`. The `// ignore` and
+way is to use `unawaited` from `dart:async`. The `// ignore` and
 `// ignore_for_file` comments also work.
 
 **GOOD:**


### PR DESCRIPTION
# Description

`unwaited` is now present in the `dart:async` package.
