### PR TITLE
convert unnecessary `.from`s to `.of`s

### DIFF
--- a/lib/src/util/boolean_expression_utilities.dart
+++ b/lib/src/util/boolean_expression_utilities.dart
@@ -12,17 +12,17 @@ import 'package:analyzer/dart/ast/token.dart';
 
 class BooleanExpressionUtilities {
   static HashSet<TokenType> BOOLEAN_OPERATIONS =
-      HashSet.from(const [TokenType.AMPERSAND_AMPERSAND, TokenType.BAR_BAR]);
+      HashSet.of(const [TokenType.AMPERSAND_AMPERSAND, TokenType.BAR_BAR]);
 
   static HashSet<TokenType> EQUALITY_OPERATIONS =
-      HashSet.from(const [TokenType.EQ_EQ, TokenType.BANG_EQ]);
+      HashSet.of(const [TokenType.EQ_EQ, TokenType.BANG_EQ]);
 
-  static HashMap<TokenType, TokenType> IMPLICATIONS = HashMap.from(const {
+  static HashMap<TokenType, TokenType> IMPLICATIONS = HashMap.of(const {
     TokenType.GT: TokenType.GT_EQ,
     TokenType.LT: TokenType.LT_EQ,
   });
 
-  static HashMap<TokenType, TokenType> NEGATIONS = HashMap.from(const {
+  static HashMap<TokenType, TokenType> NEGATIONS = HashMap.of(const {
     TokenType.EQ_EQ: TokenType.BANG_EQ,
     TokenType.BANG_EQ: TokenType.EQ_EQ,
     TokenType.GT: TokenType.LT_EQ,
@@ -32,7 +32,7 @@ class BooleanExpressionUtilities {
   });
 
   static HashSet<TokenType> TRICHOTOMY_OPERATORS =
-      HashSet.from(const [TokenType.EQ_EQ, TokenType.LT, TokenType.GT]);
+      HashSet.of(const [TokenType.EQ_EQ, TokenType.LT, TokenType.GT]);
 
-  static final HashSet<TokenType> COMPARISONS = HashSet.from(NEGATIONS.keys);
+  static final HashSet<TokenType> COMPARISONS = HashSet.of(NEGATIONS.keys);
 }

--- a/lib/src/util/tested_expressions.dart
+++ b/lib/src/util/tested_expressions.dart
@@ -100,7 +100,7 @@ class TestedExpressions {
     }
 
     _contradictions = _findContradictoryComparisons(
-        LinkedHashSet.from(facts),
+        LinkedHashSet.of(facts),
         binaryExpression != null
             ? binaryExpression.operator.type
             : TokenType.AMPERSAND_AMPERSAND);
@@ -200,7 +200,7 @@ class TestedExpressions {
         }
 
         var set = _findContradictoryComparisons(
-            HashSet.from([ex.leftOperand, ex.rightOperand]), ex.operator.type);
+            HashSet.of([ex.leftOperand, ex.rightOperand]), ex.operator.type);
         expressions.addAll(set);
       };
 }


### PR DESCRIPTION
See: https://github.com/dart-lang/linter/issues/2066 and https://github.com/dart-lang/linter/issues/2555.


/cc @srawlins @bwilkerson 

