### PR TITLE
Avoid `depend_on_referenced_packages` false positive in colocated test directory

### DIFF
--- a/lib/src/rules/depend_on_referenced_packages.dart
+++ b/lib/src/rules/depend_on_referenced_packages.dart
@@ -72,7 +72,8 @@ class DependOnReferencedPackages extends LintRule {
         for (var dep in dependencies)
           if (dep.name?.text != null) dep.name!.text!,
       if (devDependencies != null &&
-          !isInPublicDir(context.currentUnit.unit, context.package))
+          (context.inTestDir(context.currentUnit.unit) ||
+          !isInPublicDir(context.currentUnit.unit, context.package)))
         for (var dep in devDependencies)
           if (dep.name?.text != null) dep.name!.text!,
     ];


### PR DESCRIPTION
# Description

When test files are colocated (in a `test/` subdirectory of `lib/src/`) the `depend_on_referenced_packages` lint does not consider dev dependencies as part of the file's dependencies and thus gives false positives for all referenced dev dependencies.