### PR TITLE
Add rationale & example to prefer_for_elements_to_map_fromIterable

### DIFF
--- a/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
+++ b/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
@@ -8,12 +8,12 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer for elements when building maps from iterables.';
+const _desc = r"Prefer 'for' elements when building maps from iterables.";
 
 const _details = r'''
-When building maps from iterables, it is preferable to use for elements.
+When building maps from iterables, it is preferable to use 'for' elements.
 
-Using for elements brings several benefits including:
+Using 'for' elements brings several benefits including:
 
 - Performance
 - Flexibility

--- a/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
+++ b/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
@@ -13,6 +13,15 @@ const _desc = r'Prefer for elements when building maps from iterables.';
 const _details = r'''
 When building maps from iterables, it is preferable to use for elements.
 
+Using for elements brings several benefits including:
+
+- Performance
+- Flexibility
+- Readability
+- Improved type inference
+- Improved interaction with null safety
+
+
 **BAD:**
 ```dart
 Map<String, WidgetBuilder>.fromIterable(
@@ -28,6 +37,16 @@ Map<String, WidgetBuilder>.fromIterable(
 return {
   for (var demo in kAllGalleryDemos)
     '${demo.routeName}': demo.buildRoute,
+};
+```
+
+**GOOD:**
+```dart
+// Map<int, Student> is not required, type is inferred automatically.
+final pizzaRecipients = {
+  ...studentLeaders,
+  for (var student in classG)
+    if (student.isPassing) student.id: student,
 };
 ```
 ''';


### PR DESCRIPTION
# Description

Added the rationale behind this lint. Also another example that doesn't rely on Flutter, and attempts to show how the alternative can be used to good effect.

Fixes #3259 
