### PR TITLE
Move two more DartTypeUtilities static methods into extensions

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -3,7 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/dart/element/member.dart'; // ignore: implementation_imports
 
 extension ElementExtension on Element {
@@ -27,6 +29,95 @@ extension ElementExtension on Element {
       return self;
     }
   }
+}
+
+class EnumLikeClassDescription {
+  final Map<DartObject, Set<FieldElement>> _enumConstants;
+  EnumLikeClassDescription(this._enumConstants);
+
+  /// Returns a fresh map of the class's enum-like constant values.
+  Map<DartObject, Set<FieldElement>> get enumConstants => {..._enumConstants};
+}
+
+extension ClassElementExtension on ClassElement {
+  /// Returns an [EnumLikeClassDescription] for this if the latter is a valid
+  /// "enum-like" class.
+  ///
+  /// An enum-like class must meet the following requirements:
+  ///
+  /// * is concrete,
+  /// * has no public constructors,
+  /// * has no factory constructors,
+  /// * has two or more static const fields with the same type as the class,
+  /// * has no subclasses declared in the defining library.
+  ///
+  /// The returned [EnumLikeClassDescription]'s `enumConstantNames` contains all
+  /// of the static const fields with the same type as the class, with one
+  /// exception; any static const field which is marked `@Deprecated` and is
+  /// equal to another static const field with the same type as the class is not
+  /// included. Such a field is assumed to be deprecated in favor of the field
+  /// with equal value.
+  EnumLikeClassDescription? get asEnumLikeClass {
+    // See discussion: https://github.com/dart-lang/linter/issues/2083.
+
+    // Must be concrete.
+    if (isAbstract) {
+      return null;
+    }
+
+    // With only private non-factory constructors.
+    for (var constructor in constructors) {
+      if (!constructor.isPrivate || constructor.isFactory) {
+        return null;
+      }
+    }
+
+    var type = thisType;
+
+    // And 2 or more static const fields whose type is the enclosing class.
+    var enumConstantCount = 0;
+    var enumConstants = <DartObject, Set<FieldElement>>{};
+    for (var field in fields) {
+      // Ensure static const.
+      if (field.isSynthetic || !field.isConst || !field.isStatic) {
+        continue;
+      }
+      // Check for type equality.
+      if (field.type != type) {
+        continue;
+      }
+      var fieldValue = field.computeConstantValue();
+      if (fieldValue == null) {
+        continue;
+      }
+      enumConstantCount++;
+      enumConstants.putIfAbsent(fieldValue, () => {}).add(field);
+    }
+    if (enumConstantCount < 2) {
+      return null;
+    }
+
+    // And no subclasses in the defining library.
+    if (hasSubclassInDefiningCompilationUnit) return null;
+
+    return EnumLikeClassDescription(enumConstants);
+  }
+
+  bool get hasSubclassInDefiningCompilationUnit {
+    var compilationUnit = library.definingCompilationUnit;
+    for (var cls in compilationUnit.classes) {
+      InterfaceType? classType = cls.thisType;
+      do {
+        classType = classType?.superclass;
+        if (classType == thisType) {
+          return true;
+        }
+      } while (classType != null && !classType.isDartCoreObject);
+    }
+    return false;
+  }
+
+  bool get isEnumLikeClass => asEnumLikeClass != null;
 }
 
 extension AstNodeExtensions on AstNode? {

--- a/lib/src/rules/exhaustive_cases.dart
+++ b/lib/src/rules/exhaustive_cases.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Define case clauses for all constants in enum-like classes.';
 
@@ -110,7 +110,7 @@ class _Visitor extends SimpleAstVisitor {
       if (classElement.isEnum) {
         return;
       }
-      var enumDescription = DartTypeUtilities.asEnumLikeClass(classElement);
+      var enumDescription = classElement.asEnumLikeClass;
       if (enumDescription == null) {
         return;
       }

--- a/lib/src/rules/no_default_cases.dart
+++ b/lib/src/rules/no_default_cases.dart
@@ -4,11 +4,10 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'No default cases.';
 
@@ -69,9 +68,6 @@ class _Visitor extends SimpleAstVisitor {
 
   _Visitor(this.rule);
 
-  bool isEnumLikeClass(ClassElement classElement) =>
-      DartTypeUtilities.asEnumLikeClass(classElement) != null;
-
   @override
   void visitSwitchStatement(SwitchStatement statement) {
     var expressionType = statement.expression.staticType;
@@ -79,7 +75,7 @@ class _Visitor extends SimpleAstVisitor {
       for (var member in statement.members) {
         if (member is SwitchDefault) {
           var classElement = expressionType.element;
-          if (classElement.isEnum || isEnumLikeClass(classElement)) {
+          if (classElement.isEnum || classElement.isEnumLikeClass) {
             rule.reportLint(member);
           }
           return;


### PR DESCRIPTION
# Description

Move 2 static functions out of DartTypeUtilities. Helps linter comply with [AVOID defining a class that contains only static members.](https://dart.dev/guides/language/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members) and makes the code much more readable.


* `asEnumLikeClass` and `hasSubclassInDefiningCompilationUnit`
* Also moved `isEnumLikeClass` into this extension, as it seems equally utility-like as the others.