### PR TITLE
fix `use_super_parameters` false positive passing named params as positional

### DIFF
--- a/lib/src/rules/use_super_parameters.dart
+++ b/lib/src/rules/use_super_parameters.dart
@@ -169,6 +169,7 @@ class _Visitor extends SimpleAstVisitor {
       var superArg = positionalSuperArgs[i];
       var superParam = superArg.staticElement;
       if (superParam is! ParameterElement) return null;
+      if (superParam.isNamed) return null;
       bool match = false;
       for (var i = 0; i < constructorParams.length && !match; ++i) {
         var constructorParam = constructorParams[i];

--- a/test/rules/use_super_parameters_test.dart
+++ b/test/rules/use_super_parameters_test.dart
@@ -119,6 +119,17 @@ class B extends A {
 ''');
   }
 
+  test_no_lint_named_passedAsPositional() async {
+    await assertNoDiagnostics(r'''
+class A {
+  A(String x);
+}
+class B extends A {
+  B({required String x}) : super(x);
+}
+''');
+  }
+
   test_no_lint_nonSimpleIdentiferArg() async {
     await assertNoDiagnostics(r'''
 class A {

--- a/test/rules/use_super_parameters_test.dart
+++ b/test/rules/use_super_parameters_test.dart
@@ -130,7 +130,7 @@ class B extends A {
 ''');
   }
 
-  test_no_lint_nonSimpleIdentiferArg() async {
+  test_no_lint_nonSimpleIdentifierArg() async {
     await assertNoDiagnostics(r'''
 class A {
   A(int x, int y, [int? z]);


### PR DESCRIPTION
See: #3306

(Addresses case 1.)

/cc @bwilkerson 
