### PR TITLE
Clarify how the dependencies should be sorted when using `sort_pub_dependencies`

### DIFF
--- a/lib/src/rules/pub/sort_pub_dependencies.dart
+++ b/lib/src/rules/pub/sort_pub_dependencies.dart
@@ -7,10 +7,10 @@ import 'package:source_span/source_span.dart';
 
 import '../../analyzer.dart';
 
-const _desc = r'Sort pub dependencies.';
+const _desc = r'Sort pub dependencies alphabetically.';
 
 const _details = r'''
-**DO** sort pub dependencies in `pubspec.yaml`.
+**DO** sort pub dependencies alphabetically (A to Z) in `pubspec.yaml`.
 
 Sorting list of pub dependencies makes maintenance easier.
 ''';


### PR DESCRIPTION
# Description

Clarifies a bit what "Sort dependencies" means. When I read about the linter, was this not clear to me what "Sort dependencies" acutely means.
