### PR TITLE
fix `set:` label prefix rename

### DIFF
--- a/tool/canonical/readme.md
+++ b/tool/canonical/readme.md
@@ -1,7 +1,7 @@
 Tools related to Dart and Flutter lints.
 
-* `gh_labels` - emits a list of open GitHub issues that reference
-  lints in lint sets but are missing `set: ...` issue labels.
+* `gh_labels` - lists open GitHub issues that reference lint rules in 
+   lintsets but are missing `set- ...` issue labels.
 
 See: 
 


### PR DESCRIPTION
Follow-up from #3533.

(Sorry for the noise!)

/cc @bwilkerson 