### PR TITLE
New lint: Avoid unstable final fields

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -43,6 +43,7 @@ linter:
     - avoid_types_as_parameter_names
     - avoid_types_on_closure_parameters
     - avoid_unnecessary_containers
+    - avoid_unstable_final_fields
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - avoid_web_libraries_in_flutter

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -48,6 +48,7 @@ import 'rules/avoid_type_to_string.dart';
 import 'rules/avoid_types_as_parameter_names.dart';
 import 'rules/avoid_types_on_closure_parameters.dart';
 import 'rules/avoid_unnecessary_containers.dart';
+import 'rules/avoid_unstable_final_fields.dart';
 import 'rules/avoid_unused_constructor_parameters.dart';
 import 'rules/avoid_void_async.dart';
 import 'rules/avoid_web_libraries_in_flutter.dart';

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -279,6 +279,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(AvoidTypesAsParameterNames())
     ..register(AvoidTypesOnClosureParameters())
     ..register(AvoidUnnecessaryContainers())
+    ..register(AvoidUnstableFinalFields())
     ..register(AvoidUnusedConstructorParameters())
     ..register(AvoidVoidAsync())
     ..register(AvoidWebLibrariesInFlutter())

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -6,7 +6,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -505,7 +505,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
     if (prefixDeclaration is PrefixElement) {
       var declaredElement = node.identifier.staticElement?.declaration;
       if (!_isStable(declaredElement)) isStable = false;
-    } else if (prefixDeclaration is ClassElement) {
+    } else if (prefixDeclaration is InterfaceElement) {
       var declaredElement = node.identifier.staticElement?.declaration;
       if (!_isStable(declaredElement)) isStable = false;
     }

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -286,7 +286,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitInterpolationExpression(InterpolationExpression node) {
-    // TODO(eernst): Wc eould handle several cases here.
+    // TODO(eernst): Wc could handle several cases here.
     isStable = false;
   }
 
@@ -319,6 +319,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitPostfixExpression(PostfixExpression node) {
+    print('>>> PostFixExpression, $node');
     // TODO(eernst): `x.y?.z` is property accesses, so always unstable here?
     isStable = false;
   }

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -105,7 +105,7 @@ bool _isLocallyStable(Element element) {
       for (var elementAnnotation in metadata) {
         var metadataElement = elementAnnotation.element;
         if (metadataElement is ConstructorElement) {
-          var metadataOwner = metadataElement.declaration.enclosingElement3;
+          var metadataOwner = metadataElement.declaration.enclosingElement;
           if (metadataOwner is ClassElement && metadataOwner.isDartCoreObject) {
             // A declaration with `@Object()` is not considered stable.
             return false;
@@ -166,7 +166,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   bool _isStable(Element? element) {
     if (element == null) return false; // This would be an error in the program.
-    var enclosingElement = element.enclosingElement3;
+    var enclosingElement = element.enclosingElement;
     if (_isLocallyStable(element)) return true;
     if (element is PropertyAccessorElement) {
       if (element.isStatic) return false;
@@ -630,18 +630,18 @@ class _FieldVisitor extends _AbstractVisitor {
     Name? name;
     InterfaceElement? interfaceElement;
     for (var variable in node.fields.variables) {
-      var declaredElement = variable.declaredElement2;
+      var declaredElement = variable.declaredElement;
       if (declaredElement is FieldElement) {
         // A final instance variable can never violate stability.
         if (declaredElement.isFinal) continue;
         // A non-final instance variable is always a violation of stability.
         // Check if stability is required.
         interfaceElement ??=
-            declaredElement.enclosingElement3 as InterfaceElement;
+            declaredElement.enclosingElement as InterfaceElement;
         libraryUri ??= declaredElement.library.source.uri;
         name ??= Name(libraryUri, declaredElement.name);
         if (_inheritsStability(interfaceElement, name)) {
-          doReportLint(variable.name2);
+          doReportLint(variable.name);
         }
       }
     }
@@ -655,15 +655,15 @@ class _MethodVisitor extends _AbstractVisitor {
   void visitMethodDeclaration(MethodDeclaration node) {
     if (!node.isGetter) return;
     declaration = node;
-    var declaredElement = node.declaredElement2;
+    var declaredElement = node.declaredElement;
     if (declaredElement != null) {
-      var enclosingElement = declaredElement.enclosingElement3;
+      var enclosingElement = declaredElement.enclosingElement;
       if (enclosingElement is InterfaceElement) {
         var libraryUri = declaredElement.library.source.uri;
         var name = Name(libraryUri, declaredElement.name);
         if (!_inheritsStability(enclosingElement, name)) return;
         node.body.accept(this);
-        if (!isStable) doReportLint(node.name2);
+        if (!isStable) doReportLint(node.name);
       } else {
         // Extensions cannot override anything.
       }

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -103,7 +103,7 @@ bool _isLocallyStable(Element element) {
       for (var elementAnnotation in metadata) {
         var metadataElement = elementAnnotation.element;
         if (metadataElement is ConstructorElement) {
-          var metadataOwner = metadataElement.declaration.enclosingElement;
+          var metadataOwner = metadataElement.declaration.enclosingElement2;
           if (metadataOwner.isDartCoreObject) {
             // A declaration with `@Object()` is not considered stable.
             return false;
@@ -164,7 +164,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   bool _isStable(Element? element) {
     if (element == null) return false; // This would be an error in the program.
-    var enclosingElement = element.enclosingElement;
+    var enclosingElement = element.enclosingElement2;
     if (_isLocallyStable(element)) return true;
     if (element is PropertyAccessorElement) {
       if (element.isStatic) return false;
@@ -598,7 +598,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
         var element = typeAnnotation.type?.element?.declaration;
         if (element is ClassElement) return false;
         if (element is TypeParameterElement) {
-          var owner = element.enclosingElement;
+          var owner = element.enclosingElement2;
           // A class type parameter is not constant, but it is stable.
           if (owner is ClassElement) return false;
           return true;
@@ -633,7 +633,7 @@ class _FieldVisitor extends _AbstractVisitor {
         if (declaredElement.isFinal) continue;
         // A non-final instance variable is always a violation of stability.
         // Check if stability is required.
-        classElement ??= declaredElement.enclosingElement as ClassElement;
+        classElement ??= declaredElement.enclosingElement2 as ClassElement;
         libraryUri ??= declaredElement.library.source.uri;
         name ??= Name(libraryUri, declaredElement.name);
         if (_inheritsStability(classElement, name)) {
@@ -655,7 +655,7 @@ class _MethodVisitor extends _AbstractVisitor {
     declaration = node;
     var declaredElement = node.declaredElement2;
     if (declaredElement != null) {
-      var enclosingElement = declaredElement.enclosingElement;
+      var enclosingElement = declaredElement.enclosingElement2;
       if (enclosingElement is InterfaceElement) {
         var libraryUri = declaredElement.library.source.uri;
         var name = Name(libraryUri, declaredElement.name);

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -596,11 +596,11 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
           }
         }
         var element = typeAnnotation.type?.element?.declaration;
-        if (element is ClassElement) return false;
+        if (element is InterfaceElement) return false;
         if (element is TypeParameterElement) {
           var owner = element.enclosingElement2;
           // A class type parameter is not constant, but it is stable.
-          if (owner is ClassElement) return false;
+          if (owner is InterfaceElement) return false;
           return true;
         }
         // TODO(eernst): Handle `typedef` and other missing cases.
@@ -625,7 +625,7 @@ class _FieldVisitor extends _AbstractVisitor {
   void visitFieldDeclaration(FieldDeclaration node) {
     Uri? libraryUri;
     Name? name;
-    ClassElement? classElement;
+    InterfaceElement? interfaceElement;
     for (var variable in node.fields.variables) {
       var declaredElement = variable.declaredElement2;
       if (declaredElement is FieldElement) {
@@ -633,10 +633,11 @@ class _FieldVisitor extends _AbstractVisitor {
         if (declaredElement.isFinal) continue;
         // A non-final instance variable is always a violation of stability.
         // Check if stability is required.
-        classElement ??= declaredElement.enclosingElement2 as ClassElement;
+        interfaceElement ??=
+            declaredElement.enclosingElement2 as InterfaceElement;
         libraryUri ??= declaredElement.library.source.uri;
         name ??= Name(libraryUri, declaredElement.name);
-        if (_inheritsStability(classElement, name)) {
+        if (_inheritsStability(interfaceElement, name)) {
           doReportLint(node, variable.name);
         }
       }

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -92,6 +92,19 @@ bool _isLocallyStable(Element element) {
       element.isSynthetic &&
       element.correspondingSetter == null) {
     // This is a final, non-local variable, and they are stable.
+    var metadata = element.variable.metadata;
+    if (metadata.isNotEmpty) {
+      for (var elementAnnotation in metadata) {
+        var metadataElement = elementAnnotation.element;
+        if (metadataElement is ConstructorElement) {
+          var metadataOwner = metadataElement.declaration.enclosingElement;
+          if (metadataOwner.isDartCoreObject) {
+            // A declaration with `@Object()` is not considered stable.
+            return false;
+          }
+        }
+      }
+    }
     return true;
   } else if (element is FunctionElement) {
     // A tear-off of a top-level function or static method is stable,
@@ -462,7 +475,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
   }
 
   @override
-  void visitSimplStringLiteral(SimpleStringLiteral node) {
+  void visitSimpleStringLiteral(SimpleStringLiteral node) {
     // No interpolations: Keep it stable.
   }
 

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -183,7 +183,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
     return false;
   }
 
-  void doReportLint(ClassMember node, SimpleIdentifier name) {
+  void doReportLint(ClassMember node, AstNode name) {
     var contextMessages = <DiagnosticMessage>[];
     for (var cause in causes) {
       var length = cause.nameLength;

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -627,7 +627,7 @@ class _FieldVisitor extends _AbstractVisitor {
     Name? name;
     ClassElement? classElement;
     for (var variable in node.fields.variables) {
-      var declaredElement = variable.declaredElement;
+      var declaredElement = variable.declaredElement2;
       if (declaredElement is FieldElement) {
         // A final instance variable can never violate stability.
         if (declaredElement.isFinal) continue;
@@ -653,7 +653,7 @@ class _MethodVisitor extends _AbstractVisitor {
   void visitMethodDeclaration(MethodDeclaration node) {
     if (!node.isGetter) return;
     declaration = node;
-    var declaredElement = node.declaredElement;
+    var declaredElement = node.declaredElement2;
     if (declaredElement != null) {
       var enclosingElement = declaredElement.enclosingElement;
       if (enclosingElement is InterfaceElement) {

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/src/diagnostic/diagnostic.dart';
 
@@ -592,12 +593,13 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
             if (containsNonConstantType(typeArgument)) return true;
           }
         }
-        var element = typeAnnotation.type?.element?.declaration;
-        if (element is InterfaceElement) return false;
-        if (element is TypeParameterElement) {
-          var owner = element.enclosingElement3;
-          // A class type parameter is not constant, but it is stable.
-          if (owner is InterfaceElement) return false;
+        var typeAnnotationType = typeAnnotation.type;
+        if (typeAnnotationType is InterfaceType) {
+          var element = typeAnnotationType.element2.declaration;
+          if (element is InterfaceElement) return false;
+        } else if (typeAnnotationType is TypeParameterType) {
+          // We cannot rely on type parameters or parameterized types
+          // containing type parameters to be stable.
           return true;
         }
         // TODO(eernst): Handle `typedef` and other missing cases.

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -183,7 +183,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
     return false;
   }
 
-  void doReportLint(ClassMember node, AstNode name) {
+  List<DiagnosticMessage> _computeContextMessages() {
     var contextMessages = <DiagnosticMessage>[];
     for (var cause in causes) {
       var length = cause.nameLength;
@@ -193,14 +193,18 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
       contextMessages.add(
         DiagnosticMessageImpl(
             filePath: cause.library.source.fullName,
-            message: "The declaration of '$name' that requires this "
+            message: 'The declaration that requires this '
                 'declaration to be stable is',
             offset: offset,
             length: length,
             url: null),
       );
     }
-    rule.reportLint(name, contextMessages: contextMessages);
+    return contextMessages;
+  }
+
+  void doReportLint(Token? name) {
+    rule.reportLintForToken(name, contextMessages: _computeContextMessages());
   }
 
   // The following visitor methods will only be executed in the situation
@@ -638,7 +642,7 @@ class _FieldVisitor extends _AbstractVisitor {
         libraryUri ??= declaredElement.library.source.uri;
         name ??= Name(libraryUri, declaredElement.name);
         if (_inheritsStability(interfaceElement, name)) {
-          doReportLint(node, variable.name);
+          doReportLint(variable.name2);
         }
       }
     }
@@ -660,7 +664,7 @@ class _MethodVisitor extends _AbstractVisitor {
         var name = Name(libraryUri, declaredElement.name);
         if (!_inheritsStability(enclosingElement, name)) return;
         node.body.accept(this);
-        if (!isStable) doReportLint(node, node.name);
+        if (!isStable) doReportLint(node.name2);
       } else {
         // Extensions cannot override anything.
       }

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -425,16 +425,12 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
         // TODO(eernst): For now, just use the safe approximation.
         return true;
       } else {
-        // TODO(eernst): Further cases?
+        // TODO(eernst): Add missing cases. Be safe for now.
         return true;
       }
     }
 
-    print('>>> TypeLiteral, $node, $dartType'); // DEBUG
-    var namedType = node.type;
-    if (containsNonConstantType(namedType)) {
-      isStable = false;
-    }
+    if (containsNonConstantType(node.type)) isStable = false;
   }
 }
 

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -4,23 +4,65 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
+import '../util/dart_type_utilities.dart';
 
-const _desc = r'';
+const _desc = r'Avoid overriding a final field to return '
+    'different values if called multiple times';
 
 const _details = r'''
 
-**DO** ...
+**AVOID** overriding or implementing a final field as a getter which could
+return different values if it is invoked multiple times on the same receiver.
+This could occur because the getter is an implicitly induced getter of a
+non-final field, or it could be an explicitly declared getter with a body
+that isn't known to return the same value each time it is called.
+
+The underlying motivation for this rule is that if it is followed then a final
+field is an immutable property of an object. This is important for correctness
+because it is then safe to assume that the value does not change during the
+execution of an algorithm. In contrast, it may be necessary to re-check any
+other getter repeatedly if it is not known to have this property. Similarly,
+it is safe to cache the immutable property in a local variable and promote it,
+but for any other property it is necessary to check repeatedly that the
+underlying property hasn't changed since it was promoted.
 
 **BAD:**
 ```dart
+class A {
+  final int i;
+  A(this.i);
+}
 
+var j = 0;
+
+class B1 extends A {
+  int get i => ++j + super.i; // LINT.
+}
+
+class B2 implements A {
+  int i; // LINT.
+  B2(this.i);
+}
 ```
 
 **GOOD:**
 ```dart
+class A {
+  final int i;
+  A(this.i);
+}
 
+class B1 implements A {
+  late final int i = someExpression; // OK.
+}
+
+class B2 extends A {
+  int get i => super.i + 1; // OK.
+}
 ```
 
 ''';
@@ -31,22 +73,142 @@ class AvoidUnstableFinalFields extends LintRule {
             name: 'avoid_unstable_final_fields',
             description: _desc,
             details: _details,
-            group: Group.style);
+            group: Group.errors);
 
   @override
-  void registerNodeProcessors(NodeLintRegistry registry, LinterContext context) {
-    var visitor = _Visitor(this);
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this, context);
     registry.addSimpleIdentifier(this, visitor);
   }
 }
 
-class _Visitor extends SimpleAstVisitor {
-  final LintRule rule;
+bool _requiresStability(Element element) {
+  // In this first approximation of 'final getters', no other situation
+  // can make a getter stable than being the implicitly induced getter
+  // of a final instance variable.
+  if (element is! FieldElement) return false;
+  return element.isFinal;
+}
 
-  _Visitor(this.rule);
+abstract class _AbstractVisitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+  final LinterContext context;
+
+  // Initialized in `visitMethodDeclaration` if a lint might be emitted.
+  // It is then guaranteed that `declaration.isGetter` is true.
+  late final MethodDeclaration declaration;
+
+  _AbstractVisitor(this.rule, this.context);
+
+  // The following visitor methods will only be executed in the situation
+  // where `declaration` is a getter which must be stable, and the
+  // traversal is visiting the body of said getter. Hence, a lint must
+  // be emitted whenever the given body is not known to be appropriate
+  // for a stable getter.
 
   @override
-  void visitSimpleIdentifier(SimpleIdentifier node) {
-    // TODO: implement
+  void visitBlock(Block node) {
+    // TODO(eernst): Check that only one return statement exists, and it is
+    // the last statement in the body, and it returns a stable expression.
+    if (node.statements.length == 1) {
+      node.statements.first.accept(this);
+    }
+  }
+
+  @override
+  void visitBlockFunctionBody(BlockFunctionBody node) {
+    visitBlock(node.block);
+  }
+
+  @override
+  void visitExpressionFunctionBody(ExpressionFunctionBody node) {
+    node.expression.accept(this);
+  }
+
+  @override
+  void visitExpressionStatement(ExpressionStatement node) {
+    node.expression.accept(this);
+  }
+
+  @override
+  void visitParenthesizedExpression(ParenthesizedExpression node) {
+    node.unParenthesized.accept(this);
+  }
+
+  @override
+  void visitReturnStatement(ReturnStatement node) {
+    node.expression?.accept(this);
+  }
+
+  @override
+  void visitSuperExpression(SuperExpression node) {
+    rule.reportLint(declaration.name);
+  }
+}
+
+class _MethodVisitor extends _AbstractVisitor {
+  late MethodDeclaration declaration;
+
+  _MethodVisitor(super.rule, super.context);
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    if (!node.isGetter) return;
+    declaration = node;
+    var declaredElement = node.declaredElement;
+    if (declaredElement != null) {
+      if (!_requiresStability(declaredElement)) return;
+      node.body.accept(this);
+    }
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
+
+  @override
+  void visitFieldDeclaration(FieldDeclaration node) {
+    assert(!node.isStatic);
+    Uri? libraryUri;
+    Name? name;
+    ClassElement? classElement;
+    for (var variable in node.fields.variables) {
+      var declaredElement = variable.declaredElement;
+      if (declaredElement is FieldElement) {
+        // A final instance variable can never violate stability.
+        if (declaredElement.isFinal) continue;
+        // A non-final instance variable is always a violation of stability.
+        // Check if stability is required.
+        if (classElement == null) {
+          classElement = declaredElement.enclosingElement as ClassElement;
+        }
+        if (libraryUri == null) {
+          libraryUri = declaredElement.library.source.uri;
+        }
+        if (name == null) {
+          name = Name(libraryUri, declaredElement.name);
+        }
+        var overriddenList =
+        context.inheritanceManager.getOverridden2(classElement, name);
+        if (overriddenList == null) continue;
+        for (var overridden in overriddenList) {
+          if (_requiresStability(overridden)) {
+            rule.reportLint(variable.name);
+          }
+        }
+      }
+    }
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    if (!node.isStatic && node.isGetter) {
+      var visitor = _MethodVisitor(rule, context);
+      visitor.visitMethodDeclaration(node);
+    }
   }
 }

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -204,11 +204,13 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitAsExpression(AsExpression node) {
+    if (node.expression.staticType?.isBottom ?? true) return;
     node.expression.accept(this);
   }
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {
+    if (node.staticType?.isBottom ?? true) return;
     var operator = node.operator;
     if (operator.type != TokenType.EQ) {
       // TODO(eernst): Could a compound assignment be stable?
@@ -227,6 +229,8 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
+    if (node.leftOperand.staticType?.isBottom ?? true) return;
+    if (node.rightOperand.staticType?.isBottom ?? true) return;
     node.leftOperand.accept(this);
     node.rightOperand.accept(this);
     if (isStable) {
@@ -317,6 +321,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitConditionalExpression(ConditionalExpression node) {
+    if (node.condition.staticType?.isBottom ?? true) return;
     node.condition.accept(this);
     node.thenExpression.accept(this);
     node.elseExpression.accept(this);
@@ -334,6 +339,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitExpressionFunctionBody(ExpressionFunctionBody node) {
+    if (node.expression.staticType?.isBottom ?? true) return;
     node.expression.accept(this);
   }
 
@@ -351,12 +357,14 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    if (node.staticType?.isBottom ?? true) return;
     // We cannot expect a function invocation to be stable.
     isStable = false;
   }
 
   @override
   void visitIndexExpression(IndexExpression node) {
+    if (node.staticType?.isBottom ?? true) return;
     // The type system does not recognize immutable lists or similar entities,
     // so we can never hope to detect that this is stable.
     isStable = false;
@@ -379,6 +387,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitIsExpression(IsExpression node) {
+    if (node.expression.staticType?.isBottom ?? true) return;
     // Testing `e is T` where `e` is stable depends on `T`. However, there is
     // no `<type>` that denotes two different types in the context of the same
     // receiver (so class type variables represent the same type each time this
@@ -394,6 +403,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
+    if (node.staticType?.isBottom ?? true) return;
     // We could have a notion of pure functions, but for now a
     // method invocation is never stable.
     isStable = false;
@@ -401,6 +411,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitNamedExpression(NamedExpression node) {
+    if (node.staticType?.isBottom ?? true) return;
     node.expression.accept(this);
   }
 
@@ -411,11 +422,13 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitParenthesizedExpression(ParenthesizedExpression node) {
+    if (node.staticType?.isBottom ?? true) return;
     node.unParenthesized.accept(this);
   }
 
   @override
   void visitPostfixExpression(PostfixExpression node) {
+    if (node.staticType?.isBottom ?? true) return;
     // `x.y?.z` is handled in [visitPropertyAccess], this is only about
     // `<assignableExpression> <postfixOperator>`, and they are not stable.
     isStable = false;
@@ -423,6 +436,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   @override
   void visitPrefixExpression(PrefixExpression node) {
+    if (node.staticType?.isBottom ?? true) return;
     if (node.operator.type == TokenType.MINUS) {
       node.operand.accept(this);
     } else {

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
+// ignore:implementation_imports
 import 'package:analyzer/src/diagnostic/diagnostic.dart';
 
 import '../analyzer.dart';

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r' ';
+const _desc = r'';
 
 const _details = r'''
 

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -106,8 +106,7 @@ bool _isLocallyStable(Element element) {
         var metadataElement = elementAnnotation.element;
         if (metadataElement is ConstructorElement) {
           var metadataOwner = metadataElement.declaration.enclosingElement3;
-          if (metadataOwner is ClassElement &&
-              metadataOwner.isDartCoreObject) {
+          if (metadataOwner is ClassElement && metadataOwner.isDartCoreObject) {
             // A declaration with `@Object()` is not considered stable.
             return false;
           }

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r' ';
+
+const _details = r'''
+
+**DO** ...
+
+**BAD:**
+```dart
+
+```
+
+**GOOD:**
+```dart
+
+```
+
+''';
+
+class AvoidUnstableFinalFields extends LintRule {
+  AvoidUnstableFinalFields()
+      : super(
+            name: 'avoid_unstable_final_fields',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addSimpleIdentifier(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    // TODO: implement
+  }
+}

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -183,7 +183,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
         DiagnosticMessageImpl(
             filePath: cause.library.source.fullName,
             message: "The declaration of '$name' that requires this "
-                "declaration to be stable is here.\n",
+                "declaration to be stable is",
             offset: offset,
             length: length,
             url: null),
@@ -429,9 +429,14 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
   @override
   void visitPostfixExpression(PostfixExpression node) {
     if (node.staticType?.isBottom ?? true) return;
-    // `x.y?.z` is handled in [visitPropertyAccess], this is only about
-    // `<assignableExpression> <postfixOperator>`, and they are not stable.
-    isStable = false;
+    if (node.operator.type == TokenType.BANG) {
+      // A non-null assertion expression, `e!`: stable if `e` is stable.
+      node.operand.accept(this);
+    } else {
+      // `x.y?.z` is handled in [visitPropertyAccess], this is only about
+      // `<assignableExpression> <postfixOperator>`, and they are not stable.
+      isStable = false;
+    }
   }
 
   @override

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -116,8 +116,10 @@ bool _isLocallyStable(Element element) {
     // A tear-off of a top-level function or static method is stable,
     // local functions and function literals are not.
     return element.isStatic;
-  } else if (element is ClassElement) {
-    // A reified type of a class is stable.
+  } else if (element is EnumElement ||
+      element is MixinElement ||
+      element is ClassElement) {
+    // A reified type of a class/mixin/enum is stable.
     return true;
   } else if (element is MethodElement) {
     // An instance method tear-off is never stable,
@@ -147,9 +149,9 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
 
   _AbstractVisitor(this.rule, this.context);
 
-  bool _inheritsStability(ClassElement classElement, Name name) {
+  bool _inheritsStability(InterfaceElement interfaceElement, Name name) {
     var overriddenList =
-        context.inheritanceManager.getOverridden2(classElement, name);
+        context.inheritanceManager.getOverridden2(interfaceElement, name);
     if (overriddenList == null) return false;
     for (var overridden in overriddenList) {
       if (_isLocallyStable(overridden)) {
@@ -654,7 +656,7 @@ class _MethodVisitor extends _AbstractVisitor {
     var declaredElement = node.declaredElement;
     if (declaredElement != null) {
       var enclosingElement = declaredElement.enclosingElement;
-      if (enclosingElement is ClassElement) {
+      if (enclosingElement is InterfaceElement) {
         var libraryUri = declaredElement.library.source.uri;
         var name = Name(libraryUri, declaredElement.name);
         if (!_inheritsStability(enclosingElement, name)) return;

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -168,7 +168,7 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
     if (_isLocallyStable(element)) return true;
     if (element is PropertyAccessorElement) {
       if (element.isStatic) return false;
-      if (enclosingElement is! ClassElement) {
+      if (enclosingElement is! InterfaceElement) {
         // This should not happen, a top-level variable `isStatic`.
         // TODO(eernst): Do something like `throw Unhandled(...)`.
         return false;

--- a/lib/src/rules/avoid_unstable_final_fields.dart
+++ b/lib/src/rules/avoid_unstable_final_fields.dart
@@ -162,22 +162,25 @@ abstract class _AbstractVisitor extends ThrowingAstVisitor<void> {
   void doReportLint(ClassMember node, SimpleIdentifier name) {
     var contextMessages = <DiagnosticMessage>[];
     for (var cause in causes) {
+      var length = cause.nameLength;
+      var offset = cause.nameOffset;
+      if (offset < 0) offset = cause.variable.nameOffset;
+      if (offset < 0) offset = 0;
       contextMessages.add(
         DiagnosticMessageImpl(
-            filePath: cause.library.source.fullName ?? 'unknown library',
+            filePath: cause.library.source.fullName,
             message: "The declaration of '$name' that requires this "
-                "declaration to be stable is here",
-            offset: cause.nameOffset,
-            length: cause.nameLength,
-            url: cause.library.source.uri.toString()),
+                "declaration to be stable is here.\n",
+            offset: offset,
+            length: length,
+            url: null),
       );
     }
     rule.reportLint(
       name,
       contextMessages: contextMessages,
-      ignoreSyntheticNodes: false,
+      ignoreSyntheticNodes: true,
     );
-
   }
 
   // The following visitor methods will only be executed in the situation

--- a/test_data/integration/public_member_api_docs/.dart_tool/package_config.json
+++ b/test_data/integration/public_member_api_docs/.dart_tool/package_config.json
@@ -1,0 +1,14 @@
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "public_member_api_docs",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "2.13"
+    }
+  ],
+  "generated": "2022-07-07T14:16:50.175540Z",
+  "generator": "pub",
+  "generatorVersion": "2.18.0-216.0.dev"
+}

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -12,7 +12,7 @@ class A {
 var j = 0;
 
 class B1 extends A {
-  int get i => ++j + super.i; //L INT
+  int get i => ++j + super.i; //LINT
   B1(super.i);
 }
 

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -1,0 +1,6 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// test w/ `dart test -N avoid_unstable_final_fields`
+

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -140,12 +140,16 @@ class F11<X> implements E {
   Type get o => X; //LINT
 }
 
-class F12 implements E {
-  F12 get o => const F12(42); //OK
-  const F12(int whatever);
+class F12<X> implements E {
+  Type get o => F12<X>; //LINT
 }
 
 class F13 implements E {
-  F13 get o => F13(jTop); //LINT
-  F13(int whatever);
+  F13 get o => const F13(42); //OK
+  const F13(int whatever);
+}
+
+class F14 implements E {
+  F14 get o => F14(jTop); //LINT
+  F14(int whatever);
 }

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -161,3 +161,11 @@ class F15 implements E {
 class F16 implements E {
   String get o => 'Stuff, $cNever, but not $jTop'; //LINT
 }
+
+class F17 implements E {
+  bool get o => this is E; //OK
+}
+
+class F18 implements E {
+  bool get o => jTop is int; //LINT
+}

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -21,16 +21,32 @@ class B2 implements A {
   B2(this.i);
 }
 
-class C {
-  final int i;
-  C(this.i);
-}
-
-class D1 implements C {
+class B3 implements A {
   late final int i = j++; //OK
 }
 
-class D2 extends C {
+class B4 extends A {
   int get i => super.i + 1; //OK
-  D2(super.i);
+  B4(super.i);
+}
+
+class B5 implements A {
+  final int j;
+  int get i => j; //OK
+  B5(this.j);
+}
+
+class B6 implements A {
+  int get i => 1; //OK
+}
+
+class C<X> {
+  final C<X>? next;
+  C(this.next);
+}
+
+C<Never> cNever = C<Never>(null);
+
+class D1<X> implements C<X> {
+  final C<X>? next => cNever;
 }

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -179,3 +179,13 @@ class F17 implements E {
 class F18 implements E {
   bool get o => jTop is int; //LINT
 }
+
+class G {
+  @Object()
+  final String s;
+  G(this.s);
+}
+
+class H1 implements G {
+  String get s => '${++jTop}'; //OK
+}

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -210,3 +210,51 @@ class G {
 class H1 implements G {
   String get s => '${++jTop}'; //OK
 }
+
+class I {
+  final int i;
+  I(this.i);
+}
+
+mixin J1 on I {
+  int get i => ++jTop + super.i; //LINT
+}
+
+mixin J2 implements I {
+  int get i => ++jTop; //LINT
+}
+
+mixin J3 on I {
+  int get i => super.i - 1; //OK
+}
+
+mixin J4 implements I {
+  int get i => 1; //OK
+}
+
+mixin J5 on I {
+  int get i => -super.i; //OK
+}
+
+class K {
+  final Object? o;
+  K(this.o);
+}
+
+mixin K1 on K {
+  Object get o => super.o!; //OK
+}
+
+class L {
+  @Object()
+  final String s;
+  L(this.s);
+}
+
+mixin L1 on L {
+  String get s => '$jTop'; //OK
+}
+
+mixin L2 implements L {
+  String get s => '${-jTop}'; //OK
+}

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -153,3 +153,11 @@ class F14 implements E {
   F14 get o => F14(jTop); //LINT
   F14(int whatever);
 }
+
+class F15 implements E {
+  String get o => 'Something $cNever, and ${1 + 1} more things'; //OK
+}
+
+class F16 implements E {
+  String get o => 'Stuff, $cNever, but not $jTop'; //LINT
+}

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -241,20 +241,203 @@ class K {
   K(this.o);
 }
 
-mixin K1 on K {
+mixin L1 on K {
   Object get o => super.o!; //OK
 }
 
-class L {
+class M {
   @Object()
   final String s;
-  L(this.s);
+  M(this.s);
 }
 
-mixin L1 on L {
+mixin N1 on M {
   String get s => '$jTop'; //OK
 }
 
-mixin L2 implements L {
+mixin N2 implements M {
   String get s => '${-jTop}'; //OK
+}
+
+abstract class O {
+  final int i;
+  O(this.i);
+}
+
+enum P1 implements O {
+  a, b, c;
+  final int i = jTop++; //OK
+}
+
+enum P2 implements O {
+  a(10), b(12), c(14);
+  final int j;
+  int get i => j; //OK
+  const P2(this.j);
+}
+
+enum P3 implements O {
+  a, b, c;
+  int get i => 1; //OK
+}
+
+enum P4 implements O {
+  a, b, c;
+  int get i { //OK
+    return 1;
+  }
+}
+
+enum P5 implements O {
+  a, b, c;
+  int get i { //LINT
+    return jTop;
+  }
+}
+
+enum P6 implements O {
+  aa(true, 4), bb(true, 8), cc(false, 12);
+  final bool b;
+  final int j;
+  int get i => b ? j : 10; //OK
+  const P6(this.b, this.j);
+}
+
+bool bTop = true;
+
+enum P7 implements O {
+  aa(3), bb(5), cc(7);
+  final int j;
+  int get i => bTop ? 2 * j : 10; //LINT
+  const P7(this.j);
+}
+
+enum P8 implements O {
+  a, b, c;
+  int get i => throw 0; //OK
+}
+
+enum P9 implements O {
+  a, b, c;
+  int get i { //OK
+    throw 0;
+  }
+}
+
+abstract class Q {
+  abstract final Object? o;
+}
+
+enum R1 implements Q {
+  a, b, c;
+  Function get o => m; //LINT
+  void m() {}
+  static late final Function fStatic = () {};
+}
+
+enum R2 implements Q {
+  a, b, c;
+  Function get o => () {}; //LINT
+}
+
+enum R3 implements Q {
+  a, b, c;
+  Function get o => print..toString(); //OK
+}
+
+enum R4 implements Q {
+  a, b, c;
+  Function get o => math.cos; //OK
+}
+
+enum R5 implements Q {
+  a, b, c;
+  Function get o => F1.fStatic; //OK
+}
+
+enum R6 implements Q {
+  a, b, c;
+  List<int> get o => []; //LINT
+}
+
+enum R7 implements Q {
+  a, b, c;
+  Set<double> get o => const {}; //OK
+}
+
+enum R8 implements Q {
+  a, b, c;
+  Object get o => <String, String>{}; //LINT
+}
+
+enum R9 implements Q {
+  a, b, c;
+  Symbol get o => #symbol; //OK
+}
+
+enum R10 implements Q {
+  a, b, c;
+  Type get o => int; //OK
+}
+
+enum R11<X> implements Q {
+  a, b, c;
+  Type get o => X; //LINT
+}
+
+enum R12<X> implements Q {
+  a, b, c;
+  Type get o => F12<X>; //OK
+}
+
+enum R13 implements Q {
+  a(-1), b(-2), c(-3);
+  F13 get o => const F13(42); //OK
+  const R13(int whatever);
+}
+
+enum R14 implements Q {
+  a(-10), b(-20), c(-30);
+  F14 get o => F14(jTop); //LINT
+  const R14(int whatever);
+}
+
+enum R15 implements Q {
+  a, b, c;
+  String get o => 'Something $cNever, and ${1 * 1} more things'; //OK
+}
+
+enum R16 implements Q {
+  a, b, c;
+  String get o => 'Stuff, $cNever, but not $jTop'; //LINT
+}
+
+enum R17 implements Q {
+  a, b, c;
+  bool get o => this is Q; //OK
+}
+
+enum R18 implements Q {
+  a, b, c;
+  bool get o => jTop is int; //LINT
+}
+
+enum R20Helper {
+  a.named(999), b.named(-0.888), c.named(77.7);
+  const R20Helper.named(num n);
+}
+
+enum R20 implements Q {
+  a, b, c;
+  R20Helper get o => R20Helper.b; //OK
+}
+
+enum R21 implements Q {
+  a, b, c;
+  bool get o => identical(const <int>[], const <int>[]); //OK
+}
+
+enum R22 implements Q {
+  a, b, c;
+  bool get o => identical(<int>[], const <int>[]); //LINT
 }

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -100,7 +100,7 @@ class D1<X> implements C<X> {
 }
 
 class E {
-  final Object o;
+  final Object? o;
   E(this.o);
 }
 
@@ -178,6 +178,11 @@ class F17 implements E {
 
 class F18 implements E {
   bool get o => jTop is int; //LINT
+}
+
+class F19 extends E {
+  Object get o => super.o!; //OK
+  F19(super.o);
 }
 
 class G {

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -28,7 +28,7 @@ class B3 implements A {
 }
 
 class B4 extends A {
-  int get i => super.i + 1; //OK
+  int get i => super.i - 1; //OK
   B4(super.i);
 }
 
@@ -69,7 +69,7 @@ class B10 implements A {
 class B11 implements A {
   bool b;
   final int j;
-  int get i => b ? j : 10; //LINT
+  int get i => b ? 2 * j : 10; //LINT
   B11(this.b, this.j);
 }
 
@@ -165,7 +165,7 @@ class F14 implements E {
 }
 
 class F15 implements E {
-  String get o => 'Something $cNever, and ${1 + 1} more things'; //OK
+  String get o => 'Something $cNever, and ${1 * 1} more things'; //OK
 }
 
 class F16 implements E {
@@ -183,6 +183,22 @@ class F18 implements E {
 class F19 extends E {
   Object get o => super.o!; //OK
   F19(super.o);
+}
+
+class F20Helper {
+  const F20Helper.named(int i);
+}
+
+class F20 implements E {
+  F20Helper get o => const F20Helper.named(15); //OK
+}
+
+class F21 implements E {
+  bool get o => identical(const <int>[], const <int>[]); //OK
+}
+
+class F22 implements E {
+  bool get o => identical(<int>[], const <int>[]); //LINT
 }
 
 class G {

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -141,7 +141,7 @@ class F11<X> implements E {
 }
 
 class F12<X> implements E {
-  Type get o => F12<X>; //LINT
+  Type get o => F12<X>; //OK
 }
 
 class F13 implements E {

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -4,15 +4,17 @@
 
 // test w/ `dart test -N avoid_unstable_final_fields`
 
+import 'dart:math' as math;
+
 class A {
   final int i;
   A(this.i);
 }
 
-var j = 0;
+var jTop = 0;
 
 class B1 extends A {
-  int get i => ++j + super.i; //LINT
+  int get i => ++jTop + super.i; //LINT
   B1(super.i);
 }
 
@@ -22,7 +24,7 @@ class B2 implements A {
 }
 
 class B3 implements A {
-  late final int i = j++; //OK
+  late final int i = jTop++; //OK
 }
 
 class B4 extends A {
@@ -40,13 +42,110 @@ class B6 implements A {
   int get i => 1; //OK
 }
 
-class C<X> {
-  final C<X>? next;
-  C(this.next);
+class B7 implements A {
+  int get i { //OK
+    return 1;
+  }
 }
 
-C<Never> cNever = C<Never>(null);
+class B8 implements A {
+  int get i { //LINT
+    return jTop;
+  }
+}
+
+class B9 extends A {
+  int get i => -super.i; //OK
+  B9(super.i);
+}
+
+class B10 implements A {
+  final bool b;
+  final int j;
+  int get i => b ? j : 10; //OK
+  B10(this.b, this.j);
+}
+
+class B11 implements A {
+  bool b;
+  final int j;
+  int get i => b ? j : 10; //LINT
+  B11(this.b, this.j);
+}
+
+class C<X> {
+  final C<X>? next;
+  final C<X>? nextNext = null;
+  final X? value = null;
+  const C(this.next);
+}
+
+const cNever = C<Never>(null);
 
 class D1<X> implements C<X> {
-  final C<X>? next => cNever;
+  late X x;
+  C<X>? get next => cNever; //OK
+  C<X>? get nextNext => this.next?.next; //OK
+  X? get value => x; //LINT
+}
+
+class E {
+  final Object o;
+  E(this.o);
+}
+
+class F1 implements E {
+  Function get o => m; //LINT
+  void m() {}
+  static late final Function fStatic = () {};
+}
+
+class F2 implements E {
+  Function get o => () {}; //LINT
+}
+
+class F3 implements E {
+  Function get o => print..toString(); //OK
+}
+
+class F4 implements E {
+  Function get o => math.cos; //OK
+}
+
+class F5 implements E {
+  Function get o => F1.fStatic; //OK
+}
+
+class F6 implements E {
+  List<int> get o => []; //LINT
+}
+
+class F7 implements E {
+  Set<double> get o => const {}; //OK
+}
+
+class F8 implements E {
+  Object get o => <String, String>{}; //LINT
+}
+
+class F9 implements E {
+  Symbol get o => #symbol; //OK
+}
+
+class F10 implements E {
+  Type get o => int; //OK
+}
+
+class F11<X> implements E {
+  Type get o => X; //LINT
+}
+
+class F12 implements E {
+  F12 get o => const F12(42); //OK
+  const F12(int whatever);
+}
+
+class F13 implements E {
+  F13 get o => F13(jTop); //LINT
+  F13(int whatever);
 }

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -151,7 +151,7 @@ class F11<X> implements E {
 }
 
 class F12<X> implements E {
-  Type get o => F12<X>; //OK
+  Type get o => F12<X>; //LINT
 }
 
 class F13 implements E {
@@ -387,7 +387,7 @@ enum R11<X> implements Q {
 
 enum R12<X> implements Q {
   a, b, c;
-  Type get o => F12<X>; //OK
+  Type get o => R12<X>; //LINT
 }
 
 enum R13 implements Q {

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -73,6 +73,16 @@ class B11 implements A {
   B11(this.b, this.j);
 }
 
+class B12 implements A {
+  int get i => throw 0; //OK
+}
+
+class B13 implements A {
+  int get i { //OK
+    throw 0;
+  }
+}
+
 class C<X> {
   final C<X>? next;
   final C<X>? nextNext = null;

--- a/test_data/rules/avoid_unstable_final_fields.dart
+++ b/test_data/rules/avoid_unstable_final_fields.dart
@@ -4,3 +4,33 @@
 
 // test w/ `dart test -N avoid_unstable_final_fields`
 
+class A {
+  final int i;
+  A(this.i);
+}
+
+var j = 0;
+
+class B1 extends A {
+  int get i => ++j + super.i; //L INT
+  B1(super.i);
+}
+
+class B2 implements A {
+  int i; //LINT
+  B2(this.i);
+}
+
+class C {
+  final int i;
+  C(this.i);
+}
+
+class D1 implements C {
+  late final int i = j++; //OK
+}
+
+class D2 extends C {
+  int get i => super.i + 1; //OK
+  D2(super.i);
+}


### PR DESCRIPTION
This PR implements the lint `avoid_unstable_final_fields`, cf. issue #3440.

The basic idea is that a final field declaration is taken to indicate that the given property is immutable, and hence every override which is not guaranteed to return the same value each time it is invoked will be linted.

```dart
class A {
  final int i; // Taken to be immutable, because it's a final variable.
  A(this.i);
}

class B1 implements A {
  static _i = 0;
  int get i => ++_i; // LINT: Does not return the same object every time.
}

class B2 implements A {
  final A a = A(42);
  int get i => a.i; // OK.
}
```

The PR is intended to serve as a point of reference, facilitating discussion and feedback on the lint and the underlying ruleset, as well as on the implementation.

[Edit: Removed remarks about landing this PR.]