### PR TITLE
Improve unnecessary_late to target variable name

### DIFF
--- a/lib/src/rules/unnecessary_late.dart
+++ b/lib/src/rules/unnecessary_late.dart
@@ -81,12 +81,11 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (lateKeyword == null) {
       return;
     }
+
     for (var variable in node.variables) {
-      if (variable.initializer == null) {
-        // Is necessary if any variable is missing initializer
-        return;
+      if (variable.initializer != null) {
+        rule.reportLint(variable.name);
       }
     }
-    rule.reportLintForToken(lateKeyword);
   }
 }

--- a/lib/src/rules/unnecessary_late.dart
+++ b/lib/src/rules/unnecessary_late.dart
@@ -77,8 +77,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _visitVariableDeclarations(VariableDeclarationList node) {
-    var lateKeyword = node.lateKeyword;
-    if (lateKeyword == null) {
+    if (node.lateKeyword == null) {
       return;
     }
 

--- a/lib/src/rules/unnecessary_late.dart
+++ b/lib/src/rules/unnecessary_late.dart
@@ -77,10 +77,16 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _visitVariableDeclarations(VariableDeclarationList node) {
+    var lateKeyword = node.lateKeyword;
+    if (lateKeyword == null) {
+      return;
+    }
     for (var variable in node.variables) {
-      if (variable.isLate && variable.initializer != null) {
-        rule.reportLint(variable);
+      if (variable.initializer == null) {
+        // Is necessary if any variable is missing initializer
+        return;
       }
     }
+    rule.reportLintForToken(lateKeyword);
   }
 }

--- a/test_data/rules/unnecessary_late.dart
+++ b/test_data/rules/unnecessary_late.dart
@@ -8,9 +8,11 @@ late String unnecessaryTopLevelLate = ''; // LINT
 
 late String necessaryTopLevelLate; // OK
 
-late String unnecessaryListLateOne = '', unnecessaryListLateTwo = ''; // LINT
+late String unnecessaryListLateOne = '', // LINT
+    unnecessaryListLateTwo = ''; // LINT
 
-late String necessaryListLate, forcedNecessaryListLate = ''; // OK
+late String necessaryListLate, // OK
+    unnecessaryListLate = ''; // LINT
 
 String unnecessaryTopLevel = ''; // OK
 

--- a/test_data/rules/unnecessary_late.dart
+++ b/test_data/rules/unnecessary_late.dart
@@ -8,6 +8,10 @@ late String unnecessaryTopLevelLate = ''; // LINT
 
 late String necessaryTopLevelLate; // OK
 
+late String unnecessaryListLateOne = '', unnecessaryListLateTwo = ''; // LINT
+
+late String necessaryListLate, forcedNecessaryListLate = ''; // OK
+
 String unnecessaryTopLevel = ''; // OK
 
 class Test {


### PR DESCRIPTION
Previously the `unnecessary_late` lint triggered on the whole variable declaration range, which was a bit confusing, particularly in a list of declarations. Now the lint reports on just the name. I've also avoided looping if the list is not marked `late`. 