### PR TITLE
failing test for unknown constant value

### DIFF
--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -75,12 +75,13 @@ class _Visitor extends SimpleAstVisitor {
         continue;
       }
       var value = param.computeConstantValue();
-      if (value != null) {
+      if (value != null && value.hasKnownValue) {
         if (arg is NamedExpression) {
           arg = arg.expression;
         }
-        var expressionValue = context.evaluateConstant(arg);
-        if (expressionValue.value == value) {
+        var expressionValue = context.evaluateConstant(arg).value;
+        if ((expressionValue?.hasKnownValue ?? false) &&
+            expressionValue == value) {
           rule.reportLint(arg);
         }
       }

--- a/test/rules/avoid_redundant_argument_values_test.dart
+++ b/test/rules/avoid_redundant_argument_values_test.dart
@@ -39,6 +39,21 @@ class AvoidRedundantArgumentValuesTest extends LintRuleTest {
   @override
   String get lintRule => 'avoid_redundant_argument_values';
 
+  @FailingTest(issue: 'https://github.com/dart-lang/linter/issues/3447')
+  test_fromEnvironment() async {
+    await assertNoDiagnostics(r'''
+const bool someDefine = bool.fromEnvironment('someDefine');
+
+void f({bool test = true}) {}
+
+void g() {
+  f(
+    test: !someDefine,
+  );
+} 
+''');
+  }
+
   test_requiredNullable() async {
     await assertNoDiagnostics(r'''
 void f({required int? x}) { }


### PR DESCRIPTION
See: #3447

I think the constant evaluator should be returning `hasKnownValue == false` in this repro test?

/cc @bwilkerson @scheglov 