### PR TITLE
1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.14.0
+
+- fix `omit_local_variable_types` to not flag a local type that is 
+  required for inference
+
 # 1.13.0
 
 - allow `while (true) { ...}` in `literal_only_boolean_expressions`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.13.0';
+const String version = '1.14.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.13.0
+version: 1.14.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.14.0

- fix `omit_local_variable_types` to not flag a local type that is 
  required for inference


/cc @bwilkerson 
