### PR TITLE
enhanced enum support for `avoid_equals_and_hash_code_on_mutable_classes`

### DIFF
--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -108,7 +108,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   ClassElement? _getClassForMethod(MethodDeclaration node) =>
       // todo (pq): should this be ClassOrMixinDeclaration ?
-  node.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
+      node.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
     var inheritedAndSelfElements = <ClassElement>[

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -106,13 +106,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  ClassElement? _getClassForMethod(MethodDeclaration node) {
-    var decl = node.thisOrAncestorMatching(
-            (p) => p is EnumDeclaration || p is ClassDeclaration)
-        as NamedCompilationUnitMember?;
-    var element = decl?.declaredElement;
-    return element is ClassElement ? element : null;
-  }
+  ClassElement? _getClassForMethod(MethodDeclaration node) =>
+      // todo (pq): should this be ClassOrMixinDeclaration ?
+  node.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
     var inheritedAndSelfElements = <ClassElement>[

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -108,7 +108,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   ClassElement? _getClassForMethod(MethodDeclaration node) {
     var decl = node.thisOrAncestorMatching(
-            // todo (pq): should this be ClassOrMixinDeclaration
             (p) => p is EnumDeclaration || p is ClassDeclaration)
         as NamedCompilationUnitMember?;
     var element = decl?.declaredElement;

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -106,9 +106,14 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  ClassElement? _getClassForMethod(MethodDeclaration node) =>
-      // todo (pq): should this be ClassOrMixinDeclaration ?
-      node.thisOrAncestorOfType<ClassDeclaration>()?.declaredElement;
+  ClassElement? _getClassForMethod(MethodDeclaration node) {
+    var decl = node.thisOrAncestorMatching(
+            // todo (pq): should this be ClassOrMixinDeclaration
+            (p) => p is EnumDeclaration || p is ClassDeclaration)
+        as NamedCompilationUnitMember?;
+    var element = decl?.declaredElement;
+    return element is ClassElement ? element : null;
+  }
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
     var inheritedAndSelfElements = <ClassElement>[

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -5,6 +5,8 @@
 import 'annotate_overrides_test.dart' as annotate_overrides;
 import 'avoid_annotating_with_dynamic_test.dart'
     as avoid_annotating_with_dynamic;
+import 'avoid_equals_and_hash_code_on_mutable_classes_test.dart'
+    as avoid_equals_and_hash_code_on_mutable_classes;
 import 'avoid_function_literals_in_foreach_calls_test.dart'
     as avoid_function_literals_in_foreach_calls;
 import 'avoid_init_to_null_test.dart' as avoid_init_to_null;
@@ -66,6 +68,7 @@ import 'void_checks_test.dart' as void_checks;
 void main() {
   annotate_overrides.main();
   avoid_annotating_with_dynamic.main();
+  avoid_equals_and_hash_code_on_mutable_classes.main();
   avoid_function_literals_in_foreach_calls.main();
   avoid_init_to_null.main();
   avoid_redundant_argument_values.main();

--- a/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
+++ b/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AvoidEqualsAndHashCodeOnMutableClassesTest);
+  });
+}
+
+@reflectiveTest
+class AvoidEqualsAndHashCodeOnMutableClassesTest extends LintRuleTest {
+  @override
+  bool get addMetaPackageDep => true;
+
+  @override
+  List<String> get experiments => [
+        EnableString.enhanced_enums,
+      ];
+
+  @override
+  String get lintRule => 'avoid_equals_and_hash_code_on_mutable_classes';
+
+  @FailingTest(issue: 'https://github.com/dart-lang/sdk/issues/48404', reason: 'Needs new analyzer')
+  test_enum_bad() async {
+    await assertDiagnostics(r'''
+enum E {
+  e(1), f(2), g(3);
+  final int key;
+  const E(this.key);
+  bool operator ==(Object other) => other is E && other.key == key;
+  int get hashCode => key.hashCode;
+}
+''', [
+      lint('avoid_equals_and_hash_code_on_mutable_classes', 69, 4),
+      lint('avoid_equals_and_hash_code_on_mutable_classes', 137, 3),
+    ]);
+  }
+
+  @FailingTest(issue: 'https://github.com/dart-lang/sdk/issues/48404', reason: 'Enums cannot be marked @immutable')
+  test_enum_ok() async {
+    await assertNoDiagnostics(r'''
+import 'package:meta/meta.dart';
+
+@immutable
+enum E {
+  e(1), f(2), g(3);
+  final int key;
+  const E(this.key);
+  bool operator ==(Object other) => other is E && other.key == key;
+  int get hashCode => key.hashCode;
+}
+''');
+  }
+
+
+}

--- a/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
+++ b/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
@@ -25,7 +25,9 @@ class AvoidEqualsAndHashCodeOnMutableClassesTest extends LintRuleTest {
   @override
   String get lintRule => 'avoid_equals_and_hash_code_on_mutable_classes';
 
-  @FailingTest(issue: 'https://github.com/dart-lang/sdk/issues/48404', reason: 'Needs new analyzer')
+  @FailingTest(
+      issue: 'https://github.com/dart-lang/sdk/issues/48404',
+      reason: 'Needs new analyzer')
   test_enum_bad() async {
     await assertDiagnostics(r'''
 enum E {
@@ -41,7 +43,9 @@ enum E {
     ]);
   }
 
-  @FailingTest(issue: 'https://github.com/dart-lang/sdk/issues/48404', reason: 'Enums cannot be marked @immutable')
+  @FailingTest(
+      issue: 'https://github.com/dart-lang/sdk/issues/48404',
+      reason: 'Enums cannot be marked @immutable')
   test_enum_ok() async {
     await assertNoDiagnostics(r'''
 import 'package:meta/meta.dart';
@@ -56,6 +60,4 @@ enum E {
 }
 ''');
   }
-
-
 }

--- a/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
+++ b/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
@@ -26,31 +26,11 @@ class AvoidEqualsAndHashCodeOnMutableClassesTest extends LintRuleTest {
   String get lintRule => 'avoid_equals_and_hash_code_on_mutable_classes';
 
   @FailingTest(
-      issue: 'https://github.com/dart-lang/sdk/issues/48404',
+      issue: 'https://github.com/dart-lang/linter/issues/3094',
       reason: 'Needs new analyzer')
-  test_enum_bad() async {
-    await assertDiagnostics(r'''
-enum E {
-  e(1), f(2), g(3);
-  final int key;
-  const E(this.key);
-  bool operator ==(Object other) => other is E && other.key == key;
-  int get hashCode => key.hashCode;
-}
-''', [
-      lint('avoid_equals_and_hash_code_on_mutable_classes', 69, 4),
-      lint('avoid_equals_and_hash_code_on_mutable_classes', 137, 3),
-    ]);
-  }
-
-  @FailingTest(
-      issue: 'https://github.com/dart-lang/sdk/issues/48404',
-      reason: 'Enums cannot be marked @immutable')
-  test_enum_ok() async {
+  test_enums() async {
+    // Enums are constant by design.
     await assertNoDiagnostics(r'''
-import 'package:meta/meta.dart';
-
-@immutable
 enum E {
   e(1), f(2), g(3);
   final int key;


### PR DESCRIPTION
See: https://github.com/dart-lang/linter/issues/3094

/cc @bwilkerson 