### PR TITLE
1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - updates to `secure_pubspec_urls` to check `issue_tracker` and
   `repository` entries
 - new lint: `conditional_uri_does_not_exist`
-- performance improvements `missing_whitespace_between_adjacent_strings`
+- performance improvements for 
+  `missing_whitespace_between_adjacent_strings`
 
 # 1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # 1.16.0
 
+- doc improvements for `prefer_initializing_formals`
+- updates to `secure_pubspec_urls` to check `issue_tracker` and
+  `repository` entries
 - new lint: `conditional_uri_does_not_exist`
+- performance improvements `missing_whitespace_between_adjacent_strings`
 
 # 1.15.0
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.15.0';
+const String version = '1.16.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.15.0
+version: 1.16.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.16.0

- doc improvements for `prefer_initializing_formals`
- updates to `secure_pubspec_urls` to check `issue_tracker` and
  `repository` entries
- new lint: `conditional_uri_does_not_exist`
- performance improvements for 
  `missing_whitespace_between_adjacent_strings`


---

/cc @bwilkerson 

/fyi @DanTup @jonasfj 