### PR TITLE
add unnecessary_to_list_in_spreads

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -184,6 +184,7 @@ linter:
     - unnecessary_string_escapes
     - unnecessary_string_interpolations
     - unnecessary_this
+    - unnecessary_to_list_in_spreads
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -188,6 +188,7 @@ import 'rules/unnecessary_statements.dart';
 import 'rules/unnecessary_string_escapes.dart';
 import 'rules/unnecessary_string_interpolations.dart';
 import 'rules/unnecessary_this.dart';
+import 'rules/unnecessary_to_list_in_spreads.dart';
 import 'rules/unrelated_type_equality_checks.dart';
 import 'rules/unsafe_html.dart';
 import 'rules/use_build_context_synchronously.dart';
@@ -401,6 +402,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(UnnecessaryStringEscapes())
     ..register(UnnecessaryStringInterpolations())
     ..register(UnnecessaryThis())
+    ..register(UnnecessaryToListInSpreads())
     ..register(UnrelatedTypeEqualityChecks())
     ..register(UnsafeHtml())
     ..register(UseBuildContextSynchronously(inTestMode: inTestMode))

--- a/lib/src/rules/unnecessary_to_list_in_spreads.dart
+++ b/lib/src/rules/unnecessary_to_list_in_spreads.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+import '../util/dart_type_utilities.dart';
+
+const _desc = r'Unnecessary toList() in spreads.';
+
+const _details = r'''
+
+Unnecessary `toList()` in spreads.
+
+**BAD:**
+```dart
+children: <Widget>[
+  ...['foo', 'bar', 'baz'].map((String s) => Text(s)).toList(),
+]
+```
+
+**GOOD:**
+```dart
+children: <Widget>[
+  ...['foo', 'bar', 'baz'].map((String s) => Text(s)),
+]
+```
+
+''';
+
+class UnnecessaryToListInSpreads extends LintRule {
+  UnnecessaryToListInSpreads()
+      : super(
+          name: 'unnecessary_to_list_in_spreads',
+          description: _desc,
+          details: _details,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addSpreadElement(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitSpreadElement(SpreadElement node) {
+    var expression = node.expression;
+    if (expression is MethodInvocation &&
+        expression.methodName.name == 'toList' &&
+        DartTypeUtilities.implementsInterface(
+            expression.target?.staticType, 'Iterable', 'dart.core')) {
+      rule.reportLint(expression.methodName);
+    }
+  }
+}

--- a/test_data/rules/unnecessary_to_list_in_spreads.dart
+++ b/test_data/rules/unnecessary_to_list_in_spreads.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N unnecessary_to_list_in_spreads`
+
+var ok = [
+  ...[1, 2].whereType<int>(), // OK
+];
+
+var t1 = [
+  ...[1, 2].toList(), // LINT
+];
+var t2 = [
+  ...{1, 2}.toList(), // LINT
+];
+var t3 = [
+  ...?[1, 2].toList(), // LINT
+];
+var t4 = [
+  ...?{1, 2}.toList(), // LINT
+];
+var t5 = [
+  ...[1, 2].whereType<int>().toList(), // LINT
+];


### PR DESCRIPTION
# Description

Unnecessary `toList()` in spreads.
**BAD:**
```dart
children: <Widget>[
  ...['foo', 'bar', 'baz'].map((String s) => Text(s)).toList(),
]
```
**GOOD:**
```dart
children: <Widget>[
  ...['foo', 'bar', 'baz'].map((String s) => Text(s)),
]
```

Fixes #2965
