### PR TITLE
For `always_specify_types`, use NamedType.name.staticElement in favor of DartType.alias.

### DIFF
--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
@@ -110,8 +111,9 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitNamedType(NamedType namedType) {
     var type = namedType.type;
     if (type is InterfaceType) {
-      var element = type.alias?.element ?? type.element;
-      if (element.typeParameters.isNotEmpty &&
+      var element = namedType.name.staticElement;
+      if (element is TypeParameterizedElement &&
+          element.typeParameters.isNotEmpty &&
           namedType.typeArguments == null &&
           namedType.parent is! IsExpression &&
           !element.hasOptionalTypeArgs) {


### PR DESCRIPTION
In some circumstances, the analyzer doesn't reliably set
DartType.alias to point to the type alias that led to a type.  (This
is the ultimate cause of #3275).  I'm currently researching whether
it's possible to improve the analyzer behavior in this regard.  In the
meantime, we can fix #3275 by changing the linter to grab the type
alias element directly from NamedType.name.staticElement.

Fixes #3275.