### PR TITLE
bump markdown dep

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   github: ^9.0.0
   grinder: ^0.9.0
   lints: ^2.0.0
-  markdown: ^4.0.0
+  markdown: ^5.0.0
   matcher: ^0.12.10
   pub_semver: ^2.0.0
   test: ^1.16.1


### PR DESCRIPTION
It would probably be safest to update the SDK DEP before landing this (so the linter doesn't get ahead of what it will integrate w/ in the SDK).

@srawlins: any reason we can't bump `markdown` in the SDK?  Will that cause issues for `dartdoc`?

/cc @bwilkerson  @srawlins 
