### PR TITLE
prefer_contains: short circuit more

### DIFF
--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -90,14 +90,14 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
     var value = getIntValue(node.rightOperand, context);
-    if (value is int && value <= 0) {
-      if (_isUnassignedIndexOf(node.leftOperand)) {
+    if (value is int) {
+      if (value <= 0 && _isUnassignedIndexOf(node.leftOperand)) {
         _checkConstant(node, value, node.operator.type);
       }
     } else {
       value = getIntValue(node.leftOperand, context);
-      if (value is int && value <= 0) {
-        if (_isUnassignedIndexOf(node.rightOperand)) {
+      if (value is int) {
+        if (value <= 0 && _isUnassignedIndexOf(node.rightOperand)) {
           _checkConstant(node, value, _invertedTokenType(node.operator.type));
         }
       }

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -78,14 +78,25 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
+    // This lint rule is only concerned with these operators.
+    if (!node.operator.matchesAny([
+      TokenType.EQ_EQ,
+      TokenType.BANG_EQ,
+      TokenType.GT,
+      TokenType.GT_EQ,
+      TokenType.LT,
+      TokenType.LT_EQ,
+    ])) {
+      return;
+    }
     var value = getIntValue(node.rightOperand, context);
-    if (value is int) {
+    if (value is int && value <= 0) {
       if (_isUnassignedIndexOf(node.leftOperand)) {
         _checkConstant(node, value, node.operator.type);
       }
     } else {
       value = getIntValue(node.leftOperand, context);
-      if (value is int) {
+      if (value is int && value <= 0) {
         if (_isUnassignedIndexOf(node.rightOperand)) {
           _checkConstant(node, value, _invertedTokenType(node.operator.type));
         }
@@ -93,7 +104,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  void _checkConstant(Expression expression, int? value, TokenType type) {
+  void _checkConstant(Expression expression, int value, TokenType type) {
     if (value == -1) {
       if (type == TokenType.EQ_EQ ||
           type == TokenType.BANG_EQ ||
@@ -113,7 +124,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (type == TokenType.GT_EQ || type == TokenType.LT) {
         rule.reportLintWithDescription(expression, useContains);
       }
-    } else if (value! < -1) {
+    } else if (value < -1) {
       // 'indexOf' is always >= -1, so comparing with lesser values makes
       // no sense.
       if (type == TokenType.EQ_EQ ||
@@ -147,6 +158,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
+  /// Returns whether [expression] is an invocation of `Iterable.indexOf` or
+  /// `String.indexOf`, which is not assigned to a value.
   bool _isUnassignedIndexOf(Expression expression) {
     // Unwrap parens and `as` expressions.
     var invocation = expression.unParenthesized;


### PR DESCRIPTION
# Description

prefer_contains is the slowest "recommended" rule, and the 6th slowest rule overall (according to a recent CI benchmark). This PR should speed it up. Before this PR, the broad algorithm is:

For every binary expression:

1. If the right operand is an int:
   1. and if the left operand is an invocation of `indexOf`:
      1. and the value of the int combined with the operator should be linted, report lint.
2. Else, if the left operand is an int:
   1. and the right operand is an invocation of `indexOf`:
      1. and the value of the int combined with the operator should be linted, report lint.

I decided this was inefficient in two spots:

1. The algorithm doesn't check the operator until the innermost steps, after which other more expensive computation has been done.
2. The algorithm doesn't check whether an int operand is "interesting" (0, -1, or less than -1) until the innermost step, after deciding whether `indexOf` is being invoked.

The algorithm after this PR is more like:

1. If the operator is not interesting, stop.
2. If the right operand is an int:
   1. If that int is not interesting, stop.
   2. If the left operand is an invocation of `indexOf`:
      1. and the value of the int combined with the operator should be linted, report lint.
3. Else, if the left operand is an int:
   1. If that int is not interesting, stop.
   2. and the right operand is an invocation of `indexOf`:
      1. and the value of the int combined with the operator should be linted, report lint.