### PR TITLE
Add a new `unnecessary_late` lint

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -166,6 +166,7 @@ linter:
     - unnecessary_final
     - unnecessary_getters_setters
     - unnecessary_lambdas
+    - unnecessary_late
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_checks

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -170,6 +170,7 @@ import 'rules/unnecessary_constructor_name.dart';
 import 'rules/unnecessary_final.dart';
 import 'rules/unnecessary_getters_setters.dart';
 import 'rules/unnecessary_lambdas.dart';
+import 'rules/unnecessary_late.dart';
 import 'rules/unnecessary_new.dart';
 import 'rules/unnecessary_null_aware_assignments.dart';
 import 'rules/unnecessary_null_checks.dart';
@@ -376,6 +377,7 @@ void registerLintRules({bool inTestMode = false}) {
     //..register(UnnecessaryGetters())
     ..register(UnnecessaryGettersSetters())
     ..register(UnnecessaryLambdas())
+    ..register(UnnecessaryLate())
     ..register(UnnecessaryNullableForFinalVariableDeclarations())
     ..register(UnnecessaryNullChecks())
     ..register(UnnecessaryOverrides())

--- a/lib/src/rules/unnecessary_late.dart
+++ b/lib/src/rules/unnecessary_late.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r"Don't specify the `late` modifier when it is not needed.";
+
+const _details = r'''
+
+**DO** not specify the `late` modifier for top-level and static variables
+when the declaration contains an initializer. 
+
+Top-level and static variables with initializers are already evaluated lazily
+as if they are marked `late`.
+
+**BAD:**
+```dart
+late String badTopLevelLate = "";
+```
+
+**GOOD:**
+```dart
+late String goodTopLevelLate;
+```
+
+**BAD:**
+```dart
+class BadExample {
+  static late String badStaticLate = "";
+}
+```
+
+**GOOD:**
+```dart
+class GoodExample {
+  static late String goodStaticLate;
+}
+```
+''';
+
+class UnnecessaryLate extends LintRule {
+  UnnecessaryLate()
+      : super(
+            name: 'unnecessary_late',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addFieldDeclaration(this, visitor);
+    registry.addTopLevelVariableDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  void _visitVariableDeclarations(VariableDeclarationList node) {
+    for (var variable in node.variables) {
+      if (variable.isLate && variable.initializer != null) {
+        rule.reportLint(variable);
+      }
+    }
+  }
+
+  @override
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+    _visitVariableDeclarations(node.variables);
+  }
+
+  @override
+  void visitFieldDeclaration(FieldDeclaration node) {
+    if (node.isStatic) {
+      _visitVariableDeclarations(node.fields);
+    }
+  }
+}

--- a/lib/src/rules/unnecessary_late.dart
+++ b/lib/src/rules/unnecessary_late.dart
@@ -64,11 +64,10 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
-  void _visitVariableDeclarations(VariableDeclarationList node) {
-    for (var variable in node.variables) {
-      if (variable.isLate && variable.initializer != null) {
-        rule.reportLint(variable);
-      }
+  @override
+  void visitFieldDeclaration(FieldDeclaration node) {
+    if (node.isStatic) {
+      _visitVariableDeclarations(node.fields);
     }
   }
 
@@ -77,10 +76,11 @@ class _Visitor extends SimpleAstVisitor<void> {
     _visitVariableDeclarations(node.variables);
   }
 
-  @override
-  void visitFieldDeclaration(FieldDeclaration node) {
-    if (node.isStatic) {
-      _visitVariableDeclarations(node.fields);
+  void _visitVariableDeclarations(VariableDeclarationList node) {
+    for (var variable in node.variables) {
+      if (variable.isLate && variable.initializer != null) {
+        rule.reportLint(variable);
+      }
     }
   }
 }

--- a/lib/src/rules/unnecessary_late.dart
+++ b/lib/src/rules/unnecessary_late.dart
@@ -19,25 +19,25 @@ as if they are marked `late`.
 
 **BAD:**
 ```dart
-late String badTopLevelLate = "";
+late String badTopLevel = '';
 ```
 
 **GOOD:**
 ```dart
-late String goodTopLevelLate;
+String goodTopLevel = '';
 ```
 
 **BAD:**
 ```dart
 class BadExample {
-  static late String badStaticLate = "";
+  static late String badStatic = '';
 }
 ```
 
 **GOOD:**
 ```dart
 class GoodExample {
-  static late String goodStaticLate;
+  late String goodStatic;
 }
 ```
 ''';

--- a/test_data/rules/unnecessary_late.dart
+++ b/test_data/rules/unnecessary_late.dart
@@ -4,16 +4,20 @@
 
 // test w/ `dart test -N unnecessary_late`
 
-late String unnecessaryTopLevel = ""; // LINT
+late String unnecessaryTopLevelLate = ''; // LINT
 
-late String necessaryTopLevel; // OK
+late String necessaryTopLevelLate; // OK
+
+String unnecessaryTopLevel = ''; // OK
 
 class Test {
-  static late String unnecessaryStatic = ""; // LINT
+  static late String unnecessaryStaticLate = ''; // LINT
 
-  static late String necessaryStatic; // OK
+  static late String necessaryStaticLate; // OK
+
+  static String unnecessaryStatic = ''; // OK
 
   void test() {
-    late String necessaryLocal = ""; // OK
+    late String necessaryLocal = ''; // OK
   }
 }

--- a/test_data/rules/unnecessary_late.dart
+++ b/test_data/rules/unnecessary_late.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N unnecessary_late`
+
+late String unnecessaryTopLevel = ""; // LINT
+
+late String necessaryTopLevel; // OK
+
+class Test {
+  static late String unnecessaryStatic = ""; // LINT
+
+  static late String necessaryStatic; // OK
+
+  void test() {
+    late String necessaryLocal = ""; // OK
+  }
+}


### PR DESCRIPTION
Adds a new `unnecessary_late` lint which will detect usages of the late modifier `late` on static and top-level variables which are evaluated as if they are marked with `late` already.

I believe there are other situations where `late` may be unnecessary. The first that comes to mind is in a local variable declaration where the initializer will have no side effects. I have opted to not account for this and potential other  more complicated situations currently(unless I'm missing something obvious). I was thinking other situations could be incorporated into this lint in the future, **but if you think this** should have a more specific name such `unnecessary_static_late`, let me know :)