### PR TITLE
Include enums in `unrelated_type_equality_checks`

### DIFF
--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -527,6 +527,10 @@ class DartTypeUtilities {
         // Otherwise, they might be related.
         return false;
       } else {
+        if (leftElement.isEnum || rightElement.isEnum) {
+          // Enums are unrelated to anything but themselves.
+          return true;
+        }
         return (leftElement.supertype?.isDartCoreObject ?? false) ||
             leftElement.supertype != rightElement.supertype;
       }

--- a/test_data/rules/unrelated_type_equality_checks.dart
+++ b/test_data/rules/unrelated_type_equality_checks.dart
@@ -167,7 +167,7 @@ void function23() {
 }
 
 void function30() {
-  ClassWMethod c =  ClassWMethod();
+  ClassWMethod c = ClassWMethod();
   if (c.determinant == 0.0) print('someFunction30'); // LINT
   if (c.determinant == double) print('someFunction30'); // LINT
   if (c.determinant == c.determinspider) print('someFunction30'); // OK
@@ -176,6 +176,17 @@ void function30() {
   if (c.determinant == callable) print('someFunction30'); // OK
   SubClassWCall callable2 = SubClassWCall();
   if (c.determinant == callable2) print('someFunction30'); // OK
+}
+
+void function31() {
+  const a = EnumOne.one;
+  const b = EnumOne.two;
+  const c = EnumTwo.one;
+  final aClass = ClassBase();
+  if (a == b) print('equal type'); // OK
+  if (a == c) print('not equal type'); // LINT
+  if (a == 'text') print('not equal type'); // LINT
+  if (a == aClass) print('not equal type'); // LINT
 }
 
 class ClassBase {}
@@ -203,3 +214,7 @@ class ClassWCall {
 }
 
 class SubClassWCall extends ClassWCall {}
+
+enum EnumOne { one, two }
+
+enum EnumTwo { one }


### PR DESCRIPTION
Fixes comparisons of enums in `unrelated_type_equality_checks`.

Currently:

```dart
enum One { one }
enum Two { one }

void hello() {
  const one = One.one;
  const two = Two.one;

  if (one == two) {} // Can't be, but no lint
}
```

Closes https://github.com/dart-lang/linter/issues/3220.
