### PR TITLE
Change missing_whitespace_between_adjacent_strings to use SimpleAstVisitor

### DIFF
--- a/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
+++ b/lib/src/rules/missing_whitespace_between_adjacent_strings.dart
@@ -45,11 +45,11 @@ class MissingWhitespaceBetweenAdjacentStrings extends LintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
-    registry.addCompilationUnit(this, visitor);
+    registry.addAdjacentStrings(this, visitor);
   }
 }
 
-class _Visitor extends RecursiveAstVisitor<void> {
+class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);


### PR DESCRIPTION
Noted in discussions at https://github.com/dart-lang/linter/pull/3080#discussion_r761283802.

@bwilkerson