### PR TITLE
1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.21.0
+
+- fixed `use_key_in_widget_constructors` false positive
+  with `key` super parameter initializers
+- fixed `use_super_parameters` false positive with field
+  formal params
+- updated `unnecessary_null_checks` and 
+  `null_check_on_nullable_type_parameter` to handle
+  list/set/map literals, and `yield` and `await`
+  expressions
+
 # 1.20.0
 
 - renamed `use_super_initializers` to `use_super_parameters`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.20.0';
+const String version = '1.21.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.20.0
+version: 1.21.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.21.0

- fixed `use_key_in_widget_constructors` false positive
  with `key` super parameter initializers
- fixed `use_super_parameters` false positive with field
  formal params
- updated `unnecessary_null_checks` and 
  `null_check_on_nullable_type_parameter` to handle
  list/set/map literals, and `yield` and `await`
  expressions

---

/cc @bwilkerson 
