### PR TITLE
remove descriptions from integration test "goldens"

### DIFF
--- a/test/integration/avoid_private_typedef_functions.dart
+++ b/test/integration/avoid_private_typedef_functions.dart
@@ -36,8 +36,8 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'lib.dart 11:14 [lint] Avoid private typedef functions.',
-            'part.dart 11:14 [lint] Avoid private typedef functions.',
+            'lib.dart 11:14',
+            'part.dart 11:14',
             '2 files analyzed, 2 issues found',
           ]));
       expect(exitCode, 1);

--- a/test/integration/avoid_renaming_method_parameters.dart
+++ b/test/integration/avoid_renaming_method_parameters.dart
@@ -35,12 +35,12 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            "a.dart 31:6 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
-            "a.dart 33:12 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
-            "a.dart 34:9 [lint] The parameter 'bb' should have the name 'b' to match the name used in the overridden method.",
-            "a.dart 36:7 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
-            "a.dart 37:6 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
-            "a.dart 38:6 [lint] The parameter 'aa' should have the name 'a' to match the name used in the overridden method.",
+            'a.dart 31:6 [lint]',
+            'a.dart 33:12 [lint]',
+            'a.dart 34:9 [lint]',
+            'a.dart 36:7 [lint]',
+            'a.dart 37:6 [lint]',
+            'a.dart 38:6 [lint]',
             '3 files analyzed, 6 issues found',
           ]));
       expect(exitCode, 1);

--- a/test/integration/flutter_style_todos.dart
+++ b/test/integration/flutter_style_todos.dart
@@ -33,17 +33,17 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'a.dart 8:1 [lint] Use Flutter TODO format:',
-            'a.dart 9:1 [lint] Use Flutter TODO format:',
-            'a.dart 10:1 [lint] Use Flutter TODO format:',
-            'a.dart 11:1 [lint] Use Flutter TODO format:',
-            'a.dart 12:1 [lint] Use Flutter TODO format:',
-            'a.dart 13:1 [lint] Use Flutter TODO format:',
-            'a.dart 14:1 [lint] Use Flutter TODO format:',
-            'a.dart 15:1 [lint] Use Flutter TODO format:',
-            'a.dart 16:1 [lint] Use Flutter TODO format:',
-            'a.dart 17:1 [lint] Use Flutter TODO format:',
-            'a.dart 18:1 [lint] Use Flutter TODO format:',
+            'a.dart 8:1',
+            'a.dart 9:1',
+            'a.dart 10:1',
+            'a.dart 11:1',
+            'a.dart 12:1',
+            'a.dart 13:1',
+            'a.dart 14:1',
+            'a.dart 15:1',
+            'a.dart 16:1',
+            'a.dart 17:1',
+            'a.dart 18:1',
             '1 file analyzed, 11 issues found, in'
           ]));
       expect(exitCode, 1);

--- a/test/integration/lines_longer_than_80_chars.dart
+++ b/test/integration/lines_longer_than_80_chars.dart
@@ -33,10 +33,10 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'a.dart 7:81 [lint] Avoid lines longer than 80 characters.',
-            'a.dart 11:81 [lint] Avoid lines longer than 80 characters.',
-            'a.dart 20:81 [lint] Avoid lines longer than 80 characters.',
-            'a.dart 25:81 [lint] Avoid lines longer than 80 characters.',
+            'a.dart 7:81',
+            'a.dart 11:81',
+            'a.dart 20:81',
+            'a.dart 25:81',
             "a.dart 32:40 [hint] The diagnostic 'lines_longer_than_80_chars' doesn't need to be ignored here because it's already being ignored.",
             "a.dart 32:68 [hint] The diagnostic 'lines_longer_than_80_chars' doesn't need to be ignored here because it's already being ignored.",
             '1 file analyzed, 6 issues found, in'

--- a/test/integration/secure_pubspec_urls.dart
+++ b/test/integration/secure_pubspec_urls.dart
@@ -35,14 +35,14 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            '4:11 [lint] The url should only use secure protocols.',
-            '6:16 [lint] The url should only use secure protocols.',
-            '5:13 [lint] The url should only use secure protocols.',
-            '15:12 [lint] The url should only use secure protocols.',
-            '20:13 [lint] The url should only use secure protocols.',
-            '25:10 [lint] The url should only use secure protocols.',
-            '28:12 [lint] The url should only use secure protocols.',
-            '32:12 [lint] The url should only use secure protocols.',
+            '4:11 [lint]',
+            '6:16 [lint]',
+            '5:13 [lint]',
+            '15:12 [lint]',
+            '20:13 [lint]',
+            '25:10 [lint]',
+            '28:12 [lint]',
+            '32:12 [lint]',
             '1 file analyzed, 8 issues found',
           ]));
       expect(exitCode, 1);

--- a/test/integration/sort_pub_dependencies.dart
+++ b/test/integration/sort_pub_dependencies.dart
@@ -35,9 +35,9 @@ void main() {
       expect(
           collectingOut.trim(),
           stringContainsInOrder([
-            'pubspec.yaml 19:3 [lint] Sort pub dependencies.',
-            'pubspec.yaml 26:3 [lint] Sort pub dependencies.',
-            'pubspec.yaml 33:3 [lint] Sort pub dependencies.',
+            'pubspec.yaml 19:3',
+            'pubspec.yaml 26:3',
+            'pubspec.yaml 33:3',
             '1 file analyzed, 3 issues found',
           ]));
       expect(exitCode, 1);

--- a/test/integration/use_build_context_synchronously.dart
+++ b/test/integration/use_build_context_synchronously.dart
@@ -28,8 +28,7 @@ void main() {
       ], LinterOptions());
       var out = collectingOut.trim();
       expect(out, contains('1 file analyzed, 1 issue found'));
-      expect(out,
-          contains('22:3 [lint] Do not use BuildContexts across async gaps.'));
+      expect(out, contains('22:3'));
     });
   });
 }


### PR DESCRIPTION
References to descriptions make the messages hard to evolve.

(See related: https://github.com/flutter/flutter/pull/107541.)

(Medium-term, we might consider migrating these to reflective tests: https://github.com/dart-lang/linter/issues/3535)

/cc @bwilkerson 