### PR TITLE
Make camel_case_types cover enums

### DIFF
--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -50,6 +50,7 @@ class CamelCaseTypes extends LintRule {
     registry.addClassDeclaration(this, visitor);
     registry.addClassTypeAlias(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
+    registry.addEnumDeclaration(this, visitor);
   }
 }
 
@@ -81,6 +82,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitGenericTypeAlias(GenericTypeAlias node) {
+    check(node.name);
+  }
+
+  @override
+  void visitEnumDeclaration(EnumDeclaration node) {
     check(node.name);
   }
 }

--- a/test_data/rules/camel_case_types.dart
+++ b/test_data/rules/camel_case_types.dart
@@ -38,3 +38,7 @@ typedef f = void Function(); //LINT
 
 mixin M {}
 class c = Object with M; //LINT
+
+enum foooBar { a } //LINT
+
+enum FoooBar { a } //OK


### PR DESCRIPTION
# Description

Effective dart [mentions](https://dart.dev/guides/language/effective-dart/style#do-name-types-using-uppercamelcase) that enum names must be camel-cased. This PR adds that according to the discussion on #3091 .

Fixes #3091 
