### PR TITLE
1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.28.0
+
+- update `avoid_redundant_argument_values` to work with enum declarations
+- performance improvements for `prefer_contains`
+- new lint: `unreachable_from_main`
+- (internal): analyzer API updates and `DartTypeUtilities` refactoring
+
 # 1.27.0
 
 - fix `avoid_redundant_argument_values` when referencing required 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.27.0';
+const String version = '1.28.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.27.0
+version: 1.28.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.28.0

- update `avoid_redundant_argument_values` to work with enum declarations
- performance improvements for `prefer_contains`
- new lint: `unreachable_from_main`
- (internal): analyzer API updates and `DartTypeUtilities` refactoring


---

/cc @bwilkerson @srawlins 

/fyi @AlexV525 @a14n 
