### PR TITLE
Move last methods out from DartTypeUtilities

### DIFF
--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r"Don't explicitly catch Error or types that implement it.";
 
@@ -61,8 +61,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitCatchClause(CatchClause node) {
     var exceptionType = node.exceptionType?.type;
-    if (DartTypeUtilities.implementsInterface(
-        exceptionType, 'Error', 'dart.core')) {
+    if (exceptionType.implementsInterface('Error', 'dart.core')) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Avoid using `forEach` with a function literal.';
 
@@ -56,7 +56,7 @@ bool _hasMethodChaining(MethodInvocation node) {
 bool _isNonNullableIterable(DartType? type) =>
     type != null &&
     type.nullabilitySuffix != NullabilitySuffix.question &&
-    DartTypeUtilities.implementsInterface(type, 'Iterable', 'dart.core');
+    type.implementsInterface('Iterable', 'dart.core');
 
 class AvoidFunctionLiteralInForeachMethod extends LintRule {
   AvoidFunctionLiteralInForeachMethod()

--- a/lib/src/rules/avoid_positional_boolean_parameters.dart
+++ b/lib/src/rules/avoid_positional_boolean_parameters.dart
@@ -5,10 +5,10 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r'Avoid positional boolean parameters.';
 
@@ -103,10 +103,10 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  bool _isFormalParameterToLint(FormalParameter node) =>
-      !node.isNamed &&
-      DartTypeUtilities.isClass(
-          node.declaredElement?.type, 'bool', 'dart.core');
+  bool _isFormalParameterToLint(FormalParameter node) {
+    var type = node.declaredElement?.type;
+    return !node.isNamed && type is InterfaceType && type.isDartCoreBool;
+  }
 
   bool _isOverridingMember(Element member) {
     var classElement = member.thisOrAncestorOfType<ClassElement>();

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -45,7 +45,8 @@ bool _isFunctionExpression(AstNode node) => node is FunctionExpression;
 
 bool _isPrimitiveType(DartType type) =>
     type is InterfaceType &&
-    (type.isDartCoreBool || type.isDartCoreDouble ||
+    (type.isDartCoreBool ||
+        type.isDartCoreDouble ||
         type.isDartCoreInt ||
         type.isDartCoreNum);
 

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc =
     r'Avoid returning null from members whose return type is bool, double, int,'
@@ -45,10 +44,10 @@ double getDouble() => -1.0;
 bool _isFunctionExpression(AstNode node) => node is FunctionExpression;
 
 bool _isPrimitiveType(DartType type) =>
-    DartTypeUtilities.isClass(type, 'bool', 'dart.core') ||
-    DartTypeUtilities.isClass(type, 'num', 'dart.core') ||
-    DartTypeUtilities.isClass(type, 'int', 'dart.core') ||
-    DartTypeUtilities.isClass(type, 'double', 'dart.core');
+    type is InterfaceType &&
+    (type.isDartCoreBool && type.isDartCoreDouble ||
+        type.isDartCoreInt ||
+        type.isDartCoreNum);
 
 bool _isReturnNull(AstNode node) =>
     node is ReturnStatement && node.expression.isNullLiteral;

--- a/lib/src/rules/avoid_returning_null.dart
+++ b/lib/src/rules/avoid_returning_null.dart
@@ -45,7 +45,7 @@ bool _isFunctionExpression(AstNode node) => node is FunctionExpression;
 
 bool _isPrimitiveType(DartType type) =>
     type is InterfaceType &&
-    (type.isDartCoreBool && type.isDartCoreDouble ||
+    (type.isDartCoreBool || type.isDartCoreDouble ||
         type.isDartCoreInt ||
         type.isDartCoreNum);
 

--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -7,7 +7,6 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r'Await only futures.';
 
@@ -73,8 +72,8 @@ class _Visitor extends SimpleAstVisitor<void> {
         type.isDartAsyncFuture ||
         type.isDynamic ||
         type.extendsClass('Future', 'dart.async') ||
-        DartTypeUtilities.implementsInterface(type, 'Future', 'dart.async') ||
-        DartTypeUtilities.isClass(type, 'FutureOr', 'dart.async'))) {
+        type.implementsInterface('Future', 'dart.async') ||
+        type.isDartAsyncFutureOr)) {
       rule.reportLintForToken(node.awaitKeyword, arguments: [type]);
     }
   }

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 import '../util/leak_detector_visitor.dart';
 
 const _desc = r'Cancel instances of dart.async.StreamSubscription.';
@@ -58,8 +58,8 @@ void someFunctionOK() {
 
 ''';
 
-bool _isSubscription(DartType type) => DartTypeUtilities.implementsInterface(
-    type, 'StreamSubscription', 'dart.async');
+bool _isSubscription(DartType type) =>
+    type.implementsInterface('StreamSubscription', 'dart.async');
 
 class CancelSubscriptions extends LintRule {
   CancelSubscriptions()

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 import '../util/leak_detector_visitor.dart';
 
 const _desc = r'Close instances of `dart.core.Sink`.';
@@ -57,11 +57,9 @@ void someFunctionOK() {
 
 ''';
 
-bool _isSink(DartType type) =>
-    DartTypeUtilities.implementsInterface(type, 'Sink', 'dart.core');
+bool _isSink(DartType type) => type.implementsInterface('Sink', 'dart.core');
 
-bool _isSocket(DartType type) =>
-    DartTypeUtilities.implementsInterface(type, 'Socket', 'dart.io');
+bool _isSocket(DartType type) => type.implementsInterface('Socket', 'dart.io');
 
 class CloseSinks extends LintRule {
   CloseSinks()

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -11,7 +11,6 @@ import 'package:analyzer/dart/element/type.dart';
 import '../analyzer.dart';
 import '../ast.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 import '../util/flutter_utils.dart';
 
 const _desc = r'DO reference all public properties in debug methods.';
@@ -122,7 +121,7 @@ class _Visitor extends SimpleAstVisitor {
   void visitClassDeclaration(ClassDeclaration node) {
     // We only care about Diagnosticables.
     var type = node.declaredElement2?.thisType;
-    if (!DartTypeUtilities.implementsInterface(type, 'Diagnosticable', '')) {
+    if (!type.implementsInterface('Diagnosticable', '')) {
       return;
     }
 

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -104,7 +104,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (iterableType is InterfaceType) {
         // TODO(srawlins): Is `DartType.asInstanceOf` the more correct API here?
         var iterableInterfaces = iterableType.implementedInterfaces
-            .where((type) => type.isDartCoreString);
+            .where((type) => type.isDartCoreIterable);
         if (iterableInterfaces.length == 1 &&
             iterableInterfaces.first.typeArguments.first == staticType) {
           rule.reportLint(loopVariableType);

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -104,7 +104,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (iterableType is InterfaceType) {
         // TODO(srawlins): Is `DartType.asInstanceOf` the more correct API here?
         var iterableInterfaces = iterableType.implementedInterfaces
-            .where((type) => type.isSameAs('Iterable', 'dart.core'));
+            .where((type) => type.isDartCoreString);
         if (iterableInterfaces.length == 1 &&
             iterableInterfaces.first.typeArguments.first == staticType) {
           rule.reportLint(loopVariableType);

--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r'Omit type annotations for local variables.';
 
@@ -104,9 +103,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       var iterableType = loopParts.iterable.staticType;
       if (iterableType is InterfaceType) {
         // TODO(srawlins): Is `DartType.asInstanceOf` the more correct API here?
-        var iterableInterfaces = iterableType.implementedInterfaces.where(
-            (type) =>
-                DartTypeUtilities.isInterface(type, 'Iterable', 'dart.core'));
+        var iterableInterfaces = iterableType.implementedInterfaces
+            .where((type) => type.isSameAs('Iterable', 'dart.core'));
         if (iterableInterfaces.length == 1 &&
             iterableInterfaces.first.typeArguments.first == staticType) {
           rule.reportLint(loopVariableType);

--- a/lib/src/rules/only_throw_errors.dart
+++ b/lib/src/rules/only_throw_errors.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc =
@@ -56,8 +57,7 @@ bool _isThrowable(DartType? type) {
   var typeForInterfaceCheck = type?.typeForInterfaceCheck;
   return typeForInterfaceCheck == null ||
       typeForInterfaceCheck.isDynamic ||
-      DartTypeUtilities.implementsAnyInterface(
-          typeForInterfaceCheck, _interfaceDefinitions);
+      typeForInterfaceCheck.implementsAnyInterface(_interfaceDefinitions);
 }
 
 class OnlyThrowErrors extends LintRule {

--- a/lib/src/rules/prefer_collection_literals.dart
+++ b/lib/src/rules/prefer_collection_literals.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Use collection literals when possible.';
 
@@ -127,22 +127,26 @@ class _Visitor extends SimpleAstVisitor<void> {
     }
   }
 
-  bool _isSet(Expression expression) => _isTypeSet(expression.staticType);
+  bool _isSet(Expression expression) =>
+      expression.staticType?.isDartCoreSet ?? false;
+
   bool _isHashSet(Expression expression) =>
       _isTypeHashSet(expression.staticType);
+
   bool _isList(Expression expression) =>
-      DartTypeUtilities.isClass(expression.staticType, 'List', 'dart.core');
-  bool _isMap(Expression expression) => _isTypeMap(expression.staticType);
+      expression.staticType?.isDartCoreList ?? false;
+
+  bool _isMap(Expression expression) =>
+      expression.staticType?.isDartCoreMap ?? false;
+
   bool _isHashMap(Expression expression) =>
       _isTypeHashMap(expression.staticType);
-  bool _isTypeSet(DartType? type) =>
-      DartTypeUtilities.isClass(type, 'Set', 'dart.core');
+
   bool _isTypeHashSet(DartType? type) =>
-      DartTypeUtilities.isClass(type, 'LinkedHashSet', 'dart.collection');
-  bool _isTypeMap(DartType? type) =>
-      DartTypeUtilities.isClass(type, 'Map', 'dart.core');
+      type.isSameAs('LinkedHashSet', 'dart.collection');
+
   bool _isTypeHashMap(DartType? type) =>
-      DartTypeUtilities.isClass(type, 'LinkedHashMap', 'dart.collection');
+      type.isSameAs('LinkedHashMap', 'dart.collection');
 
   bool _shouldSkipLinkedHashLint(
       InstanceCreationExpression node, bool Function(DartType node) typeCheck) {

--- a/lib/src/rules/prefer_contains.dart
+++ b/lib/src/rules/prefer_contains.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 import '../ast.dart';
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r'Use contains for `List` and `String` instances.';
@@ -171,7 +172,7 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     var parentType = invocation.target?.staticType;
     if (parentType == null) return false;
-    if (!DartTypeUtilities.implementsAnyInterface(parentType, [
+    if (!parentType.implementsAnyInterface([
       InterfaceTypeDefinition('Iterable', 'dart.core'),
       InterfaceTypeDefinition('String', 'dart.core'),
     ])) {

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -9,7 +9,7 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 import '../ast.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Use `isEmpty` for Iterables and Maps.';
 const _details = r'''
@@ -216,8 +216,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     // Should be subtype of Iterable, Map or String.
     if (type == null ||
-        !DartTypeUtilities.implementsInterface(type, 'Iterable', 'dart.core') &&
-            !DartTypeUtilities.implementsInterface(type, 'Map', 'dart.core') &&
+        !type.implementsInterface('Iterable', 'dart.core') &&
+            !type.implementsInterface('Map', 'dart.core') &&
             !type.isDartCoreString) {
       return false;
     }

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Prefer to use whereType on iterable.';
 
@@ -53,8 +53,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (node.methodName.name != 'where') return;
     var target = node.realTarget;
     if (target == null ||
-        !DartTypeUtilities.implementsInterface(
-            target.staticType, 'Iterable', 'dart.core')) {
+        !target.staticType.implementsInterface('Iterable', 'dart.core')) {
       return;
     }
 

--- a/lib/src/rules/unawaited_futures.dart
+++ b/lib/src/rules/unawaited_futures.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'`Future` results in `async` function bodies must be '
     '`await`ed or marked `unawaited` using `dart:async`.';
@@ -83,7 +83,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (type == null) {
       return;
     }
-    if (DartTypeUtilities.implementsInterface(type, 'Future', 'dart.async')) {
+    if (type.implementsInterface('Future', 'dart.async')) {
       // Ignore a couple of special known cases.
       if (_isFutureDelayedInstanceCreationWithComputation(expr) ||
           _isMapPutIfAbsentInvocation(expr)) {

--- a/lib/src/rules/unnecessary_to_list_in_spreads.dart
+++ b/lib/src/rules/unnecessary_to_list_in_spreads.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 
 const _desc = r'Unnecessary toList() in spreads.';
 
@@ -55,10 +55,13 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitSpreadElement(SpreadElement node) {
     var expression = node.expression;
-    if (expression is MethodInvocation &&
-        expression.methodName.name == 'toList' &&
-        DartTypeUtilities.implementsInterface(
-            expression.target?.staticType, 'Iterable', 'dart.core')) {
+    if (expression is! MethodInvocation) {
+      return;
+    }
+    var target = expression.target;
+    if (expression.methodName.name == 'toList' &&
+        target != null &&
+        target.staticType.implementsInterface('Iterable', 'dart.core')) {
       rule.reportLint(expression.methodName);
     }
   }

--- a/lib/src/rules/use_key_in_widget_constructors.dart
+++ b/lib/src/rules/use_key_in_widget_constructors.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
+import '../extensions.dart';
 import '../util/flutter_utils.dart';
 
 const _desc = r'Use key in widget constructors.';
@@ -107,8 +107,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   bool _defineKeyParameter(ConstructorElement element) =>
       element.parameters.any((e) => e.name == 'key' && _isKeyType(e.type));
 
-  bool _isKeyType(DartType type) =>
-      DartTypeUtilities.implementsInterface(type, 'Key', '');
+  bool _isKeyType(DartType type) => type.implementsInterface('Key', '');
 
   bool _hasKeySuperParameterInitializerArg(ConstructorDeclaration node) {
     for (var parameter in node.parameters.parameters) {

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
-import '../util/dart_type_utilities.dart';
 
 const _desc = r'Use string buffers to compose strings.';
 
@@ -123,7 +122,7 @@ class _UseStringBufferVisitor extends SimpleAstVisitor {
 
     var left = node.leftHandSide;
     if (left is SimpleIdentifier &&
-        DartTypeUtilities.isClass(node.writeType, 'String', 'dart.core')) {
+        node.writeType.isSameAs('String', 'dart.core')) {
       if (node.operator.type == TokenType.PLUS_EQ &&
           !localElements.contains(node.writeElement?.canonicalElement)) {
         rule.reportLint(node);

--- a/lib/src/rules/use_string_buffers.dart
+++ b/lib/src/rules/use_string_buffers.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
@@ -121,8 +122,10 @@ class _UseStringBufferVisitor extends SimpleAstVisitor {
         node.operator.type != TokenType.EQ) return;
 
     var left = node.leftHandSide;
+    var writeType = node.writeType;
     if (left is SimpleIdentifier &&
-        node.writeType.isSameAs('String', 'dart.core')) {
+        writeType is InterfaceType &&
+        writeType.isDartCoreString) {
       if (node.operator.type == TokenType.PLUS_EQ &&
           !localElements.contains(node.writeElement?.canonicalElement)) {
         rule.reportLint(node);

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -236,47 +236,10 @@ class DartTypeUtilities {
   static Element? getCanonicalElementFromIdentifier(AstNode? rawNode) =>
       rawNode.canonicalElement;
 
-  static bool implementsAnyInterface(
-      DartType type, Iterable<InterfaceTypeDefinition> definitions) {
-    bool isAnyInterface(InterfaceType i) =>
-        definitions.any((d) => isInterface(i, d.name, d.library));
-
-    if (type is InterfaceType) {
-      var element = type.element2;
-      return isAnyInterface(type) ||
-          !element.isSynthetic && element.allSupertypes.any(isAnyInterface);
-    } else {
-      return false;
-    }
-  }
-
+  @Deprecated('Replace with `type.implementsInterface`')
   static bool implementsInterface(
-      DartType? type, String interface, String library) {
-    if (type is! InterfaceType) {
-      return false;
-    }
-    var interfaceType = type;
-    bool predicate(InterfaceType i) => isInterface(i, interface, library);
-    var element = interfaceType.element2;
-    return predicate(interfaceType) ||
-        !element.isSynthetic && element.allSupertypes.any(predicate);
-  }
-
-  /// todo (pq): unify and  `isInterface` into a shared method: `isInterfaceType`
-  static bool isClass(DartType? type, String? className, String? library) =>
-      type is InterfaceType &&
-      type.element2.name == className &&
-      type.element2.library.name == library;
-
-  /// todo (pq): unify and  `isInterface` into a shared method: `isInterfaceType`
-  static bool isMixin(DartType? type, String? className, String? library) =>
-      type is InterfaceType &&
-      type.element2.name == className &&
-      type.element2.library.name == library;
-
-  static bool isInterface(
-          InterfaceType type, String interface, String library) =>
-      type.element2.name == interface && type.element2.library.name == library;
+          DartType? type, String interface, String library) =>
+      type.implementsInterface(interface, library);
 
   @Deprecated('Replace with `expression.isNullLiteral`')
   static bool isNullLiteral(Expression? expression) => expression.isNullLiteral;

--- a/lib/src/util/flutter_utils.dart
+++ b/lib/src/util/flutter_utils.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 
+import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 var _collectionInterfaces = <InterfaceTypeDefinition>[
@@ -44,7 +45,7 @@ bool isWidgetProperty(DartType? type) {
     return true;
   }
   if (type is InterfaceType &&
-      DartTypeUtilities.implementsAnyInterface(type, _collectionInterfaces)) {
+      type.implementsAnyInterface(_collectionInterfaces)) {
     return type.element2.typeParameters.length == 1 &&
         isWidgetProperty(type.typeArguments.first);
   }


### PR DESCRIPTION
# Description

`DartTypeUtilities.implementsAnyInterface`, `DartTypeUtilities.implementsAnyInterface`, `DartTypeUtilities.isSameAs` become extension methods on DartType.