### PR TITLE
ensure reflective tests don't enable default on experiments

### DIFF
--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io' as io;
-
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/file_system/file_system.dart';
@@ -18,17 +16,12 @@ import 'package:analyzer/src/test_utilities/resource_provider_mixin.dart';
 import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules.dart';
 import 'package:meta/meta.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
-import 'package:yaml/yaml.dart' as yaml;
 
 export 'package:analyzer/src/dart/analysis/experiments.dart';
 export 'package:analyzer/src/dart/error/syntactic_errors.dart';
 export 'package:analyzer/src/error/codes.dart';
 export 'package:analyzer/src/test_utilities/package_config_file_builder.dart';
-
-/// Corresponds to the minimum SDK constraint in `pubspec.yaml`.
-final minSdkVersion = _parseMinSdkVersion();
 
 ExpectedError error(ErrorCode code, int offset, int length,
         {Pattern? messageContains}) =>
@@ -37,14 +30,6 @@ ExpectedError error(ErrorCode code, int offset, int length,
 ExpectedLint lint(String lintName, int offset, int length,
         {Pattern? messageContains}) =>
     ExpectedLint(lintName, offset, length, messageContains: messageContains);
-
-Version _parseMinSdkVersion() {
-  var pubspec = io.File('pubspec.yaml');
-  var yamlDoc = yaml.loadYaml(pubspec.readAsStringSync());
-  var sdkConstraint = yamlDoc['environment']['sdk'];
-  var range = VersionConstraint.parse(sdkConstraint as String) as VersionRange;
-  return range.min!;
-}
 
 typedef DiagnosticMatcher = bool Function(AnalysisError error);
 
@@ -270,12 +255,9 @@ class PubPackageResolutionTest extends _ContextResolutionTest {
     // Check for any needlessly enabled experiments.
     for (var experiment in experiments) {
       var feature = ExperimentStatus.knownFeatures[experiment];
-      var releaseVersion = feature?.releaseVersion;
-      if (releaseVersion != null && releaseVersion >= minSdkVersion) {
-        if (feature?.isEnabledByDefault ?? false) {
-          fail("The '$experiment' experiment is enabled by default, "
-              'try removing it from `experiments`.');
-        }
+      if (feature?.isEnabledByDefault ?? false) {
+        fail("The '$experiment' experiment is enabled by default, "
+            'try removing it from `experiments`.');
       }
     }
 

--- a/test/rules/annotate_overrides_test.dart
+++ b/test/rules/annotate_overrides_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class AnnotateOverridesTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'annotate_overrides';
 
   test_field() async {

--- a/test/rules/avoid_annotating_with_dynamic_test.dart
+++ b/test/rules/avoid_annotating_with_dynamic_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class AvoidAnnotatingWithDynamicTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'avoid_annotating_with_dynamic';
 
   test_fieldFormals() async {

--- a/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
+++ b/test/rules/avoid_equals_and_hash_code_on_mutable_classes_test.dart
@@ -16,12 +16,6 @@ main() {
 class AvoidEqualsAndHashCodeOnMutableClassesTest extends LintRuleTest {
   @override
   bool get addMetaPackageDep => true;
-
-  @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
   @override
   String get lintRule => 'avoid_equals_and_hash_code_on_mutable_classes';
 

--- a/test/rules/avoid_final_parameters_test.dart
+++ b/test/rules/avoid_final_parameters_test.dart
@@ -17,11 +17,6 @@ class AvoidFinalParametersTest extends LintRuleTest {
   @override
   String get lintRule => 'avoid_final_parameters';
 
-  @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
   test_super() async {
     await assertDiagnostics(r'''
 class A {

--- a/test/rules/avoid_init_to_null_test.dart
+++ b/test/rules/avoid_init_to_null_test.dart
@@ -16,9 +16,6 @@ main() {
 @reflectiveTest
 class AvoidInitToNullSuperFormalsTest extends LintRuleTest {
   @override
-  List<String> get experiments => [EnableString.super_parameters];
-
-  @override
   String get lintRule => 'avoid_init_to_null';
 
   test_nullableStringInit() async {

--- a/test/rules/avoid_redundant_argument_values_test.dart
+++ b/test/rules/avoid_redundant_argument_values_test.dart
@@ -16,9 +16,6 @@ main() {
 @reflectiveTest
 class AvoidRedundantArgumentValuesNamedArgsAnywhereTest extends LintRuleTest {
   @override
-  List<String> get experiments => [EnableString.named_arguments_anywhere];
-
-  @override
   String get lintRule => 'avoid_redundant_argument_values';
 
   test_namedArgumentBeforePositional() async {

--- a/test/rules/avoid_renaming_method_parameters_test.dart
+++ b/test/rules/avoid_renaming_method_parameters_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class AvoidRenamingMethodParametersTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'avoid_renaming_method_parameters';
 
   test_rename() async {

--- a/test/rules/avoid_returning_this_test.dart
+++ b/test/rules/avoid_returning_this_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class AvoidReturningThisTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'avoid_returning_this';
 
   test_method() async {

--- a/test/rules/avoid_setters_without_getters_test.dart
+++ b/test/rules/avoid_setters_without_getters_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class AvoidSettersWithoutGettersTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'avoid_setters_without_getters';
 
   test_enum() async {

--- a/test/rules/avoid_shadowing_type_parameters_test.dart
+++ b/test/rules/avoid_shadowing_type_parameters_test.dart
@@ -16,11 +16,6 @@ main() {
 @reflectiveTest
 class AvoidShadowingTypeParametersEnumTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'avoid_shadowing_type_parameters';
 
   test_enum() async {

--- a/test/rules/avoid_types_as_parameter_names_test.dart
+++ b/test/rules/avoid_types_as_parameter_names_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class AvoidTypesAsParameterNamesTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'avoid_types_as_parameter_names';
 
   test_super() async {

--- a/test/rules/avoid_unused_constructor_parameters_test.dart
+++ b/test/rules/avoid_unused_constructor_parameters_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class AvoidUnusedConstructorParametersTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'avoid_unused_constructor_parameters';
 
   test_super() async {

--- a/test/rules/deprecated_consistency_test.dart
+++ b/test/rules/deprecated_consistency_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class DeprecatedConsistencyTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'deprecated_consistency';
 
   test_superInit() async {

--- a/test/rules/hash_and_equals_test.dart
+++ b/test/rules/hash_and_equals_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class HashAndEqualsTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'hash_and_equals';
 
   test_enum_missingHash() async {

--- a/test/rules/library_private_types_in_public_api_test.dart
+++ b/test/rules/library_private_types_in_public_api_test.dart
@@ -16,11 +16,6 @@ main() {
 @reflectiveTest
 class LibraryPrivateTypesInPublicApiEnumTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'library_private_types_in_public_api';
 
   test_enum() async {
@@ -42,11 +37,6 @@ enum E {
 
 @reflectiveTest
 class LibraryPrivateTypesInPublicApiSuperParamTest extends LintRuleTest {
-  @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
   @override
   String get lintRule => 'library_private_types_in_public_api';
 

--- a/test/rules/prefer_asserts_in_initializer_lists_test.dart
+++ b/test/rules/prefer_asserts_in_initializer_lists_test.dart
@@ -16,11 +16,6 @@ main() {
 @reflectiveTest
 class PreferAssertsInInitializerListsSuperTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'prefer_asserts_in_initializer_lists';
 
   test_super() async {

--- a/test/rules/prefer_equal_for_default_values_test.dart
+++ b/test/rules/prefer_equal_for_default_values_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class PreferEqualForDefaultValuesTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'prefer_equal_for_default_values';
 
   test_super() async {

--- a/test/rules/prefer_final_fields_test.dart
+++ b/test/rules/prefer_final_fields_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class PreferFinalFieldsTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'prefer_final_fields';
 
   test_enum() async {

--- a/test/rules/prefer_final_parameters_test.dart
+++ b/test/rules/prefer_final_parameters_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class PreferFinalParametersTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'prefer_final_parameters';
 
   test_superParameter() async {

--- a/test/rules/public_member_api_docs_test.dart
+++ b/test/rules/public_member_api_docs_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class PublicMemberApiDocsTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'public_member_api_docs';
 
   test_enum() async {

--- a/test/rules/sort_constructors_first.dart
+++ b/test/rules/sort_constructors_first.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class SortConstructorsFirstTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'sort_constructors_first';
 
   test_ok() async {

--- a/test/rules/sort_unnamed_constructors_first.dart
+++ b/test/rules/sort_unnamed_constructors_first.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class SortUnnamedConstructorsFirstTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'sort_unnamed_constructors_first';
 
   test_ok() async {

--- a/test/rules/tighten_type_of_initializing_formals_test.dart
+++ b/test/rules/tighten_type_of_initializing_formals_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class TightenTypeOfInitializingFormalsTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'tighten_type_of_initializing_formals';
 
   test_superInit() async {

--- a/test/rules/type_init_formals_test.dart
+++ b/test/rules/type_init_formals_test.dart
@@ -16,11 +16,6 @@ main() {
 @reflectiveTest
 class TypeInitFormalsSuperTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'type_init_formals';
 
   test_super() async {

--- a/test/rules/unnecessary_overrides_test.dart
+++ b/test/rules/unnecessary_overrides_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class UnnecessaryOverridesTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'unnecessary_overrides';
 
   test_field() async {

--- a/test/rules/use_enums_test.dart
+++ b/test/rules/use_enums_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class UseEnumsTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.enhanced_enums,
-      ];
-
-  @override
   String get lintRule => 'use_enums';
 
   test_constructor_private() async {

--- a/test/rules/use_super_parameters_test.dart
+++ b/test/rules/use_super_parameters_test.dart
@@ -15,11 +15,6 @@ main() {
 @reflectiveTest
 class UseSuperParametersTest extends LintRuleTest {
   @override
-  List<String> get experiments => [
-        EnableString.super_parameters,
-      ];
-
-  @override
   String get lintRule => 'use_super_parameters';
 
   test_functionTypedFormalParameter() async {


### PR DESCRIPTION
A number of reflective tests enable experiments explicitly that are now on by default in our minimum supported SDK.  This change removes those redundant declarations and adds validation to ensure that we don't accrue similar technical debt in the future.


/cc @bwilkerson 