### PR TITLE
Add `no_logic_in_state_constructor`

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -92,6 +92,7 @@ linter:
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
     - no_logic_in_create_state
+    - no_logic_in_state_constructor
     - no_runtimeType_toString
     - non_constant_identifier_names
     - noop_primitive_operations

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -94,6 +94,7 @@ import 'rules/no_duplicate_case_values.dart';
 import 'rules/no_leading_underscores_for_library_prefixes.dart';
 import 'rules/no_leading_underscores_for_local_identifiers.dart';
 import 'rules/no_logic_in_create_state.dart';
+import 'rules/no_logic_in_state_constructor.dart';
 import 'rules/no_runtimeType_toString.dart';
 import 'rules/non_constant_identifier_names.dart';
 import 'rules/noop_primitive_operations.dart';
@@ -302,6 +303,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(NoLeadingUnderscoresForLibraryPrefixes())
     ..register(NoLeadingUnderscoresForLocalIdentifiers())
     ..register(NoLogicInCreateState())
+    ..register(NoLogicInStateConstructor())
     ..register(NoopPrimitiveOperations())
     ..register(NoRuntimeTypeToString())
     ..register(NullCheckOnNullableTypeParameter())

--- a/lib/src/rules/no_logic_in_state_constructor.dart
+++ b/lib/src/rules/no_logic_in_state_constructor.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2021, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import '../util/flutter_utils.dart';
+
+const _desc = r"Don't put any logic in the state constructor.";
+
+const _details = r'''
+**DON'T** put any logic in the `State` constructor.
+
+The constructor of a `State` object should never contain any logic as it often
+causes trouble. That logic should always go into `State.initState()`.
+
+**BAD:**
+```dart
+class FooState extends State<Foo> with SingleTickerProviderStateMixin {
+  FooState() {
+   _controller = AnimationController(vsync: this);
+  }
+
+  late final AnimationController _controller;
+}
+```
+
+**GOOD:**
+```dart
+class FooState extends State<Foo> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(vsync: this);
+}
+```
+
+**GOOD:**
+```dart
+class FooState extends State<Foo> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this);
+  }
+}
+```
+''';
+
+class NoLogicInStateConstructor extends LintRule {
+  NoLogicInStateConstructor()
+      : super(
+            name: 'no_logic_in_state_constructor',
+            description: _desc,
+            details: _details,
+            group: Group.errors);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addConstructorDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
+    var declaredElement = node.declaredElement;
+    if (declaredElement == null) return;
+    if (isState(
+        declaredElement.enclosingElement.thisType.superclass?.element)) {
+      var body = node.body;
+      if (body is BlockFunctionBody) {
+        var block = body.block;
+        if (block.statements.isNotEmpty) {
+          rule.reportLint(block);
+        }
+      }
+    }
+  }
+}

--- a/lib/src/util/flutter_utils.dart
+++ b/lib/src/util/flutter_utils.dart
@@ -39,6 +39,8 @@ bool isKDebugMode(Element? element) => _flutter.isKDebugMode(element);
 bool isStatefulWidget(ClassElement? element) =>
     _flutter.isStatefulWidget(element);
 
+bool isState(ClassElement? element) => _flutter.isState(element);
+
 bool isWidgetProperty(DartType? type) {
   if (isWidgetType(type)) {
     return true;
@@ -57,6 +59,7 @@ bool isWidgetType(DartType? type) => _flutter.isWidgetType(type);
 class _Flutter {
   static const _nameBuildContext = 'BuildContext';
   static const _nameStatefulWidget = 'StatefulWidget';
+  static const _nameState = 'State';
   static const _nameWidget = 'Widget';
   static const _nameContainer = 'Container';
   static const _nameSizedBox = 'SizedBox';
@@ -82,7 +85,7 @@ class _Flutter {
     if (element == null || !alreadySeen.add(element)) {
       return false;
     }
-    if (_isExactWidget(element, _nameWidget, _uriFramework)) {
+    if (_hasExactOrigin(element, _nameWidget, _uriFramework)) {
       return true;
     }
     return hasWidgetAsAscendant(element.supertype?.element, alreadySeen);
@@ -95,19 +98,19 @@ class _Flutter {
     if (skipNullable && type.nullabilitySuffix == NullabilitySuffix.question) {
       return false;
     }
-    return _isExactWidget(type.element, _nameBuildContext, _uriFramework);
+    return _hasExactOrigin(type.element, _nameBuildContext, _uriFramework);
   }
 
   bool isExactWidget(ClassElement element) =>
-      _isExactWidget(element, _nameWidget, _uriFramework);
+      _hasExactOrigin(element, _nameWidget, _uriFramework);
 
   bool isExactWidgetTypeContainer(DartType? type) =>
       type is InterfaceType &&
-      _isExactWidget(type.element, _nameContainer, _uriContainer);
+      _hasExactOrigin(type.element, _nameContainer, _uriContainer);
 
   bool isExactWidgetTypeSizedBox(DartType? type) =>
       type is InterfaceType &&
-      _isExactWidget(type.element, _nameSizedBox, _uriBasic);
+      _hasExactOrigin(type.element, _nameSizedBox, _uriBasic);
 
   bool isKDebugMode(Element? element) =>
       element != null &&
@@ -118,23 +121,33 @@ class _Flutter {
     if (element == null) {
       return false;
     }
-    if (_isExactWidget(element, _nameStatefulWidget, _uriFramework)) {
+    if (_hasExactOrigin(element, _nameStatefulWidget, _uriFramework)) {
       return true;
     }
     for (var type in element.allSupertypes) {
-      if (_isExactWidget(type.element, _nameStatefulWidget, _uriFramework)) {
+      if (_hasExactOrigin(type.element, _nameStatefulWidget, _uriFramework)) {
         return true;
       }
     }
     return false;
   }
 
+  bool isState(ClassElement? element) {
+    if (element == null) {
+      return false;
+    }
+    if (_hasExactOrigin(element, _nameState, _uriFramework)) {
+      return true;
+    }
+    return false;
+  }
+
   bool isWidget(ClassElement element) {
-    if (_isExactWidget(element, _nameWidget, _uriFramework)) {
+    if (_hasExactOrigin(element, _nameWidget, _uriFramework)) {
       return true;
     }
     for (var type in element.allSupertypes) {
-      if (_isExactWidget(type.element, _nameWidget, _uriFramework)) {
+      if (_hasExactOrigin(type.element, _nameWidget, _uriFramework)) {
         return true;
       }
     }
@@ -144,6 +157,6 @@ class _Flutter {
   bool isWidgetType(DartType? type) =>
       type is InterfaceType && isWidget(type.element);
 
-  bool _isExactWidget(ClassElement element, String type, Uri uri) =>
+  bool _hasExactOrigin(ClassElement element, String type, Uri uri) =>
       element.name == type && element.source.uri == uri;
 }

--- a/test_data/rules/no_logic_in_state_constructor.dart
+++ b/test_data/rules/no_logic_in_state_constructor.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N no_logic_in_state_constructor`
+
+import 'package:flutter/widgets.dart';
+
+class _Widget extends StatefulWidget {}
+mixin _Mixin {}
+
+class A extends State {
+  A(); // OK
+}
+
+class B extends State<_Widget> {
+  B(); // OK
+}
+
+class C extends State {
+  C() {} // OK
+}
+
+class D extends State {
+  D() { // OK
+    // Comment
+  }
+}
+
+class E extends State {
+  E() { // LINT
+    print('hi');
+  }
+}
+
+class F extends State<_Widget> {
+  F() { // LINT
+    print('hi');
+  }
+}
+
+class G extends State {
+  G() { // LINT
+    var i;
+  }
+}
+
+class H extends State with _Mixin {
+  H() { // LINT
+    print('hi');
+  }
+}
+
+class I {
+  I(); // OK
+}
+
+class J {
+  J() {} // OK
+}
+
+class K {
+  K() { // OK
+    print('');
+  }
+}
+
+class L extends StatefulWidget {
+  L() { // OK
+    print('');
+  }
+}

--- a/test_data/rules/use_build_context_synchronously.dart
+++ b/test_data/rules/use_build_context_synchronously.dart
@@ -14,7 +14,7 @@ extension on BuildContext {
 void mountedBinOpAnd(BuildContext context, bool condition) async {
   await Future<void>.delayed(Duration());
   if (condition && context.mounted) {
-    await Navigator.of(context).pushNamed('routeName');// OK
+    await Navigator.of(context).pushNamed('routeName'); // OK
   }
 }
 


### PR DESCRIPTION
The constructor of a `State` object is not supposed to contain any logic. That logic should go into `State.initState()`.

Closes https://github.com/dart-lang/linter/issues/3059.