### PR TITLE
catch '${x.toString()}' with noop_primitive_operations

### DIFF
--- a/lib/src/rules/noop_primitive_operations.dart
+++ b/lib/src/rules/noop_primitive_operations.dart
@@ -80,7 +80,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     var type = node.realTarget?.staticType;
     if (type == null) {
       // print(xxx.toString())
-      if (node.methodName.staticElement?.isDartCorePrint ?? false) {
+      if (node.methodName.staticElement.isDartCorePrint &&
+          node.argumentList.arguments.length == 1) {
         _checkToStringInvocation(node.argumentList.arguments.first);
       }
       return;

--- a/lib/src/rules/noop_primitive_operations.dart
+++ b/lib/src/rules/noop_primitive_operations.dart
@@ -28,6 +28,8 @@ string.toString();
 string = 'hello\n'
     'world\n'
     ''; // useless empty string
+
+'string with ${x.toString()}';
 ```
 ''';
 
@@ -47,6 +49,7 @@ class NoopPrimitiveOperations extends LintRule {
   ) {
     var visitor = _Visitor(this, context);
     registry.addAdjacentStrings(this, visitor);
+    registry.addInterpolationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -63,6 +66,16 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (literal.stringValue?.isEmpty ?? false) {
         rule.reportLint(literal);
       }
+    }
+  }
+
+  @override
+  void visitInterpolationExpression(InterpolationExpression node) {
+    var expression = node.expression;
+    if (expression is MethodInvocation &&
+        expression.methodName.name == 'toString' &&
+        expression.argumentList.arguments.isEmpty) {
+      rule.reportLint(expression.methodName);
     }
   }
 

--- a/lib/src/rules/noop_primitive_operations.dart
+++ b/lib/src/rules/noop_primitive_operations.dart
@@ -86,7 +86,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       // print(xxx.toString())
       if (node.methodName.name == 'print' &&
           node.methodName.staticElement?.library?.name == 'dart.core') {
-        rule.reportLint(node.methodName);
+        var arg = node.argumentList.arguments.first;
+        if (arg is MethodInvocation &&
+            arg.methodName.name == 'toString' &&
+            arg.argumentList.arguments.isEmpty) {
+          rule.reportLint(node.methodName);
+          return;
+        }
       }
       return;
     }

--- a/lib/src/rules/noop_primitive_operations.dart
+++ b/lib/src/rules/noop_primitive_operations.dart
@@ -82,7 +82,14 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodInvocation(MethodInvocation node) {
     var type = node.realTarget?.staticType;
-    if (type == null) return;
+    if (type == null) {
+      // print(xxx.toString())
+      if (node.methodName.name == 'print' &&
+          node.methodName.staticElement?.library?.name == 'dart.core') {
+        rule.reportLint(node.methodName);
+      }
+      return;
+    }
 
     // string.toString()
     if (type.isDartCoreString &&

--- a/lib/src/rules/noop_primitive_operations.dart
+++ b/lib/src/rules/noop_primitive_operations.dart
@@ -112,6 +112,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _checkToStringInvocation(Expression expression) {
     if (expression is MethodInvocation &&
+        expression.realTarget != null &&
         expression.realTarget is! SuperExpression &&
         expression.methodName.name == 'toString' &&
         expression.argumentList.arguments.isEmpty) {

--- a/test_data/rules/noop_primitive_operations.dart
+++ b/test_data/rules/noop_primitive_operations.dart
@@ -4,6 +4,10 @@
 
 // test w/ `dart test -N noop_primitive_operations`
 
+onStringInterpolations() {
+  var s = '${1.toString()}'; // LINT
+}
+
 onString() {
   String? nullable;
   String v = 'hello';

--- a/test_data/rules/noop_primitive_operations.dart
+++ b/test_data/rules/noop_primitive_operations.dart
@@ -9,6 +9,7 @@ onStringInterpolations() {
 }
 
 onPrint() {
+  print(''); // OK
   print(1.toString()); // LINT
   print(null.toString()); // LINT
 }

--- a/test_data/rules/noop_primitive_operations.dart
+++ b/test_data/rules/noop_primitive_operations.dart
@@ -8,6 +8,11 @@ onStringInterpolations() {
   var s = '${1.toString()}'; // LINT
 }
 
+onPrint() {
+  print(1.toString()); // LINT
+  print(null.toString()); // LINT
+}
+
 onString() {
   String? nullable;
   String v = 'hello';

--- a/test_data/rules/noop_primitive_operations.dart
+++ b/test_data/rules/noop_primitive_operations.dart
@@ -14,6 +14,14 @@ onPrint() {
   print(null.toString()); // LINT
 }
 
+class Super {
+  // Can't use 'super' as an expression
+  toString() => '${super.toString()}'; // OK
+  f() {
+    print(super.toString()); // OK
+  }
+}
+
 onString() {
   String? nullable;
   String v = 'hello';

--- a/test_data/rules/noop_primitive_operations.dart
+++ b/test_data/rules/noop_primitive_operations.dart
@@ -12,12 +12,16 @@ onPrint() {
   print(''); // OK
   print(1.toString()); // LINT
   print(null.toString()); // LINT
+
+  print(toString()); // OK
 }
 
-class Super {
-  // Can't use 'super' as an expression
-  toString() => '${super.toString()}'; // OK
+String toString() => '';
+
+class Ok {
   f() {
+    // Can't use 'super' as an expression
+    var s = '${super.toString()}'; // OK
     print(super.toString()); // OK
   }
 }


### PR DESCRIPTION
# Description

Improve` noop_primitive_operations` to catch `.toString()` in string interpolations.

Related to #3334
