### PR TITLE
prefer_contains: Move constant evaluation to be later

### DIFF
--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -169,17 +169,21 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (invocation.parent is AssignmentExpression) return false;
     if (invocation.methodName.name != 'indexOf') return false;
 
+    var parentType = invocation.target?.staticType;
+    if (parentType == null) return false;
+    if (!DartTypeUtilities.implementsAnyInterface(parentType, [
+      InterfaceTypeDefinition('Iterable', 'dart.core'),
+      InterfaceTypeDefinition('String', 'dart.core'),
+    ])) {
+      return false;
+    }
+
     var args = invocation.argumentList.arguments;
     if (args.length == 2) {
       var start = args[1];
       if (getIntValue(start, context) != 0) return false;
     }
 
-    var parentType = invocation.target?.staticType;
-    return parentType != null &&
-        DartTypeUtilities.implementsAnyInterface(parentType, [
-          InterfaceTypeDefinition('Iterable', 'dart.core'),
-          InterfaceTypeDefinition('String', 'dart.core'),
-        ]);
+    return true;
   }
 }


### PR DESCRIPTION
# Description

prefer_contains: Move constant evaluation to be later

For performance reasons

Fixes #3549