### PR TITLE
Do not report prefer_function_declarations_over_variables for non-final fields

### DIFF
--- a/lib/src/rules/prefer_function_declarations_over_variables.dart
+++ b/lib/src/rules/prefer_function_declarations_over_variables.dart
@@ -62,10 +62,18 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.initializer is FunctionExpression) {
       var function = node.thisOrAncestorOfType<FunctionBody>();
       var declaredElement = node.declaredElement;
-      if (function == null ||
-          (declaredElement != null &&
-              !function.isPotentiallyMutatedInScope(declaredElement))) {
-        rule.reportLint(node);
+      if (function == null) {
+        // When there is no enclosing function body, this is a variable
+        // definition for a field or a top-level variable, which should only
+        // be reported if final.
+        if (node.isFinal) {
+          rule.reportLint(node);
+        }
+      } else {
+        if (declaredElement != null &&
+            !function.isPotentiallyMutatedInScope(declaredElement)) {
+          rule.reportLint(node);
+        }
       }
     }
   }

--- a/test_data/rules/prefer_function_declarations_over_variables.dart
+++ b/test_data/rules/prefer_function_declarations_over_variables.dart
@@ -32,3 +32,13 @@ void main() {
 
   bad3 = print; // OK
 }
+
+var ok2 = () {}; // OK
+
+final bad4 = () {}; // LINT
+
+class C {
+  var ok3 = () {}; // OK
+
+  final bad5 = () {}; // LINT
+}


### PR DESCRIPTION
# Description

This rule should not be reported for fields or for top-level variables which can be re-assigned (non-final).

Fixes https://github.com/dart-lang/linter/issues/1628