### PR TITLE
`use_key_in_widget_constructors` to report at the constructor `name` or `returnType`

### DIFF
--- a/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/lib/src/rules/use_key_in_widget_constructors.dart
@@ -94,7 +94,7 @@ class _Visitor extends SimpleAstVisitor<void> {
           }
           return false;
         })) {
-      rule.reportLintForToken(node.firstTokenAfterCommentAndMetadata);
+      rule.reportLint(node.name ?? node.returnType);
     }
     super.visitConstructorDeclaration(node);
   }

--- a/test_data/rules/use_key_in_widget_constructors.dart
+++ b/test_data/rules/use_key_in_widget_constructors.dart
@@ -22,3 +22,9 @@ class MyWidget extends StatelessWidget {
   MyWidget.redirect() : this.withKey(key: Key('')); // OK
   MyWidget.superCall() : super(key: Key('')); // OK
 }
+
+class ConstWidget extends StatelessWidget {
+  const ConstWidget(); // LINT [9:11]
+  const ConstWidget.named(); // LINT [21:5]
+}
+

--- a/test_data/rules/use_key_in_widget_constructors.dart
+++ b/test_data/rules/use_key_in_widget_constructors.dart
@@ -27,4 +27,3 @@ class ConstWidget extends StatelessWidget {
   const ConstWidget(); // LINT [9:11]
   const ConstWidget.named(); // LINT [21:5]
 }
-


### PR DESCRIPTION
Fixes #3368
