### PR TITLE
1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.26.0
 
+- new lint: `combinators_ordering`
 - fixed `use_colored_box` and `use_decorated_box` to not over-report
   on containers without a child
 - fixed false positive for `unnecessary_parenthesis` on a map-or-set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 - fixed false positive for `prefer_final_locals` reporting on fields
 - fixed `unnecessary_overrides` to allow overrides on `@Protected`
   members
-- fixed `unnecessary_parenthesis` false positives on map and set
-  literal at the beginning of expressions
 - fixed `avoid_multiple_declarations_per_line` false positive in
   `for` statements
 - fixed `prefer_final_locals` false positive on declaration lists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
-# 1.26.0-dev
+# 1.26.0
 
+- fixed `use_colored_box` and `use_decorated_box` to not over-report
+  on containers without a child
 - fixed false positive for `unnecessary_parenthesis` on a map-or-set
   literal at the start of an expression statement
+- fixed false positive for `prefer_final_locals` reporting on fields
+- fixed `unnecessary_overrides` to allow overrides on `@Protected`
+  members
+- fixed `unnecessary_parenthesis` false positives on map and set
+  literal at the beginning of expressions
+- fixed `avoid_multiple_declarations_per_line` false positive in
+  `for` statements
+- fixed `prefer_final_locals` false positive on declaration lists
+  with at least one non-final variable
+- fixed `use_build_context_synchronously` to handle `await`s in
+  `if` conditions
 
 # 1.25.0
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.26.0-dev';
+const String version = '1.26.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.26.0-dev
+version: 1.26.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.26.0

- new lint: `combinators_ordering`
- fixed `use_colored_box` and `use_decorated_box` to not over-report
  on containers without a child
- fixed false positive for `unnecessary_parenthesis` on a map-or-set
  literal at the start of an expression statement
- fixed false positive for `prefer_final_locals` reporting on fields
- fixed `unnecessary_overrides` to allow overrides on `@Protected`
  members
- fixed `unnecessary_parenthesis` false positives on map and set
  literal at the beginning of expressions
- fixed `avoid_multiple_declarations_per_line` false positive in
  `for` statements
- fixed `prefer_final_locals` false positive on declaration lists
  with at least one non-final variable
- fixed `use_build_context_synchronously` to handle `await`s in
  `if` conditions


---

/cc @srawlins @bwilkerson @a14n 