### PR TITLE
`prefer_const_constructors_in_immutables`: optimize out sync* and extra iteration

### DIFF
--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -120,20 +120,23 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
     var selfAndInheritedClasses = _getSelfAndInheritedClasses(clazz);
-    var selfAndInheritedAnnotations =
-        selfAndInheritedClasses.expand((c) => c.metadata).map((m) => m.element);
-    return selfAndInheritedAnnotations.any(_isImmutable);
+    for (var cls in selfAndInheritedClasses) {
+      if (cls.metadata.any((m) => _isImmutable(m.element))) return true;
+    }
+    return false;
   }
 
   bool _hasMixin(ClassElement clazz) => clazz.mixins.isNotEmpty;
 
   static Iterable<ClassElement> _getSelfAndInheritedClasses(
-      ClassElement self) sync* {
+      ClassElement self) {
+    var elements = <ClassElement>[];
     ClassElement? current = self;
     var seenElements = <ClassElement>{};
     while (current != null && seenElements.add(current)) {
-      yield current;
+      elements.add(current);
       current = current.supertype?.element;
     }
+    return elements;
   }
 }

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -128,8 +128,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   bool _hasMixin(ClassElement clazz) => clazz.mixins.isNotEmpty;
 
-  static Iterable<ClassElement> _getSelfAndInheritedClasses(
-      ClassElement self) {
+  static Iterable<ClassElement> _getSelfAndInheritedClasses(ClassElement self) {
     var elements = <ClassElement>[];
     ClassElement? current = self;
     var seenElements = <ClassElement>{};

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -119,7 +119,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   bool _hasImmutableAnnotation(ClassElement clazz) {
-    var selfAndInheritedClasses = _getSelfAndInheritedClasses(clazz);
+    var selfAndInheritedClasses = _getSelfAndSuperClasses(clazz);
     for (var cls in selfAndInheritedClasses) {
       if (cls.metadata.any((m) => _isImmutable(m.element))) return true;
     }
@@ -128,14 +128,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   bool _hasMixin(ClassElement clazz) => clazz.mixins.isNotEmpty;
 
-  static Iterable<ClassElement> _getSelfAndInheritedClasses(ClassElement self) {
-    var elements = <ClassElement>[];
+  static List<ClassElement> _getSelfAndSuperClasses(ClassElement self) {
     ClassElement? current = self;
     var seenElements = <ClassElement>{};
     while (current != null && seenElements.add(current)) {
-      elements.add(current);
       current = current.supertype?.element;
     }
-    return elements;
+    return seenElements.toList();
   }
 }


### PR DESCRIPTION
Another wee optimization on a `flutter` recommended lint.  (Some context in https://github.com/dart-lang/sdk/issues/32102.)

[BEFORE](https://github.com/dart-lang/linter/runs/6497647704?check_suite_focus=true):

<img width="638" alt="image" src="https://user-images.githubusercontent.com/67586/169623667-3db5a491-db30-41d9-8563-965ec7148805.png">

[AFTER](https://github.com/dart-lang/linter/runs/6532900300?check_suite_focus=true):

<img width="696" alt="image" src="https://user-images.githubusercontent.com/67586/169623850-e8727c8e-7ac5-4c33-87e8-f61dc85e777e.png">

A pretty significant improvement!


/cc @srawlins @scheglov @bwilkerson 

/fyi @goderbauer 
