### PR TITLE
Add a note above how always_use_package_imports and avoid_relative_lib_imports complement each other

### DIFF
--- a/lib/src/rules/always_use_package_imports.dart
+++ b/lib/src/rules/always_use_package_imports.dart
@@ -18,8 +18,9 @@ that is to ensure you consistently use absolute imports for files withing the
 `lib/` directory.
 
 This is the opposite of 'prefer_relative_imports'.
-Might be used with 'avoid_relative_lib_imports' to avoid relative imports of
-files within `lib/` directory outside of it. (for example `test/`)
+
+You can also use 'avoid_relative_lib_imports' to disallow relative imports of
+files within `lib/` directory outside of it (for example `test/`).
 
 **GOOD:**
 
@@ -57,6 +58,8 @@ class AlwaysUsePackageImports extends LintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
+    // Relative paths from outside of the lib folder are handled by the
+    // `avoid_relative_lib_imports` lint.
     if (!isInLibDir(context.currentUnit.unit, context.package)) {
       return;
     }

--- a/lib/src/rules/avoid_relative_lib_imports.dart
+++ b/lib/src/rules/avoid_relative_lib_imports.dart
@@ -16,6 +16,9 @@ where the same member gets imported in two different ways.  An easy way to avoid
 that is to ensure you have no relative imports that include `lib/` in their
 paths.
 
+You can also use 'always_use_package_imports' to disallow relative imports
+between files within `lib/`.
+
 **GOOD:**
 
 ```dart
@@ -60,9 +63,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   _Visitor(this.rule);
 
   bool isRelativeLibImport(ImportDirective node) {
-    // This check is too narrow.  Really we should be checking against the
-    // resolved URI and not it's literal string content.
-    // See: https://github.com/dart-lang/linter/issues/2419
+    // Relative paths from within the `lib` folder are covered by the
+    // `always_use_package_imports` lint.
     var uriContent = node.uriContent;
     if (uriContent != null) {
       var uri = Uri.tryParse(uriContent);


### PR DESCRIPTION
See https://github.com/dart-lang/linter/pull/3225#issuecomment-1036306676.

@pq @bwilkerson 