### PR TITLE
`use_decorated_box`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Cameron Steffen <cam.steffen94@gmail.com>
 Danny Tuppeny <danny@tuppeny.com>
 Ivan Tugay <listepo@gmail.com>
 Rohan Vanheusden <rohan.vanheusden@gmail.com>
+Minh Dao <asiancorporator@yahoo.de>

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -181,6 +181,7 @@ linter:
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -185,6 +185,7 @@ import 'rules/unnecessary_this.dart';
 import 'rules/unrelated_type_equality_checks.dart';
 import 'rules/unsafe_html.dart';
 import 'rules/use_build_context_synchronously.dart';
+import 'rules/use_decorated_box.dart';
 import 'rules/use_full_hex_values_for_flutter_colors.dart';
 import 'rules/use_function_type_syntax_for_parameters.dart';
 import 'rules/use_if_null_to_convert_nulls_to_bools.dart';
@@ -388,6 +389,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(UnrelatedTypeEqualityChecks())
     ..register(UnsafeHtml())
     ..register(UseBuildContextSynchronously(inTestMode: inTestMode))
+    ..register(UseDecoratedBox())
     ..register(UseFullHexValuesForFlutterColors())
     ..register(UseFunctionTypeSyntaxForParameters())
     ..register(UseIfNullToConvertNullsToBools())

--- a/lib/src/rules/use_decorated_box.dart
+++ b/lib/src/rules/use_decorated_box.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import '../util/flutter_utils.dart';
+
+const _desc = r'Use `DecoratedBox`.';
+
+const _details = r'''
+
+**DO** use `DecoratedBox` when the `Container` only has `Decoration`.
+
+A `Container` is a heavier Widget than a `DecoratedBox`, and as bonus,
+`DecoratedBox` has a `const` constructor.
+
+**BAD:**
+```dart
+Widget buildArea() {
+  return Container(
+    decoration: const BoxDecoration(
+      color: Colors.blue,
+      borderRadius: BorderRadius.all(
+        Radius.circular(5),
+      ),
+    ),
+    child: const Text('...'),
+  );
+}
+```
+
+**GOOD:**
+```dart
+Widget buildArea() {
+  return const DecoratedBox(
+    decoration: BoxDecoration(
+      color: Colors.blue,
+      borderRadius: BorderRadius.all(
+        Radius.circular(5),
+      ),
+    ),
+    child: Text('...'),
+  );
+}
+```
+''';
+
+class UseDecoratedBox extends LintRule {
+  UseDecoratedBox()
+      : super(
+            name: 'use_decorated_box',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+
+    registry.addInstanceCreationExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if (!isExactWidgetTypeContainer(node.staticType)) {
+      return;
+    }
+
+    var data = _ArgumentData(node.argumentList);
+
+    if (data.additionalArgumentsFound || data.positionalArgumentsFound) {
+      return;
+    }
+
+    if (data.hasDecoration) {
+      rule.reportLint(node.constructorName);
+    }
+  }
+}
+
+class _ArgumentData {
+  var positionalArgumentsFound = false;
+  var additionalArgumentsFound = false;
+  var hasDecoration = false;
+
+  _ArgumentData(ArgumentList node) {
+    for (var argument in node.arguments) {
+      if (argument is! NamedExpression) {
+        positionalArgumentsFound = true;
+        return;
+      }
+      var label = argument.name.label;
+      if (label.name == 'decoration') {
+        hasDecoration = true;
+      } else if (label.name == 'child') {
+        // Ignore child
+      } else if (label.name == 'key') {
+        // Ignore key
+      } else {
+        additionalArgumentsFound = true;
+      }
+    }
+  }
+}

--- a/lib/src/rules/use_decorated_box.dart
+++ b/lib/src/rules/use_decorated_box.dart
@@ -12,7 +12,7 @@ const _desc = r'Use `DecoratedBox`.';
 
 const _details = r'''
 
-**DO** use `DecoratedBox` when the `Container` only has `Decoration`.
+**DO** use `DecoratedBox` when `Container` has only `Decoration`.
 
 A `Container` is a heavier Widget than a `DecoratedBox`, and as bonus,
 `DecoratedBox` has a `const` constructor.

--- a/lib/src/rules/use_decorated_box.dart
+++ b/lib/src/rules/use_decorated_box.dart
@@ -12,7 +12,7 @@ const _desc = r'Use `DecoratedBox`.';
 
 const _details = r'''
 
-**DO** use `DecoratedBox` when `Container` has only `Decoration`.
+**DO** use `DecoratedBox` when `Container` has only a `Decoration`.
 
 A `Container` is a heavier Widget than a `DecoratedBox`, and as bonus,
 `DecoratedBox` has a `const` constructor.

--- a/test_data/mock_packages/flutter/lib/painting.dart
+++ b/test_data/mock_packages/flutter/lib/painting.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/painting/box_decoration.dart';

--- a/test_data/mock_packages/flutter/lib/src/painting/box_decoration.dart
+++ b/test_data/mock_packages/flutter/lib/src/painting/box_decoration.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class BoxDecoration {}

--- a/test_data/rules/use_decorated_box.dart
+++ b/test_data/rules/use_decorated_box.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N use_decorated_box`
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/painting.dart';
+
+Widget containerWithoutArguments() {
+  return Container(); // OK
+}
+
+Widget containerWithKey() {
+  return Container( // OK
+    key: Key('abc'),
+  );
+}
+
+Widget containerWithDecoration() {
+  return Container( // LINT
+    decoration: BoxDecoration(),
+  );
+}
+
+Widget containerWithChild() {
+  return Container( // OK
+    child: SizedBox(),
+  );
+}
+
+Widget containerWithKeyAndChild() {
+  return Container( // OK
+    key: Key('abc'),
+    child: SizedBox(),
+  );
+}
+
+Widget containerWithKeyAndDecoration() {
+  return Container( // LINT
+    key: Key('abc'),
+    decoration: BoxDecoration(),
+  );
+}
+
+Widget containerWithDecorationAndChild() {
+  return Container( // LINT
+    decoration: BoxDecoration(),
+    child: SizedBox(),
+  );
+}
+
+Widget containerWithKeyAndDecorationAndChild() {
+  return Container( // LINT
+    key: Key('abc'),
+    decoration: BoxDecoration(),
+    child: SizedBox(),
+  );
+}

--- a/test_data/rules/use_decorated_box.dart
+++ b/test_data/rules/use_decorated_box.dart
@@ -58,3 +58,24 @@ Widget containerWithKeyAndDecorationAndChild() {
     child: SizedBox(),
   );
 }
+
+Widget containerWithAnotherArgument() {
+  return Container( // OK
+    width: 20,
+  );
+}
+
+Widget containerWithDecorationAndAdditionalArgument() {
+  return Container( // OK
+    decoration: BoxDecoration(),
+    width: 20,
+  );
+}
+
+Widget containerWithDecorationAndAdditionalArgumentAndChild() {
+  return Container( // OK
+    decoration: BoxDecoration(),
+    width: 20,
+    child: SizedBox(),
+  );
+}


### PR DESCRIPTION
## Description

Use `DecoratedBox` over `Container` when only `Decoration` is specified.

Fixes https://github.com/dart-lang/linter/issues/3060

## Kind

Style advice.

## Bad Example

```dart
Widget buildArea() {
  return Container(
    decoration: const BoxDecoration(
      color: Colors.blue,
      borderRadius: BorderRadius.all(
        Radius.circular(5),
      ),
    ),
    child: const Text('...'),
  );
}
```

## Good Example

```dart
Widget buildArea() {
  return const DecoratedBox(
    decoration: BoxDecoration(
      color: Colors.blue,
      borderRadius: BorderRadius.all(
        Radius.circular(5),
      ),
    ),
    child: Text('...'),
  );
}
```