### PR TITLE
[unsafe_html] Allow assigning to img.src.

### DIFF
--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -18,8 +18,8 @@ const _details = r'''
 **AVOID**
 
 * assigning directly to the `href` field of an AnchorElement
-* assigning directly to the `src` field of an EmbedElement, IFrameElement,
-  ImageElement, or ScriptElement
+* assigning directly to the `src` field of an EmbedElement, IFrameElement, or
+  ScriptElement
 * assigning directly to the `srcdoc` field of an IFrameElement
 * calling the `createFragment` method of Element
 * calling the `open` method of Window
@@ -124,7 +124,6 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (type.isDynamic ||
           type.extendsDartHtmlClass('EmbedElement') ||
           type.extendsDartHtmlClass('IFrameElement') ||
-          type.extendsDartHtmlClass('ImageElement') ||
           type.extendsDartHtmlClass('ScriptElement')) {
         rule.reportLint(assignment,
             arguments: ['src'], errorCode: unsafeAttributeCode);

--- a/test_data/rules/unmocked/unsafe_html.dart
+++ b/test_data/rules/unmocked/unsafe_html.dart
@@ -13,8 +13,6 @@ void main() {
   embed.src = 'foo'; // LINT
   IFrameElement()
     ..src = 'foo'; // LINT
-  ImageElement()
-    ..src = 'foo'; // LINT
 
   var script = ScriptElement();
   script.src = 'foo.js'; // LINT

--- a/test_data/rules/unsafe_html.dart
+++ b/test_data/rules/unsafe_html.dart
@@ -11,7 +11,6 @@ void main() {
   var embed = EmbedElement();
   embed.src = 'foo'; // LINT
   IFrameElement()..src = 'foo'; // LINT
-  ImageElement()..src = 'foo'; // LINT
 
   var script = ScriptElement();
   script.src = 'foo.js'; // LINT


### PR DESCRIPTION
This used to be dangerous because of img.src = 'javascript:hack' but browsers don't allow this anymore. We allow it in all other languages.