### PR TITLE
Improve description & example for avoid_print

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ Ivan Tugay <listepo@gmail.com>
 Rohan Vanheusden <rohan.vanheusden@gmail.com>
 Minh Dao <asiancorporator@yahoo.de>
 Sai Sandeep Mutyala <rageofepicfury@gmail.com>
+Kristen McWilliam <kmcwilliampublic@gmail.com>

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -14,10 +14,42 @@ const _desc = r'Avoid `print` calls in production code.';
 const _details = r'''
 **DO** avoid `print` calls in production code.
 
+For production code use `debugPrint`, a logging framework, or surround `print`
+calls with a check for `kDebugMode`.
+
 **BAD:**
 ```dart
 void f(int x) {
   print('debug: $x');
+  ...
+}
+```
+
+
+**GOOD:**
+```dart
+void f(int x) {
+  debugPrint('debug: $x');
+  ...
+}
+```
+
+
+**GOOD:**
+```dart
+void f(int x) {
+  log('log: $x');
+  ...
+}
+```
+
+
+**GOOD:**
+```dart
+void f(int x) {
+  if (kDebugMode) {
+      print('debug: $x');
+  }
   ...
 }
 ```

--- a/lib/src/rules/avoid_print.dart
+++ b/lib/src/rules/avoid_print.dart
@@ -14,8 +14,9 @@ const _desc = r'Avoid `print` calls in production code.';
 const _details = r'''
 **DO** avoid `print` calls in production code.
 
-For production code use `debugPrint`, a logging framework, or surround `print`
-calls with a check for `kDebugMode`.
+For production code, consider using a logging framework.
+If you are using Flutter, you can use `debugPrint`
+or surround `print` calls with a check for `kDebugMode`
 
 **BAD:**
 ```dart


### PR DESCRIPTION
# Description

The existing message gave no hint on what to do *instead* of using
print calls, so this gives an explanation and a few examples.

Fixes #2787 
