### PR TITLE
1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.25.0
+
+- new lint: `discarded_futures`
+- improved message and highlight range for
+  `no_duplicate_case_values`
+- performance improvements for `lines_longer_than_80_chars`,
+  `prefer_const_constructors_in_immutables`, and
+  `prefer_initializing_formals`
+
 # 1.24.0
 
 - fix `prefer_final_parameters` to support super parameters

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.24.0';
+const String version = '1.25.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.24.0
+version: 1.25.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.25.0

- new lint: `discarded_futures`
- improved message and highlight range for
  `no_duplicate_case_values`
- performance improvements for `lines_longer_than_80_chars`,
  `prefer_const_constructors_in_immutables`, and
  `prefer_initializing_formals`

---

/cc @bwilkerson 
