### PR TITLE
Add conformance rule for banned property writes

### DIFF
--- a/lib/src/rules/conformance/banned_property_write.dart
+++ b/lib/src/rules/conformance/banned_property_write.dart
@@ -1,0 +1,240 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+import '../../analyzer.dart';
+import 'conformance_rule.dart';
+import 'interop_helpers.dart';
+import 'web_bindings.dart';
+
+class _BannedPropertyWriteCode extends SecurityLintCode {
+  _BannedPropertyWriteCode(
+      {required String name,
+      required String problemMessage,
+      required String correctionMessage})
+      : super(name, problemMessage, correctionMessage: correctionMessage);
+}
+
+class BannedPropertyWrite extends ConformanceRule {
+  final String? nativeType;
+  final String? nativeProperty;
+  final String? dartHtmlType;
+  final String? dartHtmlProperty;
+  BannedPropertyWrite(
+      {required String name,
+      required String description,
+      required String details,
+      required this.nativeType,
+      required this.nativeProperty})
+      : dartHtmlType = null,
+        dartHtmlProperty = null,
+        super(name: name, description: description, details: details);
+
+  // This constructor is meant specifically to disallow specific `dart:html`
+  // APIs that aren't `external`. Using this without a separate rule disallowing
+  // the native property you are interested in would be insufficient, as this
+  // does not cover the interop case.
+  BannedPropertyWrite.withDartHtmlTypes(
+      {required String name,
+      required String description,
+      required String details,
+      required this.dartHtmlType,
+      required this.dartHtmlProperty})
+      : nativeType = null,
+        nativeProperty = null,
+        super(name: name, description: description, details: details);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _BannedPropertyWriteVisitor(this);
+    registry.addCompilationUnit(this, visitor);
+    registry.addAssignmentExpression(this, visitor);
+    registry.addMethodInvocation(this, visitor);
+  }
+}
+
+class _BannedPropertyWriteVisitor extends SimpleAstVisitor<void> {
+  final BannedPropertyWrite rule;
+
+  _BannedPropertyWriteVisitor(this.rule);
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    computeHtmlBindings(node.declaredElement?.library);
+  }
+
+  @override
+  void visitAssignmentExpression(AssignmentExpression expression) {
+    var leftHandSide = expression.leftHandSide;
+    DartType? dartTargetType;
+    String dartProperty;
+    if (leftHandSide is PropertyAccess) {
+      dartTargetType = leftHandSide.realTarget.staticType;
+      dartProperty = leftHandSide.propertyName.name;
+    } else if (leftHandSide is PrefixedIdentifier) {
+      dartTargetType = leftHandSide.prefix.staticType;
+      dartProperty = leftHandSide.identifier.name;
+    } else {
+      return;
+    }
+
+    var dartTargetTypeElement = dartTargetType?.element;
+
+    if (dartTargetType == null || dartTargetTypeElement == null) return;
+
+    var dartHtmlBindingProperty = getWebLibraryMember(
+        nativeType: rule.nativeType, nativeMember: rule.nativeProperty);
+
+    var writeElement = expression.writeElement;
+    var isExternal = false;
+    if (writeElement is PropertyAccessorElement) {
+      // Use the variable declaration instead of the synthesized setter.
+      if (writeElement.isSynthetic) {
+        var variable = writeElement.variable;
+        if (variable is FieldElement) isExternal = variable.isExternal;
+      } else {
+        isExternal = writeElement.isExternal;
+      }
+    }
+
+    // If there is no `dart:html` binding for the given native type, we can use
+    // `@JS` or `@anonymous`. This means dynamic interop is possible.
+    var canUseDynamicInterop =
+        rule.nativeType != null && !hasDartHtmlBinding(rule.nativeType!);
+
+    // Report a lint if the target type is dynamic and one of the following
+    // holds true:
+    //
+    // 1. The property name matches the `dart:html` declaration name for the
+    // given native property.
+    // 2. The property name matches the given `dart:html` property.
+    // 3. The property name matches the given native property, and the type
+    // can be dynamically interop'd.
+    if (dartTargetType.isDynamic &&
+        (dartProperty == dartHtmlBindingProperty ||
+            dartProperty == rule.dartHtmlProperty ||
+            canUseDynamicInterop && dartProperty == rule.nativeProperty)) {
+      rule.reportLint(expression,
+          errorCode: _BannedPropertyWriteCode(
+              name: rule.name,
+              problemMessage:
+                  'This conformance check is being triggered because the '
+                  'static type of the target is dynamic.',
+              correctionMessage:
+                  'Try casting the target to a non-dynamic type.'));
+    } else if (dartTargetTypeElement is ClassElement) {
+      if (isExternal &&
+          dartTargetTypeElement.hasJS &&
+          dartProperty == rule.nativeProperty) {
+        // Only `@staticInterop` classes can interop the types bound to a
+        // `@Native` class. If there is no such binding however, then there
+        // needs to be a check for `@JS` and `@anonymous` classes as well.
+        if (isStaticInteropType(dartTargetTypeElement)) {
+          rule.reportLint(expression,
+              errorCode: _BannedPropertyWriteCode(
+                  name: rule.name,
+                  problemMessage:
+                      '@staticInterop types may be used to interface native '
+                      'types, so this property write may violate conformance.',
+                  correctionMessage:
+                      'Avoid using the same name as disallowed properties in '
+                      '@staticInterop classes.'));
+        } else if (canUseDynamicInterop) {
+          rule.reportLint(expression,
+              errorCode: _BannedPropertyWriteCode(
+                  name: rule.name,
+                  problemMessage:
+                      'Since there is no `dart:html` class for this native '
+                      'type, non-`@staticInterop` `package:js` classes may be '
+                      'used to interop with it, so this property may violate '
+                      'conformance.',
+                  correctionMessage: 'Avoid using this property name in '
+                      'all `package:js` classes.'));
+        }
+      } else if (fromDartHtml(dartTargetTypeElement)) {
+        var errorCode = _BannedPropertyWriteCode(
+            name: rule.name,
+            problemMessage: 'Disallowed `dart:html` property is being used.',
+            correctionMessage: 'Avoid using it.');
+        // If we only care about Dart types, we don't need to do any further
+        // checks.
+        var dartTypeName = dartTargetTypeElement.name;
+        if (rule.dartHtmlType != null && rule.dartHtmlProperty != null) {
+          if (dartTypeName == rule.dartHtmlType &&
+              dartProperty == rule.dartHtmlProperty) {
+            rule.reportLint(expression, errorCode: errorCode);
+          }
+          return;
+        }
+
+        // Check that it is a `@Native` class.
+        var nativeTypes = getBoundNativeTypes(dartType: dartTypeName);
+        if (nativeTypes == null) return;
+
+        var nativePropertyName = getNativePropertyBinding(
+            dartType: dartTypeName, dartMember: dartProperty);
+        if (isExternal &&
+            nativeTypes.contains(rule.nativeType) &&
+            nativePropertyName == rule.nativeProperty) {
+          rule.reportLint(expression, errorCode: errorCode);
+        }
+      }
+    }
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!isJsUtilSetProperty(node)) return;
+
+    var targetType = node.argumentList.arguments[0].staticType;
+    var targetTypeElement = targetType?.element;
+
+    if (targetType == null || targetTypeElement == null) return;
+
+    var setPropertyName = node.argumentList.arguments[1];
+    if (setPropertyName is! StringLiteral ||
+        setPropertyName.stringValue != rule.nativeProperty) return;
+
+    if (targetType.isDartCoreObject) {
+      rule.reportLint(node,
+          errorCode: _BannedPropertyWriteCode(
+              name: rule.name,
+              problemMessage:
+                  'This conformance check is being triggered because the '
+                  'static type of the target is Object.',
+              correctionMessage:
+                  'Try casting the target to a non-Object type.'));
+    } else if (targetTypeElement is ClassElement) {
+      if (isNativeInteropType(targetTypeElement, rule.nativeType)) {
+        rule.reportLint(node,
+            errorCode: _BannedPropertyWriteCode(
+                name: rule.name,
+                problemMessage:
+                    "The target object's type can be used to interface native "
+                    'types, so this call to `setProperty` may violate '
+                    'conformance.',
+                correctionMessage: 'Avoid using this property name in a '
+                    '`setProperty` call.'));
+      } else if (fromDartHtml(targetTypeElement) &&
+          (getBoundNativeTypes(dartType: targetTypeElement.name)
+                  ?.contains(rule.nativeType) ??
+              false)) {
+        rule.reportLint(node,
+            errorCode: _BannedPropertyWriteCode(
+                name: rule.name,
+                problemMessage:
+                    'Disallowed `dart:html` property is being used in this '
+                    '`setProperty` call.',
+                correctionMessage:
+                    "Don't use `setProperty` on this `dart:html` class with "
+                    'this property name.'));
+      }
+    }
+  }
+}

--- a/lib/src/rules/conformance/conformance_rule.dart
+++ b/lib/src/rules/conformance/conformance_rule.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../analyzer.dart';
+
+/// Base type for all compliance checks for web libraries.
+class ConformanceRule extends LintRule {
+  ConformanceRule(
+      {required String name,
+      required String description,
+      required String details})
+      : super(
+            name: name,
+            details: details,
+            description: description,
+            group: Group.errors);
+}

--- a/lib/src/rules/conformance/descriptors.dart
+++ b/lib/src/rules/conformance/descriptors.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Class representing a pair of a type and a member on that type.
+abstract class MemberDescriptor {
+  String get type;
+  String get member;
+
+  /// Whether or not this descriptor contains a native type and member.
+  bool get isNative;
+
+  /// Whether or not this descriptor contains a `dart:html` type and member.
+  bool get isDartHtml;
+}
+
+class NativeMemberDescriptor extends MemberDescriptor {
+  @override
+  final String type;
+  @override
+  final String member;
+
+  NativeMemberDescriptor({this.type = '', this.member = ''});
+
+  @override
+  bool get isNative => true;
+
+  @override
+  bool get isDartHtml => false;
+}
+
+class DartHtmlMemberDescriptor extends MemberDescriptor {
+  @override
+  final String type;
+  @override
+  final String member;
+
+  DartHtmlMemberDescriptor({this.type = '', this.member = ''});
+
+  @override
+  bool get isNative => false;
+
+  @override
+  bool get isDartHtml => true;
+}

--- a/lib/src/rules/conformance/interop_helpers.dart
+++ b/lib/src/rules/conformance/interop_helpers.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+import 'web_bindings.dart';
+
+final String _dartInterceptorsLibrary = '_interceptors';
+final String _jsUtilLibrary = 'dart.js_util';
+final String _packageJsLibrary = 'js';
+
+final String _staticInteropAnnotationName = 'staticInterop';
+
+bool isJsUtilSetProperty(MethodInvocation node) =>
+    node.methodName.name == 'setProperty' ||
+    node.methodName.staticElement?.library?.name == _jsUtilLibrary;
+
+/// Returns whether [element] is an interop type that can be used as
+/// [nativeType].
+bool isNativeInteropType(ClassElement element, String? nativeType) {
+  if (isStaticInteropType(element)) return true;
+  // If there is no `@Native` type in `dart:html` matching [nativeType], it is
+  // possible for non-`@staticInterop` `package:js` classes to be used.
+  if (element.hasJS) {
+    return nativeType != null && !hasDartHtmlBinding(nativeType);
+  }
+  // If [element] is a subtype of `JavaScriptObject`, it can possibly be used as
+  // a native type.
+  var possibleTypes = element.allSupertypes..add(element.thisType);
+  return possibleTypes.any((type) =>
+      type.element.name == 'JavaScriptObject' &&
+      type.element.library.name == _dartInterceptorsLibrary);
+}
+
+/// Returns whether [element] is annotated with `@staticInterop`.
+bool isStaticInteropType(ClassElement element) {
+  for (var annotation in element.metadata) {
+    var annotationElement = annotation.element;
+    if (annotationElement is PropertyAccessorElement &&
+        annotationElement.name == _staticInteropAnnotationName &&
+        annotationElement.library.name == _packageJsLibrary) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/lib/src/rules/conformance/interop_helpers.dart
+++ b/lib/src/rules/conformance/interop_helpers.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 
+import 'descriptors.dart';
 import 'web_bindings.dart';
 
 final String _dartInterceptorsLibrary = '_interceptors';
@@ -17,15 +18,19 @@ bool isJsUtilSetProperty(MethodInvocation node) =>
     node.methodName.name == 'setProperty' ||
     node.methodName.staticElement?.library?.name == _jsUtilLibrary;
 
-/// Returns whether [element] is an interop type that can be used as
-/// [nativeType].
-bool isNativeInteropType(ClassElement element, String? nativeType) {
+/// Returns whether [element] is an interop type that can be used as the native
+/// type in [descriptor].
+///
+/// [bindings] is required to determine if there is a `dart:html` equivalent to
+/// this native type.
+bool isNativeInteropType(
+    {required ClassElement element,
+    required DartHtmlBindings bindings,
+    required NativeMemberDescriptor descriptor}) {
   if (isStaticInteropType(element)) return true;
   // If there is no `@Native` type in `dart:html` matching [nativeType], it is
   // possible for non-`@staticInterop` `package:js` classes to be used.
-  if (element.hasJS) {
-    return nativeType != null && !hasDartHtmlBinding(nativeType);
-  }
+  if (element.hasJS) return !bindings.hasDartHtmlBinding(descriptor);
   // If [element] is a subtype of `JavaScriptObject`, it can possibly be used as
   // a native type.
   var possibleTypes = element.allSupertypes..add(element.thisType);

--- a/lib/src/rules/conformance/web_bindings.dart
+++ b/lib/src/rules/conformance/web_bindings.dart
@@ -2,7 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+
+import '../../ast.dart';
+import 'descriptors.dart';
 
 final String _dartJsHelperLibrary = '_js_helper';
 
@@ -67,122 +71,155 @@ String? _getJsNameValue(List<ElementAnnotation> metadata) {
   return null;
 }
 
-// TODO(srujzs): The following maps are roughly a couple MB (depending on
-// encoding), as there are hundreds of types bound in `dart:html` with a varying
-// number of properties per type. If this is too large, an alternative would be
-// to do a lookup in the AST every time, but this adds considerable computation
-// time for every rule.
-
-// Mapping of native types that are bound in `dart:html` to a map of their
-// properties to those properties' Dart names.
-final Map<String, Map<String, String>> _nativeTypeToDartProperties = {};
-// Mapping of types in `dart:html` to a map of their properties to the native
-// properties that those properties bind to.
-final Map<String, Map<String, String>> _dartTypeToNativeProperties = {};
-// Mapping of types in `dart:html` to the native types they bind.
-final Map<String, List<String>> _dartTypeToNativeTypes = {};
-
-/// Computes and caches native property bindings from `dart:html`.
+/// Class that queries and caches the `dart:html` library's bindings.
 ///
-/// Specifically, computes the three maps above. Given the current [library],
-/// uses its imports and exports to find the web libraries. This mapping is
-/// necessary if the library dynamically calls a setter, since the property name
-/// may match a renamed property in `dart:html`, and we would have no reference
-/// to that binding without this processing. It's also necessary to determine
-/// whether a native type could be used with non-static interop.
-void computeHtmlBindings(LibraryElement? library) {
-  // TODO(srujzs): This is expensive. If we visit a lot of libraries before we
-  // find one that imports the web libraries, this will be unperformant.
-  // Ideally, we should only do any processing once. We should see if we can use
-  // some form of a summary of the `dart:html` libraries as they will stay
-  // static across SDK versions.
-  if (library == null || _nativeTypeToDartProperties.isNotEmpty) return;
+/// `dart:html` 'binds' native types to certain types (annotated with `@Native`)
+/// in order to provide Dart interfaces for them. This class contains methods to
+/// query back and forth between the native type/member
+class DartHtmlBindings {
+  // TODO(srujzs): The following maps are roughly a couple MB (depending on
+  // encoding), as there are hundreds of types bound in `dart:html` with a
+  // varying number of members per type. If this is too large, an alternative
+  // would be to do a lookup in the AST every time, but this adds considerable
+  // computation time for every rule.
 
-  List<LibraryElement> visited = <LibraryElement>[];
-  visited.add(library);
-  List<LibraryElement> toProcess = <LibraryElement>[];
+  /// Mapping of native types that are bound in `dart:html` to a map of their
+  /// members to those members' Dart names.
+  final Map<String, Map<String, String>> _nativeTypeToDartMembers = {};
 
-  // Fetch the elements for all the web libraries. Since they're all under
-  // `dart:html`, the processing further down happens only once.
-  for (int index = 0; index < visited.length; index++) {
-    LibraryElement currLibrary = visited[index];
-    if (_dartHtmlLibraries.contains(currLibrary.name) &&
-        !toProcess.contains(currLibrary)) {
-      toProcess.add(currLibrary);
-    }
-    for (LibraryElement lib in [
-      ...currLibrary.importedLibraries,
-      ...currLibrary.exportedLibraries
-    ]) {
-      if (!visited.contains(lib)) visited.add(lib);
-    }
+  /// Mapping of types in `dart:html` to a map of their members to the native
+  /// members that those members bind to.
+  final Map<String, Map<String, String>> _dartTypeToNativeMembers = {};
+
+  /// Mapping of types in `dart:html` to the native types they bind.
+  final Map<String, List<String>> _dartTypeToNativeTypes = {};
+
+  /// Whether or not we've processed `dart:html` bindings yet.
+  bool _computedBindings = false;
+
+  /// The library used to process the bindings.
+  LibraryElement? _library;
+
+  DartHtmlBindings();
+
+  /// Set library using the compilation unit of [node] if needed for computing
+  /// `dart:html` bindings later.
+  ///
+  /// Once it's used to compute bindings, the value does not change.
+  void cacheLibrary(AstNode node) {
+    if (_computedBindings) return;
+    var library = getCompilationUnit(node)?.declaredElement?.library;
+    if (library != null) _library = library;
   }
 
-  if (toProcess.isEmpty) return;
+  /// Computes and caches native member bindings from `dart:html`.
+  ///
+  /// Specifically, computes the three maps above. Given the current library,
+  /// uses its imports and exports to find the web libraries. This mapping is
+  /// necessary if the library dynamically calls a setter, since the member
+  /// name may match a renamed member in `dart:html`, and we would have no
+  /// reference to that binding without this processing. It's also necessary to
+  /// determine whether a native type could be used with non-static interop.
+  void _computeHtmlBindings() {
+    if (_computedBindings || _library == null) return;
 
-  for (var webLibrary in toProcess) {
-    for (var cls in webLibrary.definingCompilationUnit.classes) {
-      List<String> nativeTypes = _getNativeTypes(cls) ?? [cls.name];
-      _dartTypeToNativeTypes[cls.name] = nativeTypes;
+    // TODO(srujzs): This is expensive. If we visit a lot of libraries before we
+    // find one that imports the web libraries, this will be unperformant.
+    // Ideally, we should only do any processing once. We should see if we can
+    // use some form of a summary of the `dart:html` libraries as they will stay
+    // static across SDK versions.
+    List<LibraryElement> visited = <LibraryElement>[];
+    visited.add(_library!);
+    List<LibraryElement> toProcess = <LibraryElement>[];
 
-      Map<String, String> nativePropToDartProp = {};
-      Map<String, String> dartPropToNativeProp = {};
-
-      for (Element member in [...cls.fields, ...cls.accessors]) {
-        // Only record external members as they map to the native names.
-        if (member is ExecutableElement && !member.isExternal ||
-            member is FieldElement && !member.isExternal) continue;
-        if (member.isSynthetic || member.isPrivate) continue;
-        // Use `displayName` to avoid setters appending `=` in `name`.
-        var dartProperty = member.displayName;
-        var nativeProperty = _getJsNameValue(member.metadata) ?? dartProperty;
-
-        nativePropToDartProp[nativeProperty] = dartProperty;
-        for (var nativeType in nativeTypes) {
-          _nativeTypeToDartProperties[nativeType] = nativePropToDartProp;
-        }
-
-        dartPropToNativeProp[dartProperty] = nativeProperty;
-        _dartTypeToNativeProperties[cls.name] = dartPropToNativeProp;
+    // Fetch the elements for all the web libraries. Since they're all under
+    // `dart:html`, the processing further down happens only once.
+    for (int index = 0; index < visited.length; index++) {
+      LibraryElement currLibrary = visited[index];
+      if (_dartHtmlLibraries.contains(currLibrary.name) &&
+          !toProcess.contains(currLibrary)) {
+        toProcess.add(currLibrary);
+      }
+      for (LibraryElement lib in [
+        ...currLibrary.importedLibraries,
+        ...currLibrary.exportedLibraries
+      ]) {
+        if (!visited.contains(lib)) visited.add(lib);
       }
     }
+
+    if (toProcess.isEmpty) return;
+
+    for (var webLibrary in toProcess) {
+      for (var cls in webLibrary.definingCompilationUnit.classes) {
+        List<String> nativeTypes = _getNativeTypes(cls) ?? [cls.name];
+        _dartTypeToNativeTypes[cls.name] = nativeTypes;
+
+        Map<String, String> nativePropToDartProp = {};
+        Map<String, String> dartPropToNativeProp = {};
+
+        for (Element member in [...cls.fields, ...cls.accessors]) {
+          // Only record external members as they map to the native names.
+          if (member is ExecutableElement && !member.isExternal ||
+              member is FieldElement && !member.isExternal) continue;
+          if (member.isSynthetic || member.isPrivate) continue;
+          // Use `displayName` to avoid setters appending `=` in `name`.
+          var dartMember = member.displayName;
+          var nativeMember = _getJsNameValue(member.metadata) ?? dartMember;
+
+          nativePropToDartProp[nativeMember] = dartMember;
+          for (var nativeType in nativeTypes) {
+            _nativeTypeToDartMembers[nativeType] = nativePropToDartProp;
+          }
+
+          dartPropToNativeProp[dartMember] = nativeMember;
+          _dartTypeToNativeMembers[cls.name] = dartPropToNativeProp;
+        }
+      }
+    }
+    _computedBindings = true;
+  }
+
+  /// Gets the web library member bound to the native type and member in
+  /// [descriptor].
+  ///
+  /// If [descriptor] is not a native pair or there is no associated member for
+  /// the type and member, returns the empty string.
+  String getWebLibraryMember(MemberDescriptor descriptor) {
+    if (!descriptor.isNative) return '';
+    _computeHtmlBindings();
+    return _nativeTypeToDartMembers[descriptor.type]?[descriptor.member] ?? '';
+  }
+
+  /// Gets the native member that is bound by the `dart:html` type and member in
+  /// [descriptor].
+  ///
+  /// If [descriptor] is not a `dart:html` pair or there is no associated member
+  /// for the type and member, returns the empty string.
+  String getNativeMemberBinding(MemberDescriptor descriptor) {
+    if (!descriptor.isDartHtml) return '';
+    _computeHtmlBindings();
+    return _dartTypeToNativeMembers[descriptor.type]?[descriptor.member] ?? '';
+  }
+
+  /// Gets the native types bound to the `dart:html` type in [descriptor].
+  ///
+  /// If [descriptor] is not a `dart:html` pair or there is not a `@Native`
+  /// class in `dart:html` for that type, returns the empty list.
+  List<String> getBoundNativeTypes(MemberDescriptor descriptor) {
+    if (!descriptor.isDartHtml) return [];
+    _computeHtmlBindings();
+    return _dartTypeToNativeTypes[descriptor.type] ?? [];
+  }
+
+  /// Returns whether or not the native type in [descriptor] is bound to a
+  /// `@Native` type in `dart:html`.
+  ///
+  /// If [descriptor] is not a native pair or there is no associated member for
+  /// the type and member, returns false.
+  bool hasDartHtmlBinding(MemberDescriptor descriptor) {
+    if (!descriptor.isNative) return false;
+    _computeHtmlBindings();
+    return _nativeTypeToDartMembers.containsKey(descriptor.type);
   }
 }
-
-/// Gets the web library property bound to [nativeType].[nativeMember].
-///
-/// If either inputs are null, or there is no associated member, returns null.
-String? getWebLibraryMember({String? nativeType, String? nativeMember}) {
-  if (_nativeTypeToDartProperties.containsKey(nativeType) &&
-      _nativeTypeToDartProperties[nativeType]!.containsKey(nativeMember)) {
-    return _nativeTypeToDartProperties[nativeType]![nativeMember];
-  }
-  return null;
-}
-
-/// Gets the native property that is bound by [dartType].[dartMember].
-///
-/// If either inputs are null, or there is no associated member, returns null.
-String? getNativePropertyBinding({String? dartType, String? dartMember}) {
-  if (_dartTypeToNativeProperties.containsKey(dartType) &&
-      _dartTypeToNativeProperties[dartType]!.containsKey(dartMember)) {
-    return _dartTypeToNativeProperties[dartType]![dartMember];
-  }
-  return dartMember;
-}
-
-/// Gets the native types bound to the `dart:html` type [dartType].
-///
-/// If [dartType] is null or is not a `@Native` class in `dart:html`, returns
-/// null.
-List<String>? getBoundNativeTypes({String? dartType}) {
-  if (_dartTypeToNativeTypes.containsKey(dartType)) {
-    return _dartTypeToNativeTypes[dartType];
-  }
-  return null;
-}
-
-/// Returns whether or not [nativeType] is bound to a `@Native` type in
-/// `dart:html`.
-bool hasDartHtmlBinding(String nativeType) =>
-    _nativeTypeToDartProperties.containsKey(nativeType);

--- a/lib/src/rules/conformance/web_bindings.dart
+++ b/lib/src/rules/conformance/web_bindings.dart
@@ -1,0 +1,188 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+
+final String _dartJsHelperLibrary = '_js_helper';
+
+final String _jsNameAnnotationName = 'JSName';
+final String _nativeAnnotationName = 'Native';
+
+final List<String> _dartHtmlLibraries = [
+  'dart.dom.html',
+  'dart.dom.indexed_db',
+  'dart.dom.svg',
+  'dart.dom.web_audio',
+  'dart.dom.web_gl',
+  'dart.dom.web_sql',
+];
+
+/// Returns whether [element] comes from one of the `dart:html` libraries that
+/// contain native bindings.
+bool fromDartHtml(Element element) =>
+    _dartHtmlLibraries.contains(element.library?.name);
+
+/// Returns all the underlying native types that this class corresponds to.
+///
+/// `@Native` annotations may contain multiple classes delimited by a comma. If
+/// the class has a `@Native` annotation and has values, returns a list of
+/// those. If the class has a `@Native` annotation and does not have any values,
+/// it returns a list with just the Dart name. Otherwise, returns null.
+List<String>? _getNativeTypes(ClassElement element) {
+  for (var annotation in element.metadata) {
+    var annotationElement = annotation.element;
+    if (annotationElement is ConstructorElement &&
+        annotationElement.enclosingElement.name == _nativeAnnotationName &&
+        annotationElement.library.name == _dartJsHelperLibrary) {
+      var value =
+          annotation.computeConstantValue()?.getField('name')?.toStringValue();
+      if (value != null && value.isNotEmpty) {
+        return value.split(',');
+      } else {
+        return [element.name];
+      }
+    }
+  }
+  return null;
+}
+
+/// Returns the value in the `@JSName` annotation.
+///
+/// If the annotation exists and has a value, returns that value. Otherwise,
+/// returns null.
+String? _getJsNameValue(List<ElementAnnotation> metadata) {
+  for (var annotation in metadata) {
+    var annotationElement = annotation.element;
+    if (annotationElement is ConstructorElement &&
+        annotationElement.enclosingElement.name == _jsNameAnnotationName &&
+        annotationElement.library.name == _dartJsHelperLibrary) {
+      var value =
+          annotation.computeConstantValue()?.getField('name')?.toStringValue();
+      if (value != null && value.isNotEmpty) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+// TODO(srujzs): The following maps are roughly a couple MB (depending on
+// encoding), as there are hundreds of types bound in `dart:html` with a varying
+// number of properties per type. If this is too large, an alternative would be
+// to do a lookup in the AST every time, but this adds considerable computation
+// time for every rule.
+
+// Mapping of native types that are bound in `dart:html` to a map of their
+// properties to those properties' Dart names.
+final Map<String, Map<String, String>> _nativeTypeToDartProperties = {};
+// Mapping of types in `dart:html` to a map of their properties to the native
+// properties that those properties bind to.
+final Map<String, Map<String, String>> _dartTypeToNativeProperties = {};
+// Mapping of types in `dart:html` to the native types they bind.
+final Map<String, List<String>> _dartTypeToNativeTypes = {};
+
+/// Computes and caches native property bindings from `dart:html`.
+///
+/// Specifically, computes the three maps above. Given the current [library],
+/// uses its imports and exports to find the web libraries. This mapping is
+/// necessary if the library dynamically calls a setter, since the property name
+/// may match a renamed property in `dart:html`, and we would have no reference
+/// to that binding without this processing. It's also necessary to determine
+/// whether a native type could be used with non-static interop.
+void computeHtmlBindings(LibraryElement? library) {
+  // TODO(srujzs): This is expensive. If we visit a lot of libraries before we
+  // find one that imports the web libraries, this will be unperformant.
+  // Ideally, we should only do any processing once. We should see if we can use
+  // some form of a summary of the `dart:html` libraries as they will stay
+  // static across SDK versions.
+  if (library == null || _nativeTypeToDartProperties.isNotEmpty) return;
+
+  List<LibraryElement> visited = <LibraryElement>[];
+  visited.add(library);
+  List<LibraryElement> toProcess = <LibraryElement>[];
+
+  // Fetch the elements for all the web libraries. Since they're all under
+  // `dart:html`, the processing further down happens only once.
+  for (int index = 0; index < visited.length; index++) {
+    LibraryElement currLibrary = visited[index];
+    if (_dartHtmlLibraries.contains(currLibrary.name) &&
+        !toProcess.contains(currLibrary)) {
+      toProcess.add(currLibrary);
+    }
+    for (LibraryElement lib in [
+      ...currLibrary.importedLibraries,
+      ...currLibrary.exportedLibraries
+    ]) {
+      if (!visited.contains(lib)) visited.add(lib);
+    }
+  }
+
+  if (toProcess.isEmpty) return;
+
+  for (var webLibrary in toProcess) {
+    for (var cls in webLibrary.definingCompilationUnit.classes) {
+      List<String> nativeTypes = _getNativeTypes(cls) ?? [cls.name];
+      _dartTypeToNativeTypes[cls.name] = nativeTypes;
+
+      Map<String, String> nativePropToDartProp = {};
+      Map<String, String> dartPropToNativeProp = {};
+
+      for (Element member in [...cls.fields, ...cls.accessors]) {
+        // Only record external members as they map to the native names.
+        if (member is ExecutableElement && !member.isExternal ||
+            member is FieldElement && !member.isExternal) continue;
+        if (member.isSynthetic || member.isPrivate) continue;
+        // Use `displayName` to avoid setters appending `=` in `name`.
+        var dartProperty = member.displayName;
+        var nativeProperty = _getJsNameValue(member.metadata) ?? dartProperty;
+
+        nativePropToDartProp[nativeProperty] = dartProperty;
+        for (var nativeType in nativeTypes) {
+          _nativeTypeToDartProperties[nativeType] = nativePropToDartProp;
+        }
+
+        dartPropToNativeProp[dartProperty] = nativeProperty;
+        _dartTypeToNativeProperties[cls.name] = dartPropToNativeProp;
+      }
+    }
+  }
+}
+
+/// Gets the web library property bound to [nativeType].[nativeMember].
+///
+/// If either inputs are null, or there is no associated member, returns null.
+String? getWebLibraryMember({String? nativeType, String? nativeMember}) {
+  if (_nativeTypeToDartProperties.containsKey(nativeType) &&
+      _nativeTypeToDartProperties[nativeType]!.containsKey(nativeMember)) {
+    return _nativeTypeToDartProperties[nativeType]![nativeMember];
+  }
+  return null;
+}
+
+/// Gets the native property that is bound by [dartType].[dartMember].
+///
+/// If either inputs are null, or there is no associated member, returns null.
+String? getNativePropertyBinding({String? dartType, String? dartMember}) {
+  if (_dartTypeToNativeProperties.containsKey(dartType) &&
+      _dartTypeToNativeProperties[dartType]!.containsKey(dartMember)) {
+    return _dartTypeToNativeProperties[dartType]![dartMember];
+  }
+  return dartMember;
+}
+
+/// Gets the native types bound to the `dart:html` type [dartType].
+///
+/// If [dartType] is null or is not a `@Native` class in `dart:html`, returns
+/// null.
+List<String>? getBoundNativeTypes({String? dartType}) {
+  if (_dartTypeToNativeTypes.containsKey(dartType)) {
+    return _dartTypeToNativeTypes[dartType];
+  }
+  return null;
+}
+
+/// Returns whether or not [nativeType] is bound to a `@Native` type in
+/// `dart:html`.
+bool hasDartHtmlBinding(String nativeType) =>
+    _nativeTypeToDartProperties.containsKey(nativeType);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dev_dependencies:
   cli_util: ^0.3.0
   github: ^9.0.0
   grinder: ^0.9.0
+  js: ^0.6.4
   lints: ^1.0.0
   markdown: ^4.0.0
   matcher: ^0.12.10

--- a/test/all.dart
+++ b/test/all.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/src/lint/io.dart';
 
 import 'ascii_utils_test.dart' as ascii_utils;
+import 'conformance_checks_test.dart' as conformance_checks_test;
 import 'engine_test.dart' as engine_test;
 import 'formatter_test.dart' as formatter_test;
 import 'integration_test.dart' as integration_test;
@@ -23,6 +24,7 @@ void main() {
   outSink = MockIOSink();
 
   ascii_utils.main();
+  conformance_checks_test.main();
   engine_test.main();
   formatter_test.main();
   integration_test.main();

--- a/test/conformance/test_data/banned_property_write/disallow_set_foo_bar.dart
+++ b/test/conformance/test_data/banned_property_write/disallow_set_foo_bar.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Test that native types that don't have a `dart:html` `@Native` class
+// equivalent are still checked.
+
+@JS()
+library disallow_set_foo_bar;
+
+import 'dart:js_util';
+import 'package:js/js.dart';
+
+@JS()
+class FooWithSetter {
+  external FooWithSetter();
+  // Silence avoid_setters_without_getters.
+  external String get bar;
+  external set bar(String val);
+}
+
+@JS()
+class FooWithVar {
+  external FooWithVar();
+  external String bar;
+}
+
+@JS()
+@staticInterop
+class StaticFooWithSetter {
+  external StaticFooWithSetter();
+}
+
+extension StaticFooWithSetterExtension on StaticFooWithSetter {
+  external set bar(String val);
+}
+
+@JS()
+@staticInterop
+class StaticFooWithNonExternal {
+  external StaticFooWithNonExternal();
+}
+
+extension StaticFooWithSetterNonExternalExtension on StaticFooWithNonExternal {
+  set bar(String val) {}
+  set barWithJsUtil(String val) =>
+      setProperty<String>(this, 'bar', val); // LINT
+}
+
+void main() {
+  var bar = 'bar';
+
+  var fooSetter = FooWithSetter();
+  fooSetter.bar = bar; // LINT
+  (fooSetter as dynamic).bar = bar; // LINT
+
+  var fooVar = FooWithVar();
+  fooVar.bar = bar; // LINT
+
+  var staticFooSetter = StaticFooWithSetter();
+  staticFooSetter.bar = bar; // LINT
+
+  var staticFooNonExt = StaticFooWithNonExternal();
+  staticFooNonExt.bar = bar;
+
+  setProperty(fooSetter, 'bar', bar); // LINT
+  setProperty(staticFooSetter, 'bar', bar); // LINT
+  Object fooObj = fooSetter;
+  setProperty(fooObj, 'bar', bar); // LINT
+}

--- a/test/conformance/test_data/banned_property_write/disallow_set_htmldocument_title.dart
+++ b/test/conformance/test_data/banned_property_write/disallow_set_htmldocument_title.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Test that Dart-specific properties are checked.
+
+@JS()
+library disallow_set_htmldocument_title;
+
+import 'dart:html';
+import 'dart:js_util';
+import 'package:js/js.dart';
+
+@JS()
+@staticInterop
+class HtmlDocumentWithSetter {
+  external HtmlDocumentWithSetter();
+}
+
+extension HtmlDocumentWithSetterExtension on HtmlDocumentWithSetter {
+  external set title(String val);
+}
+
+@JS()
+@staticInterop
+class HtmlDocumentWithVar {
+  external HtmlDocumentWithVar();
+}
+
+extension HtmlDocumentWithVarExtension on HtmlDocumentWithVar {
+  external String title;
+}
+
+@JS()
+@staticInterop
+class HtmlDocumentWithNonExternal {
+  external HtmlDocumentWithNonExternal();
+}
+
+extension HtmlDocumentWithNonExternalExtension on HtmlDocumentWithNonExternal {
+  set title(String val) {}
+  set titleWithJsUtil(String val) => setProperty<String>(this, 'title', val);
+}
+
+void main() {
+  var title = 'title';
+  // We don't need a real HtmlDocument here for static checks.
+  HtmlDocument htmlDocument = 0 as HtmlDocument;
+
+  htmlDocument.title = title; // LINT
+  (htmlDocument as dynamic).title = title; // LINT
+
+  var nonExt = HtmlDocumentWithNonExternal();
+  nonExt.title = title;
+
+  // Note that the following do not trigger any lints, because we're using the
+  // Dart declaration for the rule. Only calls to that `dart:html` declaration
+  // or dynamic calls with the same property name are checked.
+  var extSetter = HtmlDocumentWithSetter();
+  extSetter.title = title;
+
+  var extVar = HtmlDocumentWithVar();
+  extVar.title = title;
+
+  setProperty(extSetter, 'title', title);
+  setProperty(htmlDocument, 'title', title);
+  Object htmlDocumentObj = htmlDocument;
+  setProperty(htmlDocumentObj, 'title', title);
+}

--- a/test/conformance/test_data/banned_property_write/disallow_set_htmlinputelement_webkitdirectory.dart
+++ b/test/conformance/test_data/banned_property_write/disallow_set_htmlinputelement_webkitdirectory.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Test that properties and class names that are renamed from their `@Native`
+// equivalents are still checked.
+
+@JS()
+library disallow_set_htmlinputelement_webkitdirectory;
+
+import 'dart:html';
+import 'dart:js_util';
+import 'package:js/js.dart';
+
+@JS()
+@staticInterop
+class HTMLInputElementWithSetter {
+  external HTMLInputElementWithSetter();
+}
+
+extension HTMLInputElementWithSetterExtension on HTMLInputElementWithSetter {
+  external set webkitdirectory(bool val);
+}
+
+@JS()
+@staticInterop
+class HTMLInputElementWithVar {
+  external HTMLInputElementWithVar();
+}
+
+extension HTMLInputElementWithVarExtension on HTMLInputElementWithVar {
+  external bool webkitdirectory;
+}
+
+@JS()
+@staticInterop
+class HTMLInputElementWithNonExternal {
+  external HTMLInputElementWithNonExternal();
+}
+
+extension HTMLInputElementWithNonExternalExtension
+    on HTMLInputElementWithNonExternal {
+  set webkitdirectory(bool val) {}
+  set webkitdirectoryWithJsUtil(bool val) =>
+      setProperty<bool>(this, 'webkitdirectory', val); // LINT
+}
+
+void main() {
+  var webkitdirectory = true;
+  // We don't need a real HTMLInputElement here for static checks.
+  InputElement inputElement = 0 as InputElement;
+
+  inputElement.directory = webkitdirectory; // LINT
+  (inputElement as dynamic).directory = webkitdirectory; // LINT
+
+  var extSetter = HTMLInputElementWithSetter();
+  extSetter.webkitdirectory = webkitdirectory; // LINT
+
+  var extVar = HTMLInputElementWithVar();
+  extVar.webkitdirectory = webkitdirectory; // LINT
+
+  var nonExt = HTMLInputElementWithNonExternal();
+  nonExt.webkitdirectory = webkitdirectory;
+
+  setProperty(extSetter, 'webkitdirectory', webkitdirectory); // LINT
+  setProperty(inputElement, 'webkitdirectory', webkitdirectory); // LINT
+  Object inputElementObject = inputElement;
+  setProperty(inputElementObject, 'webkitdirectory', webkitdirectory); // LINT
+}

--- a/test/conformance/test_data/banned_property_write/disallow_set_window_name.dart
+++ b/test/conformance/test_data/banned_property_write/disallow_set_window_name.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Test that properties that are disallowed from being set are checked using the
+// native type and property.
+
+@JS()
+library disallow_set_window_name;
+
+import 'dart:html';
+import 'dart:js_util';
+import 'package:js/js.dart';
+
+@JS()
+@staticInterop
+class WindowWithSetter {
+  external WindowWithSetter();
+}
+
+extension WindowWithSetterExtension on WindowWithSetter {
+  external set name(String val);
+}
+
+@JS()
+@staticInterop
+class WindowWithVar {
+  external WindowWithVar();
+}
+
+extension WindowWithVarExtension on WindowWithVar {
+  external String name;
+}
+
+@JS()
+@staticInterop
+class WindowWithNonExternal {
+  external WindowWithNonExternal();
+}
+
+extension WindowWithNonExternalExtension on WindowWithNonExternal {
+  set name(String val) {}
+  set nameWthJsUtil(String val) =>
+      setProperty<String>(this, 'name', val); // LINT
+}
+
+void main() {
+  var name = 'name';
+
+  window.name = name; // LINT
+  (window as dynamic).name = name; // LINT
+
+  var extSetter = WindowWithSetter();
+  extSetter.name = name; // LINT
+
+  var extVar = WindowWithVar();
+  extVar.name = name; // LINT
+
+  var nonExt = WindowWithNonExternal();
+  nonExt.name = name;
+
+  setProperty(extSetter, 'name', name); // LINT
+  setProperty(window, 'name', name); // LINT
+  Object windowObj = window;
+  setProperty(windowObj, 'name', name); // LINT
+}

--- a/test/conformance/test_rules/banned_property_write/disallow_set_foo_bar.dart
+++ b/test/conformance/test_rules/banned_property_write/disallow_set_foo_bar.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:linter/src/rules/conformance/banned_property_write.dart';
+
+class DisallowSetFooBar extends BannedPropertyWrite {
+  DisallowSetFooBar()
+      : super(
+            name: 'disallow_set_foo_bar',
+            description: 'Avoid setting Foo.bar.',
+            details: 'This lint is only meant for testing conformance rules. '
+                'This lint should not be published.',
+            nativeType: 'Foo',
+            nativeProperty: 'bar');
+}

--- a/test/conformance/test_rules/banned_property_write/disallow_set_htmldocument_title.dart
+++ b/test/conformance/test_rules/banned_property_write/disallow_set_htmldocument_title.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:linter/src/rules/conformance/banned_property_write.dart';
+
+class DisallowSetHtmlDocumentTitle extends BannedPropertyWrite {
+  DisallowSetHtmlDocumentTitle()
+      : super.withDartHtmlTypes(
+            name: 'disallow_set_htmldocument_title',
+            description: 'Avoid setting HtmlDocument.title.',
+            details: 'This lint is only meant for testing conformance rules. '
+                'This lint should not be published.',
+            dartHtmlType: 'HtmlDocument',
+            dartHtmlProperty: 'title');
+}

--- a/test/conformance/test_rules/banned_property_write/disallow_set_htmlinputelement_webkitdirectory.dart
+++ b/test/conformance/test_rules/banned_property_write/disallow_set_htmlinputelement_webkitdirectory.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:linter/src/rules/conformance/banned_property_write.dart';
+
+class DisallowSetHTMLInputElementWebkitDirectory extends BannedPropertyWrite {
+  DisallowSetHTMLInputElementWebkitDirectory()
+      : super(
+            name: 'disallow_set_htmlinputelement_webkitdirectory',
+            description: 'Avoid setting HTMLInputElement.webkitdirectory.',
+            details: 'This lint is only meant for testing conformance rules. '
+                'This lint should not be published.',
+            nativeType: 'HTMLInputElement',
+            nativeProperty: 'webkitdirectory');
+}

--- a/test/conformance/test_rules/banned_property_write/disallow_set_window_name.dart
+++ b/test/conformance/test_rules/banned_property_write/disallow_set_window_name.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:linter/src/rules/conformance/banned_property_write.dart';
+
+class DisallowSetWindowName extends BannedPropertyWrite {
+  DisallowSetWindowName()
+      : super(
+            name: 'disallow_set_window_name',
+            description: 'Avoid setting window.name.',
+            details: 'This lint is only meant for testing conformance rules. '
+                'This lint should not be published.',
+            nativeType: 'Window',
+            nativeProperty: 'name');
+}

--- a/test/conformance_checks_test.dart
+++ b/test/conformance_checks_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:linter/src/analyzer.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'conformance/test_rules/banned_property_write/disallow_set_foo_bar.dart';
+import 'conformance/test_rules/banned_property_write/disallow_set_htmldocument_title.dart';
+import 'conformance/test_rules/banned_property_write/disallow_set_htmlinputelement_webkitdirectory.dart';
+import 'conformance/test_rules/banned_property_write/disallow_set_window_name.dart';
+import 'rule_test.dart';
+import 'test_constants.dart';
+
+/// All the test rules registered for these tests.
+List<LintRule> get conformanceTestRules => _bannedPropertyWriteTestRules;
+
+List<LintRule> _bannedPropertyWriteTestRules = [
+  DisallowSetFooBar(),
+  DisallowSetHtmlDocumentTitle(),
+  DisallowSetHTMLInputElementWebkitDirectory(),
+  DisallowSetWindowName(),
+];
+
+void main() {
+  void register(LintRule rule) => Analyzer.facade.register(rule);
+  group('banned_property_write', () {
+    // Register all the test rules for this check.
+    _bannedPropertyWriteTestRules.forEach(register);
+    for (var entry in Directory(p.join(
+            p.join(conformanceTestsDir, 'test_data'), 'banned_property_write'))
+        .listSync()) {
+      if (entry is! File) continue;
+
+      var ruleName = p.basenameWithoutExtension(entry.path);
+      testRule(ruleName, entry, useMockSdk: false);
+    }
+  });
+}

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -12,6 +12,7 @@ import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
 import '../test_data/rules/experiments/experiments.dart';
+import 'conformance_checks_test.dart' as conformance_test;
 import 'integration/always_require_non_null_named_parameters.dart'
     as always_require_non_null_named_parameters;
 import 'integration/avoid_private_typedef_functions.dart'
@@ -158,7 +159,9 @@ void coreTests() {
 
         var registered = Analyzer.facade.registeredRules
             .where((r) =>
-                r.maturity != Maturity.deprecated && !experiments.contains(r))
+                r.maturity != Maturity.deprecated &&
+                !experiments.contains(r) &&
+                !conformance_test.conformanceTestRules.contains(r))
             .map((r) => r.name);
 
         for (var l in configuredLints) {
@@ -167,13 +170,7 @@ void coreTests() {
           }
         }
 
-        expect(
-            configuredLints,
-            unorderedEquals(Analyzer.facade.registeredRules
-                .where((r) =>
-                    r.maturity != Maturity.deprecated &&
-                    !experiments.contains(r))
-                .map((r) => r.name)));
+        expect(configuredLints, unorderedEquals(registered));
       });
     });
   });

--- a/test/test_constants.dart
+++ b/test/test_constants.dart
@@ -4,6 +4,7 @@
 
 import 'package:path/path.dart' as path;
 
+final String conformanceTestsDir = path.join('test', 'conformance');
 final String integrationTestDir = path.join('test_data', 'integration');
 final String ruleTestDir = path.join('test_data', 'rules');
 final String testConfigDir = path.join('test', 'configs');


### PR DESCRIPTION
# Description

- Adds general conformance rule type (ConformanceRule)
- Adds rule to check disallowed property writes for native and Dart
  names (BannedPropertyWrite)
- Adds tests and test rules to validate the above
- Updates js dependency to 0.64 to include static interop

Fixes # (issue)

https://github.com/dart-lang/linter/issues/3142

There are certain parts I would like feedback on:

- Whether the way I'm using rules vs codes makes sense. I expect rule creators to instantiate a `BannedPropertyWrite` rule, and place the description in there, while the `SecurityLintCode` is meant to inform the user why the rule was triggered (because the type is dynamic, because interop, etc.). Does this make sense? Should it be reversed? Or is my mental model of this off?
- Whether the way I cache `dart:html` types and properties is ok from both a memory and time perspective. If there's a faster and more memory-efficient way to do this, I'm definitely open to it, as this may likely be expensive to compute across linter runs.

Thanks and let me know if you have questions.