### PR TITLE
1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.22.0
+
+- fixed false positives for `unnecessary_getters_setters`
+  and `prefer_final_fields`with enhanced enums
+- updated to analyzer 3.4.0 APIs
+- fixed null-safe variance in `invariant_booleans`
+
 # 1.21.2
 
 - several `use_super_parameters` false positive fixes

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.21.2';
+const String version = '1.20.0';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.20.0';
+const String version = '1.22.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.21.2
+version: 1.22.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.22.0

- fixed false positives for `unnecessary_getters_setters`
  and `prefer_final_fields`with enhanced enums
- updated to analyzer 3.4.0 APIs
- fixed null-safe variance in `invariant_booleans`

---

/cc @bwilkerson 
