### PR TITLE
1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.15.0
+
+- new lint: `use_decorated_box`
+- new lint: `no_leading_underscores_for_library_prefixes`
+- new lint: `no_leading_underscores_for_local_identifiers`
+- new lint: `secure_pubspec_urls`
+- new lint: `sized_box_shrink_expand`
+- new lint: `avoid_final_parameters`
+- improved docs for `omit_local_variable_types`
+
 # 1.14.0
 
 - fix `omit_local_variable_types` to not flag a local type that is 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.14.0';
+const String version = '1.15.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.14.0
+version: 1.15.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.15.0

- new lint: `use_decorated_box`
- new lint: `no_leading_underscores_for_library_prefixes`
- new lint: `no_leading_underscores_for_local_identifiers`
- new lint: `secure_pubspec_urls`
- new lint: `sized_box_shrink_expand`
- new lint: `avoid_final_parameters`
- improved docs for `omit_local_variable_types`

---

/cc @bwilkerson 

/fyi @domesticmouse @minhqdao @sigurdm @mat100payette @natebosch 
