### PR TITLE
prefer_final_locals: no lint on fields

### DIFF
--- a/lib/src/rules/prefer_final_locals.dart
+++ b/lib/src/rules/prefer_final_locals.dart
@@ -75,14 +75,14 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.isConst || node.isFinal) return;
 
     var function = node.thisOrAncestorOfType<FunctionBody>();
+    if (function == null) return;
 
     for (var variable in node.variables) {
       if (variable.equals == null || variable.initializer == null) {
         return;
       }
       var declaredElement = variable.declaredElement;
-      if (function != null &&
-          declaredElement != null &&
+      if (declaredElement != null &&
           function.isPotentiallyMutatedInScope(declaredElement)) {
         return;
       }

--- a/test_data/rules/prefer_final_locals.dart
+++ b/test_data/rules/prefer_final_locals.dart
@@ -40,3 +40,7 @@ void multiWithAMutation() {
   print(mutated);
   print(unmutated);
 }
+
+class Coverage {
+  int testedLines = 0; // OK
+}


### PR DESCRIPTION
# Description

#3459 has introduced a bug where class fields are no subject to diagnostics. This PR fixes the problem. 
