### PR TITLE
use_late_for_private_fields_and_variables: handling of enum

### DIFF
--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -129,6 +129,11 @@ class _Visitor extends UnifyingAstVisitor<void> {
   }
 
   @override
+  void visitEnumDeclaration(EnumDeclaration node) {
+    // See: https://dart.dev/tools/diagnostic-messages#late_final_field_with_const_constructor
+  }
+
+  @override
   void visitFieldDeclaration(FieldDeclaration node) {
     for (var variable in node.fields.variables) {
       var parent = node.parent;

--- a/test_data/rules/use_late_for_private_fields_and_variables.dart
+++ b/test_data/rules/use_late_for_private_fields_and_variables.dart
@@ -80,3 +80,11 @@ class ContentChannelException {
 
   Exception get exception => _exception!;
 }
+
+enum MyEnum {
+  a('');
+
+  const MyEnum([this._private]);
+
+  final String? _private; // OK (enum constructor must be const)
+}


### PR DESCRIPTION
Fixes #3421
