### PR TITLE
handle functions in asserts for require_trailing_commas

### DIFF
--- a/lib/src/rules/require_trailing_commas.dart
+++ b/lib/src/rules/require_trailing_commas.dart
@@ -163,6 +163,15 @@ class _Visitor extends SimpleAstVisitor<void> {
       return true;
     }
 
+    // Exception is allowed if the last parameter is a anonymous function call.
+    // This case arises a lot in asserts.
+    if (lastNode is FunctionExpressionInvocation &&
+        lastNode.function is FunctionExpression &&
+        _isSameLine(lastNode.argumentList.leftParenthesis,
+            lastNode.argumentList.rightParenthesis)) {
+      return true;
+    }
+
     // Exception is allowed if the last parameter is a set, map or list literal.
     if (lastNode is SetOrMapLiteral || lastNode is ListLiteral) return true;
 

--- a/lib/src/rules/require_trailing_commas.dart
+++ b/lib/src/rules/require_trailing_commas.dart
@@ -152,18 +152,18 @@ class _Visitor extends SimpleAstVisitor<void> {
       _lineInfo.getLocation(token2.offset).lineNumber;
 
   bool _shouldAllowTrailingCommaException(AstNode lastNode) {
-    // No exceptions are allowed if the last parameter is named.
+    // No exceptions are allowed if the last argument is named.
     if (lastNode is FormalParameter && lastNode.isNamed) return false;
 
-    // No exceptions are allowed if the entire last parameter fits on one line.
+    // No exceptions are allowed if the entire last argument fits on one line.
     if (_isSameLine(lastNode.beginToken, lastNode.endToken)) return false;
 
-    // Exception is allowed if the last parameter is a function literal.
+    // Exception is allowed if the last argument is a function literal.
     if (lastNode is FunctionExpression && lastNode.body is BlockFunctionBody) {
       return true;
     }
 
-    // Exception is allowed if the last parameter is a anonymous function call.
+    // Exception is allowed if the last argument is a anonymous function call.
     // This case arises a lot in asserts.
     if (lastNode is FunctionExpressionInvocation &&
         lastNode.function is FunctionExpression &&
@@ -172,7 +172,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return true;
     }
 
-    // Exception is allowed if the last parameter is a set, map or list literal.
+    // Exception is allowed if the last argument is a set, map or list literal.
     if (lastNode is SetOrMapLiteral || lastNode is ListLiteral) return true;
 
     return false;

--- a/test_data/rules/require_trailing_commas.dart
+++ b/test_data/rules/require_trailing_commas.dart
@@ -258,6 +258,15 @@ class RequireTrailingCommasExample {
       }(),
       'comment',
     );
+
+    dynamic f;
+    f((a, b, c) {
+      return true;
+    } (
+      '',
+      '',
+      '',
+    )); // LINT
   }
 }
 

--- a/test_data/rules/require_trailing_commas.dart
+++ b/test_data/rules/require_trailing_commas.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// test w/ `dart test -N require_trailing_commas`
+
 class RequireTrailingCommasExample {
   RequireTrailingCommasExample.constructor1(Object param1, Object param2);
 
@@ -240,6 +242,21 @@ class RequireTrailingCommasExample {
     assert(
       false,
       'a very very very very very very very very very long string',
+    );
+
+    assert(() {
+      return true;
+    }());
+
+    assert(() {
+      return true;
+    }(), 'comment'); // LINT
+
+    assert(
+      () {
+        return true;
+      }(),
+      'comment',
     );
   }
 }


### PR DESCRIPTION
# Description

This PR prevents `require_trailing_commas` to trigger on asserts with function like the following one:

```dart
    assert(() {
      _debugIsRenderViewInitialized = true;
      return true;
    }());
```
