### PR TITLE
prefer_final_locals: handling of declaration list

### DIFF
--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -87,6 +87,10 @@ class _Visitor extends SimpleAstVisitor<void> {
         return;
       }
     }
-    rule.reportLint(node);
+    if (node.keyword != null) {
+      rule.reportLintForToken(node.keyword);
+    } else if (node.type != null) {
+      rule.reportLint(node.type);
+    }
   }
 }

--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -61,7 +61,7 @@ class PreferFinalLocals extends LintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
-    registry.addVariableDeclaration(this, visitor);
+    registry.addVariableDeclarationList(this, visitor);
   }
 }
 
@@ -71,20 +71,22 @@ class _Visitor extends SimpleAstVisitor<void> {
   _Visitor(this.rule);
 
   @override
-  void visitVariableDeclaration(VariableDeclaration node) {
-    if (node.isConst ||
-        node.isFinal ||
-        node.equals == null ||
-        node.initializer == null) {
-      return;
-    }
+  void visitVariableDeclarationList(VariableDeclarationList node) {
+    if (node.isConst || node.isFinal) return;
 
     var function = node.thisOrAncestorOfType<FunctionBody>();
-    var declaredElement = node.declaredElement;
-    if (function != null &&
-        declaredElement != null &&
-        !function.isPotentiallyMutatedInScope(declaredElement)) {
-      rule.reportLint(node.name);
+
+    for (var variable in node.variables) {
+      if (variable.equals == null || variable.initializer == null) {
+        return;
+      }
+      var declaredElement = variable.declaredElement;
+      if (function != null &&
+          declaredElement != null &&
+          function.isPotentiallyMutatedInScope(declaredElement)) {
+        return;
+      }
     }
+    rule.reportLint(node);
   }
 }

--- a/test_data/rules/prefer_final_locals.dart
+++ b/test_data/rules/prefer_final_locals.dart
@@ -27,6 +27,12 @@ void multiUnmutated() {
   print(unmutated2);
 }
 
+void multiUnmutatedWithType() {
+  String unmutated1 = 'hello', unmutated2 = 'world'; // LINT
+  print(unmutated1);
+  print(unmutated2);
+}
+
 void multiWithAMutation() {
   var mutated = 'hello', unmutated = 'unmutated'; // OK
   print(mutated);

--- a/test_data/rules/prefer_final_locals.dart
+++ b/test_data/rules/prefer_final_locals.dart
@@ -20,3 +20,17 @@ void mutableCase() {
   label = 'hello world';
   print(label);
 }
+
+void multiUnmutated() {
+  var unmutated1 = 'hello', unmutated2 = 'world'; // LINT
+  print(unmutated1);
+  print(unmutated2);
+}
+
+void multiWithAMutation() {
+  var mutated = 'hello', unmutated = 'unmutated'; // OK
+  print(mutated);
+  mutated = 'world';
+  print(mutated);
+  print(unmutated);
+}


### PR DESCRIPTION
# Description

`prefer_final_locals` should trigger only if all variables in the declaration list can be final.

Related to #3444 