### PR TITLE
re-add `DartTypeUtilities.isClass`

### DIFF
--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -241,6 +241,13 @@ class DartTypeUtilities {
           DartType? type, String interface, String library) =>
       type.implementsInterface(interface, library);
 
+  // todo(pq): remove and replace w/ an extension (pending internal migration)
+  @Deprecated('Slated for removal')
+  static bool isClass(DartType? type, String? className, String? library) =>
+      type is InterfaceType &&
+      type.element2.name == className &&
+      type.element2.library.name == library;
+
   @Deprecated('Replace with `expression.isNullLiteral`')
   static bool isNullLiteral(Expression? expression) => expression.isNullLiteral;
 


### PR DESCRIPTION
Back out part of https://github.com/dart-lang/linter/pull/3600.

`DartTypeUtities.isClass` is used internally and blocking a roll.

https://dart-in-g3-qa-prod.corp.google.com/dg3/Home#/cbuild/find/d839a48e5f0be0488269cd5d557769aa9b051664

/cc @srawlins @bwilkerson 

/fyi @scheglov 
