### PR TITLE
1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.24.0
+
+- fix `prefer_final_parameters` to support super parameters
+- new lint: `unnecessary_to_list_in_spreads`
+- fix `unawaited_futures` to handle string interpolated
+  futures
+- update `use_colored_box` to not flag nullable colors
+- new lint: `unnecessary_null_aware_operator_on_extension_on_nullable`
+
 # 1.23.0
 
 - fixed `no_leading_underscores_for_local_identifiers`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.23.0';
+const String version = '1.24.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.23.0
+version: 1.24.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.24.0

- fix `prefer_final_parameters` to support super parameters
- new lint: `unnecessary_to_list_in_spreads`
- fix `unawaited_futures` to handle string interpolated
  futures
- update `use_colored_box` to not flag nullable colors
- new lint: `unnecessary_null_aware_operator_on_extension_on_nullable`

---

/cc @bwilkerson 
