### PR TITLE
enum-like: Account for equal-valued fields if one is deprecated

### DIFF
--- a/test_data/rules/exhaustive_cases.dart
+++ b/test_data/rules/exhaustive_cases.dart
@@ -146,4 +146,17 @@ void dep(DeprecatedFields e) {
       print('baz');
       break;
   }
+
+  switch (e) {
+    // OK
+    case DeprecatedFields.oldFoo:
+      print('oldFoo');
+      break;
+    case DeprecatedFields.bar:
+      print('bar');
+      break;
+    case DeprecatedFields.baz:
+      print('baz');
+      break;
+  }
 }

--- a/test_data/rules/exhaustive_cases.dart
+++ b/test_data/rules/exhaustive_cases.dart
@@ -111,3 +111,39 @@ void ae(ActualEnum e) {
       print('e');
   }
 }
+
+// Some fields are deprecated.
+class DeprecatedFields {
+  final int i;
+  const DeprecatedFields._(this.i);
+
+  @deprecated
+  static const oldFoo = newFoo;
+  static const newFoo = DeprecatedFields._(1);
+  static const bar = DeprecatedFields._(2);
+  static const baz = DeprecatedFields._(3);
+}
+
+void dep(DeprecatedFields e) {
+  switch (e) {
+    // OK
+    case DeprecatedFields.newFoo:
+      print('newFoo');
+      break;
+    case DeprecatedFields.bar:
+      print('bar');
+      break;
+    case DeprecatedFields.baz:
+      print('baz');
+      break;
+  }
+
+  switch (e) { // LINT
+    case DeprecatedFields.newFoo:
+      print('newFoo');
+      break;
+    case DeprecatedFields.baz:
+      print('baz');
+      break;
+  }
+}


### PR DESCRIPTION
# Description

This adds some logic to DartTypeUtilities.asEnumLikeClass (IMHO this is begging to be an extension on ClassElement :D ) to account for equal-valued fields.

We store each field (enum-like value) in a mapping keyed to the field's constant value. Then only need to have a case for each constant value.

Fixes #3017 
