### PR TITLE
work around upcomming flow-analysis improvements

### DIFF
--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -40,9 +40,10 @@ DartType? getExpectedType(PostfixExpression node) {
   var realNode =
       node.thisOrAncestorMatching((e) => e.parent is! ParenthesizedExpression);
   var parent = realNode?.parent;
-  var withAwait = parent is AwaitExpression;
-  if (withAwait) {
-    parent = parent!.parent;
+  var withAwait = false;
+  if (parent is AwaitExpression) {
+    withAwait = true;
+    parent = parent.parent;
   }
 
   // in return value


### PR DESCRIPTION
The roll for 1.21.0 is blocked due to a newly flagged `unnecessary_non_null_assertion`.

```
ERROR: third_party/dart/linter/lib/src/rules/unnecessary_null_checks.dart

45: parent = parent!.parent; The '!' will have no effect because the receiver can't be null. #unnecessary_non_null_assertion
```

https://fusion2.corp.google.com/invocations/07bd1269-3e54-4ec1-ad8e-1b3b4ca53809/targets/%2F%2Fthird_party%2Fdart%2Fanalyzer:analyzer_tests_src_fasta_recovery_partial_code_method_declaration_test/log

This swizzles the flow around to sidestep this skew between HEAD and the latest published analyzer.

/cc @scheglov @bwilkerson 

