### PR TITLE
`no_leading_underscores_for_local_identifiers`: allow underscores in catch clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# <next>
+
+- fix to `no_leading_underscores_for_local_identifiers` to allow
+  underscores in catch clauses
+
 # 1.16.0
 
 - doc improvements for `prefer_initializing_formals`

--- a/lib/src/rules/no_leading_underscores_for_local_identifiers.dart
+++ b/lib/src/rules/no_leading_underscores_for_local_identifiers.dart
@@ -89,7 +89,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitCatchClause(CatchClause node) {
-    checkIdentifier(node.exceptionParameter);
+    checkIdentifier(node.exceptionParameter, isJustUnderscoresOK: true);
     checkIdentifier(node.stackTraceParameter);
   }
 

--- a/test_data/rules/no_leading_underscores_for_local_identifiers.dart
+++ b/test_data/rules/no_leading_underscores_for_local_identifiers.dart
@@ -9,6 +9,8 @@ const _foo1 = 1; // OK
 final _foo2 = 2; // OK
 
 void fn() {
+  try {
+  } catch(_) { } // OK
   var _f1, // LINT
       _f2; // LINT
   const _foo1 = 1; // LINT


### PR DESCRIPTION
Fixes a false positive in the common case:

```dart
    try {
      ...
    } catch (_) {
      ...  
   }
```

/cc @bwilkerson 