### PR TITLE
stop (needlessly) (re)sorting member ast nodes

### DIFF
--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -55,12 +55,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
-  void check(NodeList<ClassMember> classMembers) {
-    // Sort members by offset.
-    var members = classMembers.toList()
-      ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
-
+  void check(NodeList<ClassMember> members) {
     var other = false;
+    // Members are sorted by source position in the AST.
     for (var member in members) {
       if (member is ConstructorDeclaration) {
         if (other) {

--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -55,12 +55,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
-  void check(NodeList<ClassMember> classMembers) {
-    // Sort members by offset.
-    var members = classMembers.toList()
-      ..sort((ClassMember m1, ClassMember m2) => m1.offset - m2.offset);
-
+  void check(NodeList<ClassMember> members) {
     var seenConstructor = false;
+    // Members are sorted by source position in the AST.
     for (var member in members) {
       if (member is ConstructorDeclaration) {
         if (member.name == null) {


### PR DESCRIPTION
Benchmarking is showing pretty measurable improvements.

Before:

```
#62 sort_constructors_first                                                    12
#122 sort_unnamed_constructors_first                                            5
```

After:

```
#124 sort_constructors_first                                                    6
#172 sort_unnamed_constructors_first                                            3
```

🎉 🎉 🎉 

Cheers for the catch Brian!

/cc @bwilkerson @scheglov 