### PR TITLE
Implement `move_color_to_decoration`

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -85,6 +85,7 @@ linter:
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - missing_whitespace_between_adjacent_strings
+    - move_color_to_decoration
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -87,6 +87,7 @@ import 'rules/lines_longer_than_80_chars.dart';
 import 'rules/list_remove_unrelated_type.dart';
 import 'rules/literal_only_boolean_expressions.dart';
 import 'rules/missing_whitespace_between_adjacent_strings.dart';
+import 'rules/move_color_to_decoration.dart';
 import 'rules/no_adjacent_strings_in_list.dart';
 import 'rules/no_default_cases.dart';
 import 'rules/no_duplicate_case_values.dart';
@@ -288,6 +289,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(ListRemoveUnrelatedType())
     ..register(LiteralOnlyBooleanExpressions())
     ..register(MissingWhitespaceBetweenAdjacentStrings())
+    ..register(MoveColorToDecoration())
     ..register(NoAdjacentStringsInList())
     ..register(NoDefaultCases())
     ..register(NoDuplicateCaseValues())

--- a/lib/src/rules/move_color_to_decoration.dart
+++ b/lib/src/rules/move_color_to_decoration.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import '../util/flutter_utils.dart';
+
+const _desc = r'Move color to decoration.';
+
+const _details = r'''Don't provide `Container` with both non-null `color` and
+`decoration`. Place `color` inside `decoration` instead.
+
+**BAD:**
+```dart
+Widget buildArea() {
+  return Container(
+    color: Colors.black,
+    decoration: BoxDecoration(
+      border: Border.all(color: Colors.white),
+    ),
+  );
+}
+```
+
+**GOOD:**
+```dart
+Widget buildArea() {
+  return Container(
+    decoration: BoxDecoration(
+      border: Border.all(color: Colors.white),
+      color: Colors.black,
+    ),
+  );
+}
+```
+''';
+
+class MoveColorToDecoration extends LintRule {
+  MoveColorToDecoration()
+      : super(
+            name: 'move_color_to_decoration',
+            description: _desc,
+            details: _details,
+            group: Group.errors);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+
+    registry.addInstanceCreationExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if (!isExactWidgetTypeContainer(node.staticType)) {
+      return;
+    }
+
+    var data = _ArgumentData(node.argumentList);
+
+    if (data.wasPositionalArgumentFound) {
+      return;
+    }
+
+    if (data.hasColor && data.hasDecoration) {
+      rule.reportLint(node.constructorName);
+    }
+  }
+}
+
+class _ArgumentData {
+  var wasPositionalArgumentFound = false;
+  var hasColor = false;
+  var hasDecoration = false;
+
+  _ArgumentData(ArgumentList node) {
+    for (var argument in node.arguments) {
+      if (argument is! NamedExpression) {
+        wasPositionalArgumentFound = true;
+        return;
+      }
+      var label = argument.name.label;
+      if (label.name == 'color' && argument.expression is! NullLiteral) {
+        hasColor = true;
+      } else if (label.name == 'decoration' &&
+          argument.expression is! NullLiteral) {
+        hasDecoration = true;
+      }
+    }
+  }
+}

--- a/test_data/mock_packages/flutter/lib/material.dart
+++ b/test_data/mock_packages/flutter/lib/material.dart
@@ -3,5 +3,6 @@
 // found in the LICENSE file.
 
 export 'src/material/button.dart';
+export 'src/material/colors.dart';
 export 'src/material/scaffold.dart';
 export 'widgets.dart';

--- a/test_data/mock_packages/flutter/lib/painting.dart
+++ b/test_data/mock_packages/flutter/lib/painting.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/painting/box_decoration.dart';

--- a/test_data/mock_packages/flutter/lib/src/material/colors.dart
+++ b/test_data/mock_packages/flutter/lib/src/material/colors.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class Colors {
+  Colors._();
+
+  static const Color transparent = Color();
+}

--- a/test_data/mock_packages/flutter/lib/src/painting/box_decoration.dart
+++ b/test_data/mock_packages/flutter/lib/src/painting/box_decoration.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class BoxDecoration {}

--- a/test_data/rules/move_color_to_decoration.dart
+++ b/test_data/rules/move_color_to_decoration.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N move_color_to_decoration`
+
+import 'package:flutter/material.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart';
+
+
+Widget onlyColor() {
+  return Container( // OK
+    color: Colors.transparent,
+  );
+}
+
+Widget onlyDecoration() {
+  return Container( // OK
+    decoration: BoxDecoration(),
+  );
+}
+
+Widget colorAndDecoration() {
+  return Container( // LINT
+    color: Colors.transparent,
+    decoration: BoxDecoration(),
+  );
+}
+
+Widget bothNull() {
+  return Container( // OK
+    color: null,
+    decoration: null,
+  );
+}
+
+Widget colorIsNull() {
+  return Container( // OK
+    color: null,
+    decoration: BoxDecoration(),
+  );
+}
+
+Widget decorationIsNull() {
+  return Container( // OK
+    color: Colors.transparent,
+    decoration: null,
+  );
+}
+
+Widget colorWithChild() {
+  return Container( // OK
+    color: Colors.transparent,
+    child: SizedBox(),
+  );
+}
+
+Widget withThirdNonNullArgument() {
+  return Container( // LINT
+    color: Colors.transparent,
+    decoration: BoxDecoration(),
+    child: SizedBox(),
+  );
+}


### PR DESCRIPTION
## Description

When a `Container` is provided with both `color` and `decoration` (both non-null), an error is thrown at runtime, and there is currently nothing that warns you about that beforehand. This rule prevents you from running into the error by prompting to move `color` into `decoration`.

Fixes https://github.com/dart-lang/linter/issues/3063
