### PR TITLE
use_super_initializers: report diagnostic on constructor node

### DIFF
--- a/lib/src/rules/use_super_initializers.dart
+++ b/lib/src/rules/use_super_initializers.dart
@@ -72,7 +72,9 @@ class _Visitor extends SimpleAstVisitor {
 
   _Visitor(this.rule, this.context);
 
-  void check(SuperConstructorInvocation superInvocation,
+  void check(
+      ConstructorDeclaration node,
+      SuperConstructorInvocation superInvocation,
       FormalParameterList parameters) {
     var constructorElement = superInvocation.staticElement;
     if (constructorElement == null) return;
@@ -80,11 +82,11 @@ class _Visitor extends SimpleAstVisitor {
     // todo(pq): consolidate logic shared w/ server
     //  (https://github.com/dart-lang/linter/issues/3263)
 
+    var identifiers = _checkForConvertiblePositionalParams(
+        constructorElement, superInvocation, parameters);
+
     // Bail if there are positional params that can't be converted.
-    if (!_checkForConvertiblePositionalParams(
-        constructorElement, superInvocation, parameters)) {
-      return;
-    }
+    if (identifiers == null) return;
 
     for (var parameter in parameters.parameters) {
       var parameterElement = parameter.declaredElement;
@@ -92,26 +94,32 @@ class _Visitor extends SimpleAstVisitor {
       if (parameterElement.isNamed) {
         if (_checkNamedParameter(
             parameter, parameterElement, constructorElement, superInvocation)) {
-          _reportOnIdentifier(parameter.identifier);
+          var identifier = parameter.identifier?.name;
+          if (identifier != null) {
+            identifiers.add(identifier);
+          }
         }
       }
     }
+
+    _reportLint(node, identifiers);
   }
 
   @override
   visitConstructorDeclaration(ConstructorDeclaration node) {
     for (var initializer in node.initializers.reversed) {
       if (initializer is SuperConstructorInvocation) {
-        check(initializer, node.parameters);
+        check(node, initializer, node.parameters);
         return;
       }
     }
   }
 
   /// Check if all super positional parameters can be converted to use super-
-  /// initializers. Return `false` if there are parameters that can't be
-  /// converted since this will short-circuit the lint.
-  bool _checkForConvertiblePositionalParams(
+  /// initializers. Return a list of convertible named parameters or `null` if
+  /// there are parameters that can't be converted since this will short-circuit
+  /// the lint.
+  List<String>? _checkForConvertiblePositionalParams(
       ConstructorElement constructorElement,
       SuperConstructorInvocation superInvocation,
       FormalParameterList parameters) {
@@ -120,14 +128,14 @@ class _Visitor extends SimpleAstVisitor {
       if (arg is SimpleIdentifier) {
         positionalSuperArgs.add(arg);
       } else if (arg is! NamedExpression) {
-        return false;
+        return null;
       }
     }
 
-    if (positionalSuperArgs.isEmpty) return true;
+    if (positionalSuperArgs.isEmpty) return [];
 
     var constructorParams = parameters.parameters;
-    var convertibleConstructorParams = <FormalParameter>[];
+    var convertibleConstructorParams = <String>[];
     var matchedConstructorParamIndex = 0;
 
     // For each super arg, ensure there is a constructor param (in the right
@@ -135,7 +143,7 @@ class _Visitor extends SimpleAstVisitor {
     for (var i = 0; i < positionalSuperArgs.length; ++i) {
       var superArg = positionalSuperArgs[i];
       var superParam = superArg.staticElement;
-      if (superParam is! ParameterElement) return false;
+      if (superParam is! ParameterElement) return null;
       bool match = false;
       for (var i = 0; i < constructorParams.length && !match; ++i) {
         var constructorParam = constructorParams[i];
@@ -146,20 +154,22 @@ class _Visitor extends SimpleAstVisitor {
           var superType = superParam.type;
           var argType = constructorElement.type;
           if (!context.typeSystem.isSubtypeOf(argType, superType)) {
-            return false;
+            return null;
           }
 
           match = true;
-          convertibleConstructorParams.add(constructorParam);
+          var identifier = constructorParam.identifier?.name;
+          if (identifier != null) {
+            convertibleConstructorParams.add(identifier);
+          }
           // Ensure we're not out of order.
-          if (i < matchedConstructorParamIndex) return false;
+          if (i < matchedConstructorParamIndex) return null;
           matchedConstructorParamIndex = i;
         }
       }
     }
-    _reportOnFirstParam(convertibleConstructorParams);
 
-    return true;
+    return convertibleConstructorParams;
   }
 
   /// Return `true` if the named [parameter] can be converted into a super
@@ -214,29 +224,17 @@ class _Visitor extends SimpleAstVisitor {
     return null;
   }
 
-  void _reportOnFirstParam(List<FormalParameter> params) {
-    var firstIdentifier = params.first.identifier;
-    if (firstIdentifier == null) return;
-
-    if (params.length == 1) {
-      _reportOnIdentifier(firstIdentifier);
-    } else {
-      var identifiers = <String>[];
-      for (var param in params) {
-        var name = param.identifier?.name;
-        if (name == null) return; // Bail.
-        identifiers.add(name);
-      }
+  void _reportLint(ConstructorDeclaration node, List<String> identifiers) {
+    if (identifiers.isEmpty) return;
+    var token = node.firstTokenAfterCommentAndMetadata;
+    if (identifiers.length > 1) {
       var msg = identifiers.quotedAndCommaSeparatedWithAnd;
-      rule.reportLint(firstIdentifier,
+      rule.reportLintForToken(token,
           errorCode: UseSuperInitializers.multipleParams, arguments: [msg]);
+    } else {
+      rule.reportLintForToken(token,
+          errorCode: UseSuperInitializers.singleParam,
+          arguments: [identifiers.first]);
     }
-  }
-
-  void _reportOnIdentifier(SimpleIdentifier? identifier) {
-    if (identifier == null) return;
-    rule.reportLint(identifier,
-        errorCode: UseSuperInitializers.singleParam,
-        arguments: [identifier.name]);
   }
 }

--- a/lib/src/rules/use_super_initializers.dart
+++ b/lib/src/rules/use_super_initializers.dart
@@ -226,13 +226,13 @@ class _Visitor extends SimpleAstVisitor {
 
   void _reportLint(ConstructorDeclaration node, List<String> identifiers) {
     if (identifiers.isEmpty) return;
-    var token = node.firstTokenAfterCommentAndMetadata;
+    var target = node.name ?? node.returnType;
     if (identifiers.length > 1) {
       var msg = identifiers.quotedAndCommaSeparatedWithAnd;
-      rule.reportLintForToken(token,
+      rule.reportLint(target,
           errorCode: UseSuperInitializers.multipleParams, arguments: [msg]);
     } else {
-      rule.reportLintForToken(token,
+      rule.reportLint(target,
           errorCode: UseSuperInitializers.singleParam,
           arguments: [identifiers.first]);
     }

--- a/test/rules/use_super_initializers_test.dart
+++ b/test/rules/use_super_initializers_test.dart
@@ -25,13 +25,13 @@ class UseSuperInitializersTest extends LintRuleTest {
   test_named() async {
     await assertDiagnostics(r'''
 class A {
-  A({int? x, int? y});
+  const A({int? x, int? y});
 }
 class B extends A {
-  B({int? x, int? y}) : super(x: x, y: y);
+  const B({int? x, int? y}) : super(x: x, y: y);
 }
 ''', [
-      lint('use_super_initializers', 57, 1),
+      lint('use_super_initializers', 69, 1),
     ]);
   }
 

--- a/test/rules/use_super_initializers_test.dart
+++ b/test/rules/use_super_initializers_test.dart
@@ -31,8 +31,7 @@ class B extends A {
   B({int? x, int? y}) : super(x: x, y: y);
 }
 ''', [
-      lint('use_super_initializers', 65, 1),
-      lint('use_super_initializers', 73, 1),
+      lint('use_super_initializers', 57, 1),
     ]);
   }
 
@@ -183,7 +182,7 @@ class B extends A {
   B(int x, {int? foo}) : super(x, foo: 0); 
 }
 ''', [
-      lint('use_super_initializers', 65, 1),
+      lint('use_super_initializers', 59, 1),
     ]);
   }
 
@@ -196,7 +195,7 @@ class B extends A {
   B(int x) : super(x);
 }
 ''', [
-      lint('use_super_initializers', 62, 1),
+      lint('use_super_initializers', 56, 1),
     ]);
   }
 
@@ -209,7 +208,7 @@ class B extends A {
   B([int x = 0]) : super(x);
 }
 ''', [
-      lint('use_super_initializers', 53, 1),
+      lint('use_super_initializers', 46, 1),
     ]);
   }
 
@@ -224,7 +223,7 @@ class C extends B {
   C(int foo, int bar) : super(foo, bar);
 }
 ''', [
-      lint('use_super_initializers', 99, 3),
+      lint('use_super_initializers', 93, 1),
     ]);
   }
 
@@ -237,7 +236,7 @@ class B extends A {
   B(int x, int y) : super(x, y: y);
 }
 ''', [
-      lint('use_super_initializers', 62, 1),
+      lint('use_super_initializers', 56, 1),
     ]);
   }
 
@@ -252,7 +251,7 @@ class C extends B {
   C(int baz, int foo, int bar) : super(foo, bar);
 }
 ''', [
-      lint('use_super_initializers', 108, 3),
+      lint('use_super_initializers', 93, 1),
     ]);
   }
 
@@ -265,8 +264,7 @@ class B extends A {
   B(int x, {int? y}) : super(x, y: y);
 }
 ''', [
-      lint('use_super_initializers', 62, 1),
-      lint('use_super_initializers', 71, 1),
+      lint('use_super_initializers', 56, 1),
     ]);
   }
 }


### PR DESCRIPTION
Updates to move the diagnostic range from individual identifiers to the constructor node.

/fyi @jacob314 

/cc @bwilkerson 
