### PR TITLE
Move traverseNodesInDFS to extension

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
@@ -147,6 +149,44 @@ extension AstNodeExtension on AstNode? {
       }
     }
     return null;
+  }
+
+  /// Builds the list resulting from traversing the node in DFS and does not
+  /// include the node itself.
+  ///
+  /// It excludes the nodes for which the [excludeCriteria] returns true. If
+  /// [excludeCriteria] is not provided, all nodes are included.
+  Iterable<AstNode> traverseNodesInDFS({AstNodePredicate? excludeCriteria}) {
+    var self = this;
+    if (self == null) {
+      return [];
+    }
+    var nodes = <AstNode>{};
+    var nodesToVisit = List.of(self.childEntities.whereType<AstNode>());
+    if (excludeCriteria == null) {
+      while (nodesToVisit.isNotEmpty) {
+        var node = nodesToVisit.removeAt(0);
+        nodes.add(node);
+        var i = 0;
+        // Queue up child nodes in the order they appear in `childEntities`.
+        for (var child in node.childEntities) {
+          if (child is AstNode) nodesToVisit.insert(i++, child);
+        }
+      }
+    } else {
+      while (nodesToVisit.isNotEmpty) {
+        var node = nodesToVisit.removeAt(0);
+        if (excludeCriteria(node)) continue;
+        nodes.add(node);
+        var i = 0;
+        // Queue up child nodes in the order they appear in `childEntities`.
+        for (var child in node.childEntities) {
+          if (child is AstNode) nodesToVisit.insert(i++, child);
+        }
+      }
+    }
+
+    return nodes;
   }
 }
 

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -135,7 +135,7 @@ extension InterfaceElementExtension on InterfaceElement {
       name == otherName && library.name == otherLibrary;
 }
 
-extension AstNodeExtension on AstNode? {
+extension NullableAstNodeExtension on AstNode? {
   Element? get canonicalElement {
     var self = this;
     if (self is Expression) {
@@ -148,44 +148,36 @@ extension AstNodeExtension on AstNode? {
     }
     return null;
   }
+}
 
+extension AstNodeExtension on AstNode {
   /// Builds the list resulting from traversing the node in DFS and does not
   /// include the node itself.
   ///
   /// It excludes the nodes for which the [excludeCriteria] returns true. If
   /// [excludeCriteria] is not provided, all nodes are included.
   Iterable<AstNode> traverseNodesInDFS({AstNodePredicate? excludeCriteria}) {
-    var self = this;
-    if (self == null) {
-      return [];
-    }
     var nodes = <AstNode>{};
-    var nodesToVisit = List.of(self.childEntities.whereType<AstNode>());
+    var nodesToVisit = List.of(childNodes);
     if (excludeCriteria == null) {
       while (nodesToVisit.isNotEmpty) {
         var node = nodesToVisit.removeAt(0);
         nodes.add(node);
-        var i = 0;
-        // Queue up child nodes in the order they appear in `childEntities`.
-        for (var child in node.childEntities) {
-          if (child is AstNode) nodesToVisit.insert(i++, child);
-        }
+        nodesToVisit.insertAll(0, node.childNodes);
       }
     } else {
       while (nodesToVisit.isNotEmpty) {
         var node = nodesToVisit.removeAt(0);
         if (excludeCriteria(node)) continue;
         nodes.add(node);
-        var i = 0;
-        // Queue up child nodes in the order they appear in `childEntities`.
-        for (var child in node.childEntities) {
-          if (child is AstNode) nodesToVisit.insert(i++, child);
-        }
+        nodesToVisit.insertAll(0, node.childNodes);
       }
     }
 
     return nodes;
   }
+
+  Iterable<AstNode> get childNodes => childEntities.whereType<AstNode>();
 }
 
 extension BlockExtension on Block {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:collection';
-
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -11,7 +11,6 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r"Don't check for null in custom == operators.";
 
@@ -121,7 +120,8 @@ class _Visitor extends SimpleAstVisitor<void> {
             (_isParameterWithQuestionQuestion(node, parameter) ||
                 _isComparingParameterWithNull(node, parameter)));
 
-    DartTypeUtilities.traverseNodesInDFS(node.body)
+    node.body
+        .traverseNodesInDFS()
         .where(checkIfParameterIsNull)
         .forEach(rule.reportLint);
   }

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -103,8 +103,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       rule.reportLint(node);
       return;
     }
-    DartTypeUtilities.traverseNodesInDFS(node,
-            excludeCriteria: _isFunctionExpression)
+    node
+        .traverseNodesInDFS(excludeCriteria: _isFunctionExpression)
         .where(_isReturnNull)
         .forEach(rule.reportLint);
   }

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc =
     r'Avoid returning this from methods just to enable a fluent interface.';
@@ -99,8 +98,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     var body = node.body;
     if (body is BlockFunctionBody) {
-      var returnStatements = DartTypeUtilities.traverseNodesInDFS(body.block,
-              excludeCriteria: _isFunctionExpression)
+      var returnStatements = body.block
+          .traverseNodesInDFS(excludeCriteria: _isFunctionExpression)
           .where(_isReturnStatement);
       if (returnStatements.isNotEmpty && returnStatements.every(_returnsThis)) {
         rule.reportLintForToken(node.name2);

--- a/lib/src/rules/cascade_invocations.dart
+++ b/lib/src/rules/cascade_invocations.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r'Cascade consecutive method invocations on the same reference.';
 
@@ -273,7 +272,7 @@ class _CascadableExpression {
     return expressionBox.isCritical &&
         criticalNodes.any((node) =>
             isCriticalNode(node) ||
-            DartTypeUtilities.traverseNodesInDFS(node).any(isCriticalNode));
+            node.traverseNodesInDFS().any(isCriticalNode));
   }
 }
 

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -95,17 +95,16 @@ class _Visitor extends SimpleAstVisitor {
     if (method == null) {
       return;
     }
-    DartTypeUtilities.traverseNodesInDFS(method.body)
-        .whereType<SimpleIdentifier>()
-        .forEach((p) {
+    for (var p
+        in method.body.traverseNodesInDFS().whereType<SimpleIdentifier>()) {
       String debugName;
       String name;
       const debugPrefix = 'debug';
       if (p.name.startsWith(debugPrefix) &&
           p.name.length > debugPrefix.length) {
         debugName = p.name;
-        name =
-            '${p.name[debugPrefix.length].toLowerCase()}${p.name.substring(debugPrefix.length + 1)}';
+        name = '${p.name[debugPrefix.length].toLowerCase()}'
+            '${p.name.substring(debugPrefix.length + 1)}';
       } else {
         name = p.name;
         debugName =
@@ -113,7 +112,7 @@ class _Visitor extends SimpleAstVisitor {
       }
       properties.removeWhere((property) =>
           property.lexeme == debugName || property.lexeme == name);
-    });
+    }
   }
 
   bool skipForDiagnostic({Element? element, DartType? type, Token? name}) =>

--- a/lib/src/rules/invariant_booleans.dart
+++ b/lib/src/rules/invariant_booleans.dart
@@ -10,7 +10,6 @@ import '../analyzer.dart';
 import '../extensions.dart';
 import '../util/boolean_expression_utilities.dart';
 import '../util/condition_scope_visitor.dart';
-import '../util/dart_type_utilities.dart';
 import '../util/tested_expressions.dart';
 
 const _desc =
@@ -101,10 +100,10 @@ void nestedOk5() {
 
 ''';
 
-Iterable<Element?> _getElementsInExpression(Expression node) =>
-    DartTypeUtilities.traverseNodesInDFS(node)
-        .map((e) => e.canonicalElement)
-        .where((e) => e != null);
+Iterable<Element?> _getElementsInExpression(Expression node) => node
+    .traverseNodesInDFS()
+    .map((e) => e.canonicalElement)
+    .where((e) => e != null);
 
 class InvariantBooleans extends LintRule {
   InvariantBooleans()

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc =
     r"Don't reassign references to parameters of functions or methods.";
@@ -163,8 +163,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   void _reportIfSimpleParameterOrWithDefaultValue(
       FormalParameter parameter, AstNode functionOrMethodDeclaration) {
-    var nodes =
-        DartTypeUtilities.traverseNodesInDFS(functionOrMethodDeclaration);
+    var nodes = functionOrMethodDeclaration.traverseNodesInDFS();
 
     if (parameter is SimpleFormalParameter ||
         _isDefaultFormalParameterWithDefaultValue(parameter)) {

--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc =
     r'Prefer defining constructors instead of static methods to create instances.';
@@ -47,8 +47,7 @@ bool _hasNewInvocation(DartType returnType, FunctionBody body) {
   bool isInstanceCreationExpression(AstNode node) =>
       node is InstanceCreationExpression && node.staticType == returnType;
 
-  return DartTypeUtilities.traverseNodesInDFS(body)
-      .any(isInstanceCreationExpression);
+  return body.traverseNodesInDFS().any(isInstanceCreationExpression);
 }
 
 class PreferConstructorsInsteadOfStaticMethods extends LintRule {

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r'Use `forEach` to only apply a function to all the elements.';
 
@@ -109,7 +108,8 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
         arguments.first.canonicalElement == element &&
         (target == null ||
             target.canonicalElement != element &&
-                !DartTypeUtilities.traverseNodesInDFS(target)
+                !target
+                    .traverseNodesInDFS()
                     .map((e) => e.canonicalElement)
                     .contains(element))) {
       rule.reportLint(forEachStatement);

--- a/lib/src/rules/prefer_interpolation_to_compose_strings.dart
+++ b/lib/src/rules/prefer_interpolation_to_compose_strings.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Use interpolation to compose strings and values.';
 
@@ -61,21 +61,21 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.operator.type == TokenType.PLUS) {
       var leftOperand = node.leftOperand;
       var rightOperand = node.rightOperand;
-      //OK(#735): str1 + str2
+      // OK(#735): `str1 + str2`
       if (leftOperand is! StringLiteral && rightOperand is! StringLiteral) {
         return;
       }
-      //OK(#2490): str1 + r''
+      // OK(#2490): `str1 + r''`
       if (leftOperand is SimpleStringLiteral && leftOperand.isRaw ||
           rightOperand is SimpleStringLiteral && rightOperand.isRaw) {
         return;
       }
-      //OK: 'foo' + 'bar'
+      // OK: `'foo' + 'bar'`
       if (leftOperand is StringLiteral && rightOperand is StringLiteral) {
         return;
       }
       if (leftOperand.staticType?.isDartCoreString ?? false) {
-        DartTypeUtilities.traverseNodesInDFS(node).forEach(skippedNodes.add);
+        node.traverseNodesInDFS().forEach(skippedNodes.add);
         rule.reportLint(node);
       }
     }

--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Property getter recursively returns itself.';
 
@@ -108,12 +108,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   }
 
   void _verifyElement(AstNode node, ExecutableElement? element) {
-    var nodes = DartTypeUtilities.traverseNodesInDFS(node);
-    nodes
-        .where((n) =>
-            n is SimpleIdentifier &&
-            element == n.staticElement &&
-            (n.accept(visitor) ?? false))
+    node
+        .traverseNodesInDFS()
+        .whereType<SimpleIdentifier>()
+        .where(
+            (n) => element == n.staticElement && (n.accept(visitor) ?? false))
         .forEach(rule.reportLint);
   }
 }

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r"Don't create a lambda when a tear-off will do.";
@@ -42,10 +43,10 @@ bool _containsNullAwareInvocationInChain(AstNode? node) =>
         (node is IndexExpression &&
             _containsNullAwareInvocationInChain(node.target)));
 
-Iterable<Element?> _extractElementsOfSimpleIdentifiers(AstNode node) =>
-    DartTypeUtilities.traverseNodesInDFS(node)
-        .whereType<SimpleIdentifier>()
-        .map((e) => e.staticElement);
+Iterable<Element?> _extractElementsOfSimpleIdentifiers(AstNode node) => node
+    .traverseNodesInDFS()
+    .whereType<SimpleIdentifier>()
+    .map((e) => e.staticElement);
 
 class UnnecessaryLambdas extends LintRule {
   UnnecessaryLambdas()

--- a/lib/src/rules/unreachable_from_main.dart
+++ b/lib/src/rules/unreachable_from_main.dart
@@ -89,7 +89,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     var declarationByElement = <Element, Declaration>{};
     for (var declaration in topDeclarations) {
-      var element = declaration.declaredElement;
+      var element = declaration.declaredElement2;
       if (element != null) {
         if (element is TopLevelVariableElement) {
           declarationByElement[element] = declaration;
@@ -144,7 +144,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
 
     var unusedMembers = topDeclarations.difference(usedMembers).where((e) {
-      var element = e.declaredElement;
+      var element = e.declaredElement2;
       return element != null &&
           element.isPublic &&
           !element.hasVisibleForTesting;

--- a/lib/src/rules/unreachable_from_main.dart
+++ b/lib/src/rules/unreachable_from_main.dart
@@ -11,7 +11,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = 'Unreachable top-level members in executable libraries.';
 
@@ -105,27 +105,27 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // The following map contains for every declaration the set of the
     // declarations it references.
-    var dependencies = Map<Declaration, Set<Declaration>>.fromIterable(
-      topDeclarations,
-      value: (declaration) =>
-          DartTypeUtilities.traverseNodesInDFS(declaration as Declaration)
-              .expand((e) => [
-                    if (e is SimpleIdentifier) e.staticElement,
-                    // with `id++` staticElement of `id` is null
-                    if (e is CompoundAssignmentExpression) ...[
-                      e.readElement,
-                      e.writeElement,
-                    ],
-                  ])
-              .whereNotNull()
-              .map((e) => e.thisOrAncestorMatching((a) =>
-                  a.enclosingElement3 == null ||
-                  a.enclosingElement3 is CompilationUnitElement))
-              .map((e) => declarationByElement[e])
-              .whereNotNull()
-              .where((e) => e != declaration)
-              .toSet(),
-    );
+    var dependencies = {
+      for (var declaration in topDeclarations)
+        declaration: declaration
+            .traverseNodesInDFS()
+            .expand((e) => [
+                  if (e is SimpleIdentifier) e.staticElement,
+                  // with `id++` staticElement of `id` is null
+                  if (e is CompoundAssignmentExpression) ...[
+                    e.readElement,
+                    e.writeElement,
+                  ],
+                ])
+            .whereNotNull()
+            .map((e) => e.thisOrAncestorMatching((a) =>
+                a.enclosingElement3 == null ||
+                a.enclosingElement3 is CompilationUnitElement))
+            .map((e) => declarationByElement[e])
+            .whereNotNull()
+            .where((e) => e != declaration)
+            .toSet(),
+    };
 
     var usedMembers = entryPoints.toSet();
     // The following variable will be used to visit every reachable declaration

--- a/lib/src/util/condition_scope_visitor.dart
+++ b/lib/src/util/condition_scope_visitor.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 Element? _getLeftElement(AssignmentExpression assignment) =>
     assignment.writeElement?.canonicalElement;
@@ -351,7 +350,7 @@ abstract class ConditionScopeVisitor extends RecursiveAstVisitor {
         return false;
       }
 
-      for (var ref in DartTypeUtilities.traverseNodesInDFS(condition)) {
+      for (var ref in condition.traverseNodesInDFS()) {
         if (ref is SimpleIdentifier) {
           var element = ref.staticElement;
           if (element == null) {

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -20,7 +20,7 @@ bool canonicalElementsAreEqual(Element? element1, Element? element2) =>
 
 /// Returns whether the canonical elements from two nodes are equal.
 ///
-/// As in, [AstNodeExtension.canonicalElement], the two nodes must be
+/// As in, [NullableAstNodeExtension.canonicalElement], the two nodes must be
 /// [Expression]s in order to be compared (otherwise `false` is returned).
 ///
 /// The two nodes must both be a [SimpleIdentifier], [PrefixedIdentifier], or

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -77,7 +77,7 @@ bool canonicalElementsFromIdentifiersAreEqual(
 }
 
 class DartTypeUtilities {
-  @Deprecated('Replace with type.extendsClass')
+  @Deprecated('Replace with `type.extendsClass`')
   static bool extendsClass(
           DartType? type, String? className, String? library) =>
       type.extendsClass(className, library!);
@@ -279,23 +279,10 @@ class DartTypeUtilities {
     return true;
   }
 
-  /// Builds the list resulting from traversing the node in DFS and does not
-  /// include the node itself, it excludes the nodes for which the exclusion
-  /// predicate returns true, if not provided, all is included.
+  @Deprecated('Replace with `node.traverseNodesInDFS`')
   static Iterable<AstNode> traverseNodesInDFS(AstNode node,
-      {AstNodePredicate? excludeCriteria}) {
-    var nodes = <AstNode>{};
-    void recursiveCall(node) {
-      if (node is AstNode &&
-          (excludeCriteria == null || !excludeCriteria(node))) {
-        nodes.add(node);
-        node.childEntities.forEach(recursiveCall);
-      }
-    }
-
-    node.childEntities.forEach(recursiveCall);
-    return nodes;
-  }
+          {AstNodePredicate? excludeCriteria}) =>
+      node.traverseNodesInDFS(excludeCriteria: excludeCriteria);
 
   /// Returns whether [leftType] and [rightType] are _definitely_ unrelated.
   ///

--- a/lib/src/util/leak_detector_visitor.dart
+++ b/lib/src/util/leak_detector_visitor.dart
@@ -10,7 +10,7 @@ import 'package:meta/meta.dart';
 
 import '../analyzer.dart';
 import '../ast.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 _Predicate _hasConstructorFieldInitializers(
         VariableDeclaration v) =>
@@ -54,7 +54,7 @@ _VisitVariableDeclaration _buildVariableReporter(
         return;
       }
 
-      var containerNodes = DartTypeUtilities.traverseNodesInDFS(container);
+      var containerNodes = container.traverseNodesInDFS();
 
       var validators = <Iterable<AstNode>>[];
       for (var f in predicateBuilders) {


### PR DESCRIPTION
# Description

Move `DartTypeUtilities.traverseNodesInDFS` to be an extension method on AstNode.

I also refactored it to be non-recursive. This appears to save ~3% in the big benchmark, but I don't know what the error window is... it might be a negligible performance change.

It is used internally, so I've kept the old static method with a deprecation.