### PR TITLE
enhanced enum support for `sort_constructors_first`

### DIFF
--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -46,6 +46,7 @@ class SortConstructorsFirst extends LintRule {
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
+    registry.addEnumDeclaration(this, visitor);
   }
 }
 
@@ -54,10 +55,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
-  @override
-  void visitClassDeclaration(ClassDeclaration node) {
+  void check(NodeList<ClassMember> classMembers) {
     // Sort members by offset.
-    var members = node.members.toList()
+    var members = classMembers.toList()
       ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
 
     var other = false;
@@ -70,5 +70,15 @@ class _Visitor extends SimpleAstVisitor<void> {
         other = true;
       }
     }
+  }
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    check(node.members);
+  }
+
+  @override
+  void visitEnumDeclaration(EnumDeclaration node) {
+    check(node.members);
   }
 }

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -56,6 +56,7 @@ import 'prefer_generic_function_type_aliases_test.dart'
     as prefer_generic_function_type_aliases;
 import 'prefer_spread_collections_test.dart' as prefer_spread_collections;
 import 'public_member_api_docs_test.dart' as public_member_api_docs;
+import 'sort_constructors_first.dart' as sort_constructors_first;
 import 'super_goes_last_test.dart' as super_goes_last;
 import 'tighten_type_of_initializing_formals_test.dart'
     as tighten_type_of_initializing_formals;
@@ -104,6 +105,7 @@ void main() {
   prefer_generic_function_type_aliases.main();
   prefer_spread_collections.main();
   public_member_api_docs.main();
+  sort_constructors_first.main();
   super_goes_last.main();
   tighten_type_of_initializing_formals.main();
   type_init_formals.main();

--- a/test/rules/sort_constructors_first.dart
+++ b/test/rules/sort_constructors_first.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(SortConstructorsFirstTest);
+  });
+}
+
+@reflectiveTest
+class SortConstructorsFirstTest extends LintRuleTest {
+  @override
+  List<String> get experiments => [
+        EnableString.enhanced_enums,
+      ];
+
+  @override
+  String get lintRule => 'sort_constructors_first';
+
+  test_ok() async {
+    await assertNoDiagnostics(r'''
+enum A {
+  a,b,c;
+  const A();
+  int f() => 0;
+}
+''');
+  }
+
+  test_unsorted() async {
+    await assertDiagnostics(r'''
+enum A {
+  a,b,c;
+  int f() => 0;
+  const A();
+}
+''', [
+      lint('sort_constructors_first', 42, 1),
+    ]);
+  }
+}


### PR DESCRIPTION
Fixes #3207

/cc @bwilkerson 