### PR TITLE
`prefer_initializing_formals` iteration optimizations

### DIFF
--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -103,9 +103,9 @@ Iterable<AssignmentExpression> _getAssignmentExpressionsInConstructorBody(
 }
 
 Iterable<ConstructorFieldInitializer>
-_getConstructorFieldInitializersInInitializers(
-    ConstructorDeclaration node) =>
-    node.initializers.whereType<ConstructorFieldInitializer>();
+    _getConstructorFieldInitializersInInitializers(
+            ConstructorDeclaration node) =>
+        node.initializers.whereType<ConstructorFieldInitializer>();
 
 Element? _getLeftElement(AssignmentExpression assignment) =>
     DartTypeUtilities.getCanonicalElement(assignment.writeElement);
@@ -120,10 +120,10 @@ Element? _getRightElement(AssignmentExpression assignment) =>
 class PreferInitializingFormals extends LintRule {
   PreferInitializingFormals()
       : super(
-      name: 'prefer_initializing_formals',
-      description: _desc,
-      details: _details,
-      group: Group.style);
+            name: 'prefer_initializing_formals',
+            description: _desc,
+            details: _details,
+            group: Group.style);
 
   @override
   void registerNodeProcessors(
@@ -163,7 +163,7 @@ class _Visitor extends SimpleAstVisitor<void> {
               node.declaredElement?.enclosingElement &&
           parameters.contains(rightElement) &&
           (!parametersUsedMoreThanOnce.contains(rightElement) &&
-              !(rightElement as ParameterElement).isNamed ||
+                  !(rightElement as ParameterElement).isNamed ||
               leftElement.name == rightElement.name);
     }
 
@@ -181,7 +181,7 @@ class _Visitor extends SimpleAstVisitor<void> {
                 true) &&
             parameters.contains(staticElement) &&
             (!parametersUsedMoreThanOnce.contains(expression.staticElement) &&
-                !staticElement.isNamed ||
+                    !staticElement.isNamed ||
                 (constructorFieldInitializer.fieldName.staticElement?.name ==
                     expression.staticElement?.name));
       }


### PR DESCRIPTION
Our [benchmark bot](https://github.com/dart-lang/linter/runs/6532600308?check_suite_focus=true), while not rigorous, does suggest a significant improvement.

Before:

![image](https://user-images.githubusercontent.com/67586/169621475-6e04863b-9bea-4976-aef0-d5dbacfc587b.png)


After:

![image](https://user-images.githubusercontent.com/67586/169621488-4c560426-d416-4086-921d-22a6ec04a864.png)

Note that this is a recommended lint so *any* improvement will be felt by lots of folks.


/cc @srawlins @scheglov @bwilkerson 