### PR TITLE
handle multiline-strings in require_trailing_commas

### DIFF
--- a/lib/src/rules/require_trailing_commas.dart
+++ b/lib/src/rules/require_trailing_commas.dart
@@ -149,7 +149,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   bool _isSameLine(Token token1, Token token2) =>
       _lineInfo.getLocation(token1.offset).lineNumber ==
-      _lineInfo.getLocation(token2.offset).lineNumber;
+      _lineInfo.getLocation(token2.end).lineNumber;
 
   bool _shouldAllowTrailingCommaException(AstNode lastNode) {
     // No exceptions are allowed if the last argument is named.
@@ -162,6 +162,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (lastNode is FunctionExpression && lastNode.body is BlockFunctionBody) {
       return true;
     }
+
+    // Exception is allowed if the last argument is a (multiline) string literal.
+    if (lastNode is StringLiteral) return true;
 
     // Exception is allowed if the last argument is a anonymous function call.
     // This case arises a lot in asserts.

--- a/test_data/rules/require_trailing_commas.dart
+++ b/test_data/rules/require_trailing_commas.dart
@@ -262,11 +262,15 @@ class RequireTrailingCommasExample {
     dynamic f;
     f((a, b, c) {
       return true;
-    } (
+    }(
       '',
       '',
       '',
     )); // LINT
+
+    f('''
+A multiline string
+      '''); // OK
   }
 }
 


### PR DESCRIPTION
# Description

This PR prevents `require_trailing_commas` to trigger on multiline-strings like the following one:

```dart
  print('''
    --help      Print a usage message.
    --temp-dir  A location where temporary files may be written. Defaults to a
                directory in the system temp folder. If a temp_dir is not
                specified, then the default temp_dir will be created, used, and
                removed automatically.
    ''');
```