### PR TITLE
Add improved text for type_init_formals

### DIFF
--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -22,6 +22,9 @@ a constructor parameter is using `super.x` to forward to a super constructor,
 then the type of the parameter is understood to be the same as the super
 constructor parameter.
 
+Type annotating an initializing formal with a different type than that of the
+field is OK.
+
 **GOOD:**
 ```dart
 class Point {


### PR DESCRIPTION
# Description

Add text to address #3214

Fixes #3214

It appears that the spelling "OK" is the most common in this package.