### PR TITLE
1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 1.23.0
+
+- fixed `no_leading_underscores_for_local_identifiers`
+  to lint local function declarations 
+- fixed `avoid_init_to_null` to correctly handle super
+  initializing defaults that are non-null
+- updated `no_leading_underscores_for_local_identifiers`
+  to allow identifiers with just underscores
+- fixed `flutter_style_todos` to support usernames that
+  start with a digit
+- updated `require_trailing_commas` to handle functions
+  in asserts and multi-line strings
+- updated `unsafe_html` to allow assignments to 
+  `img.src`
+- fixed `unnecessary_null_checks` to properly handle map
+  literal entries
+
 # 1.22.0
 
 - fixed false positives for `unnecessary_getters_setters`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.22.0';
+const String version = '1.23.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.22.0
+version: 1.23.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
-  analyzer: ^3.4.1
+  analyzer: ^4.0.0
   args: ^2.0.0
   collection: ^1.15.0
   glob: ^2.0.0


### PR DESCRIPTION
# 1.23.0

- fixed `no_leading_underscores_for_local_identifiers`
  to lint local function declarations 
- fixed `avoid_init_to_null` to correctly handle super
  initializing defaults that are non-null
- updated `no_leading_underscores_for_local_identifiers`
  to allow identifiers with just underscores
- fixed `flutter_style_todos` to support usernames that
  start with a digit
- updated `require_trailing_commas` to handle functions
  in asserts and multi-line strings
- updated `unsafe_html` to allow assignments to 
  `img.src`
- fixed `unnecessary_null_checks` to properly handle map
  literal entries



/cc @bwilkerson 
