### PR TITLE
rename local functions with `_`s

### DIFF
--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -131,7 +131,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _hasAssertNotNull(Expression node, String name) {
-    bool _hasSameName(Expression rawExpression) {
+    bool hasSameName(Expression rawExpression) {
       var expression = rawExpression.unParenthesized;
       return expression is SimpleIdentifier && expression.name == name;
     }
@@ -145,7 +145,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (expression.operator.type == TokenType.BANG_EQ) {
         var operands = [expression.leftOperand, expression.rightOperand];
         return operands.any(DartTypeUtilities.isNullLiteral) &&
-            operands.any(_hasSameName);
+            operands.any(hasSameName);
       }
     }
     return false;

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -273,13 +273,13 @@ class _CascadableExpression {
       !_hasCriticalDependencies(expressionBox);
 
   bool _hasCriticalDependencies(_CascadableExpression expressionBox) {
-    bool _isCriticalNode(AstNode node) =>
+    bool isCriticalNode(AstNode node) =>
         DartTypeUtilities.getCanonicalElementFromIdentifier(node) ==
         expressionBox.element;
     return expressionBox.isCritical &&
         criticalNodes.any((node) =>
-            _isCriticalNode(node) ||
-            DartTypeUtilities.traverseNodesInDFS(node).any(_isCriticalNode));
+            isCriticalNode(node) ||
+            DartTypeUtilities.traverseNodesInDFS(node).any(isCriticalNode));
   }
 }
 

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -44,11 +44,11 @@ class Point {
 ''';
 
 bool _hasNewInvocation(DartType returnType, FunctionBody body) {
-  bool _isInstanceCreationExpression(AstNode node) =>
+  bool isInstanceCreationExpression(AstNode node) =>
       node is InstanceCreationExpression && node.staticType == returnType;
 
   return DartTypeUtilities.traverseNodesInDFS(body)
-      .any(_isInstanceCreationExpression);
+      .any(isInstanceCreationExpression);
 }
 
 class PreferConstructorsInsteadOfStaticMethods extends LintRule {

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -158,7 +158,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     var parameters = node.parameters?.parameters ?? <FormalParameter>[];
     if (parameters.length != arguments.length) return;
 
-    bool _matches(Expression argument, FormalParameter parameter) {
+    bool matches(Expression argument, FormalParameter parameter) {
       if (argument is SimpleIdentifier) {
         return argument.name == parameter.identifier?.name;
       }
@@ -166,7 +166,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     for (var i = 0; i < arguments.length; ++i) {
-      if (!_matches(arguments[i], parameters[i])) {
+      if (!matches(arguments[i], parameters[i])) {
         return;
       }
     }

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -28,7 +28,7 @@ void main() {
 void defineLinterEngineTests() {
   group('engine', () {
     group('reporter', () {
-      void _test(
+      void doTest(
           String label, String expected, Function(PrintingReporter r) report) {
         test(label, () {
           String? msg;
@@ -38,9 +38,9 @@ void defineLinterEngineTests() {
         });
       }
 
-      _test('exception', 'EXCEPTION: LinterException: foo',
+      doTest('exception', 'EXCEPTION: LinterException: foo',
           (r) => r.exception(LinterException('foo')));
-      _test('warn', 'WARN: foo', (r) => r.warn('foo'));
+      doTest('warn', 'WARN: foo', (r) => r.warn('foo'));
     });
 
     group('exceptions', () {


### PR DESCRIPTION
These will be flagged by the next linter release which updates `non_constant_identifier_names` to flag local functions.

See:

* https://github.com/flutter/flutter/pull/102615
* https://dart-review.googlesource.com/c/sdk/+/242391
* dart-lang/linter#3360

/cc @bwilkerson 