### PR TITLE
Move DartTypeUtilities.overridesMethod to an extension

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -138,3 +138,36 @@ extension AstNodeExtensions on AstNode? {
 extension ExpressionExtensions on Expression? {
   bool get isNullLiteral => this?.unParenthesized is NullLiteral;
 }
+
+extension MethodDeclarationExtension on MethodDeclaration {
+  /// Returns whether this method is an override of a method in any supertype.
+  bool get isOverride {
+    var parent = this.parent;
+    if (parent is! ClassOrMixinDeclaration) {
+      return false;
+    }
+    var name = declaredElement?.name;
+    if (name == null) {
+      return false;
+    }
+    var parentElement = parent.declaredElement;
+    if (parentElement == null) {
+      return false;
+    }
+    var parentLibrary = parentElement.library;
+
+    if (isGetter) {
+      // Search supertypes for a getter of the same name.
+      return parentElement.allSupertypes
+          .any((t) => t.lookUpGetter2(name, parentLibrary) != null);
+    } else if (isSetter) {
+      // Search supertypes for a setter of the same name.
+      return parentElement.allSupertypes
+          .any((t) => t.lookUpSetter2(name, parentLibrary) != null);
+    } else {
+      // Search supertypes for a method of the same name.
+      return parentElement.allSupertypes
+          .any((t) => t.lookUpMethod2(name, parentLibrary) != null);
+    }
+  }
+}

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc =
@@ -78,7 +79,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     var parent = node.parent;
     if (parent is ClassOrMixinDeclaration || parent is EnumDeclaration) {
-      if (DartTypeUtilities.overridesMethod(node)) {
+      if (node.isOverride) {
         return;
       }
 

--- a/lib/src/rules/use_setters_to_change_properties.dart
+++ b/lib/src/rules/use_setters_to_change_properties.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc =
     r'Use a setter for operations that conceptually change a property.';
@@ -57,7 +56,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitMethodDeclaration(MethodDeclaration node) {
     if (node.isSetter ||
         node.isGetter ||
-        DartTypeUtilities.overridesMethod(node) ||
+        node.isOverride ||
         node.parameters?.parameters.length != 1 ||
         node.returnType?.type?.isVoid != true) {
       return;

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -308,30 +308,6 @@ class DartTypeUtilities {
     return true;
   }
 
-  static bool overridesMethod(MethodDeclaration node) {
-    var parent = node.parent;
-    if (parent is! ClassOrMixinDeclaration) {
-      return false;
-    }
-    var name = node.declaredElement?.name;
-    if (name == null) {
-      return false;
-    }
-    var clazz = parent;
-    var classElement = clazz.declaredElement;
-    if (classElement == null) {
-      return false;
-    }
-    var library = classElement.library;
-    return classElement.allSupertypes
-        .map(node.isGetter
-            ? (InterfaceType t) => t.lookUpGetter2
-            : node.isSetter
-                ? (InterfaceType t) => t.lookUpSetter2
-                : (InterfaceType t) => t.lookUpMethod2)
-        .any((lookUp) => lookUp(name, library) != null);
-  }
-
   /// Builds the list resulting from traversing the node in DFS and does not
   /// include the node itself, it excludes the nodes for which the exclusion
   /// predicate returns true, if not provided, all is included.


### PR DESCRIPTION
# Description

Move `DartTypeUtilities.overridesMethod` to an extension, and rename it `get isOverride` (sticks to convention of other bool-returning getters). I also refactored the end of the method body to be more readable.
