### PR TITLE
Move four more methods out of DartTypeUtilities

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -128,6 +128,19 @@ extension ClassElementExtension on ClassElement {
   bool get isEnumLikeClass => asEnumLikeClass != null;
 }
 
+extension ConstructorElementExtension on ConstructorElement {
+  /// Returns whether `this` is the same element as the [className] constructor
+  /// named [constructorName] declared in [uri].
+  bool isSameAs({
+    required String uri,
+    required String className,
+    required String constructorName,
+  }) =>
+      library.name == uri &&
+      enclosingElement3.name == className &&
+      name == constructorName;
+}
+
 extension InterfaceElementExtension on InterfaceElement {
   /// Returns whether this element is exactly [otherName] declared in
   /// [otherLibrary].

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -179,7 +179,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       InvocationExpression node, FunctionExpression nodeToLint) {
     var nodeToLintParams = nodeToLint.parameters?.parameters;
     if (nodeToLintParams == null ||
-        !DartTypeUtilities.matchesArgumentsWithParameters(
+        !argumentsMatchParameters(
             node.argumentList.arguments, nodeToLintParams)) {
       return;
     }

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -236,7 +236,7 @@ class _UnnecessaryMethodOverrideVisitor
     var declarationParameters = declaration.parameters;
     if (declarationParameters != null &&
         node.methodName.staticElement == _inheritedMethod &&
-        DartTypeUtilities.matchesArgumentsWithParameters(
+        argumentsMatchParameters(
             node.argumentList.arguments, declarationParameters.parameters)) {
       node.target?.accept(this);
     }

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -142,7 +142,7 @@ bool _hasNonComparableOperands(TypeSystem typeSystem, BinaryExpression node) {
   }
   return !left.isNullLiteral &&
       !right.isNullLiteral &&
-      DartTypeUtilities.unrelatedTypes(typeSystem, leftType, rightType) &&
+      typesAreUnrelated(typeSystem, leftType, rightType) &&
       !(_isFixNumIntX(leftType) && _isCoreInt(rightType));
 }
 

--- a/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
+++ b/lib/src/rules/use_full_hex_values_for_flutter_colors.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc =
     r'Prefer an 8-digit hexadecimal integer(0xFFFFFFFF) to instantiate Color.';
@@ -54,8 +54,9 @@ class _Visitor extends SimpleAstVisitor {
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     var element = node.constructorName.staticElement;
-    if (DartTypeUtilities.isConstructorElement(element,
-        uriStr: 'dart.ui', className: 'Color', constructorName: '')) {
+    if (element != null &&
+        element.isSameAs(
+            uri: 'dart.ui', className: 'Color', constructorName: '')) {
       var arguments = node.argumentList.arguments;
       if (arguments.isNotEmpty) {
         var argument = arguments.first;

--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -11,7 +11,6 @@ import 'package:analyzer/error/error.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r'Use late for private members with a non-nullable type.';
 
@@ -91,11 +90,12 @@ class _Visitor extends RecursiveAstVisitor<void> {
     var element = node.writeElement?.canonicalElement;
     if (element != null) {
       var assignee = node.leftHandSide;
+      var rhsType = node.rightHandSide.staticType;
       if (assignee is SimpleIdentifier && assignee.inDeclarationContext()) {
         // This is OK.
       } else if (node.operator.type == TokenType.EQ &&
-          DartTypeUtilities.isNonNullable(
-              context, node.rightHandSide.staticType)) {
+          rhsType != null &&
+          context.typeSystem.isNonNullable(rhsType)) {
         // This is OK; non-null access.
       } else {
         nullableAccess[currentUnit]?.add(element);

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -13,6 +13,56 @@ import '../extensions.dart';
 
 typedef AstNodePredicate = bool Function(AstNode node);
 
+bool argumentsMatchParameters(
+    NodeList<Expression> arguments, NodeList<FormalParameter> parameters) {
+  var namedParameters = <String, Element?>{};
+  var namedArguments = <String, Element>{};
+  var positionalParameters = <Element?>[];
+  var positionalArguments = <Element>[];
+  for (var parameter in parameters) {
+    var identifier = parameter.name;
+    if (identifier != null) {
+      if (parameter.isNamed) {
+        namedParameters[identifier.lexeme] = parameter.declaredElement;
+      } else {
+        positionalParameters.add(parameter.declaredElement);
+      }
+    }
+  }
+  for (var argument in arguments) {
+    if (argument is NamedExpression) {
+      var element = argument.expression.canonicalElement;
+      if (element == null) {
+        return false;
+      }
+      namedArguments[argument.name.label.name] = element;
+    } else {
+      var element = argument.canonicalElement;
+      if (element == null) {
+        return false;
+      }
+      positionalArguments.add(element);
+    }
+  }
+  if (positionalParameters.length != positionalArguments.length ||
+      namedParameters.keys.length != namedArguments.keys.length) {
+    return false;
+  }
+  for (var i = 0; i < positionalArguments.length; i++) {
+    if (positionalArguments[i] != positionalParameters[i]) {
+      return false;
+    }
+  }
+
+  for (var key in namedParameters.keys) {
+    if (namedParameters[key] != namedArguments[key]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 /// Returns whether the canonical elements of [element1] and [element2] are
 /// equal.
 bool canonicalElementsAreEqual(Element? element1, Element? element2) =>
@@ -76,6 +126,106 @@ bool canonicalElementsFromIdentifiersAreEqual(
   return false;
 }
 
+/// Returns whether [leftType] and [rightType] are _definitely_ unrelated.
+///
+/// For the purposes of this function, here are some "relation" rules:
+/// * `dynamic` and `Null` are considered related to any other type.
+/// * Two types which are equal modulo nullability are considered related,
+///   e.g. `int` and `int`, `String` and `String?`, `List<String>` and
+///   `List<String>`, `List<T>` and `List<T>`, and type variables `A` and `A`.
+/// * Two types such that one is a subtype of the other, modulo nullability,
+///   such as `List<dynamic>` and `Iterable<dynamic>`, and type variables `A`
+///   and `B` where `A extends B`, are considered related.
+/// * Two interface types:
+///   * are related if they represent the same class, modulo type arguments,
+///     modulo nullability, and each of their pair-wise type arguments are
+///     related, e.g. `List<dynamic>` and `List<int>`, and `Future<T>` and
+///     `Future<S>` where `S extends T`.
+///   * are unrelated if [leftType]'s supertype is [Object].
+///   * are related if their supertypes are equal, e.g. `List<dynamic>` and
+///     `Set<dynamic>`.
+/// * Two type variables are related if their bounds are related.
+/// * Otherwise, the types are related.
+// TODO(srawlins): typedefs and functions in general.
+bool typesAreUnrelated(
+    TypeSystem typeSystem, DartType? leftType, DartType? rightType) {
+  // If we don't have enough information, or can't really compare the types,
+  // return false as they _might_ be related.
+  if (leftType == null ||
+      leftType.isBottom ||
+      leftType.isDynamic ||
+      rightType == null ||
+      rightType.isBottom ||
+      rightType.isDynamic) {
+    return false;
+  }
+  var promotedLeftType = typeSystem.promoteToNonNull(leftType);
+  var promotedRightType = typeSystem.promoteToNonNull(rightType);
+  if (promotedLeftType == promotedRightType ||
+      typeSystem.isSubtypeOf(promotedLeftType, promotedRightType) ||
+      typeSystem.isSubtypeOf(promotedRightType, promotedLeftType)) {
+    return false;
+  }
+  if (promotedLeftType is InterfaceType && promotedRightType is InterfaceType) {
+    // In this case, [leftElement] and [rightElement] each represent
+    // the same class, like `int`, or `Iterable<String>`.
+    var leftElement = promotedLeftType.element2;
+    var rightElement = promotedRightType.element2;
+    if (leftElement == rightElement) {
+      // In this case, [leftElement] and [rightElement] represent the same
+      // class, modulo generics, e.g. `List<int>` and `List<dynamic>`. Now we
+      // need to check type arguments.
+      var leftTypeArguments = promotedLeftType.typeArguments;
+      var rightTypeArguments = promotedRightType.typeArguments;
+      if (leftTypeArguments.length != rightTypeArguments.length) {
+        // I cannot think of how we would enter this block, but it guards
+        // against RangeError below.
+        return false;
+      }
+      for (var i = 0; i < leftTypeArguments.length; i++) {
+        // If any of the pair-wise type arguments are unrelated, then
+        // [leftType] and [rightType] are unrelated.
+        if (typesAreUnrelated(
+            typeSystem, leftTypeArguments[i], rightTypeArguments[i])) {
+          return true;
+        }
+      }
+      // Otherwise, they might be related.
+      return false;
+    } else {
+      return (leftElement.supertype?.isDartCoreObject ?? false) ||
+          leftElement.supertype != rightElement.supertype;
+    }
+  } else if (promotedLeftType is TypeParameterType &&
+      promotedRightType is TypeParameterType) {
+    return typesAreUnrelated(typeSystem, promotedLeftType.element.bound,
+        promotedRightType.element.bound);
+  } else if (promotedLeftType is FunctionType) {
+    if (_isFunctionTypeUnrelatedToType(promotedLeftType, promotedRightType)) {
+      return true;
+    }
+  } else if (promotedRightType is FunctionType) {
+    if (_isFunctionTypeUnrelatedToType(promotedRightType, promotedLeftType)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _isFunctionTypeUnrelatedToType(FunctionType type1, DartType type2) {
+  if (type2 is FunctionType) {
+    return false;
+  }
+  if (type2 is InterfaceType) {
+    var element2 = type2.element2;
+    if (element2 is ClassElement &&
+        element2.lookUpConcreteMethod('call', element2.library) != null) {
+      return false;
+    }
+  }
+  return true;
+}
+
 class DartTypeUtilities {
   @Deprecated('Replace with `type.extendsClass`')
   static bool extendsClass(
@@ -127,21 +277,9 @@ class DartTypeUtilities {
       type.element2.name == className &&
       type.element2.library.name == library;
 
-  static bool isConstructorElement(ConstructorElement? element,
-          {required String uriStr,
-          required String className,
-          required String constructorName}) =>
-      element != null &&
-      element.library.name == uriStr &&
-      element.enclosingElement3.name == className &&
-      element.name == constructorName;
-
   static bool isInterface(
           InterfaceType type, String interface, String library) =>
       type.element2.name == interface && type.element2.library.name == library;
-
-  static bool isNonNullable(LinterContext context, DartType? type) =>
-      type != null && context.typeSystem.isNonNullable(type);
 
   @Deprecated('Replace with `expression.isNullLiteral`')
   static bool isNullLiteral(Expression? expression) => expression.isNullLiteral;
@@ -229,162 +367,15 @@ class DartTypeUtilities {
     return null;
   }
 
-  static bool matchesArgumentsWithParameters(
-      NodeList<Expression> arguments, NodeList<FormalParameter> parameters) {
-    var namedParameters = <String, Element?>{};
-    var namedArguments = <String, Element>{};
-    var positionalParameters = <Element?>[];
-    var positionalArguments = <Element>[];
-    for (var parameter in parameters) {
-      var identifier = parameter.name;
-      if (identifier != null) {
-        if (parameter.isNamed) {
-          namedParameters[identifier.lexeme] = parameter.declaredElement;
-        } else {
-          positionalParameters.add(parameter.declaredElement);
-        }
-      }
-    }
-    for (var argument in arguments) {
-      if (argument is NamedExpression) {
-        var element = argument.expression.canonicalElement;
-        if (element == null) {
-          return false;
-        }
-        namedArguments[argument.name.label.name] = element;
-      } else {
-        var element = argument.canonicalElement;
-        if (element == null) {
-          return false;
-        }
-        positionalArguments.add(element);
-      }
-    }
-    if (positionalParameters.length != positionalArguments.length ||
-        namedParameters.keys.length != namedArguments.keys.length) {
-      return false;
-    }
-    for (var i = 0; i < positionalArguments.length; i++) {
-      if (positionalArguments[i] != positionalParameters[i]) {
-        return false;
-      }
-    }
-
-    for (var key in namedParameters.keys) {
-      if (namedParameters[key] != namedArguments[key]) {
-        return false;
-      }
-    }
-
-    return true;
-  }
+  @Deprecated('Use `argumentsMatchParameters`')
+  static bool matchesArgumentsWithParameters(NodeList<Expression> arguments,
+          NodeList<FormalParameter> parameters) =>
+      argumentsMatchParameters(arguments, parameters);
 
   @Deprecated('Replace with `node.traverseNodesInDFS`')
   static Iterable<AstNode> traverseNodesInDFS(AstNode node,
           {AstNodePredicate? excludeCriteria}) =>
       node.traverseNodesInDFS(excludeCriteria: excludeCriteria);
-
-  /// Returns whether [leftType] and [rightType] are _definitely_ unrelated.
-  ///
-  /// For the purposes of this function, here are some "relation" rules:
-  /// * `dynamic` and `Null` are considered related to any other type.
-  /// * Two types which are equal modulo nullability are considered related,
-  ///   e.g. `int` and `int`, `String` and `String?`, `List<String>` and
-  ///   `List<String>`, `List<T>` and `List<T>`, and type variables `A` and `A`.
-  /// * Two types such that one is a subtype of the other, modulo nullability,
-  ///   such as `List<dynamic>` and `Iterable<dynamic>`, and type variables `A`
-  ///   and `B` where `A extends B`, are considered related.
-  /// * Two interface types:
-  ///   * are related if they represent the same class, modulo type arguments,
-  ///     modulo nullability, and each of their pair-wise type arguments are
-  ///     related, e.g. `List<dynamic>` and `List<int>`, and `Future<T>` and
-  ///     `Future<S>` where `S extends T`.
-  ///   * are unrelated if [leftType]'s supertype is [Object].
-  ///   * are related if their supertypes are equal, e.g. `List<dynamic>` and
-  ///     `Set<dynamic>`.
-  /// * Two type variables are related if their bounds are related.
-  /// * Otherwise, the types are related.
-  // TODO(srawlins): typedefs and functions in general.
-  static bool unrelatedTypes(
-      TypeSystem typeSystem, DartType? leftType, DartType? rightType) {
-    // If we don't have enough information, or can't really compare the types,
-    // return false as they _might_ be related.
-    if (leftType == null ||
-        leftType.isBottom ||
-        leftType.isDynamic ||
-        rightType == null ||
-        rightType.isBottom ||
-        rightType.isDynamic) {
-      return false;
-    }
-    var promotedLeftType = typeSystem.promoteToNonNull(leftType);
-    var promotedRightType = typeSystem.promoteToNonNull(rightType);
-    if (promotedLeftType == promotedRightType ||
-        typeSystem.isSubtypeOf(promotedLeftType, promotedRightType) ||
-        typeSystem.isSubtypeOf(promotedRightType, promotedLeftType)) {
-      return false;
-    }
-    if (promotedLeftType is InterfaceType &&
-        promotedRightType is InterfaceType) {
-      // In this case, [leftElement] and [rightElement] each represent
-      // the same class, like `int`, or `Iterable<String>`.
-      var leftElement = promotedLeftType.element2;
-      var rightElement = promotedRightType.element2;
-      if (leftElement == rightElement) {
-        // In this case, [leftElement] and [rightElement] represent the same
-        // class, modulo generics, e.g. `List<int>` and `List<dynamic>`. Now we
-        // need to check type arguments.
-        var leftTypeArguments = promotedLeftType.typeArguments;
-        var rightTypeArguments = promotedRightType.typeArguments;
-        if (leftTypeArguments.length != rightTypeArguments.length) {
-          // I cannot think of how we would enter this block, but it guards
-          // against RangeError below.
-          return false;
-        }
-        for (var i = 0; i < leftTypeArguments.length; i++) {
-          // If any of the pair-wise type arguments are unrelated, then
-          // [leftType] and [rightType] are unrelated.
-          if (unrelatedTypes(
-              typeSystem, leftTypeArguments[i], rightTypeArguments[i])) {
-            return true;
-          }
-        }
-        // Otherwise, they might be related.
-        return false;
-      } else {
-        return (leftElement.supertype?.isDartCoreObject ?? false) ||
-            leftElement.supertype != rightElement.supertype;
-      }
-    } else if (promotedLeftType is TypeParameterType &&
-        promotedRightType is TypeParameterType) {
-      return unrelatedTypes(typeSystem, promotedLeftType.element.bound,
-          promotedRightType.element.bound);
-    } else if (promotedLeftType is FunctionType) {
-      if (_isFunctionTypeUnrelatedToType(promotedLeftType, promotedRightType)) {
-        return true;
-      }
-    } else if (promotedRightType is FunctionType) {
-      if (_isFunctionTypeUnrelatedToType(promotedRightType, promotedLeftType)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  static bool _isFunctionTypeUnrelatedToType(
-      FunctionType type1, DartType type2) {
-    if (type2 is FunctionType) {
-      return false;
-    }
-    if (type2 is InterfaceType) {
-      var element2 = type2.element2;
-      if (element2 is ClassElement &&
-          element2.lookUpConcreteMethod('call', element2.library) != null) {
-        return false;
-      }
-    }
-    return true;
-  }
 }
 
 class InterfaceTypeDefinition {

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -113,8 +113,7 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
     if (targetType is InterfaceType) {
       var typeArgument = _findIterableTypeArgument(definition, targetType);
       if (typeArgument != null &&
-          DartTypeUtilities.unrelatedTypes(
-              typeSystem, argument.staticType, typeArgument)) {
+          typesAreUnrelated(typeSystem, argument.staticType, typeArgument)) {
         rule.reportLint(node,
             arguments: [typeArgument.getDisplayString(withNullability: true)]);
       }


### PR DESCRIPTION
# Description

* `DartTypeUtilities.isConstructorElement` becomes a method `isSameAs` on ConstructorElement
* `DartTypeUtilities.matchesArgumentsWithParameters` becomes a top-level method, `argumentsMatchParameters`, with the same parameters, unchanged body.
* `DartTypeUtilities.unrelatedTypes` becomes a top-level method, `typesAreUnrelated`, with the same parameters, unchanged body.
* `DartTypeUtilities.isNonNullable` is inlined into the single spot which called it.