### PR TITLE
Add `use_colored_box`

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -186,6 +186,7 @@ linter:
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously
+    - use_colored_box
     - use_decorated_box
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -190,6 +190,7 @@ import 'rules/unnecessary_this.dart';
 import 'rules/unrelated_type_equality_checks.dart';
 import 'rules/unsafe_html.dart';
 import 'rules/use_build_context_synchronously.dart';
+import 'rules/use_colored_box.dart';
 import 'rules/use_decorated_box.dart';
 import 'rules/use_full_hex_values_for_flutter_colors.dart';
 import 'rules/use_function_type_syntax_for_parameters.dart';
@@ -399,6 +400,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(UnrelatedTypeEqualityChecks())
     ..register(UnsafeHtml())
     ..register(UseBuildContextSynchronously(inTestMode: inTestMode))
+    ..register(UseColoredBox())
     ..register(UseDecoratedBox())
     ..register(UseFullHexValuesForFlutterColors())
     ..register(UseFunctionTypeSyntaxForParameters())

--- a/lib/src/rules/use_colored_box.dart
+++ b/lib/src/rules/use_colored_box.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import '../util/flutter_utils.dart';
+
+const _desc = r'Use `ColoredBox`.';
+
+const _details = r'''
+
+**DO** use `ColoredBox` when `Container` has only a `Color`.
+
+A `Container` is a heavier Widget than a `ColoredBox`, and as bonus,
+`ColoredBox` has a `const` constructor.
+
+**BAD:**
+```dart
+Widget buildArea() {
+  return Container(
+    color: Colors.blue,
+    child: const Text('hello'),
+  );
+}
+```
+
+**GOOD:**
+```dart
+Widget buildArea() {
+  return const ColoredBox(
+    color: Colors.blue,
+    child: Text('hello'),
+  );
+}
+```
+''';
+
+class UseColoredBox extends LintRule {
+  UseColoredBox()
+      : super(
+            name: 'use_colored_box',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+
+    registry.addInstanceCreationExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if (!isExactWidgetTypeContainer(node.staticType)) {
+      return;
+    }
+
+    var data = _ArgumentData(node.argumentList);
+
+    if (data.additionalArgumentsFound || data.positionalArgumentsFound) {
+      return;
+    }
+
+    if (data.hasColor) {
+      rule.reportLint(node.constructorName);
+    }
+  }
+}
+
+class _ArgumentData {
+  var positionalArgumentsFound = false;
+  var additionalArgumentsFound = false;
+  var hasColor = false;
+
+  _ArgumentData(ArgumentList node) {
+    for (var argument in node.arguments) {
+      if (argument is! NamedExpression) {
+        positionalArgumentsFound = true;
+        return;
+      }
+      var label = argument.name.label;
+      if (label.name == 'color') {
+        hasColor = true;
+      } else if (label.name == 'child') {
+        // Ignore child
+      } else if (label.name == 'key') {
+        // Ignore key
+      } else {
+        additionalArgumentsFound = true;
+      }
+    }
+  }
+}

--- a/test_data/rules/use_colored_box.dart
+++ b/test_data/rules/use_colored_box.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N use_colored_box`
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+class Color {
+  Color(int value);
+}
+
+Widget containerWithoutArguments() {
+  return Container(); // OK
+}
+
+Widget containerWithKey() {
+  return Container( // OK
+    key: Key('abc'),
+  );
+}
+
+Widget containerWithColor() {
+  return Container( // LINT
+    color: Color(0xffffffff),
+  );
+}
+
+Widget containerWithChild() {
+  return Container( // OK
+    child: SizedBox(),
+  );
+}
+
+Widget containerWithKeyAndChild() {
+  return Container( // OK
+    key: Key('abc'),
+    child: SizedBox(),
+  );
+}
+
+Widget containerWithKeyAndColor() {
+  return Container( // LINT
+    key: Key('abc'),
+    color: Color(0xffffffff),
+  );
+}
+
+Widget containerWithColorAndChild() {
+  return Container( // LINT
+    color: Color(0xffffffff),
+    child: SizedBox(),
+  );
+}
+
+Widget containerWithKeyAndColorAndChild() {
+  return Container( // LINT
+    key: Key('abc'),
+    color: Color(0xffffffff),
+    child: SizedBox(),
+  );
+}
+
+Widget containerWithAnotherArgument() {
+  return Container( // OK
+    width: 20,
+  );
+}
+
+Widget containerWithColorAndAdditionalArgument() {
+  return Container( // OK
+    color: Color(0xffffffff),
+    width: 20,
+  );
+}
+
+Widget containerWithColorAndAdditionalArgumentAndChild() {
+  return Container( // OK
+    color: Color(0xffffffff),
+    width: 20,
+    child: SizedBox(),
+  );
+}


### PR DESCRIPTION
## Description

Use `ColoredBox` over `Container` when only the `Color` is specified.

Addresses https://github.com/flutter/flutter/issues/90722 and https://github.com/dart-lang/linter/issues/3255

## Kind

Style advice.

## Bad Example

```dart
Widget buildArea() {
  return Container(
    color: Colors.blue,
    child: const Text('...'),
  );
}
```

## Good Example

```dart
Widget buildArea() {
  return const ColoredBox(
    color: Colors.blue,
    child: Text('...'),
  );
}
```