### PR TITLE
super param support for `avoid_unused_constructor_parameters`

### DIFF
--- a/lib/src/rules/avoid_unused_constructor_parameters.dart
+++ b/lib/src/rules/avoid_unused_constructor_parameters.dart
@@ -58,6 +58,7 @@ class _ConstructorVisitor extends RecursiveAstVisitor {
           var element = p.declaredElement;
           return element != null &&
               element is! FieldFormalParameterElement &&
+              element is! SuperFormalParameterElement &&
               !element.hasDeprecated &&
               !element.name.isJustUnderscores;
         }).toSet();

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -9,6 +9,8 @@ import 'avoid_redundant_argument_values.dart'
     as avoid_redundant_argument_values;
 import 'avoid_shadowing_type_parameters.dart'
     as avoid_shadowing_type_parameters;
+import 'avoid_unused_constructor_parameters.dart'
+    as avoid_unused_constructor_parameters;
 import 'conditional_uri_does_not_exist.dart' as conditional_uri_does_not_exist;
 import 'deprecated_consistency.dart' as deprecated_consistency;
 import 'file_names.dart' as file_names;
@@ -46,6 +48,7 @@ void main() {
   avoid_init_to_null.main();
   avoid_redundant_argument_values.main();
   avoid_shadowing_type_parameters.main();
+  avoid_unused_constructor_parameters.main();
   conditional_uri_does_not_exist.main();
   deprecated_consistency.main();
   file_names.main();

--- a/test/rules/avoid_unused_constructor_parameters.dart
+++ b/test/rules/avoid_unused_constructor_parameters.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AvoidUnusedConstructorParametersTest);
+  });
+}
+
+@reflectiveTest
+class AvoidUnusedConstructorParametersTest extends LintRuleTest {
+  @override
+  List<String> get experiments => [
+        EnableString.super_parameters,
+      ];
+
+  @override
+  String get lintRule => 'avoid_unused_constructor_parameters';
+
+  test_super() async {
+    await assertNoDiagnostics(r'''
+class A {
+  String a;
+  String b;
+  A(this.a, this.b);
+}
+class B extends A {
+  B(super.a, super.b);
+}
+''');
+  }
+}


### PR DESCRIPTION
See: #3131.

/cc @bwilkerson 