### PR TITLE
add no_top_public_members_in_executable_libraries

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -94,6 +94,7 @@ linter:
     - no_leading_underscores_for_local_identifiers
     - no_logic_in_create_state
     - no_runtimeType_toString
+    - no_top_public_members_in_executable_libraries
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -96,6 +96,7 @@ import 'rules/no_leading_underscores_for_library_prefixes.dart';
 import 'rules/no_leading_underscores_for_local_identifiers.dart';
 import 'rules/no_logic_in_create_state.dart';
 import 'rules/no_runtimeType_toString.dart';
+import 'rules/no_top_public_members_in_executable_libraries.dart';
 import 'rules/non_constant_identifier_names.dart';
 import 'rules/noop_primitive_operations.dart';
 import 'rules/null_check_on_nullable_type_parameter.dart';
@@ -311,6 +312,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(NoLogicInCreateState())
     ..register(NoopPrimitiveOperations())
     ..register(NoRuntimeTypeToString())
+    ..register(NoTopPublicMembersInExecutableLibraries())
     ..register(NullCheckOnNullableTypeParameter())
     ..register(NullClosures())
     ..register(OmitLocalVariableTypes())

--- a/lib/src/rules/no_top_public_members_in_executable_libraries.dart
+++ b/lib/src/rules/no_top_public_members_in_executable_libraries.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = 'No top public members in executable libraries.';
+
+const _details = r'''
+
+Top-level members in an executable library should be private (or relocated to
+within main), to prevent unused members.
+
+**BAD:**
+
+```dart
+main() {}
+void f() {}
+```
+
+**GOOD:**
+
+```dart
+main() {}
+void _f() {}
+``
+
+''';
+
+class NoTopPublicMembersInExecutableLibraries extends LintRule {
+  NoTopPublicMembersInExecutableLibraries()
+      : super(
+          name: 'no_top_public_members_in_executable_libraries',
+          description: _desc,
+          details: _details,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(
+    NodeLintRegistry registry,
+    LinterContext context,
+  ) {
+    var visitor = _Visitor(this);
+    registry.addCompilationUnit(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule);
+
+  final LintRule rule;
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    if (!_isInsideExecutableLibrary(node)) return;
+    for (var member in node.declarations) {
+      if (member is FunctionDeclaration && member.name.name == 'main') continue;
+      if (member is TopLevelVariableDeclaration) {
+        member.variables.variables.forEach(_visitDeclaration);
+      } else {
+        _visitDeclaration(member);
+      }
+    }
+  }
+
+  void _visitDeclaration(Declaration node) {
+    var element = node.declaredElement;
+    if (element != null && element.isPublic && !element.hasVisibleForTesting) {
+      rule.reportLint(node);
+    }
+  }
+
+  bool _isInsideExecutableLibrary(AstNode node) {
+    var root = node.root;
+    if (root is! CompilationUnit) return false;
+    var library = root.declaredElement?.library;
+    return library != null &&
+        library.exportNamespace.definedNames.containsKey('main');
+  }
+}

--- a/test/integration/no_top_public_members_in_executable_libraries.dart
+++ b/test/integration/no_top_public_members_in_executable_libraries.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:analyzer/src/lint/io.dart';
+import 'package:linter/src/analyzer.dart';
+import 'package:linter/src/cli.dart' as cli;
+import 'package:path/path.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+import '../test_constants.dart';
+
+void main() {
+  group('no_top_public_members_in_executable_libraries', () {
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
+    setUp(() {
+      exitCode = 0;
+      outSink = collectingOut;
+    });
+    tearDown(() {
+      collectingOut.buffer.clear();
+      outSink = currentOut;
+      exitCode = 0;
+    });
+
+    test('detects lints', () async {
+      await cli.runLinter([
+        '$integrationTestDir/no_top_public_members_in_executable_libraries',
+        '--rules=no_top_public_members_in_executable_libraries',
+      ], LinterOptions());
+      var files = Directory(
+              '$integrationTestDir/no_top_public_members_in_executable_libraries')
+          .listSync()
+          .whereType<File>()
+          .toList();
+      var lintsByFile = <File, List<int>>{
+        for (var file in files)
+          file: file
+              .readAsLinesSync()
+              .asMap()
+              .entries
+              .where((e) => e.value.endsWith('// LINT'))
+              .map((e) => e.key + 1)
+              .toList()
+      };
+      expect(
+        collectingOut.trim(),
+        stringContainsInOrder([
+          for (var entry in lintsByFile.entries) ...[
+            for (var line in entry.value) '${basename(entry.key.path)} $line:',
+          ],
+          '${lintsByFile.length} file${lintsByFile.length == 1 ? '' : 's'} analyzed, ${lintsByFile.values.expand((e) => e).length} issues found, in',
+        ]),
+      );
+      expect(exitCode, lintsByFile.values.expand((e) => e).isEmpty ? 0 : 1);
+    });
+  });
+}

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -31,6 +31,8 @@ import 'integration/exhaustive_cases.dart' as exhaustive_cases;
 import 'integration/flutter_style_todos.dart' as flutter_style_todos;
 import 'integration/lines_longer_than_80_chars.dart'
     as lines_longer_than_80_chars;
+import 'integration/no_top_public_members_in_executable_libraries.dart'
+    as no_top_public_members_in_executable_libraries;
 import 'integration/only_throw_errors.dart' as only_throw_errors;
 import 'integration/overridden_fields.dart' as overridden_fields;
 import 'integration/packages_file_test.dart' as packages_file_test;
@@ -207,6 +209,7 @@ void ruleTests() {
     prefer_mixin.main();
     use_build_context_synchronously.main();
     prefer_const_constructors.main();
+    no_top_public_members_in_executable_libraries.main();
   });
 }
 

--- a/test_data/integration/no_top_public_members_in_executable_libraries/non_executable.dart
+++ b/test_data/integration/no_top_public_members_in_executable_libraries/non_executable.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N no_top_public_members_in_executable_libraries`
+
+const a = 1; // OK
+
+int v = 1; // OK
+
+typedef A = String; // OK
+
+class C {} // OK
+
+mixin M {} // OK
+
+enum E { e } // OK
+
+void f() {} // OK

--- a/test_data/rules/no_top_public_members_in_executable_libraries.dart
+++ b/test_data/rules/no_top_public_members_in_executable_libraries.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N no_top_public_members_in_executable_libraries`
+
+import 'package:meta/meta.dart';
+
+main() {} // OK
+
+const a = 1; // LINT
+
+int v = 1; // LINT
+
+typedef A = String; // LINT
+
+class C {} // LINT
+
+mixin M {} // LINT
+
+enum E { e } // LINT
+
+void f() {} // LINT
+
+_insideFunction() {
+  inner() {} // OK
+}
+
+@visibleForTesting
+void forTest() {} // OK


### PR DESCRIPTION
# Description

Top-level members in an executable library should be private (or relocated to within main), to prevent unused members.

**BAD:**

```dart
main() {}
void f() {}
```

**GOOD:**

```dart
main() {}
void _f() {}
```

Fixes #1258 
