### PR TITLE
1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.21.1
+
+- bumped language lower-bound constraint to `2.15.0`
+
 # 1.21.0
 
 - fixed `use_key_in_widget_constructors` false positive

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.21.0';
+const String version = '1.21.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.21.0
+version: 1.21.1
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.21.1

- bumped language lower-bound constraint to `2.15.0`

---

/cc @bwilkerson 
