### PR TITLE
Move 4 static DartTypeUtilities methods to extensions

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -8,6 +8,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/src/dart/element/member.dart'; // ignore: implementation_imports
 
+import 'util/dart_type_utilities.dart';
+
 extension ElementExtension on Element {
   Element get canonicalElement {
     var self = this;
@@ -117,10 +119,15 @@ extension ClassElementExtension on ClassElement {
     return false;
   }
 
+  /// Returns whether this class is exactly [otherName] declared in
+  /// [otherLibrary].
+  bool isClass(String otherName, String otherLibrary) =>
+      name == otherName && library.name == otherLibrary;
+
   bool get isEnumLikeClass => asEnumLikeClass != null;
 }
 
-extension AstNodeExtensions on AstNode? {
+extension AstNodeExtension on AstNode? {
   Element? get canonicalElement {
     var self = this;
     if (self is Expression) {
@@ -135,6 +142,60 @@ extension AstNodeExtensions on AstNode? {
   }
 }
 
-extension ExpressionExtensions on Expression? {
+extension BlockExtension on Block {
+  /// Returns the last statement of this block, or `null` if this is empty.
+  ///
+  /// If the last immediate statement of this block is a [Block], recurses into
+  /// it to find the last statement.
+  Statement? get lastStatement {
+    if (statements.isEmpty) {
+      return null;
+    }
+    var lastStatement = statements.last;
+    if (lastStatement is Block) {
+      return lastStatement.lastStatement;
+    }
+    return lastStatement;
+  }
+}
+
+extension DartTypeExtension on DartType? {
+  bool extendsClass(String? className, String library) =>
+      _extendsClass(this, <ClassElement>{}, className, library);
+
+  static bool _extendsClass(DartType? type, Set<ClassElement> seenTypes,
+          String? className, String? library) =>
+      type is InterfaceType &&
+      seenTypes.add(type.element) &&
+      (DartTypeUtilities.isClass(type, className, library) ||
+          _extendsClass(type.superclass, seenTypes, className, library));
+}
+
+extension ExpressionExtension on Expression? {
   bool get isNullLiteral => this?.unParenthesized is NullLiteral;
+}
+
+extension InterfaceTypeExtension on InterfaceType {
+  /// Returns the collection of all interfaces that this type implements,
+  /// including itself.
+  Iterable<InterfaceType> get implementedInterfaces {
+    void searchSupertypes(InterfaceType? type, Set<ClassElement> alreadyVisited,
+        List<InterfaceType> interfaceTypes) {
+      if (type == null || !alreadyVisited.add(type.element)) {
+        return;
+      }
+      interfaceTypes.add(type);
+      searchSupertypes(type.superclass, alreadyVisited, interfaceTypes);
+      for (var interface in type.interfaces) {
+        searchSupertypes(interface, alreadyVisited, interfaceTypes);
+      }
+      for (var mixin in type.mixins) {
+        searchSupertypes(mixin, alreadyVisited, interfaceTypes);
+      }
+    }
+
+    var interfaceTypes = <InterfaceType>[];
+    searchSupertypes(this, {}, interfaceTypes);
+    return interfaceTypes;
+  }
 }

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Avoid slow async `dart:io` methods.';
 
@@ -104,7 +104,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _checkFileMethods(MethodInvocation node, DartType? type) {
-    if (DartTypeUtilities.extendsClass(type, 'File', 'dart.io')) {
+    if (type.extendsClass('File', 'dart.io')) {
       if (_fileMethodNames.contains(node.methodName.name)) {
         rule.reportLint(node);
       }
@@ -112,7 +112,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _checkDirectoryMethods(MethodInvocation node, DartType? type) {
-    if (DartTypeUtilities.extendsClass(type, 'Directory', 'dart.io')) {
+    if (type.extendsClass('Directory', 'dart.io')) {
       if (_dirMethodNames.contains(node.methodName.name)) {
         rule.reportLint(node);
       }

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Await only futures.';
@@ -71,7 +72,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (!(type == null ||
         type.isDartAsyncFuture ||
         type.isDynamic ||
-        DartTypeUtilities.extendsClass(type, 'Future', 'dart.async') ||
+        type.extendsClass('Future', 'dart.async') ||
         DartTypeUtilities.implementsInterface(type, 'Future', 'dart.async') ||
         DartTypeUtilities.isClass(type, 'FutureOr', 'dart.async'))) {
       rule.reportLintForToken(node.awaitKeyword, arguments: [type]);

--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Do not pass `null` as an argument where a closure is expected.';
 
@@ -233,8 +233,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     var type = node.staticType;
     for (var constructor in _constructorsWithNonNullableArguments) {
       if (constructorName.name?.name == constructor.name) {
-        if (DartTypeUtilities.extendsClass(
-            type, constructor.type, constructor.library)) {
+        if (type.extendsClass(constructor.type, constructor.library)) {
           _checkNullArgForClosure(
               node.argumentList, constructor.positional, constructor.named);
         }

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Omit type annotations for local variables.';
@@ -102,9 +103,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
       var iterableType = loopParts.iterable.staticType;
       if (iterableType is InterfaceType) {
-        var iterableInterfaces = DartTypeUtilities.getImplementedInterfaces(
-                iterableType)
-            .where((type) =>
+        var iterableInterfaces = iterableType.implementedInterfaces.where(
+            (type) =>
                 DartTypeUtilities.isInterface(type, 'Iterable', 'dart.core'));
         if (iterableInterfaces.length == 1 &&
             iterableInterfaces.first.typeArguments.first == staticType) {

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -103,6 +103,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       }
       var iterableType = loopParts.iterable.staticType;
       if (iterableType is InterfaceType) {
+        // TODO(srawlins): Is `DartType.asInstanceOf` the more correct API here?
         var iterableInterfaces = iterableType.implementedInterfaces.where(
             (type) =>
                 DartTypeUtilities.isInterface(type, 'Iterable', 'dart.core'));

--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _dartCollectionUri = 'dart.collection';
 const _dartConvertUri = 'dart.convert';
@@ -75,20 +75,16 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  /// Check for "legacy"  classes that cannot easily be made `mixin`s for
+  /// Check for "legacy" classes that cannot easily be made `mixin`s for
   /// compatibility reasons.
   /// (See: https://github.com/dart-lang/linter/issues/2082)
   static bool isAllowed(ClassElement element) =>
       // todo (pq): remove allowlist once legacy mixins are otherwise annotated.
       // see: https://github.com/dart-lang/sdk/issues/45343
-      DartTypeUtilities.isClassElement(
-          element, _iterableMixinName, _dartCollectionUri) ||
-      DartTypeUtilities.isClassElement(
-          element, _listMixinName, _dartCollectionUri) ||
-      DartTypeUtilities.isClassElement(
-          element, _mapMixinName, _dartCollectionUri) ||
-      DartTypeUtilities.isClassElement(
-          element, _setMixinName, _dartCollectionUri) ||
-      DartTypeUtilities.isClassElement(
-          element, _stringConversionSinkName, _dartConvertUri);
+
+      element.isClass(_iterableMixinName, _dartCollectionUri) ||
+      element.isClass(_listMixinName, _dartCollectionUri) ||
+      element.isClass(_mapMixinName, _dartCollectionUri) ||
+      element.isClass(_setMixinName, _dartCollectionUri) ||
+      element.isClass(_stringConversionSinkName, _dartConvertUri);
 }

--- a/lib/src/rules/unsafe_html.dart
+++ b/lib/src/rules/unsafe_html.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _descPrefix = r'Avoid unsafe HTML APIs';
 const _desc = '$_descPrefix.';
@@ -37,7 +37,7 @@ var script = ScriptElement()..src = 'foo.js';
 extension on DartType? {
   /// Returns whether this type extends [className] from the dart:html library.
   bool extendsDartHtmlClass(String className) =>
-      DartTypeUtilities.extendsClass(this, className, 'dart.dom.html');
+      extendsClass(className, 'dart.dom.html');
 }
 
 class UnsafeHtml extends LintRule {

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -324,8 +324,7 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
 
   bool _isLastStatementAnExitStatement(Statement? statement) {
     if (statement is Block) {
-      return _isLastStatementAnExitStatement(
-          DartTypeUtilities.getLastStatementInBlock(statement));
+      return _isLastStatementAnExitStatement(statement.lastStatement);
     } else {
       if (statement is BreakStatement) {
         return statement.label == null;

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -20,7 +20,7 @@ bool canonicalElementsAreEqual(Element? element1, Element? element2) =>
 
 /// Returns whether the canonical elements from two nodes are equal.
 ///
-/// As in, [AstNodeExtensions.canonicalElement], the two nodes must be
+/// As in, [AstNodeExtension.canonicalElement], the two nodes must be
 /// [Expression]s in order to be compared (otherwise `false` is returned).
 ///
 /// The two nodes must both be a [SimpleIdentifier], [PrefixedIdentifier], or
@@ -77,45 +77,14 @@ bool canonicalElementsFromIdentifiersAreEqual(
 }
 
 class DartTypeUtilities {
+  @Deprecated('Replace with type.extendsClass')
   static bool extendsClass(
           DartType? type, String? className, String? library) =>
-      _extendsClass(type, <ClassElement>{}, className, library);
+      type.extendsClass(className, library!);
 
   @Deprecated('Replace with `rawNode.canonicalElement`')
   static Element? getCanonicalElementFromIdentifier(AstNode? rawNode) =>
       rawNode.canonicalElement;
-
-  static Iterable<InterfaceType> getImplementedInterfaces(InterfaceType type) {
-    void recursiveCall(InterfaceType? type, Set<ClassElement> alreadyVisited,
-        List<InterfaceType> interfaceTypes) {
-      if (type == null || !alreadyVisited.add(type.element)) {
-        return;
-      }
-      interfaceTypes.add(type);
-      recursiveCall(type.superclass, alreadyVisited, interfaceTypes);
-      for (var interface in type.interfaces) {
-        recursiveCall(interface, alreadyVisited, interfaceTypes);
-      }
-      for (var mixin in type.mixins) {
-        recursiveCall(mixin, alreadyVisited, interfaceTypes);
-      }
-    }
-
-    var interfaceTypes = <InterfaceType>[];
-    recursiveCall(type, <ClassElement>{}, interfaceTypes);
-    return interfaceTypes;
-  }
-
-  static Statement? getLastStatementInBlock(Block node) {
-    if (node.statements.isEmpty) {
-      return null;
-    }
-    var lastStatement = node.statements.last;
-    if (lastStatement is Block) {
-      return getLastStatementInBlock(lastStatement);
-    }
-    return lastStatement;
-  }
 
   static bool hasInheritedMethod(MethodDeclaration node) =>
       lookUpInheritedMethod(node) != null;
@@ -151,10 +120,6 @@ class DartTypeUtilities {
       type is InterfaceType &&
       type.element.name == className &&
       type.element.library.name == library;
-
-  static bool isClassElement(
-          ClassElement element, String className, String library) =>
-      element.name == className && element.library.name == library;
 
   static bool isConstructorElement(ConstructorElement? element,
           {required String uriStr,
@@ -436,13 +401,6 @@ class DartTypeUtilities {
     }
     return false;
   }
-
-  static bool _extendsClass(DartType? type, Set<ClassElement> seenTypes,
-          String? className, String? library) =>
-      type is InterfaceType &&
-      seenTypes.add(type.element) &&
-      (isClass(type, className, library) ||
-          _extendsClass(type.superclass, seenTypes, className, library));
 
   static bool _isFunctionTypeUnrelatedToType(
       FunctionType type1, DartType type2) {


### PR DESCRIPTION
# Description

* `isClassElement` can be `isClass` on ClassElementExtension; added documentation
* `getLastStatementInBlock` can be `get lastStatement` on BlockExtension; added documentation
* `extendsClass` can be `extendsClass` on DartTypeExtension
* `getImplementedInterfaces` can be `get implementedInterfaces` on InterfaceTypeExtension

Only `extendsClass` is used internally, so kept that with a Deprecation notice.

I think readability is improved in each case.