### PR TITLE
avoid_multiple_declarations_per_line: handling of for

### DIFF
--- a/lib/src/rules/avoid_multiple_declarations_per_line.dart
+++ b/lib/src/rules/avoid_multiple_declarations_per_line.dart
@@ -50,8 +50,10 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitVariableDeclarationList(VariableDeclarationList node) {
-    var variables = node.variables;
+    var parent = node.parent;
+    if (parent is ForPartsWithDeclarations && parent.variables == node) return;
 
+    var variables = node.variables;
     if (variables.length > 1) {
       var secondVariable = variables[1];
       rule.reportLint(secondVariable.name);

--- a/test_data/rules/avoid_multiple_declarations_per_line.dart
+++ b/test_data/rules/avoid_multiple_declarations_per_line.dart
@@ -51,3 +51,11 @@ extension GoodExtension on Object {
   static String? bar;
   static String? baz;
 }
+
+// https://github.com/dart-lang/linter/issues/2543
+okInForLoop() {
+  for (var i = 0, j = 0; i < 2 && j < 2; ++i, ++j) // OK
+  {
+    //
+  }
+}


### PR DESCRIPTION
# Description

`avoid_multiple_declarations_per_line` shouldn't apply in for declaration list.

Fixes #2543

Related to #3444
