### PR TITLE
Use package_config.json format for mock packages files.

### DIFF
--- a/test/integration/packages_file_test.dart
+++ b/test/integration/packages_file_test.dart
@@ -26,9 +26,9 @@ void main() {
       outSink = currentOut;
       exitCode = 0;
     });
-    group('.packages', () {
+    group('package_config.json', () {
       test('basic', () async {
-        // Requires .packages to analyze cleanly.
+        // Requires package_config.json to analyze cleanly.
         await cli.runLinter([
           '$integrationTestDir/p5',
           '--packages',

--- a/test/rules/avoid_final_parameters_test.dart
+++ b/test/rules/avoid_final_parameters_test.dart
@@ -33,6 +33,8 @@ class B extends A {
   B(final super.a, final super.b);
 }
 ''', [
+      error(HintCode.UNNECESSARY_FINAL, 83, 5),
+      error(HintCode.UNNECESSARY_FINAL, 98, 5),
       lint('avoid_final_parameters', 83, 13),
       lint('avoid_final_parameters', 98, 13),
     ]);

--- a/test/rules/prefer_contains_test.dart
+++ b/test/rules/prefer_contains_test.dart
@@ -22,7 +22,7 @@ class PreferContainsTest extends LintRuleTest {
 List<int> list = [];
 condition() {
   var next;
-  while ((next = list.indexOf('{')) != -1) {}
+  while ((next = list.indexOf(42)) != -1) {}
 }
 ''', [
       // No lint

--- a/test_data/integration/avoid_relative_lib_imports/_packages
+++ b/test_data/integration/avoid_relative_lib_imports/_packages
@@ -1,1 +1,11 @@
-p6:../p6/lib/
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "p6",
+      "rootUri": "../p6",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    }
+  ]
+}

--- a/test_data/integration/avoid_renaming_method_parameters/_packages
+++ b/test_data/integration/avoid_renaming_method_parameters/_packages
@@ -1,1 +1,11 @@
-avoid_renaming_method_parameters:lib/
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "avoid_renaming_method_parameters",
+      "rootUri": ".",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    }
+  ]
+}

--- a/test_data/integration/depend_on_referenced_packages/_packages
+++ b/test_data/integration/depend_on_referenced_packages/_packages
@@ -1,5 +1,35 @@
-flutter_gen:vendor/flutter_gen
-sample_project:lib/
-public_dep:vendor/public_dep/
-private_dep:vendor/private_dep/
-transitive_dep:vendor/transitive_dep/
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "flutter_gen",
+      "rootUri": "vendor/flutter_gen",
+      "packageUri": ".",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "sample_project",
+      "rootUri": ".",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "public_dep",
+      "rootUri": "vendor/public_dep",
+      "packageUri": ".",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "private_dep",
+      "rootUri": "vendor/private_dep",
+      "packageUri": ".",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "transitive_dep",
+      "rootUri": "vendor/transitive_dep",
+      "packageUri": ".",
+      "languageVersion": "2.17"
+    }
+  ]
+}

--- a/test_data/integration/p4/_packages
+++ b/test_data/integration/p4/_packages
@@ -1,1 +1,11 @@
-p4:lib/
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "p4",
+      "rootUri": ".",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    }
+  ]
+}

--- a/test_data/integration/p5/_packages
+++ b/test_data/integration/p5/_packages
@@ -1,1 +1,11 @@
-p6:../p6/lib/
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "p6",
+      "rootUri": "../p6",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    }
+  ]
+}

--- a/test_data/integration/prefer_relative_imports/_packages
+++ b/test_data/integration/prefer_relative_imports/_packages
@@ -1,3 +1,23 @@
-sample_project:lib/
-p6:../p6/lib/
-internal_path_package:vendor/internal_path_package/lib/
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "sample_project",
+      "rootUri": ".",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "p6",
+      "rootUri": "../p6",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "internal_path_package",
+      "rootUri": "vendor/internal_path_package",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    }
+  ]
+}

--- a/test_data/rules/.mock_packages
+++ b/test_data/rules/.mock_packages
@@ -1,4 +1,29 @@
-fixnum:../mock_packages/fixnum/lib/
-flutter:../mock_packages/flutter/lib/
-meta:../mock_packages/meta/lib/
-test_api:../mock_packages/test_api/lib/
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "fixnum",
+      "rootUri": "../mock_packages/fixnum",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "flutter",
+      "rootUri": "../mock_packages/flutter",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "meta",
+      "rootUri": "../mock_packages/meta",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "test_api",
+      "rootUri": "../mock_packages/test_api",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    }
+  ]
+}


### PR DESCRIPTION
We are removing `.packages` format, and the analyzer stopped supporting it.