### PR TITLE
bump language lower-bound to 2.15

### DIFF
--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -141,7 +141,7 @@ Future runLinter(List<String> args, LinterOptions initialLintOptions) async {
     filesToLint.addAll(
       collectFiles(path)
           .map((file) => _absoluteNormalizedPath(file.path))
-          .map((path) => File(path)),
+          .map(File.new),
     );
   }
 

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -40,9 +40,8 @@ DartType? getExpectedType(PostfixExpression node) {
   var realNode =
       node.thisOrAncestorMatching((e) => e.parent is! ParenthesizedExpression);
   var parent = realNode?.parent;
-  var withAwait = false;
-  if (parent is AwaitExpression) {
-    withAwait = true;
+  var withAwait = parent is AwaitExpression;
+  if (withAwait) {
     parent = parent.parent;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/dart-lang/linter
 documentation: https://dart-lang.github.io/linter/lints
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   analyzer: ^3.3.1


### PR DESCRIPTION
Follow-up from: https://github.com/dart-lang/linter/commit/d1de2e9f4a3cdfc7a44a787905781eb6fa08d532

/cc @bwilkerson 
