### PR TITLE
Move 6 DartTypeUtilities methods to MethodDeclaration extension methods

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -267,6 +267,8 @@ extension InterfaceTypeExtension on InterfaceType {
 }
 
 extension MethodDeclarationExtension on MethodDeclaration {
+  bool get hasInheritedMethod => lookUpInheritedMethod() != null;
+
   /// Returns whether this method is an override of a method in any supertype.
   bool get isOverride {
     var name = declaredElement2?.name;
@@ -292,5 +294,72 @@ extension MethodDeclarationExtension on MethodDeclaration {
       return parentElement.allSupertypes
           .any((t) => t.lookUpMethod2(name, parentLibrary) != null);
     }
+  }
+
+  PropertyAccessorElement? lookUpGetter() {
+    var declaredElement = declaredElement2;
+    if (declaredElement == null) {
+      return null;
+    }
+    var parent = declaredElement.enclosingElement3;
+    if (parent is ClassElement) {
+      return parent.lookUpGetter(name2.lexeme, declaredElement.library);
+    }
+    if (parent is ExtensionElement) {
+      return parent.getGetter(name2.lexeme);
+    }
+    return null;
+  }
+
+  PropertyAccessorElement? lookUpInheritedConcreteGetter() {
+    var declaredElement = declaredElement2;
+    if (declaredElement == null) {
+      return null;
+    }
+    var parent = declaredElement.enclosingElement3;
+    if (parent is ClassElement) {
+      return parent.lookUpInheritedConcreteGetter(
+          name2.lexeme, declaredElement.library);
+    }
+    // Extensions don't inherit.
+    return null;
+  }
+
+  MethodElement? lookUpInheritedConcreteMethod() {
+    var declaredElement = declaredElement2;
+    if (declaredElement != null) {
+      var parent = declaredElement.enclosingElement3;
+      if (parent is ClassElement) {
+        return parent.lookUpInheritedConcreteMethod(
+            name2.lexeme, declaredElement.library);
+      }
+    }
+    // Extensions don't inherit.
+    return null;
+  }
+
+  PropertyAccessorElement? lookUpInheritedConcreteSetter() {
+    var declaredElement = declaredElement2;
+    if (declaredElement != null) {
+      var parent = declaredElement.enclosingElement3;
+      if (parent is ClassElement) {
+        return parent.lookUpInheritedConcreteSetter(
+            name2.lexeme, declaredElement.library);
+      }
+    }
+    // Extensions don't inherit.
+    return null;
+  }
+
+  MethodElement? lookUpInheritedMethod() {
+    var declaredElement = declaredElement2;
+    if (declaredElement != null) {
+      var parent = declaredElement.enclosingElement3;
+      if (parent is ClassElement) {
+        return parent.lookUpInheritedMethod(
+            name2.lexeme, declaredElement.library);
+      }
+    }
+    return null;
   }
 }

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Avoid positional boolean parameters.';
@@ -92,7 +93,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         !node.isSetter &&
         !declaredElement.isPrivate &&
         !node.isOperator &&
-        !DartTypeUtilities.hasInheritedMethod(node) &&
+        !node.hasInheritedMethod &&
         !_isOverridingMember(declaredElement)) {
       var parametersToLint =
           node.parameters?.parameters.where(_isFormalParameterToLint);

--- a/lib/src/rules/avoid_setters_without_getters.dart
+++ b/lib/src/rules/avoid_setters_without_getters.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Avoid setters without getters.';
 
@@ -44,12 +44,6 @@ class Good {
 
 ''';
 
-bool _hasGetter(MethodDeclaration node) =>
-    DartTypeUtilities.lookUpGetter(node) != null;
-
-bool _hasInheritedSetter(MethodDeclaration node) =>
-    DartTypeUtilities.lookUpInheritedConcreteSetter(node) != null;
-
 class AvoidSettersWithoutGetters extends LintRule {
   AvoidSettersWithoutGetters()
       : super(
@@ -86,8 +80,8 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitMembers(NodeList<ClassMember> members) {
     for (var member in members.whereType<MethodDeclaration>()) {
       if (member.isSetter &&
-          !_hasInheritedSetter(member) &&
-          !_hasGetter(member)) {
+          member.lookUpInheritedConcreteSetter() == null &&
+          member.lookUpGetter() == null) {
         rule.reportLintForToken(member.name2);
       }
     }

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -213,7 +213,7 @@ class _UnnecessaryGetterOverrideVisitor
 
   @override
   ExecutableElement? getInheritedElement(MethodDeclaration node) =>
-      DartTypeUtilities.lookUpInheritedConcreteGetter(node);
+      node.lookUpInheritedConcreteGetter();
 
   @override
   void visitPropertyAccess(PropertyAccess node) {
@@ -228,8 +228,7 @@ class _UnnecessaryMethodOverrideVisitor
   _UnnecessaryMethodOverrideVisitor(super.rule);
 
   @override
-  ExecutableElement? getInheritedElement(node) =>
-      DartTypeUtilities.lookUpInheritedMethod(node);
+  ExecutableElement? getInheritedElement(node) => node.lookUpInheritedMethod();
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
@@ -249,7 +248,7 @@ class _UnnecessaryOperatorOverrideVisitor
 
   @override
   ExecutableElement? getInheritedElement(node) =>
-      DartTypeUtilities.lookUpInheritedConcreteMethod(node);
+      node.lookUpInheritedConcreteMethod();
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
@@ -286,7 +285,7 @@ class _UnnecessarySetterOverrideVisitor
 
   @override
   ExecutableElement? getInheritedElement(node) =>
-      DartTypeUtilities.lookUpInheritedConcreteSetter(node);
+      node.lookUpInheritedConcreteSetter();
 
   @override
   void visitAssignmentExpression(AssignmentExpression node) {

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc =
     r'Start the name of the method with to/_to or as/_as if applicable.';
@@ -85,7 +85,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         nodeParameters.parameters.isEmpty &&
         !_isVoid(node.returnType) &&
         !_beginsWithAsOrTo(node.name2.lexeme) &&
-        !DartTypeUtilities.hasInheritedMethod(node) &&
+        !node.hasInheritedMethod &&
         _checkBody(node.body)) {
       rule.reportLintForToken(node.name2);
     }

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -236,9 +236,6 @@ class DartTypeUtilities {
   static Element? getCanonicalElementFromIdentifier(AstNode? rawNode) =>
       rawNode.canonicalElement;
 
-  static bool hasInheritedMethod(MethodDeclaration node) =>
-      lookUpInheritedMethod(node) != null;
-
   static bool implementsAnyInterface(
       DartType type, Iterable<InterfaceTypeDefinition> definitions) {
     bool isAnyInterface(InterfaceType i) =>
@@ -283,89 +280,6 @@ class DartTypeUtilities {
 
   @Deprecated('Replace with `expression.isNullLiteral`')
   static bool isNullLiteral(Expression? expression) => expression.isNullLiteral;
-
-  static PropertyAccessorElement? lookUpGetter(MethodDeclaration node) {
-    var declaredElement = node.declaredElement2;
-    if (declaredElement == null) {
-      return null;
-    }
-    var parent = declaredElement.enclosingElement3;
-    if (parent is ClassElement) {
-      return parent.lookUpGetter(node.name2.lexeme, declaredElement.library);
-    }
-    if (parent is ExtensionElement) {
-      return parent.getGetter(node.name2.lexeme);
-    }
-    return null;
-  }
-
-  static PropertyAccessorElement? lookUpInheritedConcreteGetter(
-      MethodDeclaration node) {
-    var declaredElement = node.declaredElement2;
-    if (declaredElement == null) {
-      return null;
-    }
-    var parent = declaredElement.enclosingElement3;
-    if (parent is ClassElement) {
-      return parent.lookUpInheritedConcreteGetter(
-          node.name2.lexeme, declaredElement.library);
-    }
-    // Extensions don't inherit.
-    return null;
-  }
-
-  static MethodElement? lookUpInheritedConcreteMethod(MethodDeclaration node) {
-    var declaredElement = node.declaredElement2;
-    if (declaredElement != null) {
-      var parent = declaredElement.enclosingElement3;
-      if (parent is ClassElement) {
-        return parent.lookUpInheritedConcreteMethod(
-            node.name2.lexeme, declaredElement.library);
-      }
-    }
-    // Extensions don't inherit.
-    return null;
-  }
-
-  static PropertyAccessorElement? lookUpInheritedConcreteSetter(
-      MethodDeclaration node) {
-    var declaredElement = node.declaredElement2;
-    if (declaredElement != null) {
-      var parent = declaredElement.enclosingElement3;
-      if (parent is ClassElement) {
-        return parent.lookUpInheritedConcreteSetter(
-            node.name2.lexeme, declaredElement.library);
-      }
-    }
-    // Extensions don't inherit.
-    return null;
-  }
-
-  static MethodElement? lookUpInheritedMethod(MethodDeclaration node) {
-    var declaredElement = node.declaredElement2;
-    if (declaredElement != null) {
-      var parent = declaredElement.enclosingElement3;
-      if (parent is ClassElement) {
-        return parent.lookUpInheritedMethod(
-            node.name2.lexeme, declaredElement.library);
-      }
-    }
-    return null;
-  }
-
-  static PropertyAccessorElement? lookUpSetter(MethodDeclaration node) {
-    var declaredElement = node.declaredElement2;
-    if (declaredElement != null) {
-      var parent = declaredElement.enclosingElement3;
-      if (parent is ClassElement) {
-        return parent.lookUpSetter(node.name2.lexeme, declaredElement.library);
-      }
-      if (parent is ExtensionElement) {
-        return parent.getSetter(node.name2.lexeme);
-      }
-    }
-    return null;
-  }
 
   @Deprecated('Use `argumentsMatchParameters`')
   static bool matchesArgumentsWithParameters(NodeList<Expression> arguments,


### PR DESCRIPTION
# Description

* `DartTypeUtilities.hasInheritedMethod()` moved to be a getter on MethodDeclarationExtension.
* `DartTypeUtilities.lookUpGetter`, `DartTypeUtilities.lookUpInheritedConcreteGetter`, `DartTypeUtilities.lookUpInheritedConcreteMethod`, `DartTypeUtilities.lookUpInheritedConcreteSetter`, `DartTypeUtilities.lookUpInheritedMethod` are all moved to be zero-parameter methods on MethodDeclarationExtension.
* `DartTypeUtilities.lookUpSetter` was unused and is deleted.

None of these are used internally.