### PR TITLE
Move 5 static functions out of DartTypeUtilities

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -439,6 +439,7 @@ class _ElementVisitorAdapter extends GeneralizingElementVisitor {
 }
 
 extension ElementExtension on Element? {
+  // TODO(srawlins): Move to extensions.dart.
   bool get isDartCorePrint {
     var self = this;
     return self is FunctionElement &&

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/element/member.dart'; // ignore: implementation_imports
+
+extension ElementExtension on Element {
+  Element get canonicalElement {
+    var self = this;
+    if (self is PropertyAccessorElement) {
+      var variable = self.variable;
+      if (variable is FieldMember) {
+        // A field element defined in a parameterized type where the values of
+        // the type parameters are known.
+        //
+        // This concept should be invisible when comparing FieldElements, but a
+        // bug in the analyzer causes FieldElements to not evaluate as
+        // equivalent to equivalent FieldMembers. See
+        // https://github.com/dart-lang/sdk/issues/35343.
+        return variable.declaration;
+      } else {
+        return variable;
+      }
+    } else {
+      return self;
+    }
+  }
+}
+
+extension AstNodeExtensions on AstNode? {
+  Element? get canonicalElement {
+    var self = this;
+    if (self is Expression) {
+      var node = self.unParenthesized;
+      if (node is Identifier) {
+        return node.staticElement?.canonicalElement;
+      } else if (node is PropertyAccess) {
+        return node.propertyName.staticElement?.canonicalElement;
+      }
+    }
+    return null;
+  }
+}
+
+extension ExpressionExtensions on Expression? {
+  bool get isNullLiteral => this?.unParenthesized is NullLiteral;
+}

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -144,7 +144,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
       if (expression.operator.type == TokenType.BANG_EQ) {
         var operands = [expression.leftOperand, expression.rightOperand];
-        return operands.any(DartTypeUtilities.isNullLiteral) &&
+        return operands.any((e) => e.isNullLiteral) &&
             operands.any(hasSameName);
       }
     }

--- a/lib/src/rules/always_require_non_null_named_parameters.dart
+++ b/lib/src/rules/always_require_non_null_named_parameters.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Specify `@required` on named parameters without defaults.';
 

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -9,7 +9,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r"Don't explicitly initialize variables to null.";
 

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -98,8 +98,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (defaultValue != 'null') return;
     }
 
-    if (DartTypeUtilities.isNullLiteral(node.defaultValue) &&
-        isNullable(declaredElement.type)) {
+    if (node.defaultValue.isNullLiteral && isNullable(declaredElement.type)) {
       rule.reportLint(node);
     }
   }
@@ -110,7 +109,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (declaredElement != null &&
         !node.isConst &&
         !node.isFinal &&
-        DartTypeUtilities.isNullLiteral(node.initializer) &&
+        node.initializer.isNullLiteral &&
         isNullable(declaredElement.type)) {
       rule.reportLint(node);
     }

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r"Don't check for null in custom == operators.";

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -49,24 +49,21 @@ bool _isComparingEquality(TokenType tokenType) =>
 
 bool _isComparingParameterWithNull(BinaryExpression node, Element? parameter) =>
     _isComparingEquality(node.operator.type) &&
-    ((DartTypeUtilities.isNullLiteral(node.leftOperand) &&
+    ((node.leftOperand.isNullLiteral &&
             _isParameter(node.rightOperand, parameter)) ||
-        (DartTypeUtilities.isNullLiteral(node.rightOperand) &&
+        (node.rightOperand.isNullLiteral &&
             _isParameter(node.leftOperand, parameter)));
 
 bool _isParameter(Expression expression, Element? parameter) =>
-    DartTypeUtilities.getCanonicalElementFromIdentifier(expression) ==
-    parameter;
+    expression.canonicalElement == parameter;
 
 bool _isParameterWithQuestion(AstNode node, Element? parameter) =>
     (node is PropertyAccess &&
         node.operator.type == TokenType.QUESTION_PERIOD &&
-        DartTypeUtilities.getCanonicalElementFromIdentifier(node.target) ==
-            parameter) ||
+        node.target.canonicalElement == parameter) ||
     (node is MethodInvocation &&
         node.operator?.type == TokenType.QUESTION_PERIOD &&
-        DartTypeUtilities.getCanonicalElementFromIdentifier(node.target) ==
-            parameter);
+        node.target.canonicalElement == parameter);
 
 bool _isParameterWithQuestionQuestion(
         BinaryExpression node, Element? parameter) =>
@@ -107,8 +104,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    var parameter = DartTypeUtilities.getCanonicalElementFromIdentifier(
-        parameters.first.identifier);
+    var parameter = parameters.first.identifier.canonicalElement;
 
     // Analyzer will produce UNNECESSARY_NULL_COMPARISON_FALSE|TRUE
     // See: https://github.com/dart-lang/linter/issues/2864

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -50,7 +50,7 @@ bool _isPrimitiveType(DartType type) =>
     DartTypeUtilities.isClass(type, 'double', 'dart.core');
 
 bool _isReturnNull(AstNode node) =>
-    node is ReturnStatement && DartTypeUtilities.isNullLiteral(node.expression);
+    node is ReturnStatement && node.expression.isNullLiteral;
 
 class AvoidReturningNull extends LintRule {
   AvoidReturningNull()
@@ -98,8 +98,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _visitFunctionBody(FunctionBody node) {
-    if (node is ExpressionFunctionBody &&
-        DartTypeUtilities.isNullLiteral(node.expression)) {
+    if (node is ExpressionFunctionBody && node.expression.isNullLiteral) {
       rule.reportLint(node);
       return;
     }

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc =

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Cascade consecutive method invocations on the same reference.';

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -74,8 +74,7 @@ Element? _getElementFromVariableDeclarationStatement(
 ExecutableElement? _getExecutableElementFromMethodInvocation(
     MethodInvocation node) {
   if (_isInvokedWithoutNullAwareOperator(node.operator)) {
-    var executableElement =
-        DartTypeUtilities.getCanonicalElementFromIdentifier(node.methodName);
+    var executableElement = node.methodName.canonicalElement;
     if (executableElement is ExecutableElement) {
       return executableElement;
     }
@@ -86,22 +85,20 @@ ExecutableElement? _getExecutableElementFromMethodInvocation(
 Element? _getPrefixElementFromExpression(Expression rawExpression) {
   var expression = rawExpression.unParenthesized;
   if (expression is PrefixedIdentifier) {
-    return DartTypeUtilities.getCanonicalElementFromIdentifier(
-        expression.prefix);
+    return expression.prefix.canonicalElement;
   } else if (expression is PropertyAccess &&
       _isInvokedWithoutNullAwareOperator(expression.operator) &&
       expression.target is SimpleIdentifier) {
-    return DartTypeUtilities.getCanonicalElementFromIdentifier(
-        expression.target);
+    return expression.target.canonicalElement;
   }
   return null;
 }
 
 Element? _getTargetElementFromCascadeExpression(CascadeExpression node) =>
-    DartTypeUtilities.getCanonicalElementFromIdentifier(node.target);
+    node.target.canonicalElement;
 
 Element? _getTargetElementFromMethodInvocation(MethodInvocation node) =>
-    DartTypeUtilities.getCanonicalElementFromIdentifier(node.target);
+    node.target.canonicalElement;
 
 bool _isInvokedWithoutNullAwareOperator(Token? token) =>
     token?.type == TokenType.PERIOD;
@@ -184,8 +181,7 @@ class _CascadableExpression {
     var leftExpression = node.leftHandSide.unParenthesized;
     if (leftExpression is SimpleIdentifier) {
       return _CascadableExpression._internal(
-          DartTypeUtilities.getCanonicalElement(leftExpression.staticElement),
-          [node.rightHandSide],
+          leftExpression.staticElement?.canonicalElement, [node.rightHandSide],
           canReceive: node.operator.type != TokenType.QUESTION_QUESTION_EQ,
           isCritical: true);
     }
@@ -220,14 +216,12 @@ class _CascadableExpression {
 
   factory _CascadableExpression._fromPrefixedIdentifier(
           PrefixedIdentifier node) =>
-      _CascadableExpression._internal(
-          DartTypeUtilities.getCanonicalElementFromIdentifier(node.prefix), [],
+      _CascadableExpression._internal(node.prefix.canonicalElement, [],
           canJoin: true, canReceive: true, canBeCascaded: true);
 
   factory _CascadableExpression._fromPropertyAccess(PropertyAccess node) {
     var targetIsSimple = node.target is SimpleIdentifier;
-    return _CascadableExpression._internal(
-        DartTypeUtilities.getCanonicalElementFromIdentifier(node.target), [],
+    return _CascadableExpression._internal(node.target.canonicalElement, [],
         // If the target is something like `(a + b).x`, then node can neither
         // join, nor receive.
         //
@@ -274,8 +268,7 @@ class _CascadableExpression {
 
   bool _hasCriticalDependencies(_CascadableExpression expressionBox) {
     bool isCriticalNode(AstNode node) =>
-        DartTypeUtilities.getCanonicalElementFromIdentifier(node) ==
-        expressionBox.element;
+        node.canonicalElement == expressionBox.element;
     return expressionBox.isCritical &&
         criticalNodes.any((node) =>
             isCriticalNode(node) ||

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -102,7 +102,7 @@ void nestedOk5() {
 
 Iterable<Element?> _getElementsInExpression(Expression node) =>
     DartTypeUtilities.traverseNodesInDFS(node)
-        .map(DartTypeUtilities.getCanonicalElementFromIdentifier)
+        .map((e) => e.canonicalElement)
         .where((e) => e != null);
 
 class InvariantBooleans extends LintRule {

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/boolean_expression_utilities.dart';
 import '../util/condition_scope_visitor.dart';
 import '../util/dart_type_utilities.dart';

--- a/lib/src/rules/join_return_with_assignment.dart
+++ b/lib/src/rules/join_return_with_assignment.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../util/dart_type_utilities.dart' as type_utils;
 
 const _desc = r'Join return statement with assignment when possible.';
 
@@ -118,9 +118,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       thirdLastExpression =
           _getExpressionFromAssignmentStatement(thirdLastStatement);
     }
-    if (!DartTypeUtilities.canonicalElementsFromIdentifiersAreEqual(
+    if (!type_utils.canonicalElementsFromIdentifiersAreEqual(
             secondLastExpression, thirdLastExpression) &&
-        DartTypeUtilities.canonicalElementsFromIdentifiersAreEqual(
+        type_utils.canonicalElementsFromIdentifiersAreEqual(
             lastExpression, secondLastExpression)) {
       rule.reportLint(secondLastStatement);
     }

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../util/dart_type_utilities.dart' as type_utils;
 
 const _desc = r'Prefer using `??=` over testing for null.';
 
@@ -39,7 +39,7 @@ String get fullName {
 
 bool _checkExpression(Expression expression, Expression condition) =>
     expression is AssignmentExpression &&
-    DartTypeUtilities.canonicalElementsFromIdentifiersAreEqual(
+    type_utils.canonicalElementsFromIdentifiersAreEqual(
         expression.leftHandSide, condition);
 
 bool _checkStatement(Statement statement, Expression condition) {
@@ -56,10 +56,10 @@ Expression? _getExpressionCondition(Expression rawExpression) {
   var expression = rawExpression.unParenthesized;
   if (expression is BinaryExpression &&
       expression.operator.type == TokenType.EQ_EQ) {
-    if (DartTypeUtilities.isNullLiteral(expression.rightOperand)) {
+    if (expression.rightOperand.isNullLiteral) {
       return expression.leftOperand;
     }
-    if (DartTypeUtilities.isNullLiteral(expression.leftOperand)) {
+    if (expression.leftOperand.isNullLiteral) {
       return expression.rightOperand;
     }
   }

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart' as type_utils;
 
 const _desc = r'Prefer using `??=` over testing for null.';

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -93,9 +93,7 @@ bool _containedInFormal(Element element, FormalParameter formal) {
 bool _containedInInitializer(
         Element element, ConstructorInitializer initializer) =>
     initializer is ConstructorFieldInitializer &&
-    DartTypeUtilities.getCanonicalElementFromIdentifier(
-            initializer.fieldName) ==
-        element;
+    initializer.fieldName.canonicalElement == element;
 
 class PreferFinalFields extends LintRule {
   PreferFinalFields()
@@ -142,8 +140,7 @@ class _MutatedFieldsCollector extends RecursiveAstVisitor<void> {
   }
 
   void _addMutatedFieldElement(CompoundAssignmentExpression assignment) {
-    var element =
-        DartTypeUtilities.getCanonicalElement(assignment.writeElement);
+    var element = assignment.writeElement?.canonicalElement;
     if (element is FieldElement) {
       _mutatedFields.add(element);
     }

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Private field could be final.';
 

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -95,9 +95,7 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
   @override
   void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
     var arguments = node.argumentList.arguments;
-    if (arguments.length == 1 &&
-        DartTypeUtilities.getCanonicalElementFromIdentifier(arguments.first) ==
-            element) {
+    if (arguments.length == 1 && arguments.first.canonicalElement == element) {
       rule.reportLint(forEachStatement);
     }
   }
@@ -107,14 +105,12 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
     var arguments = node.argumentList.arguments;
     var target = node.target;
     if (arguments.length == 1 &&
-        DartTypeUtilities.getCanonicalElementFromIdentifier(arguments.first) ==
-            element &&
+        arguments.first.canonicalElement == element &&
         (target == null ||
-            (DartTypeUtilities.getCanonicalElementFromIdentifier(target) !=
-                    element &&
+            target.canonicalElement != element &&
                 !DartTypeUtilities.traverseNodesInDFS(target)
-                    .map(DartTypeUtilities.getCanonicalElementFromIdentifier)
-                    .contains(element)))) {
+                    .map((e) => e.canonicalElement)
+                    .contains(element))) {
       rule.reportLint(forEachStatement);
     }
   }

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Use `forEach` to only apply a function to all the elements.';

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Use initializing formals when possible.';
 

--- a/lib/src/rules/prefer_initializing_formals.dart
+++ b/lib/src/rules/prefer_initializing_formals.dart
@@ -108,14 +108,13 @@ Iterable<ConstructorFieldInitializer>
         node.initializers.whereType<ConstructorFieldInitializer>();
 
 Element? _getLeftElement(AssignmentExpression assignment) =>
-    DartTypeUtilities.getCanonicalElement(assignment.writeElement);
+    assignment.writeElement?.canonicalElement;
 
 Iterable<Element?> _getParameters(ConstructorDeclaration node) =>
     node.parameters.parameters.map((e) => e.identifier?.staticElement);
 
 Element? _getRightElement(AssignmentExpression assignment) =>
-    DartTypeUtilities.getCanonicalElementFromIdentifier(
-        assignment.rightHandSide);
+    assignment.rightHandSide.canonicalElement;
 
 class PreferInitializingFormals extends LintRule {
   PreferInitializingFormals()

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Avoid null in null-aware assignment.';
 

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -60,7 +60,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.writeElement is PropertyAccessorElement) return;
 
     if (node.operator.type == TokenType.QUESTION_QUESTION_EQ &&
-        DartTypeUtilities.isNullLiteral(node.rightHandSide)) {
+        node.rightHandSide.isNullLiteral) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Avoid using `null` in `if null` operators.';
 

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -55,8 +55,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitBinaryExpression(BinaryExpression node) {
     if (node.operator.type == TokenType.QUESTION_QUESTION &&
-        (DartTypeUtilities.isNullLiteral(node.rightOperand) ||
-            DartTypeUtilities.isNullLiteral(node.leftOperand))) {
+        (node.rightOperand.isNullLiteral || node.leftOperand.isNullLiteral)) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -257,8 +257,7 @@ class _UnnecessaryOperatorOverrideVisitor
         parameters != null &&
         parameters.length == 1 &&
         parameters.first.identifier?.staticElement ==
-            DartTypeUtilities.getCanonicalElementFromIdentifier(
-                node.rightOperand)) {
+            node.rightOperand.canonicalElement) {
       var leftPart = node.leftOperand.unParenthesized;
       if (leftPart is SuperExpression) {
         visitSuperExpression(leftPart);
@@ -294,8 +293,7 @@ class _UnnecessarySetterOverrideVisitor
     if (parameters != null &&
         parameters.length == 1 &&
         parameters.first.identifier?.staticElement ==
-            DartTypeUtilities.getCanonicalElementFromIdentifier(
-                node.rightHandSide)) {
+            node.rightHandSide.canonicalElement) {
       var leftPart = node.leftHandSide.unParenthesized;
       if (leftPart is PropertyAccess) {
         if (node.writeElement == _inheritedMethod) {

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc =

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -139,8 +139,8 @@ bool _hasNonComparableOperands(TypeSystem typeSystem, BinaryExpression node) {
   if (leftType == null || rightType == null) {
     return false;
   }
-  return !DartTypeUtilities.isNullLiteral(left) &&
-      !DartTypeUtilities.isNullLiteral(right) &&
+  return !left.isNullLiteral &&
+      !right.isNullLiteral &&
       DartTypeUtilities.unrelatedTypes(typeSystem, leftType, rightType) &&
       !(_isFixNumIntX(leftType) && _isCoreInt(rightType));
 }

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc =

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -152,9 +152,9 @@ class _Visitor extends UnifyingAstVisitor<void> {
 
     Element? element;
     if (parent is AssignmentExpression && parent.leftHandSide == node) {
-      element = DartTypeUtilities.getCanonicalElement(parent.writeElement);
+      element = parent.writeElement?.canonicalElement;
     } else {
-      element = DartTypeUtilities.getCanonicalElementFromIdentifier(node);
+      element = node.canonicalElement;
     }
 
     if (element != null) {

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/error/error.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Use late for private members with a non-nullable type.';

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Use rethrow to rethrow a caught exception.';
 

--- a/lib/src/rules/use_rethrow_when_possible.dart
+++ b/lib/src/rules/use_rethrow_when_possible.dart
@@ -64,13 +64,10 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitThrowExpression(ThrowExpression node) {
     if (node.parent is Expression || node.parent is ArgumentList) return;
 
-    var element =
-        DartTypeUtilities.getCanonicalElementFromIdentifier(node.expression);
+    var element = node.expression.canonicalElement;
     if (element != null) {
       var catchClause = node.thisOrAncestorOfType<CatchClause>();
-      var exceptionParameter =
-          DartTypeUtilities.getCanonicalElementFromIdentifier(
-              catchClause?.exceptionParameter);
+      var exceptionParameter = catchClause?.exceptionParameter.canonicalElement;
       if (element == exceptionParameter) {
         rule.reportLint(node);
       }

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -65,10 +65,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     void checkExpression(Expression expression) {
       if (expression is AssignmentExpression &&
           expression.operator.type == TokenType.EQ) {
-        var leftOperand =
-            DartTypeUtilities.getCanonicalElement(expression.writeElement);
-        var rightOperand = DartTypeUtilities.getCanonicalElementFromIdentifier(
-            expression.rightHandSide);
+        var leftOperand = expression.writeElement?.canonicalElement;
+        var rightOperand = expression.rightHandSide.canonicalElement;
         var parameterElement = node.declaredElement?.parameters.first;
         if (rightOperand == parameterElement && leftOperand is FieldElement) {
           rule.reportLint(node.name);

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc =

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -124,8 +124,7 @@ class _UseStringBufferVisitor extends SimpleAstVisitor {
     if (left is SimpleIdentifier &&
         DartTypeUtilities.isClass(node.writeType, 'String', 'dart.core')) {
       if (node.operator.type == TokenType.PLUS_EQ &&
-          !localElements.contains(
-              DartTypeUtilities.getCanonicalElement(node.writeElement))) {
+          !localElements.contains(node.writeElement?.canonicalElement)) {
         rule.reportLint(node);
       }
       if (node.operator.type == TokenType.EQ) {

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Use string buffers to compose strings.';

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -11,7 +11,7 @@ import '../analyzer.dart';
 import '../util/dart_type_utilities.dart';
 
 Element? _getLeftElement(AssignmentExpression assignment) =>
-    DartTypeUtilities.getCanonicalElement(assignment.writeElement);
+    assignment.writeElement?.canonicalElement;
 
 List<Expression?> _splitConjunctions(Expression? rawExpression) {
   var expression = rawExpression?.unParenthesized;
@@ -435,7 +435,7 @@ class _UndefinedExpression extends ExpressionBox {
   String toString() => '$element got undefined';
 
   static _UndefinedExpression? forElement(Element? element) {
-    var canonicalElement = DartTypeUtilities.getCanonicalElement(element);
+    var canonicalElement = element?.canonicalElement;
     if (canonicalElement == null) return null;
     return _UndefinedExpression._internal(canonicalElement);
   }

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 Element? _getLeftElement(AssignmentExpression assignment) =>

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -146,6 +146,10 @@ class DartTypeUtilities {
           DartType? type, String? className, String? library) =>
       _extendsClass(type, <ClassElement>{}, className, library);
 
+  @Deprecated('Replace with `rawNode.canonicalElement`')
+  static Element? getCanonicalElementFromIdentifier(AstNode? rawNode) =>
+      rawNode.canonicalElement;
+
   static Iterable<InterfaceType> getImplementedInterfaces(InterfaceType type) {
     void recursiveCall(InterfaceType? type, Set<ClassElement> alreadyVisited,
         List<InterfaceType> interfaceTypes) {
@@ -246,6 +250,9 @@ class DartTypeUtilities {
 
   static bool isNonNullable(LinterContext context, DartType? type) =>
       type != null && context.typeSystem.isNonNullable(type);
+
+  @Deprecated('Replace with `expression.isNullLiteral`')
+  static bool isNullLiteral(Expression? expression) => expression.isNullLiteral;
 
   static PropertyAccessorElement? lookUpGetter(MethodDeclaration node) {
     var declaredElement = node.declaredElement;

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -6,11 +6,11 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:analyzer/src/dart/element/member.dart'; // ignore: implementation_imports
 import 'package:analyzer/src/dart/element/type.dart'; // ignore: implementation_imports
 
 import '../analyzer.dart';
 import '../ast.dart';
+import '../extensions.dart';
 
 typedef AstNodePredicate = bool Function(AstNode node);
 
@@ -565,54 +565,13 @@ class InterfaceTypeDefinition {
   }
 }
 
-extension ElementExtensions on Element {
-  Element get canonicalElement {
-    var self = this;
-    if (self is PropertyAccessorElement) {
-      var variable = self.variable;
-      if (variable is FieldMember) {
-        // A field element defined in a parameterized type where the values of
-        // the type parameters are known.
-        //
-        // This concept should be invisible when comparing FieldElements, but a
-        // bug in the analyzer causes FieldElements to not evaluate as
-        // equivalent to equivalent FieldMembers. See
-        // https://github.com/dart-lang/sdk/issues/35343.
-        return variable.declaration;
-      } else {
-        return variable;
-      }
-    } else {
-      return self;
-    }
-  }
-}
-
-extension AstNodeExtensions on AstNode? {
-  Element? get canonicalElement {
-    var self = this;
-    if (self is Expression) {
-      var node = self.unParenthesized;
-      if (node is Identifier) {
-        return node.staticElement?.canonicalElement;
-      } else if (node is PropertyAccess) {
-        return node.propertyName.staticElement?.canonicalElement;
-      }
-    }
-    return null;
-  }
-}
-
-extension ExpressionExtensions on Expression? {
-  bool get isNullLiteral => this?.unParenthesized is NullLiteral;
-}
-
 extension DartTypeExtensions on DartType {
   /// Returns the type which should be used when conducting "interface checks"
   /// on `this`.
   ///
   /// If `this` is a type variable, then the type-for-interface-check of its
   /// promoted bound or bound is returned. Otherwise, `this` is returned.
+  // TODO(srawlins): Move to extensions.dart.
   DartType get typeForInterfaceCheck {
     if (this is TypeParameterType) {
       if (this is TypeParameterTypeImpl) {


### PR DESCRIPTION
# Description

Move 5 static functions out of DartTypeUtilities. Helps linter comply with [AVOID defining a class that contains only static members.](https://dart.dev/guides/language/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members) and makes the code much more readable.

* `canonicalElementsAreEqual` can be a top-level function
* `canonicalElementsFromIdentifiersAreEqual` can be a top-level function
* `getCanonicalElement` can be an extension on `Element` and be shortened to `canonicalElement` 🎉 
* `getCanonicalElementFromIdentifier` can be an extension on `AstNode` and renamed to be much shorter: `canonicalElement` 🎉 
* `isNullLiteral` can be an extension on `Expression`

