### PR TITLE
Check for Set/Maps at start of expr statements broadly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.26.0-dev
+
+- fixed false positive for `unnecessary_parenthesis` on a map-or-set
+  literal at the start of an expression statement
+
 # 1.25.0
 
 - new lint: `discarded_futures`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.25.0';
+const String version = '1.26.0-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.25.0
+version: 1.26.0-dev
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -99,6 +99,12 @@ main() async {
   ({false: 'false', true: 'true'}).forEach((k, v) => print('$k: $v'));
   ({false, true}).forEach(print);
   ({false, true}).length;
+  ({false, true}).length.toString();
+  ({1, 2, 3}) + {4};
+  ({1, 2, 3}).cast<num>;
+  /* comment */ ({1, 2, 3}).length;
+  // comment
+  ({1, 2, 3}).length;
   print(({1, 2, 3}).length); // LINT
   ([false, true]).forEach(print); // LINT
 }
@@ -132,4 +138,8 @@ class UnnecessaryParenthesis {
   UnnecessaryParenthesis()
       : c = (ClassWithClassWithFunction()
           ..c = (ClassWithFunction()..f = () => 42)); // OK
+}
+
+extension<T> on Set<T> {
+  Set<T> operator+(Set<T> other) => {...this, ...other};
 }


### PR DESCRIPTION
# Description

Check for Sets and Maps at start of expression statements broadly.

Fixes #3474
