### PR TITLE
add support for field formals to `avoid_annotating_with_dynamic`

### DIFF
--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -48,6 +48,7 @@ class AvoidAnnotatingWithDynamic extends LintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
+    registry.addFieldFormalParameter(this, visitor);
     registry.addSimpleFormalParameter(this, visitor);
     registry.addSuperFormalParameter(this, visitor);
   }
@@ -57,6 +58,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
+
+  @override
+  void visitFieldFormalParameter(FieldFormalParameter node) {
+    _checkNode(node, node.type);
+  }
 
   @override
   void visitSimpleFormalParameter(SimpleFormalParameter node) {

--- a/test/rules/avoid_annotating_with_dynamic.dart
+++ b/test/rules/avoid_annotating_with_dynamic.dart
@@ -22,6 +22,17 @@ class AvoidAnnotatingWithDynamicTest extends LintRuleTest {
   @override
   String get lintRule => 'avoid_annotating_with_dynamic';
 
+  test_fieldFormals() async {
+    await assertDiagnostics(r'''
+class A {
+  var a;
+  A(dynamic this.a);
+}
+''', [
+      lint('avoid_annotating_with_dynamic', 23, 14),
+    ]);
+  }
+
   test_super() async {
     await assertDiagnostics(r'''
 class A {


### PR DESCRIPTION
Follow-up from #3166 

/cc @bwilkerson 
