### PR TITLE
rev the min. dep on package:args

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ analysis server and the `dart analyze` command in the [Dart command-line tool][d
 [![Build Status](https://github.com/dart-lang/linter/workflows/linter/badge.svg)](https://github.com/dart-lang/linter/actions)
 [![Coverage Status](https://coveralls.io/repos/dart-lang/linter/badge.svg)](https://coveralls.io/r/dart-lang/linter)
 [![Pub](https://img.shields.io/pub/v/linter.svg)](https://pub.dev/packages/linter)
+[![package publisher](https://img.shields.io/pub/publisher/linter.svg)](https://pub.dev/packages/linter/publisher)
 
 ## Installing
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   analyzer: ^4.0.0
-  args: ^2.0.0
+  args: ^2.1.0
   collection: ^1.15.0
   glob: ^2.0.0
   http: ^0.13.0


### PR DESCRIPTION
- rev the min. dep on package:args
- add an additional markdown badge to the readme

`package:args` `2.1.0` introduced a new `mandatory` named param to one of it's APIs; it looks like linter is using this param; here's the error I saw against package:args 2.0.0 locally:

```
  error • tool/rule.dart:21:7 • The named parameter 'mandatory' isn't defined. Try correcting the name to an
          existing named parameter's name, or defining a named parameter with the name 'mandatory'. •
          undefined_named_parameter
```
