### PR TITLE
Stop using FeatureSet.forTesting()

### DIFF
--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/src/analysis_options/analysis_options_provider.dart';
 import 'package:analyzer/src/generated/engine.dart';
@@ -265,11 +264,7 @@ void testRule(String ruleName, File file,
         var optionsImpl = AnalysisOptionsImpl();
         applyToAnalysisOptions(optionsImpl, optionMap);
 
-        // todo(pq): replace w/ `contextFeatures` when analyzer latestSdkLanguageVersion is updated to 2.14.0
-        var features = FeatureSet.forTesting(
-            sdkVersion: '2.14.0',
-            additionalFeatures: [Feature.constructor_tearoffs]);
-        // var features = optionsImpl.contextFeatures;
+        var features = optionsImpl.contextFeatures;
 
         Spelunker(file.absolute.path, featureSet: features).spelunk();
         print('');


### PR DESCRIPTION
I would like to remove it.

You always want to go through `AnalysisContextCollection`, which discovers the pertinent analysis options file.
Even in tests. It is a question of configuring the file system, the actual, or in-memory, or overlay.