### PR TITLE
Fix secure_pubspec_urls lint, and check `issue_tracker` and `repository`

### DIFF
--- a/lib/src/rules/pub/secure_pubspec_urls.dart
+++ b/lib/src/rules/pub/secure_pubspec_urls.dart
@@ -42,7 +42,7 @@ class SecurePubspecUrls extends LintRule {
 
   @override
   LintCode get lintCode => const LintCode(
-      'secure_pubspec_urls', 'The url should only only use secure protocols.',
+      'secure_pubspec_urls', 'The url should only use secure protocols.',
       correctionMessage: "Try using 'https'.");
 }
 
@@ -60,6 +60,16 @@ class Visitor extends PubspecVisitor<void> {
         rule.reportPubLint(node);
       }
     }
+  }
+
+  @override
+  void visitPackageIssueTracker(PSEntry issueTracker) {
+    _checkUrl(issueTracker.value);
+  }
+
+  @override
+  void visitPackageRepository(PSEntry repostory) {
+    _checkUrl(repostory.value);
   }
 
   @override

--- a/test/integration/secure_pubspec_urls.dart
+++ b/test/integration/secure_pubspec_urls.dart
@@ -35,12 +35,14 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'pubspec.yaml 4:11 [lint] The url should only only use secure protocols.',
-            'pubspec.yaml 14:12 [lint] The url should only only use secure protocols.',
-            'pubspec.yaml 19:13 [lint] The url should only only use secure protocols.',
-            'pubspec.yaml 27:12 [lint] The url should only only use secure protocols.',
-            'pubspec.yaml 31:12 [lint] The url should only only use secure protocols.',
-            '1 file analyzed, 5 issues found',
+            '4:11 [lint] The url should only use secure protocols.',
+            '6:16 [lint] The url should only use secure protocols.',
+            '5:13 [lint] The url should only use secure protocols.',
+            '15:12 [lint] The url should only use secure protocols.',
+            '20:13 [lint] The url should only use secure protocols.',
+            '28:12 [lint] The url should only use secure protocols.',
+            '32:12 [lint] The url should only use secure protocols.',
+            '1 file analyzed, 7 issues found',
           ]));
       expect(exitCode, 1);
     });

--- a/test_data/integration/secure_pubspec_urls/pubspec.yaml
+++ b/test_data/integration/secure_pubspec_urls/pubspec.yaml
@@ -1,8 +1,9 @@
 name: fancy
 description: Fancy pre-built things.
 version: 1.1.1
-homepage: http://github.com/dart-lang/linter
-repository: http://github.com/dart-lang/linter
+homepage: http://github.com/dart-lang/linter # lint
+repository: http://github.com/dart-lang/linter # lint
+issue_tracker: http://github.com/dart-lang/linter/issues # lint
 
 environment:
   sdk: ">=2.15.2 <3.0.0"
@@ -21,7 +22,7 @@ dev_dependencies:
 
 dependency_overrides:
   kittens:
-    git: http://github.com/munificent/kittens.git # lint
+    git: http://github.com/munificent/kittens.git # lint, needs fix in analyzer
   kittens2:
     git:
       url: http://github.com/munificent/kittens2.git # lint


### PR DESCRIPTION
Fixes `only only` :rofl: 

Adds checks for:
 * `repository`
 * `issue_tracker`

/cc @sigurdm

------------

Also noticed bug in analyzer wrt. to handling of git references, will fix that separately.