### PR TITLE
enhanced enum support for `avoid_returning_this`

### DIFF
--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -77,14 +77,15 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isOperator) return;
 
     var parent = node.parent;
-    if (parent is ClassOrMixinDeclaration) {
+    if (parent is ClassOrMixinDeclaration || parent is EnumDeclaration) {
       if (DartTypeUtilities.overridesMethod(node)) {
         return;
       }
 
       var returnType = node.declaredElement?.returnType;
       if (returnType is InterfaceType &&
-          returnType.element == parent.declaredElement) {
+          // ignore: cast_nullable_to_non_nullable
+          returnType.element == (parent as Declaration).declaredElement) {
       } else {
         return;
       }

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -9,6 +9,7 @@ import 'avoid_function_literals_in_foreach_calls.dart'
 import 'avoid_init_to_null.dart' as avoid_init_to_null;
 import 'avoid_redundant_argument_values.dart'
     as avoid_redundant_argument_values;
+import 'avoid_returning_this.dart' as avoid_returning_this;
 import 'avoid_shadowing_type_parameters.dart'
     as avoid_shadowing_type_parameters;
 import 'avoid_types_as_parameter_names.dart' as avoid_types_as_parameter_names;
@@ -55,6 +56,7 @@ void main() {
   avoid_function_literals_in_foreach_calls.main();
   avoid_init_to_null.main();
   avoid_redundant_argument_values.main();
+  avoid_returning_this.main();
   avoid_shadowing_type_parameters.main();
   avoid_types_as_parameter_names.main();
   avoid_unused_constructor_parameters.main();

--- a/test/rules/avoid_returning_this.dart
+++ b/test/rules/avoid_returning_this.dart
@@ -16,8 +16,8 @@ main() {
 class AvoidReturningThisTest extends LintRuleTest {
   @override
   List<String> get experiments => [
-    EnableString.enhanced_enums,
-  ];
+        EnableString.enhanced_enums,
+      ];
 
   @override
   String get lintRule => 'avoid_returning_this';

--- a/test/rules/avoid_returning_this.dart
+++ b/test/rules/avoid_returning_this.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AvoidReturningThisTest);
+  });
+}
+
+@reflectiveTest
+class AvoidReturningThisTest extends LintRuleTest {
+  @override
+  List<String> get experiments => [
+    EnableString.enhanced_enums,
+  ];
+
+  @override
+  String get lintRule => 'avoid_returning_this';
+
+  test_method() async {
+    await assertDiagnostics(r'''
+enum A {
+  a,b,c;
+  A a() => this;
+}
+''', [
+      lint('avoid_returning_this', 22, 1),
+    ]);
+  }
+}


### PR DESCRIPTION
Fixes #3092

/cc @bwilkerson 