### PR TITLE
Reimpliment isOnlyUnderscores with a loop

### DIFF
--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../utils.dart';
+import '../util/ascii_utils.dart';
 
 const _desc = r'Specify type annotations.';
 
@@ -130,7 +130,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     var identifier = param.identifier;
     if (identifier != null &&
         param.type == null &&
-        !isJustUnderscores(identifier.name)) {
+        !identifier.name.isJustUnderscores) {
       if (param.keyword != null) {
         rule.reportLintForToken(param.keyword);
       } else {

--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../utils.dart';
+import '../util/ascii_utils.dart';
 
 const _desc = r'Avoid defining unused parameters in constructors.';
 
@@ -59,7 +59,7 @@ class _ConstructorVisitor extends RecursiveAstVisitor {
           return element != null &&
               element is! FieldFormalParameterElement &&
               !element.hasDeprecated &&
-              !isJustUnderscores(element.name);
+              !element.name.isJustUnderscores;
         }).toSet();
 
   @override

--- a/lib/src/rules/empty_catches.dart
+++ b/lib/src/rules/empty_catches.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../utils.dart';
+import '../util/ascii_utils.dart';
 
 const _desc = r'Avoid empty catch blocks.';
 
@@ -75,7 +75,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     // Skip exceptions named with underscores.
     var exceptionParameter = node.exceptionParameter;
     if (exceptionParameter != null &&
-        isJustUnderscores(exceptionParameter.name)) {
+        exceptionParameter.name.isJustUnderscores) {
       return;
     }
 

--- a/lib/src/rules/no_leading_underscores_for_local_identifiers.dart
+++ b/lib/src/rules/no_leading_underscores_for_local_identifiers.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
+import '../util/ascii_utils.dart';
 import '../utils.dart';
 
 const _desc = r'Avoid leading underscores for local identifiers.';
@@ -81,7 +82,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (!hasLeadingUnderscore(id.name)) {
       return;
     }
-    if (isJustUnderscoresOK && isJustUnderscores(id.name)) {
+    if (isJustUnderscoresOK && id.name.isJustUnderscores) {
       return;
     }
     rule.reportLint(id);

--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
+import '../util/ascii_utils.dart';
 import '../utils.dart';
 
 const _desc = r'Name non-constant identifiers using lowerCamelCase.';
@@ -63,7 +64,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (id == null) {
       return;
     }
-    if (underscoresOk && isJustUnderscores(id.name)) {
+    if (underscoresOk && id.name.isJustUnderscores) {
       // For example, `___` is OK in a callback.
       return;
     }

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 import '../ast.dart';
-import '../utils.dart';
+import '../util/ascii_utils.dart';
 
 const _desc = r'Type annotate public APIs.';
 
@@ -141,7 +141,7 @@ class _VisitorHelper extends RecursiveAstVisitor {
   void visitSimpleFormalParameter(SimpleFormalParameter param) {
     if (param.type == null) {
       var paramName = param.identifier?.name;
-      if (paramName != null && !isJustUnderscores(paramName)) {
+      if (paramName != null && !paramName.isJustUnderscores) {
         rule.reportLint(param);
       }
     }

--- a/lib/src/util/ascii_utils.dart
+++ b/lib/src/util/ascii_utils.dart
@@ -58,3 +58,18 @@ bool isValidDartFileName(String name) {
   }
   return true;
 }
+
+extension StringExtensions on String {
+  /// Returns whether `this` is just underscores.
+  bool get isJustUnderscores {
+    if (isEmpty) {
+      return false;
+    }
+    for (var i = 0; i < length; i++) {
+      if (!isUnderScore(codeUnitAt(i))) {
+        return false;
+      }
+    }
+    return false;
+  }
+}

--- a/lib/src/util/ascii_utils.dart
+++ b/lib/src/util/ascii_utils.dart
@@ -70,6 +70,6 @@ extension StringExtensions on String {
         return false;
       }
     }
-    return false;
+    return true;
   }
 }

--- a/lib/src/util/ascii_utils.dart
+++ b/lib/src/util/ascii_utils.dart
@@ -65,11 +65,18 @@ extension StringExtensions on String {
     if (isEmpty) {
       return false;
     }
-    for (var i = 0; i < length; i++) {
-      if (!isUnderScore(codeUnitAt(i))) {
-        return false;
-      }
+    switch (length) {
+      case 1:
+        return this == '_';
+      case 2:
+        return this == '__';
+      default:
+        for (var i = 0; i < length; i++) {
+          if (!isUnderScore(codeUnitAt(i))) {
+            return false;
+          }
+        }
+        return true;
     }
-    return true;
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -41,8 +41,6 @@ final _lowerCaseUnderScoreWithLeadingUnderscores =
 
 final _pubspec = RegExp(r'^_?pubspec\.yaml$');
 
-final _underscores = RegExp(r'^_+$');
-
 // A library prefix here is defined as:
 // * An optional leading `?`,
 // * then any number of underscores, `_`,
@@ -61,9 +59,6 @@ bool isDartFileName(String fileName) => fileName.endsWith('.dart');
 
 /// Returns `true` if this [name] is a legal Dart identifier.
 bool isIdentifier(String name) => _identifier.hasMatch(name);
-
-/// Returns `true` of the given [name] is composed only of `_`s.
-bool isJustUnderscores(String name) => _underscores.hasMatch(name);
 
 /// Returns `true` if this [id] is `lowerCamelCase`.
 bool isLowerCamelCase(String id) =>

--- a/test/ascii_utils_test.dart
+++ b/test/ascii_utils_test.dart
@@ -6,6 +6,24 @@ import 'package:linter/src/util/ascii_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('fileNames', () {
+    group('good', () {
+      for (var name in goodFileNames) {
+        test(name, () {
+          expect(isValidDartFileName(name), isTrue);
+        });
+      }
+    });
+
+    group('bad', () {
+      for (var name in badFileNames) {
+        test(name, () {
+          expect(isValidDartFileName(name), isFalse);
+        });
+      }
+    });
+  });
+
   group('isOnlyUnderscores', () {
     test(
       'empty is not',
@@ -26,23 +44,6 @@ void main() {
       'multiple underscores is',
       () => expect('___'.isJustUnderscores, isTrue),
     );
-  });
-  group('fileNames', () {
-    group('good', () {
-      for (var name in goodFileNames) {
-        test(name, () {
-          expect(isValidDartFileName(name), isTrue);
-        });
-      }
-    });
-
-    group('bad', () {
-      for (var name in badFileNames) {
-        test(name, () {
-          expect(isValidDartFileName(name), isFalse);
-        });
-      }
-    });
   });
 }
 

--- a/test/ascii_utils_test.dart
+++ b/test/ascii_utils_test.dart
@@ -24,7 +24,7 @@ void main() {
     });
   });
 
-  group('isOnlyUnderscores', () {
+  group('isJustUnderscores', () {
     test(
       'empty is not',
       () => expect(''.isJustUnderscores, isFalse),
@@ -43,6 +43,11 @@ void main() {
     test(
       'multiple underscores is',
       () => expect('___'.isJustUnderscores, isTrue),
+    );
+
+    test(
+      'underscores followed by non-underscores is not',
+      () => expect('__x'.isJustUnderscores, isFalse),
     );
   });
 }

--- a/test/ascii_utils_test.dart
+++ b/test/ascii_utils_test.dart
@@ -6,6 +6,27 @@ import 'package:linter/src/util/ascii_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('isOnlyUnderscores', () {
+    test(
+      'empty is not',
+      () => expect(''.isJustUnderscores, isFalse),
+    );
+
+    test(
+      'non-underscore is not',
+      () => expect('A'.isJustUnderscores, isFalse),
+    );
+
+    test(
+      'one underscore is',
+      () => expect('_'.isJustUnderscores, isTrue),
+    );
+
+    test(
+      'multiple underscores is',
+      () => expect('___'.isJustUnderscores, isTrue),
+    );
+  });
   group('fileNames', () {
     group('good', () {
       for (var name in goodFileNames) {


### PR DESCRIPTION
# Description

isOnlyUnderscores is used in a few lint rules, including non_constant_identifier_names, which is the 2nd slowest core lint rule, and 8th slowest overall (according to a recent CI benchmark).

The idea here is simple, though unvetted by me in Dart: the regular expression engine may be heavy to fire up, so instead just do a simple character walk.
