### PR TITLE
update `depend_on_referenced_packages` to skip `flutter_gen`

### DIFF
--- a/lib/src/rules/depend_on_referenced_packages.dart
+++ b/lib/src/rules/depend_on_referenced_packages.dart
@@ -84,10 +84,23 @@ class DependOnReferencedPackages extends LintRule {
 }
 
 class _Visitor extends SimpleAstVisitor {
+  /// Virtual packages will not have explicit dependencies
+  /// and get skipped.
+  static const virtualPackages = [
+    //https://github.com/dart-lang/linter/issues/3308
+    'flutter_gen',
+  ];
+
   final DependOnReferencedPackages rule;
   final List<String> availableDeps;
 
   _Visitor(this.rule, this.availableDeps);
+
+  @override
+  void visitExportDirective(ExportDirective node) => _checkDirective(node);
+
+  @override
+  void visitImportDirective(ImportDirective node) => _checkDirective(node);
 
   void _checkDirective(UriBasedDirective node) {
     // Is it a package: uri?
@@ -100,13 +113,8 @@ class _Visitor extends SimpleAstVisitor {
     if (firstSlash == -1) return;
 
     var packageName = uriContent.substring(8, firstSlash);
+    if (virtualPackages.contains(packageName)) return;
     if (availableDeps.contains(packageName)) return;
     rule.reportLint(node.uri);
   }
-
-  @override
-  void visitImportDirective(ImportDirective node) => _checkDirective(node);
-
-  @override
-  void visitExportDirective(ExportDirective node) => _checkDirective(node);
 }

--- a/test_data/integration/depend_on_referenced_packages/_packages
+++ b/test_data/integration/depend_on_referenced_packages/_packages
@@ -1,3 +1,4 @@
+flutter_gen:vendor/flutter_gen
 sample_project:lib/
 public_dep:vendor/public_dep/
 private_dep:vendor/private_dep/

--- a/test_data/integration/depend_on_referenced_packages/lib/public.dart
+++ b/test_data/integration/depend_on_referenced_packages/lib/public.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:flutter_gen/gen.dart'; // OK
+
 import 'package:sample_project/sample_project.dart'; // OK
 import 'package:public_dep/public_dep.dart'; // OK
 import 'package:private_dep/private_dep.dart'; // LINT


### PR DESCRIPTION
Fixes #3308

/cc @bwilkerson @jakemac53 

/fyi @goderbauer 