### PR TITLE
Lint for `SizedBox.shrink(...)` and `SizedBox.expand(...)`

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -146,6 +146,7 @@ linter:
     - recursive_getters
     - require_trailing_commas
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -150,6 +150,7 @@ import 'rules/public_member_api_docs.dart';
 import 'rules/recursive_getters.dart';
 import 'rules/require_trailing_commas.dart';
 import 'rules/sized_box_for_whitespace.dart';
+import 'rules/sized_box_shrink_expand.dart';
 import 'rules/slash_for_doc_comments.dart';
 import 'rules/sort_child_properties_last.dart';
 import 'rules/sort_constructors_first.dart';
@@ -348,6 +349,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(RecursiveGetters())
     ..register(RequireTrailingCommas())
     ..register(SizedBoxForWhitespace())
+    ..register(SizedBoxShrinkExpand())
     ..register(SlashForDocComments())
     ..register(SortChildPropertiesLast())
     ..register(SortConstructorsFirst())

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -74,26 +74,20 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    var visitor = _WidthOrHeightArgumentVisitor();
-    node.visitChildren(visitor);
-    if (visitor.seenIncompatibleParams) {
+    var data = _ArgumentData(node.argumentList);
+
+    if (data.seenIncompatibleParams) {
       return;
     }
-    if (visitor.seenChild && (visitor.seenWidth || visitor.seenHeight) ||
-        visitor.seenWidth && visitor.seenHeight) {
+    if (data.seenChild && (data.seenWidth || data.seenHeight) ||
+        data.seenWidth && data.seenHeight) {
       rule.reportLint(node.constructorName);
     }
   }
 }
 
-class _WidthOrHeightArgumentVisitor extends SimpleAstVisitor<void> {
-  var seenWidth = false;
-  var seenHeight = false;
-  var seenChild = false;
-  var seenIncompatibleParams = false;
-
-  @override
-  void visitArgumentList(ArgumentList node) {
+class _ArgumentData {
+  _ArgumentData(ArgumentList node) {
     for (var name in node.arguments
         .cast<NamedExpression>()
         .map((arg) => arg.name.label.name)) {
@@ -110,4 +104,9 @@ class _WidthOrHeightArgumentVisitor extends SimpleAstVisitor<void> {
       }
     }
   }
+
+  var seenWidth = false;
+  var seenHeight = false;
+  var seenChild = false;
+  var seenIncompatibleParams = false;
 }

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -93,13 +93,14 @@ class _ArgumentData {
         positionalArgumentFound = true;
         return;
       }
-      if (argument.name.label.name == 'width') {
+      var label = argument.name.label;
+      if (label.name == 'width') {
         seenWidth = true;
-      } else if (argument.name.label.name == 'height') {
+      } else if (label.name == 'height') {
         seenHeight = true;
-      } else if (argument.name.label.name == 'child') {
+      } else if (label.name == 'child') {
         seenChild = true;
-      } else if (argument.name.label.name == 'key') {
+      } else if (label.name == 'key') {
         // key doesn't matter (both SizedBox and Container have it)
       } else {
         incompatibleParamsFound = true;

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -76,7 +76,7 @@ class _Visitor extends SimpleAstVisitor {
 
     var data = _ArgumentData(node.argumentList);
 
-    if (data.seenIncompatibleParams) {
+    if (data.incompatibleParamsFound || data.positionalArgumentFound) {
       return;
     }
     if (data.seenChild && (data.seenWidth || data.seenHeight) ||
@@ -88,25 +88,28 @@ class _Visitor extends SimpleAstVisitor {
 
 class _ArgumentData {
   _ArgumentData(ArgumentList node) {
-    for (var name in node.arguments
-        .cast<NamedExpression>()
-        .map((arg) => arg.name.label.name)) {
-      if (name == 'width') {
+    for (var argument in node.arguments) {
+      if (argument is! NamedExpression) {
+        positionalArgumentFound = true;
+        return;
+      }
+      if (argument.name.label.name == 'width') {
         seenWidth = true;
-      } else if (name == 'height') {
+      } else if (argument.name.label.name == 'height') {
         seenHeight = true;
-      } else if (name == 'child') {
+      } else if (argument.name.label.name == 'child') {
         seenChild = true;
-      } else if (name == 'key') {
-        // key doesn't matter (both SiezdBox and Container have it)
+      } else if (argument.name.label.name == 'key') {
+        // key doesn't matter (both SizedBox and Container have it)
       } else {
-        seenIncompatibleParams = true;
+        incompatibleParamsFound = true;
       }
     }
   }
 
+  var incompatibleParamsFound = false;
+  var positionalArgumentFound = false;
   var seenWidth = false;
   var seenHeight = false;
   var seenChild = false;
-  var seenIncompatibleParams = false;
 }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -9,13 +9,13 @@ import '../analyzer.dart';
 import '../util/flutter_utils.dart';
 
 const _sizedBoxShrinkDescription =
-    r'Use the SizedBox.shrink(...) named constructor.';
+    r'Use the `SizedBox.shrink(...)` named constructor.';
 
 const _sizedBoxExpandDescription =
-    r'Use the SizedBox.expand(...) named constructor';
+    r'Use the `SizedBox.expand(...)` named constructor';
 
 const _details =
-    r'''Use SizedBox.shrink and SizedBox.expand constructors appropriately.
+    r'''Use `SizedBox.shrink(...)` and `SizedBox.expand(...)` constructors appropriately.
 
 The `SizedBox.shrink(...)` and `SizedBox.expand(...)` constructors should be used
 instead of the more general `SizedBox(...)` constructor for specific use cases. 

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -124,14 +124,10 @@ class _ArgumentData {
       return argument.value?.toDouble();
     } else if (argument is DoubleLiteral) {
       return argument.value;
-    } else if (argument is PropertyAccess &&
-        (argument.propertyName.name == 'infinity' ||
-            argument.propertyName.name == 'INFINITY')) {
-      var target = argument.target;
-      if ((target is SimpleIdentifier && target.name == 'double') ||
-          (target is PrefixedIdentifier && target.name == 'double')) {
-        return double.infinity;
-      }
+    } else if (argument is PrefixedIdentifier &&
+        argument.identifier.name == 'infinity' &&
+        argument.prefix.name == 'double') {
+      return double.infinity;
     }
     return null;
   }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -89,6 +89,9 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     var data = _ArgumentData(node.argumentList);
+    if (data.positionalArgumentFound) {
+      return;
+    }
     if (data.width == 0 && data.height == 0) {
       rule.reportLint(node.constructorName, errorCode: useShrink);
     } else if (data.width == double.infinity &&
@@ -100,7 +103,11 @@ class _Visitor extends SimpleAstVisitor {
 
 class _ArgumentData {
   _ArgumentData(ArgumentList node) {
-    for (var argument in node.arguments.cast<NamedExpression>()) {
+    for (var argument in node.arguments) {
+      if (argument is! NamedExpression) {
+        positionalArgumentFound = true;
+        return;
+      }
       if (argument.name.label.name == 'width') {
         var argumentVisitor = _ArgumentVisitor();
         argument.expression.visitChildren(argumentVisitor);
@@ -113,6 +120,7 @@ class _ArgumentData {
     }
   }
 
+  var positionalArgumentFound = false;
   double? width;
   double? height;
 }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -110,39 +110,30 @@ class _ArgumentData {
         return;
       }
       if (argument.name.label.name == 'width') {
-        var argumentVisitor = _ArgumentVisitor();
-        argument.expression.visitChildren(argumentVisitor);
-        width = argumentVisitor.argument;
+        width = _argumentValue(argument.expression);
       } else if (argument.name.label.name == 'height') {
-        var argumentVisitor = _ArgumentVisitor();
-        argument.expression.visitChildren(argumentVisitor);
-        height = argumentVisitor.argument;
+        height = _argumentValue(argument.expression);
       }
     }
+  }
+
+  double? _argumentValue(Expression argument) {
+    if (argument is IntegerLiteral) {
+      return argument.value?.toDouble();
+    } else if (argument is DoubleLiteral) {
+      return argument.value;
+    } else if (argument is PropertyAccess &&
+        (argument.propertyName.name == 'infinity' ||
+            argument.propertyName.name == 'INFINITY')) {
+      var target = argument.target;
+      if (target is SimpleIdentifier && target.name == 'double') {
+        return double.infinity;
+      }
+    }
+    return null;
   }
 
   var positionalArgumentFound = false;
   double? width;
   double? height;
-}
-
-class _ArgumentVisitor extends SimpleAstVisitor {
-  double? argument;
-
-  @override
-  visitIntegerLiteral(IntegerLiteral node) {
-    argument = node.value!.toDouble();
-  }
-
-  @override
-  visitDoubleLiteral(DoubleLiteral node) {
-    argument = node.value;
-  }
-
-  @override
-  visitSimpleIdentifier(SimpleIdentifier node) {
-    if (node.name.toLowerCase() == 'infinity') {
-      argument = double.infinity;
-    }
-  }
 }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import '../util/flutter_utils.dart';
+
+const _desc = r'SizedBox shrink and expand.';
+
+const _details =
+    r'''Use SizedBox.shrink and SizedBox.expand constructors appropriately.
+
+The `SizedBox.shrink(...)` and `SizedBox.expand(...)` constructors should be used
+instead of the more general `SizedBox(...)` constructor for specific use cases. 
+
+**Examples**
+
+**BAD:**
+```
+Widget buildLogo() {
+  return SizedBox(
+    height: 0,
+    width: 0,
+    child:const MyLogo(),
+  );
+}
+```
+
+```
+Widget buildLogo() {
+  return SizedBox(
+    height: double.infinity,
+    width: double.infinity,
+    child:const MyLogo(),
+  );
+}
+```
+
+
+**GOOD:**
+```
+Widget buildLogo() {
+  return SizedBox.shrink(
+    child:const MyLogo(),
+  );
+}
+```
+
+```
+Widget buildLogo() {
+  return SizedBox.expand(
+    child:const MyLogo(),
+  );
+}
+```
+''';
+
+class SizedBoxShrinkExpand extends LintRule {
+  SizedBoxShrinkExpand()
+      : super(
+            name: 'sized_box_shrink_expand',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+
+    registry.addInstanceCreationExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if (!isExactWidgetTypeContainer(node.staticType)) {
+      return;
+    }
+
+    var visitor = _WidthOrHeightArgumentVisitor();
+    node.visitChildren(visitor);
+    if (visitor.seenIncompatibleParams) {
+      return;
+    }
+    if (visitor.seenChild && (visitor.seenWidth || visitor.seenHeight) ||
+        visitor.seenWidth && visitor.seenHeight) {
+      rule.reportLint(node.constructorName);
+    }
+  }
+}
+
+class _WidthOrHeightArgumentVisitor extends SimpleAstVisitor<void> {
+  var seenWidth = false;
+  var seenHeight = false;
+  var seenChild = false;
+  var seenIncompatibleParams = false;
+
+  @override
+  void visitArgumentList(ArgumentList node) {
+    for (var name in node.arguments
+        .cast<NamedExpression>()
+        .map((arg) => arg.name.label.name)) {
+      if (name == 'width') {
+        seenWidth = true;
+      } else if (name == 'height') {
+        seenHeight = true;
+      } else if (name == 'child') {
+        seenChild = true;
+      } else if (name == 'key') {
+        // key doesn't matter (both SiezdBox and Container have it)
+      } else {
+        seenIncompatibleParams = true;
+      }
+    }
+  }
+}

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -12,7 +12,8 @@ const _details =
     r'''Use `SizedBox.shrink(...)` and `SizedBox.expand(...)` constructors appropriately.
 
 The `SizedBox.shrink(...)` and `SizedBox.expand(...)` constructors should be used
-instead of the more general `SizedBox(...)` constructor for specific use cases. 
+instead of the more general `SizedBox(...)` constructor when the named constructors
+capture the intent of the code more succinctly. 
 
 **Examples**
 

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -63,7 +63,7 @@ class SizedBoxShrinkExpand extends LintRule {
   SizedBoxShrinkExpand()
       : super(
             name: 'sized_box_shrink_expand',
-            description: '',
+            description: 'Use SizedBox shrink and expand named constructors.',
             details: _details,
             group: Group.style) {
     lintCode = LintCode(name, 'Unused');

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -65,9 +65,7 @@ class SizedBoxShrinkExpand extends LintRule {
             name: 'sized_box_shrink_expand',
             description: 'Use SizedBox shrink and expand named constructors.',
             details: _details,
-            group: Group.style) {
-    lintCode = LintCode(name, 'Unused');
-  }
+            group: Group.style);
 
   @override
   void registerNodeProcessors(
@@ -76,15 +74,17 @@ class SizedBoxShrinkExpand extends LintRule {
 
     registry.addInstanceCreationExpression(this, visitor);
   }
-
-  @override
-  late LintCode lintCode;
 }
 
 class _Visitor extends SimpleAstVisitor {
   final SizedBoxShrinkExpand rule;
 
   _Visitor(this.rule);
+
+  static const LintCode useShrink = LintCode(
+      'sized_box_shrink_expand', "Use the 'SizedBox.shrink' constructor.");
+  static const LintCode useExpand = LintCode(
+      'sized_box_shrink_expand', "Use the 'SizedBox.expand' constructor.");
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
@@ -96,12 +96,10 @@ class _Visitor extends SimpleAstVisitor {
 
     var data = _ArgumentData(node.argumentList);
     if (data.width == 0 && data.height == 0) {
-      rule.lintCode = LintCode(rule.name, _sizedBoxShrinkDescription);
-      rule.reportLint(node.constructorName);
+      rule.reportLint(node.constructorName, errorCode: useShrink);
     } else if (data.width == double.infinity &&
         data.height == double.infinity) {
-      rule.lintCode = LintCode(rule.name, _sizedBoxExpandDescription);
-      rule.reportLint(node.constructorName);
+      rule.reportLint(node.constructorName, errorCode: useExpand);
     }
   }
 }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -8,12 +8,12 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
 
-const _desc = r'SizedBox shrink and expand.';
+const _sizedBoxShrinkDescription = r'SizedBox.shrink constructor preferred.';
 
-const _details =
-    r'''Use SizedBox.shrink and SizedBox.expand constructors appropriately.
+const _sizedBoxShrinkDetails =
+    r'''Use SizedBox.shrink constructor appropriately.
 
-The `SizedBox.shrink(...)` and `SizedBox.expand(...)` constructors should be used
+The `SizedBox.shrink(...)` constructor should be used
 instead of the more general `SizedBox(...)` constructor for specific use cases. 
 
 **Examples**
@@ -29,6 +29,27 @@ Widget buildLogo() {
 }
 ```
 
+**GOOD:**
+```
+Widget buildLogo() {
+  return SizedBox.shrink(
+    child:const MyLogo(),
+  );
+}
+```
+''';
+
+const _sizedBoxExpandDescription = r'SizedBox.expand constructor preferred.';
+
+const _sizedBoxExpandDetails =
+    r'''Use SizedBox.expand constructor appropriately.
+
+The `SizedBox.expand(...)` constructor should be used
+instead of the more general `SizedBox(...)` constructor for specific use cases. 
+
+**Examples**
+
+**BAD:**
 ```
 Widget buildLogo() {
   return SizedBox(
@@ -39,15 +60,7 @@ Widget buildLogo() {
 }
 ```
 
-
 **GOOD:**
-```
-Widget buildLogo() {
-  return SizedBox.shrink(
-    child:const MyLogo(),
-  );
-}
-```
 
 ```
 Widget buildLogo() {
@@ -58,12 +71,14 @@ Widget buildLogo() {
 ```
 ''';
 
+late LintCode _lintCode;
+
 class SizedBoxShrinkExpand extends LintRule {
   SizedBoxShrinkExpand()
       : super(
             name: 'sized_box_shrink_expand',
-            description: _desc,
-            details: _details,
+            description: '',
+            details: '',
             group: Group.style);
 
   @override
@@ -75,6 +90,9 @@ class SizedBoxShrinkExpand extends LintRule {
   }
 }
 
+// TODO(domesticmouse): populate _lintCode based on analysis
+LintCode get lintCode => _lintCode;
+
 class _Visitor extends SimpleAstVisitor {
   final LintRule rule;
 
@@ -82,6 +100,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    // TODO(domesticmouse): figure out how to confirm this is an instance of `SizedBox`
     if (!isExactWidgetTypeContainer(node.staticType)) {
       return;
     }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -8,12 +8,6 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
 
-const _sizedBoxShrinkDescription =
-    r'Use the `SizedBox.shrink(...)` named constructor.';
-
-const _sizedBoxExpandDescription =
-    r'Use the `SizedBox.expand(...)` named constructor';
-
 const _details =
     r'''Use `SizedBox.shrink(...)` and `SizedBox.expand(...)` constructors appropriately.
 

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -128,7 +128,8 @@ class _ArgumentData {
         (argument.propertyName.name == 'infinity' ||
             argument.propertyName.name == 'INFINITY')) {
       var target = argument.target;
-      if (target is SimpleIdentifier && target.name == 'double') {
+      if ((target is SimpleIdentifier && target.name == 'double') ||
+          (target is PrefixedIdentifier && target.name == 'double')) {
         return double.infinity;
       }
     }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -111,9 +111,10 @@ class _ArgumentData {
         positionalArgumentFound = true;
         return;
       }
-      if (argument.name.label.name == 'width') {
+      var label = argument.name.label;
+      if (label.name == 'width') {
         width = _argumentValue(argument.expression);
-      } else if (argument.name.label.name == 'height') {
+      } else if (label.name == 'height') {
         height = _argumentValue(argument.expression);
       }
     }

--- a/lib/src/rules/sized_box_shrink_expand.dart
+++ b/lib/src/rules/sized_box_shrink_expand.dart
@@ -18,7 +18,7 @@ capture the intent of the code more succinctly.
 **Examples**
 
 **BAD:**
-```
+```dart
 Widget buildLogo() {
   return SizedBox(
     height: 0,
@@ -27,7 +27,8 @@ Widget buildLogo() {
   );
 }
 ```
-```
+
+```dart
 Widget buildLogo() {
   return SizedBox(
     height: double.infinity,
@@ -38,14 +39,15 @@ Widget buildLogo() {
 ```
 
 **GOOD:**
-```
+```dart
 Widget buildLogo() {
   return SizedBox.shrink(
     child:const MyLogo(),
   );
 }
 ```
-```
+
+```dart
 Widget buildLogo() {
   return SizedBox.expand(
     child:const MyLogo(),
@@ -77,9 +79,9 @@ class _Visitor extends SimpleAstVisitor {
   _Visitor(this.rule);
 
   static const LintCode useShrink = LintCode(
-      'sized_box_shrink_expand', "Use the 'SizedBox.shrink' constructor.");
+      'sized_box_shrink_expand', 'Use the `SizedBox.shrink` constructor.');
   static const LintCode useExpand = LintCode(
-      'sized_box_shrink_expand', "Use the 'SizedBox.expand' constructor.");
+      'sized_box_shrink_expand', 'Use the `SizedBox.expand` constructor.');
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {

--- a/lib/src/util/flutter_utils.dart
+++ b/lib/src/util/flutter_utils.dart
@@ -31,6 +31,9 @@ bool isExactWidget(ClassElement element) => _flutter.isExactWidget(element);
 bool isExactWidgetTypeContainer(DartType? type) =>
     _flutter.isExactWidgetTypeContainer(type);
 
+bool isExactWidgetTypeSizedBox(DartType? type) =>
+    _flutter.isExactWidgetTypeSizedBox(type);
+
 bool isKDebugMode(Element? element) => _flutter.isKDebugMode(element);
 
 bool isStatefulWidget(ClassElement? element) =>
@@ -56,16 +59,19 @@ class _Flutter {
   static const _nameStatefulWidget = 'StatefulWidget';
   static const _nameWidget = 'Widget';
   static const _nameContainer = 'Container';
+  static const _nameSizedBox = 'SizedBox';
 
   final String packageName;
   final String widgetsUri;
 
+  final Uri _uriBasic;
   final Uri _uriContainer;
   final Uri _uriFramework;
   final Uri _uriFoundation;
 
   _Flutter(this.packageName, String uriPrefix)
       : widgetsUri = '$uriPrefix/widgets.dart',
+        _uriBasic = Uri.parse('$uriPrefix/src/widgets/basic.dart'),
         _uriContainer = Uri.parse('$uriPrefix/src/widgets/container.dart'),
         _uriFramework = Uri.parse('$uriPrefix/src/widgets/framework.dart'),
         _uriFoundation = Uri.parse('$uriPrefix/src/foundation/constants.dart');
@@ -98,6 +104,10 @@ class _Flutter {
   bool isExactWidgetTypeContainer(DartType? type) =>
       type is InterfaceType &&
       _isExactWidget(type.element, _nameContainer, _uriContainer);
+
+  bool isExactWidgetTypeSizedBox(DartType? type) =>
+      type is InterfaceType &&
+      _isExactWidget(type.element, _nameSizedBox, _uriBasic);
 
   bool isKDebugMode(Element? element) =>
       element != null &&

--- a/test_data/mock_packages/flutter/lib/src/widgets/basic.dart
+++ b/test_data/mock_packages/flutter/lib/src/widgets/basic.dart
@@ -122,6 +122,14 @@ class Row extends Flex {
   });
 }
 
+class SizedBox extends SingleChildRenderObjectWidget {
+  const SizedBox({Key? key, double? width, double? height, Widget? child});
+  const SizedBox.expand({Key? key, Widget? child});
+  const SizedBox.shrink({Key? key, Widget? child});
+  SizedBox.fromSize({Key? key, Widget? child, Size? size});
+  const SizedBox.square({Key? key, Widget? child, double? dimension});
+}
+
 class Transform extends SingleChildRenderObjectWidget {
   const Transform({
     Key key,

--- a/test_data/rules/sized_box_shrink_expand.dart
+++ b/test_data/rules/sized_box_shrink_expand.dart
@@ -8,8 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 Widget sizedBoxWithZeroWidthZeroHeight() {
-  return SizedBox(
-    // LINT
+  return SizedBox( // LINT
     height: 0,
     width: 0,
     child: Container(),
@@ -17,8 +16,7 @@ Widget sizedBoxWithZeroWidthZeroHeight() {
 }
 
 Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
-  return SizedBox(
-    // LINT
+  return SizedBox( // LINT
     height: double.INFINITY,
     width: double.INFINITY,
     child: Container(),
@@ -26,8 +24,7 @@ Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
 }
 
 Widget sizedBoxWithInfiniteWidthzeroHeight() {
-  return SizedBox(
-    // OK
+  return SizedBox( // OK
     height: 0,
     width: double.INFINITY,
     child: Container(),
@@ -35,8 +32,7 @@ Widget sizedBoxWithInfiniteWidthzeroHeight() {
 }
 
 Widget sizedBoxWithZeroWidthInfiniteHeight() {
-  return SizedBox(
-    // OK
+  return SizedBox( // OK
     height: double.INFINITY,
     width: 0,
     child: Container(),
@@ -44,8 +40,7 @@ Widget sizedBoxWithZeroWidthInfiniteHeight() {
 }
 
 Widget sizedBoxWithMixedWidthsAndHeights() {
-  return SizedBox(
-    // OK
+  return SizedBox( // OK
     height: 26,
     width: 42,
     child: Container(),
@@ -53,32 +48,28 @@ Widget sizedBoxWithMixedWidthsAndHeights() {
 }
 
 Widget sizedBoxWithZeroWidth() {
-  return SizedBox(
-    // OK
+  return SizedBox( // OK
     width: 0,
     child: Container(),
   );
 }
 
 Widget sizedBoxWithInfiniteWidth() {
-  return SizedBox(
-    // OK
+  return SizedBox( // OK
     width: double.INFINITY,
     child: Container(),
   );
 }
 
 Widget sizedBoxWithZeroHeight() {
-  return SizedBox(
-    // OK
+  return SizedBox( // OK
     height: 0,
     child: Container(),
   );
 }
 
 Widget sizedBoxWithInfiniteHeight() {
-  return SizedBox(
-    // OK
+  return SizedBox( // OK
     height: double.INFINITY,
     child: Container(),
   );

--- a/test_data/rules/sized_box_shrink_expand.dart
+++ b/test_data/rules/sized_box_shrink_expand.dart
@@ -25,6 +25,33 @@ Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
   );
 }
 
+Widget sizedBoxWithInfiniteWidthzeroHeight() {
+  return SizedBox(
+    // OK
+    height: double.0,
+    width: double.infinity,
+    child: Container(),
+  );
+}
+
+Widget sizedBoxWithZeroWidthInfiniteHeight() {
+  return SizedBox(
+    // OK
+    height: double.infinity,
+    width: 0,
+    child: Container(),
+  );
+}
+
+Widget sizedBoxWithMixedWidthsAndHeights() {
+  return SizedBox(
+    // OK
+    height: 26,
+    width: 42,
+    child: Container(),
+  );
+}
+
 Widget sizedBoxWithZeroWidth() {
   return SizedBox(
     // OK

--- a/test_data/rules/sized_box_shrink_expand.dart
+++ b/test_data/rules/sized_box_shrink_expand.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test_data/rules/sized_box_shrink_expand.dart
+++ b/test_data/rules/sized_box_shrink_expand.dart
@@ -19,8 +19,8 @@ Widget sizedBoxWithZeroWidthZeroHeight() {
 Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
   return SizedBox(
     // LINT
-    height: double.infinity,
-    width: double.infinity,
+    height: double.INFINITY,
+    width: double.INFINITY,
     child: Container(),
   );
 }
@@ -28,8 +28,8 @@ Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
 Widget sizedBoxWithInfiniteWidthzeroHeight() {
   return SizedBox(
     // OK
-    height: double.0,
-    width: double.infinity,
+    height: 0,
+    width: double.INFINITY,
     child: Container(),
   );
 }
@@ -37,7 +37,7 @@ Widget sizedBoxWithInfiniteWidthzeroHeight() {
 Widget sizedBoxWithZeroWidthInfiniteHeight() {
   return SizedBox(
     // OK
-    height: double.infinity,
+    height: double.INFINITY,
     width: 0,
     child: Container(),
   );
@@ -63,7 +63,7 @@ Widget sizedBoxWithZeroWidth() {
 Widget sizedBoxWithInfiniteWidth() {
   return SizedBox(
     // OK
-    width: double.infinity,
+    width: double.INFINITY,
     child: Container(),
   );
 }
@@ -79,7 +79,7 @@ Widget sizedBoxWithZeroHeight() {
 Widget sizedBoxWithInfiniteHeight() {
   return SizedBox(
     // OK
-    height: double.infinity,
+    height: double.INFINITY,
     child: Container(),
   );
 }

--- a/test_data/rules/sized_box_shrink_expand.dart
+++ b/test_data/rules/sized_box_shrink_expand.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N sized_box_shrink_expand`
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+Widget sizedBoxWithZeroWidthZeroHeight() {
+  return SizedBox(
+    // LINT
+    height: 0,
+    width: 0,
+    child: Container(),
+  );
+}
+
+Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
+  return SizedBox(
+    // LINT
+    height: double.infinity,
+    width: double.infinity,
+    child: Container(),
+  );
+}
+
+Widget sizedBoxWithZeroWidth() {
+  return SizedBox(
+    // OK
+    width: 0,
+    child: Container(),
+  );
+}
+
+Widget sizedBoxWithInfiniteWidth() {
+  return SizedBox(
+    // OK
+    width: double.infinity,
+    child: Container(),
+  );
+}
+
+Widget sizedBoxWithZeroHeight() {
+  return SizedBox(
+    // OK
+    height: 0,
+    child: Container(),
+  );
+}
+
+Widget sizedBoxWithInfiniteHeight() {
+  return SizedBox(
+    // OK
+    height: double.infinity,
+    child: Container(),
+  );
+}

--- a/test_data/rules/sized_box_shrink_expand.dart
+++ b/test_data/rules/sized_box_shrink_expand.dart
@@ -17,8 +17,8 @@ Widget sizedBoxWithZeroWidthZeroHeight() {
 
 Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
   return SizedBox( // LINT
-    height: double.INFINITY,
-    width: double.INFINITY,
+    height: double.infinity,
+    width: double.infinity,
     child: Container(),
   );
 }
@@ -26,14 +26,14 @@ Widget sizedBoxWithInfiniteWidthInfiniteHeight() {
 Widget sizedBoxWithInfiniteWidthzeroHeight() {
   return SizedBox( // OK
     height: 0,
-    width: double.INFINITY,
+    width: double.infinity,
     child: Container(),
   );
 }
 
 Widget sizedBoxWithZeroWidthInfiniteHeight() {
   return SizedBox( // OK
-    height: double.INFINITY,
+    height: double.infinity,
     width: 0,
     child: Container(),
   );
@@ -56,7 +56,7 @@ Widget sizedBoxWithZeroWidth() {
 
 Widget sizedBoxWithInfiniteWidth() {
   return SizedBox( // OK
-    width: double.INFINITY,
+    width: double.infinity,
     child: Container(),
   );
 }
@@ -70,7 +70,7 @@ Widget sizedBoxWithZeroHeight() {
 
 Widget sizedBoxWithInfiniteHeight() {
   return SizedBox( // OK
-    height: double.INFINITY,
+    height: double.infinity,
     child: Container(),
   );
 }


### PR DESCRIPTION
Hey @pq,

This is the start of a lint for `SizedBox.shrink(...)` and `SizedBox.expand(...)`. When finished, this will fix https://github.com/dart-lang/linter/issues/2072. I'm using https://github.com/dart-lang/linter/pull/2049 as the starting point. 

However, I'm hitting an issue with `double.infinity` and I can't see how to patch it into the mock_packages.

```console
$ dart test -N sized_box_shrink_expand
00:03 +0 -1: test/rule_test.dart: rule dart sized_box_shrink_expand [E]                                                                                                        
  Unexpected diagnostics:
  
  test_data/rules/sized_box_shrink_expand.dart 55:20 The getter 'infinity' isn't defined for the type 'double'.
  test_data/rules/sized_box_shrink_expand.dart 23:19 The getter 'infinity' isn't defined for the type 'double'.
  test_data/rules/sized_box_shrink_expand.dart 39:19 The getter 'infinity' isn't defined for the type 'double'.
  test_data/rules/sized_box_shrink_expand.dart 22:20 The getter 'infinity' isn't defined for the type 'double'.
  package:test_api           fail
  test/rule_test.dart 249:7  testRule.<fn>
  
00:03 +0 -1: loading test/rule_test.dart                                                                                                                                       
Consider enabling the flag chain-stack-traces to receive more detailed exceptions.
For example, 'dart test --chain-stack-traces'.
```

Halp?