### PR TITLE
1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.19.2
+
+- update `use_super_initializers` to lint once on the constructor
+  name (rather than individual parameter identifiers)
+
 # 1.19.1
 
 - new lint: `use_super_initializers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # 1.19.2
 
-- update `use_super_initializers` to lint once on the constructor
-  name (rather than individual parameter identifiers)
-
-# 1.19.1
-
 - new lint: `use_super_initializers`
 - new lint: `use_enums`
 - new lint: `use_colored_box`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.19.1';
+const String version = '1.19.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.19.1
+version: 1.19.2
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.19.2

- update `use_super_initializers` to lint once on the constructor
  name (rather than individual parameter identifiers)

---

/cc @bwilkerson 