### PR TITLE
generate fix status documentation

### DIFF
--- a/test/all.dart
+++ b/test/all.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/src/lint/io.dart';
 
 import 'ascii_utils_test.dart' as ascii_utils;
+import 'doc_test.dart' as doc_test;
 import 'engine_test.dart' as engine_test;
 import 'formatter_test.dart' as formatter_test;
 import 'integration_test.dart' as integration_test;
@@ -23,6 +24,7 @@ void main() {
   outSink = MockIOSink();
 
   ascii_utils.main();
+  doc_test.main();
   engine_test.main();
   formatter_test.main();
   integration_test.main();

--- a/test/doc_test.dart
+++ b/test/doc_test.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../tool/doc.dart';
+
+void main() {
+  group('doc generation', () {
+    test('fixStatus (sanity)', () async {
+      var fixStatusMap = await fetchFixStatusMap();
+      // Doc generation reads the fix status map to associate fix status
+      // badges with rule documentation.  Here we check one for sanity.
+      // If the file moves or format changes, we'd expect this to fail.
+      expect(fixStatusMap['always_declare_return_types'], 'hasFix');
+    });
+  });
+}

--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -30,10 +30,10 @@ void main(List<String> args) async {
 }
 
 String getMachineListing(Iterable<LintRule> ruleRegistry,
-    {bool pretty = true}) {
+    {Map<String, String>? fixStatusMap, bool pretty = true}) {
   var rules = List<LintRule>.of(ruleRegistry, growable: false)..sort();
   var encoder = pretty ? JsonEncoder.withIndent('  ') : JsonEncoder();
-
+  fixStatusMap ??= {};
   var json = encoder.convert([
     for (var rule in rules)
       {
@@ -48,6 +48,7 @@ String getMachineListing(Iterable<LintRule> ruleRegistry,
           if (flutterRules.contains(rule.name)) 'flutter',
           if (pedanticRules.contains(rule.name)) 'pedantic',
         ],
+        'fixStatus': fixStatusMap[rule.name] ?? 'unregistered',
         'details': rule.details,
       }
   ]);


### PR DESCRIPTION
See https://github.com/dart-lang/linter/issues/2650.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/67586/179084951-9eb05d1f-638a-429a-97b2-160c150231ae.png">

<img width="889" alt="image" src="https://user-images.githubusercontent.com/67586/179084991-6ec86b1a-5b17-4182-b676-2b7fc6a49720.png">

Sample machine.json output:

```json
  {
    "name": "always_use_package_imports",
    "description": "Avoid relative imports for files in `lib/`.",
    "group": "errors",
    "maturity": "stable",
    "incompatible": [],
    "sets": [],
    "fixStatus": "hasFix",
    "details": "*DO* avoid relative imports for files in `lib/`.\n\nWhen mixing relative and absolute imports it's possible to create confusion\nwhere the same member gets imported in two different ways. One way to avoid\nthat is to ensure you consistently use absolute imports for files withing the\n`lib/` directory.\n\nThis is the opposite of 'prefer_relative_imports'.\n\nYou can also use 'avoid_relative_lib_imports' to disallow relative imports of\nfiles within `lib/` directory outside of it (for example `test/`).\n\n**GOOD:**\n\n```dart\nimport 'package:foo/bar.dart';\n\nimport 'package:foo/baz.dart';\n\nimport 'package:foo/src/baz.dart';\n...\n```\n\n**BAD:**\n\n```dart\nimport 'baz.dart';\n\nimport 'src/bag.dart'\n\nimport '../lib/baz.dart';\n\n...\n```\n\n"
  },
  {
    "name": "avoid_dynamic_calls",
    "description": "Avoid method calls or property accesses on a \"dynamic\" target.",
    "group": "errors",
    "maturity": "stable",
    "incompatible": [],
    "sets": [],
    "fixStatus": "needsEvaluation",
    "details": "\n**DO** avoid method calls or accessing properties on an object that is either\nexplicitly or implicitly statically typed \"dynamic\". Dynamic calls are treated\nslightly different in every runtime environment and compiler, but most\nproduction modes (and even some development modes) have both compile size and\nruntime performance penalties associated with dynamic calls.\n\nAdditionally, targets typed \"dynamic\" disables most static analysis, meaning it\nis easier to lead to a runtime \"NoSuchMethodError\" or \"NullError\" than properly\nstatically typed Dart code.\n\nThere is an exception to methods and properties that exist on \"Object?\":\n- a.hashCode\n- a.runtimeType\n- a.noSuchMethod(someInvocation)\n- a.toString()\n\n... these members are dynamically dispatched in the web-based runtimes, but not\nin the VM-based ones. Additionally, they are so common that it would be very\npunishing to disallow `any.toString()` or `any == true`, for example.\n\nNote that despite \"Function\" being a type, the semantics are close to identical\nto \"dynamic\", and calls to an object that is typed \"Function\" will also trigger\nthis lint.\n\n**BAD:**\n```dart\nvoid explicitDynamicType(dynamic object) {\n  print(object.foo());\n}\n\nvoid implicitDynamicType(object) {\n  print(object.foo());\n}\n\nabstract class SomeWrapper {\n  T doSomething<T>();\n}\n\nvoid inferredDynamicType(SomeWrapper wrapper) {\n  var object = wrapper.doSomething();\n  print(object.foo());\n}\n\nvoid callDynamic(dynamic function) {\n  function();\n}\n\nvoid functionType(Function function) {\n  function();\n}\n```\n\n**GOOD:**\n```dart\nvoid explicitType(Fooable object) {\n  object.foo();\n}\n\nvoid castedType(dynamic object) {\n  (object as Fooable).foo();\n}\n\nabstract class SomeWrapper {\n  T doSomething<T>();\n}\n\nvoid inferredType(SomeWrapper wrapper) {\n  var object = wrapper.doSomething<Fooable>();\n  object.foo();\n}\n\nvoid functionTypeWithParameters(Function() function) {\n  function();\n}\n```\n\n"
  },
```


I do wish I had a nice place to link out to describe quick-fixes.  Is there one I'm missing?

/cc @bwilkerson @parlough @srawlins 
