### PR TITLE
Remove subclasses of LintCode

### DIFF
--- a/lib/src/rules/no_duplicate_case_values.dart
+++ b/lib/src/rules/no_duplicate_case_values.dart
@@ -38,10 +38,10 @@ switch (v) {
 
 ''';
 
-String message(String value1, String value2) =>
-    'Do not use more than one case with same value ($value1 and $value2)';
-
 class NoDuplicateCaseValues extends LintRule {
+  static const LintCode code = LintCode('no_duplicate_case_values',
+      'Do not use more than one case with same value ({0} and {1}');
+
   NoDuplicateCaseValues()
       : super(
             name: 'no_duplicate_case_values',
@@ -55,19 +55,6 @@ class NoDuplicateCaseValues extends LintRule {
     var visitor = _Visitor(this, context);
     registry.addSwitchStatement(this, visitor);
   }
-
-  void reportLintWithDescription(AstNode node, String description) {
-    reporter.reportErrorForNode(_LintCode(name, description), node, []);
-  }
-}
-
-class _LintCode extends LintCode {
-  static final registry = <String, _LintCode>{};
-
-  factory _LintCode(String name, String message) =>
-      registry.putIfAbsent(name + message, () => _LintCode._(name, message));
-
-  _LintCode._(String name, String message) : super(name, message);
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
@@ -94,8 +81,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
         var duplicateValue = values[value];
         if (duplicateValue != null) {
-          rule.reportLintWithDescription(member,
-              message(duplicateValue.toString(), expression.toString()));
+          rule.reportLint(member,
+              errorCode: NoDuplicateCaseValues.code,
+              arguments: [duplicateValue.toString(), expression.toString()]);
         } else {
           values[value] = expression;
         }

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -10,11 +10,6 @@ import '../analyzer.dart';
 import '../ast.dart';
 import '../util/dart_type_utilities.dart';
 
-const alwaysFalse =
-    'Always false because indexOf is always greater or equal -1.';
-const alwaysTrue = 'Always true because indexOf is always greater or equal -1.';
-const useContains = 'Use contains instead of indexOf';
-
 const _desc = r'Use contains for `List` and `String` instances.';
 const _details = r'''
 
@@ -38,6 +33,15 @@ if (lunchBox.indexOf('sandwich') == -1) return 'so hungry...';
 ''';
 
 class PreferContainsOverIndexOf extends LintRule {
+  static const LintCode alwaysFalse = LintCode('prefer_contains',
+      'Always false because indexOf is always greater or equal -1.');
+
+  static const LintCode alwaysTrue = LintCode('prefer_contains',
+      'Always true because indexOf is always greater or equal -1.');
+
+  static const LintCode useContains =
+      LintCode('prefer_contains', 'Use contains instead of indexOf');
+
   PreferContainsOverIndexOf()
       : super(
             name: 'prefer_contains',
@@ -51,22 +55,6 @@ class PreferContainsOverIndexOf extends LintRule {
     var visitor = _Visitor(this, context);
     registry.addBinaryExpression(this, visitor);
   }
-
-  void reportLintWithDescription(AstNode? node, String description) {
-    if (node != null) {
-      reporter.reportErrorForNode(_LintCode(name, description), node, []);
-    }
-  }
-}
-
-/// TODO create common MultiMessageLintCode class
-class _LintCode extends LintCode {
-  static final registry = <String, _LintCode>{};
-
-  factory _LintCode(String name, String message) =>
-      registry.putIfAbsent(name + message, () => _LintCode._(name, message));
-
-  _LintCode._(String name, String message) : super(name, message);
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
@@ -99,19 +87,23 @@ class _Visitor extends SimpleAstVisitor<void> {
           type == TokenType.BANG_EQ ||
           type == TokenType.LT_EQ ||
           type == TokenType.GT) {
-        rule.reportLintWithDescription(expression, useContains);
+        rule.reportLint(expression,
+            errorCode: PreferContainsOverIndexOf.useContains);
       } else if (type == TokenType.LT) {
         // indexOf < -1 is always false
-        rule.reportLintWithDescription(expression, alwaysFalse);
+        rule.reportLint(expression,
+            errorCode: PreferContainsOverIndexOf.alwaysFalse);
       } else if (type == TokenType.GT_EQ) {
         // indexOf >= -1 is always true
-        rule.reportLintWithDescription(expression, alwaysTrue);
+        rule.reportLint(expression,
+            errorCode: PreferContainsOverIndexOf.alwaysTrue);
       }
     } else if (value == 0) {
       // 'indexOf >= 0' is same as 'contains',
       // and 'indexOf < 0' is same as '!contains'
       if (type == TokenType.GT_EQ || type == TokenType.LT) {
-        rule.reportLintWithDescription(expression, useContains);
+        rule.reportLint(expression,
+            errorCode: PreferContainsOverIndexOf.useContains);
       }
     } else if (value! < -1) {
       // 'indexOf' is always >= -1, so comparing with lesser values makes
@@ -119,11 +111,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (type == TokenType.EQ_EQ ||
           type == TokenType.LT_EQ ||
           type == TokenType.LT) {
-        rule.reportLintWithDescription(expression, alwaysFalse);
+        rule.reportLint(expression,
+            errorCode: PreferContainsOverIndexOf.alwaysFalse);
       } else if (type == TokenType.BANG_EQ ||
           type == TokenType.GT_EQ ||
           type == TokenType.GT) {
-        rule.reportLintWithDescription(expression, alwaysTrue);
+        rule.reportLint(expression,
+            errorCode: PreferContainsOverIndexOf.alwaysTrue);
       }
     }
   }

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -11,12 +11,6 @@ import '../analyzer.dart';
 import '../ast.dart';
 import '../util/dart_type_utilities.dart';
 
-const alwaysFalse = 'Always false because length is always greater or equal 0.';
-
-const alwaysTrue = 'Always true because length is always greater or equal 0.';
-
-const useIsEmpty = 'Use isEmpty instead of length';
-const useIsNotEmpty = 'Use isNotEmpty instead of length';
 const _desc = r'Use `isEmpty` for Iterables and Maps.';
 const _details = r'''
 
@@ -44,6 +38,18 @@ if (words.length != 0) return words.join(' ');
 ''';
 
 class PreferIsEmpty extends LintRule {
+  static const LintCode alwaysFalse = LintCode('prefer_is_empty',
+      'Always false because length is always greater or equal 0.');
+
+  static const LintCode alwaysTrue = LintCode('prefer_is_empty',
+      'Always true because length is always greater or equal 0.');
+
+  static const LintCode useIsEmpty =
+      LintCode('prefer_is_empty', 'Use isEmpty instead of length');
+
+  static const LintCode useIsNotEmpty =
+      LintCode('prefer_is_empty', 'Use isNotEmpty instead of length');
+
   PreferIsEmpty()
       : super(
             name: 'prefer_is_empty',
@@ -57,19 +63,6 @@ class PreferIsEmpty extends LintRule {
     var visitor = _Visitor(this, context);
     registry.addBinaryExpression(this, visitor);
   }
-
-  void reportLintWithDescription(AstNode node, String description) {
-    reporter.reportErrorForNode(_LintCode(name, description), node, []);
-  }
-}
-
-class _LintCode extends LintCode {
-  static final registry = <String, _LintCode>{};
-
-  factory _LintCode(String name, String message) =>
-      registry.putIfAbsent(name + message, () => _LintCode._(name, message));
-
-  _LintCode._(String name, String message) : super(name, message);
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
@@ -122,31 +115,31 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (value == 0) {
       if (operator.type == TokenType.EQ_EQ ||
           operator.type == TokenType.LT_EQ) {
-        rule.reportLintWithDescription(expression, useIsEmpty);
+        rule.reportLint(expression, errorCode: PreferIsEmpty.useIsEmpty);
       } else if (operator.type == TokenType.GT ||
           operator.type == TokenType.BANG_EQ) {
-        rule.reportLintWithDescription(expression, useIsNotEmpty);
+        rule.reportLint(expression, errorCode: PreferIsEmpty.useIsNotEmpty);
       } else if (operator.type == TokenType.LT) {
-        rule.reportLintWithDescription(expression, alwaysFalse);
+        rule.reportLint(expression, errorCode: PreferIsEmpty.alwaysFalse);
       } else if (operator.type == TokenType.GT_EQ) {
-        rule.reportLintWithDescription(expression, alwaysTrue);
+        rule.reportLint(expression, errorCode: PreferIsEmpty.alwaysTrue);
       }
     } else if (value == 1) {
       if (constantOnRight) {
         // 'length >= 1' is same as 'isNotEmpty',
         // and 'length < 1' is same as 'isEmpty'
         if (operator.type == TokenType.GT_EQ) {
-          rule.reportLintWithDescription(expression, useIsNotEmpty);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.useIsNotEmpty);
         } else if (operator.type == TokenType.LT) {
-          rule.reportLintWithDescription(expression, useIsEmpty);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.useIsEmpty);
         }
       } else {
         // '1 <= length' is same as 'isNotEmpty',
         // and '1 > length' is same as 'isEmpty'
         if (operator.type == TokenType.LT_EQ) {
-          rule.reportLintWithDescription(expression, useIsNotEmpty);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.useIsNotEmpty);
         } else if (operator.type == TokenType.GT) {
-          rule.reportLintWithDescription(expression, useIsEmpty);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.useIsEmpty);
         }
       }
     } else if (value < 0) {
@@ -155,22 +148,22 @@ class _Visitor extends SimpleAstVisitor<void> {
         if (operator.type == TokenType.EQ_EQ ||
             operator.type == TokenType.LT_EQ ||
             operator.type == TokenType.LT) {
-          rule.reportLintWithDescription(expression, alwaysFalse);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.alwaysFalse);
         } else if (operator.type == TokenType.BANG_EQ ||
             operator.type == TokenType.GT_EQ ||
             operator.type == TokenType.GT) {
-          rule.reportLintWithDescription(expression, alwaysTrue);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.alwaysTrue);
         }
       } else {
         // 'length' is always >= 0, so comparing with negative makes no sense.
         if (operator.type == TokenType.EQ_EQ ||
             operator.type == TokenType.GT_EQ ||
             operator.type == TokenType.GT) {
-          rule.reportLintWithDescription(expression, alwaysFalse);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.alwaysFalse);
         } else if (operator.type == TokenType.BANG_EQ ||
             operator.type == TokenType.LT_EQ ||
             operator.type == TokenType.LT) {
-          rule.reportLintWithDescription(expression, alwaysTrue);
+          rule.reportLint(expression, errorCode: PreferIsEmpty.alwaysTrue);
         }
       }
     }


### PR DESCRIPTION
This removes unnecessary subclasses of `LintCode` by using static fields instead. I think this is a better approach to having custom messages.