### PR TITLE
1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.18.0
+
+- extend `camel_case_types` to cover enums
+- fix `no_leading_underscores_for_local_identifiers` to not 
+  mis-flag field formal parameters with default values
+- fix `prefer_function_declarations_over_variables` to not
+  mis-flag non-final fields
+- performance improvements for `prefer_contains`
+- update `exhaustive_cases` to skip deprecated values that
+  redirect to other values
+
 # 1.17.1
 
 - update to `analyzer` version 3.0

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.17.1';
+const String version = '1.18.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.17.1
+version: 1.18.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.18.0

- extend `camel_case_types` to cover enums
- fix `no_leading_underscores_for_local_identifiers` to not 
  mis-flag field formal parameters with default values
- fix `prefer_function_declarations_over_variables` to not
  mis-flag non-final fields
- performance improvements for `prefer_contains`
- update `exhaustive_cases` to skip deprecated values that
  redirect to other values

---

/cc @srawlins 

/fyi @goderbauer 
