### PR TITLE
`use_colored_box` to not lint for nullable color

### DIFF
--- a/lib/src/rules/use_colored_box.dart
+++ b/lib/src/rules/use_colored_box.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
@@ -90,7 +91,9 @@ class _ArgumentData {
         return;
       }
       var label = argument.name.label;
-      if (label.name == 'color') {
+      if (label.name == 'color' &&
+          argument.staticType?.nullabilitySuffix !=
+              NullabilitySuffix.question) {
         hasColor = true;
       } else if (label.name == 'child') {
         // Ignore child

--- a/test_data/rules/use_colored_box.dart
+++ b/test_data/rules/use_colored_box.dart
@@ -82,3 +82,9 @@ Widget containerWithColorAndAdditionalArgumentAndChild() {
     child: SizedBox(),
   );
 }
+
+Widget nullableColor(Color? myColor) {
+  return Container( // OK
+    color: myColor
+  );
+}


### PR DESCRIPTION
Fixes dart-lang/sdk#58733

