### PR TITLE
1.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.21.2
+
+- several `use_super_parameters` false positive fixes
+- updated `depend_on_referenced_packages` to treat
+  `flutter_gen` as a virtual package, not needing an
+  explicit dependency
+
 # 1.21.1
 
 - bumped language lower-bound constraint to `2.15.0`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.21.1';
+const String version = '1.21.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.21.1
+version: 1.21.2
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.21.2

- several `use_super_parameters` false positive fixes
- updated `depend_on_referenced_packages` to treat
  `flutter_gen` as a virtual package, not needing an
  explicit dependency

---


/cc @bwilkerson 