### PR TITLE
Speed up use_late_for_private_fields_and_variables

### DIFF
--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -74,7 +74,7 @@ class UseLateForPrivateFieldsAndVariables extends LintRule {
   }
 }
 
-class _Visitor extends UnifyingAstVisitor<void> {
+class _Visitor extends RecursiveAstVisitor<void> {
   static final lateables =
       <CompilationUnitElement, List<VariableDeclaration>>{};
 
@@ -85,6 +85,24 @@ class _Visitor extends UnifyingAstVisitor<void> {
 
   CompilationUnitElement? currentUnit;
   _Visitor(this.rule, this.context);
+
+  @override
+  void visitAssignmentExpression(AssignmentExpression node) {
+    var element = node.writeElement?.canonicalElement;
+    if (element != null) {
+      var assignee = node.leftHandSide;
+      if (assignee is SimpleIdentifier && assignee.inDeclarationContext()) {
+        // This is OK.
+      } else if (node.operator.type == TokenType.EQ &&
+          DartTypeUtilities.isNonNullable(
+              context, node.rightHandSide.staticType)) {
+        // This is OK; non-null access.
+      } else {
+        nullableAccess[currentUnit]?.add(element);
+      }
+    }
+    super.visitAssignmentExpression(node);
+  }
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
@@ -120,7 +138,7 @@ class _Visitor extends UnifyingAstVisitor<void> {
       if (areAllLibraryUnitsVisited) {
         _checkAccess(libraryUnitsInContext);
 
-        // clean up
+        // Clean up.
         for (var unit in libraryUnitsInContext) {
           lateables.remove(unit);
           nullableAccess.remove(unit);
@@ -136,53 +154,44 @@ class _Visitor extends UnifyingAstVisitor<void> {
 
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
-    for (var variable in node.fields.variables) {
-      var parent = node.parent;
-      // see https://github.com/dart-lang/linter/pull/2189#issuecomment-660115569
-      // We could also include public members in private classes but to do that
-      // we'd need to ensure that there are no instances of either the
-      // enclosing class or any subclass of the enclosing class that are ever
-      // accessible outside this library.
-      if (parent != null &&
-          (Identifier.isPrivateName(variable.name.name) ||
-              _isPrivateExtension(parent))) {
-        _visit(variable);
+    var parent = node.parent;
+    if (parent != null) {
+      var parentIsPrivateExtension = _isPrivateExtension(parent);
+      for (var variable in node.fields.variables) {
+        // See
+        // https://github.com/dart-lang/linter/pull/2189#issuecomment-660115569.
+        // We could also include public members in private classes but to do
+        // that we'd need to ensure that there are no instances of either the
+        // enclosing class or any subclass of the enclosing class that are ever
+        // accessible outside this library.
+        if (parentIsPrivateExtension ||
+            Identifier.isPrivateName(variable.name.name)) {
+          _visit(variable);
+        }
       }
     }
     super.visitFieldDeclaration(node);
   }
 
   @override
-  void visitNode(AstNode node) {
-    var parent = node.parent;
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    var element = node.staticElement?.canonicalElement;
+    _visitIdentifierOrPropertyAccess(node, element);
+    super.visitPrefixedIdentifier(node);
+  }
 
-    Element? element;
-    if (parent is AssignmentExpression && parent.leftHandSide == node) {
-      element = parent.writeElement?.canonicalElement;
-    } else {
-      element = node.canonicalElement;
-    }
+  @override
+  void visitPropertyAccess(PropertyAccess node) {
+    var element = node.propertyName.staticElement?.canonicalElement;
+    _visitIdentifierOrPropertyAccess(node, element);
+    super.visitPropertyAccess(node);
+  }
 
-    if (element != null) {
-      if (parent is Expression) {
-        parent = parent.unParenthesized;
-      }
-      if (node is SimpleIdentifier && node.inDeclarationContext()) {
-        // ok
-      } else if (parent is PostfixExpression &&
-          parent.operand == node &&
-          parent.operator.type == TokenType.BANG) {
-        // ok non-null access
-      } else if (parent is AssignmentExpression &&
-          parent.operator.type == TokenType.EQ &&
-          DartTypeUtilities.isNonNullable(
-              context, parent.rightHandSide.staticType)) {
-        // ok non-null access
-      } else {
-        nullableAccess[currentUnit]?.add(element);
-      }
-    }
-    super.visitNode(node);
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    var element = node.staticElement?.canonicalElement;
+    _visitIdentifierOrPropertyAccess(node, element);
+    super.visitSimpleIdentifier(node);
   }
 
   @override
@@ -221,5 +230,27 @@ class _Visitor extends UnifyingAstVisitor<void> {
       return;
     }
     lateables[currentUnit]?.add(variable);
+  }
+
+  /// Checks whether [expression], which must be an [Identifier] or
+  /// [PropertyAccess], and its [canonicalElement], represent a nullable access.
+  void _visitIdentifierOrPropertyAccess(
+      Expression expression, Element? canonicalElement) {
+    assert(expression is Identifier || expression is PropertyAccess);
+    if (canonicalElement != null) {
+      var parent = expression.parent;
+      if (parent is Expression) {
+        parent = parent.unParenthesized;
+      }
+      if (expression is SimpleIdentifier && expression.inDeclarationContext()) {
+        // This is OK.
+      } else if (parent is PostfixExpression &&
+          parent.operand == expression &&
+          parent.operator.type == TokenType.BANG) {
+        // This is OK; non-null access.
+      } else {
+        nullableAccess[currentUnit]?.add(canonicalElement);
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

The gist is that UnifyingAstVisitor was a little expensive, as we ultimately only do any work if we're looking at (1) the left side of an AssignmentExpression, or (2) an Identifier or a PropertyAccess. So it wasn't too hard to just visit those nodes with a RecursiveAstVisitor.

Also in `visitFieldDeclaration`, I moved the `parent != null` check to be outside the for loop

I also tidied up a few comments to be [formatted like sentences](https://dart.dev/guides/language/effective-dart/documentation#do-format-comments-like-sentences).

Fixes https://github.com/dart-lang/linter/issues/3584

Does not address the P1 memory leak or the false positive bug.