### PR TITLE
`avoid_redundant_argument_values` support for `named-arguments-anywhere`

### DIFF
--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -71,10 +71,11 @@ class _Visitor extends SimpleAstVisitor {
     for (var i = arguments.length - 1; i >= 0; --i) {
       var arg = arguments[i];
       var param = arg.staticParameterElement;
-      if (param == null || param.hasRequired || param.isRequiredNamed) {
+      if (param == null ||
+          param.hasRequired ||
+          param.isRequiredNamed ||
+          param.isRequiredPositional) {
         continue;
-      } else if (param.isRequiredPositional) {
-        break;
       }
       var value = param.computeConstantValue();
       if (value != null) {

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -5,6 +5,8 @@
 import 'avoid_function_literals_in_foreach_calls.dart'
     as avoid_function_literals_in_foreach_calls;
 import 'avoid_init_to_null.dart' as avoid_init_to_null;
+import 'avoid_redundant_argument_values.dart'
+    as avoid_redundant_argument_values;
 import 'avoid_shadowing_type_parameters.dart'
     as avoid_shadowing_type_parameters;
 import 'conditional_uri_does_not_exist.dart' as conditional_uri_does_not_exist;
@@ -39,6 +41,7 @@ import 'void_checks.dart' as void_checks;
 void main() {
   avoid_function_literals_in_foreach_calls.main();
   avoid_init_to_null.main();
+  avoid_redundant_argument_values.main();
   avoid_shadowing_type_parameters.main();
   conditional_uri_does_not_exist.main();
   file_names.main();

--- a/test/rules/avoid_redundant_argument_values.dart
+++ b/test/rules/avoid_redundant_argument_values.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/src/dart/analysis/experiments.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AvoidRedundantArgumentValuesTest);
+  });
+}
+
+@reflectiveTest
+class AvoidRedundantArgumentValuesTest extends LintRuleTest {
+  @override
+  List<String> get experiments => [EnableString.named_arguments_anywhere];
+
+  @override
+  String get lintRule => 'avoid_redundant_argument_values';
+
+  test_namedArgumentBeforePositional() async {
+    await assertDiagnostics(r'''
+void foo(int a, int b, {bool c = true}) {}
+
+void f() {
+  foo(0, c: true, 1);
+}
+''', [
+      lint('avoid_redundant_argument_values', 67, 4),
+    ]);
+  }
+}


### PR DESCRIPTION
Fixes #3082

/cc @scheglov @bwilkerson 