### PR TITLE
trigger use_decorated_box and use_colored_box only with child

### DIFF
--- a/lib/src/rules/use_colored_box.dart
+++ b/lib/src/rules/use_colored_box.dart
@@ -73,7 +73,7 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    if (data.hasColor) {
+    if (data.hasChild && data.hasColor) {
       rule.reportLint(node.constructorName);
     }
   }
@@ -83,6 +83,7 @@ class _ArgumentData {
   var positionalArgumentsFound = false;
   var additionalArgumentsFound = false;
   var hasColor = false;
+  var hasChild = false;
 
   _ArgumentData(ArgumentList node) {
     for (var argument in node.arguments) {
@@ -96,7 +97,7 @@ class _ArgumentData {
               NullabilitySuffix.question) {
         hasColor = true;
       } else if (label.name == 'child') {
-        // Ignore child
+        hasChild = true;
       } else if (label.name == 'key') {
         // Ignore key
       } else {

--- a/lib/src/rules/use_decorated_box.dart
+++ b/lib/src/rules/use_decorated_box.dart
@@ -82,7 +82,7 @@ class _Visitor extends SimpleAstVisitor {
       return;
     }
 
-    if (data.hasDecoration) {
+    if (data.hasChild && data.hasDecoration) {
       rule.reportLint(node.constructorName);
     }
   }
@@ -92,6 +92,7 @@ class _ArgumentData {
   var positionalArgumentsFound = false;
   var additionalArgumentsFound = false;
   var hasDecoration = false;
+  var hasChild = false;
 
   _ArgumentData(ArgumentList node) {
     for (var argument in node.arguments) {
@@ -103,7 +104,7 @@ class _ArgumentData {
       if (label.name == 'decoration') {
         hasDecoration = true;
       } else if (label.name == 'child') {
-        // Ignore child
+        hasChild = true;
       } else if (label.name == 'key') {
         // Ignore key
       } else {

--- a/test_data/rules/use_colored_box.dart
+++ b/test_data/rules/use_colored_box.dart
@@ -22,7 +22,7 @@ Widget containerWithKey() {
 }
 
 Widget containerWithColor() {
-  return Container( // LINT
+  return Container( // OK
     color: Color(0xffffffff),
   );
 }
@@ -41,7 +41,7 @@ Widget containerWithKeyAndChild() {
 }
 
 Widget containerWithKeyAndColor() {
-  return Container( // LINT
+  return Container( // OK
     key: Key('abc'),
     color: Color(0xffffffff),
   );

--- a/test_data/rules/use_decorated_box.dart
+++ b/test_data/rules/use_decorated_box.dart
@@ -19,7 +19,7 @@ Widget containerWithKey() {
 }
 
 Widget containerWithDecoration() {
-  return Container( // LINT
+  return Container( // OK
     decoration: BoxDecoration(),
   );
 }
@@ -38,7 +38,7 @@ Widget containerWithKeyAndChild() {
 }
 
 Widget containerWithKeyAndDecoration() {
-  return Container( // LINT
+  return Container( // OK
     key: Key('abc'),
     decoration: BoxDecoration(),
   );


### PR DESCRIPTION
# Description

A `Container` without child (and without constraint) will [introduce a LimitedBox in the tree](https://github.com/flutter/flutter/blob/160e0712a8bb6f2d10dfca703c91e60d0e0a0c5e/packages/flutter/lib/src/widgets/container.dart#L386-L391). So it is not correct in the code in description to replace the Container with a DecoratedBox.

This PR requires a `child` parameter to be specified to trigger. This will prevent false positives.

Fixes #3479, #3344
