### PR TITLE
1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# <next>
+# 1.17.0
 
+- new lint: `unnecessary_late`
 - fix to `no_leading_underscores_for_local_identifiers` to allow
   underscores in catch clauses
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.16.0';
+const String version = '1.17.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.16.0
+version: 1.17.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.17.0

- new lint: `unnecessary_late`
- fix to `no_leading_underscores_for_local_identifiers` to allow
  underscores in catch clauses

---

/cc @bwilkerson

/fyi @parlough 
