### PR TITLE
remove unnecessary rule name duplication from lint test expectations

### DIFF
--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -27,10 +27,6 @@ ExpectedError error(ErrorCode code, int offset, int length,
         {Pattern? messageContains}) =>
     ExpectedError(code, offset, length, messageContains: messageContains);
 
-ExpectedLint lint(String lintName, int offset, int length,
-        {Pattern? messageContains}) =>
-    ExpectedLint(lintName, offset, length, messageContains: messageContains);
-
 typedef DiagnosticMatcher = bool Function(AnalysisError error);
 
 class AnalysisOptionsFileConfig {
@@ -118,6 +114,9 @@ class ExpectedLint extends ExpectedDiagnostic {
 abstract class LintRuleTest extends PubPackageResolutionTest {
   String? get lintRule;
 
+  ExpectedLint lint(int offset, int length, {Pattern? messageContains}) =>
+      ExpectedLint(lintRule!, offset, length, messageContains: messageContains);
+
   @override
   List<String> get _lintRules => [if (lintRule != null) lintRule!];
 
@@ -197,17 +196,18 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
       buffer.writeln('To accept the current state, expect:');
       for (var actual in errors) {
         late String diagnosticKind;
-        late Object description;
+        Object? description;
         if (actual.errorCode is LintCode) {
           diagnosticKind = 'lint';
-          description = "'${actual.errorCode.name}'";
         } else {
           diagnosticKind = 'error';
           description = actual.errorCode;
         }
         buffer.write('  $diagnosticKind(');
-        buffer.write(description);
-        buffer.write(', ');
+        if (description != null) {
+          buffer.write(description);
+          buffer.write(', ');
+        }
         buffer.write(actual.offset);
         buffer.write(', ');
         buffer.write(actual.length);

--- a/test/rules/annotate_overrides_test.dart
+++ b/test/rules/annotate_overrides_test.dart
@@ -28,7 +28,7 @@ enum A implements O {
   int get x => 0;
 }
 ''', [
-      lint('annotate_overrides', 76, 1),
+      lint(76, 1),
     ]);
   }
 
@@ -39,7 +39,7 @@ enum A {
   String toString() => '';
 }
 ''', [
-      lint('annotate_overrides', 27, 8),
+      lint(27, 8),
     ]);
   }
 

--- a/test/rules/avoid_annotating_with_dynamic_test.dart
+++ b/test/rules/avoid_annotating_with_dynamic_test.dart
@@ -24,7 +24,7 @@ class A {
   A(dynamic this.a);
 }
 ''', [
-      lint('avoid_annotating_with_dynamic', 23, 14),
+      lint(23, 14),
     ]);
   }
 
@@ -39,8 +39,8 @@ class B extends A {
   B(dynamic super.a, dynamic super.b);
 }
 ''', [
-      lint('avoid_annotating_with_dynamic', 75, 15),
-      lint('avoid_annotating_with_dynamic', 92, 15),
+      lint(75, 15),
+      lint(92, 15),
     ]);
   }
 }

--- a/test/rules/avoid_final_parameters_test.dart
+++ b/test/rules/avoid_final_parameters_test.dart
@@ -30,8 +30,8 @@ class B extends A {
 ''', [
       error(HintCode.UNNECESSARY_FINAL, 83, 5),
       error(HintCode.UNNECESSARY_FINAL, 98, 5),
-      lint('avoid_final_parameters', 83, 13),
-      lint('avoid_final_parameters', 98, 13),
+      lint(83, 13),
+      lint(98, 13),
     ]);
   }
 }

--- a/test/rules/avoid_init_to_null_test.dart
+++ b/test/rules/avoid_init_to_null_test.dart
@@ -25,7 +25,7 @@ class A {
   A({this.a = null});
 }
 ''', [
-      lint('avoid_init_to_null', 28, 13),
+      lint(28, 13),
     ]);
   }
 
@@ -39,8 +39,8 @@ class B extends A {
   B({super.a = null});
 }
 ''', [
-      lint('avoid_init_to_null', 28, 13),
-      lint('avoid_init_to_null', 72, 14),
+      lint(28, 13),
+      lint(72, 14),
     ]);
   }
 
@@ -111,7 +111,7 @@ int i = null;
     await assertDiagnostics(r'''
 int? ii = null;
 ''', [
-      lint('avoid_init_to_null', 5, 9),
+      lint(5, 9),
     ]);
   }
 }

--- a/test/rules/avoid_redundant_argument_values_test.dart
+++ b/test/rules/avoid_redundant_argument_values_test.dart
@@ -26,7 +26,7 @@ void f() {
   foo(0, c: true, 1);
 }
 ''', [
-      lint('avoid_redundant_argument_values', 67, 4),
+      lint(67, 4),
     ]);
   }
 }
@@ -47,7 +47,7 @@ enum TestEnum {
   final bool test;
 }
 ''', [
-      lint(lintRule, 26, 5),
+      lint(26, 5),
     ]);
   }
 

--- a/test/rules/avoid_renaming_method_parameters_test.dart
+++ b/test/rules/avoid_renaming_method_parameters_test.dart
@@ -28,7 +28,7 @@ enum A with C {
   int f(int x) => x;
 }
 ''', [
-      lint('avoid_renaming_method_parameters', 82, 1),
+      lint(82, 1),
     ]);
   }
 }

--- a/test/rules/avoid_returning_this_test.dart
+++ b/test/rules/avoid_returning_this_test.dart
@@ -24,7 +24,7 @@ enum A {
   A aa() => this;
 }
 ''', [
-      lint('avoid_returning_this', 22, 2),
+      lint(22, 2),
     ]);
   }
 }

--- a/test/rules/avoid_setters_without_getters_test.dart
+++ b/test/rules/avoid_setters_without_getters_test.dart
@@ -24,7 +24,7 @@ enum A {
   set x(int x) {}
 }
 ''', [
-      lint('avoid_setters_without_getters', 24, 1),
+      lint(24, 1),
     ]);
   }
 }

--- a/test/rules/avoid_shadowing_type_parameters_test.dart
+++ b/test/rules/avoid_shadowing_type_parameters_test.dart
@@ -25,7 +25,7 @@ enum E<T> {
   void fn<T>() {}
 }
 ''', [
-      lint('avoid_shadowing_type_parameters', 33, 1),
+      lint(33, 1),
     ]);
   }
 }

--- a/test/rules/avoid_types_as_parameter_names_test.dart
+++ b/test/rules/avoid_types_as_parameter_names_test.dart
@@ -27,7 +27,7 @@ class B extends A {
   B(super.String);
 }
 ''', [
-      lint('avoid_types_as_parameter_names', 67, 6),
+      lint(67, 6),
     ]);
   }
 }

--- a/test/rules/conditional_uri_does_not_exist_test.dart
+++ b/test/rules/conditional_uri_does_not_exist_test.dart
@@ -30,10 +30,8 @@ import ''
 ''',
       [
         error(HintCode.UNUSED_IMPORT, 7, 2),
-        lint('conditional_uri_does_not_exist', 35, 16,
-            messageContains: 'dart:missing_1'),
-        lint('conditional_uri_does_not_exist', 120, 16,
-            messageContains: 'dart:missing_2'),
+        lint(35, 16, messageContains: 'dart:missing_1'),
+        lint(120, 16, messageContains: 'dart:missing_2'),
       ],
     );
   }
@@ -50,10 +48,8 @@ import ''
 ''',
       [
         error(HintCode.UNUSED_IMPORT, 7, 2),
-        lint('conditional_uri_does_not_exist', 35, 16,
-            messageContains: 'missing_1.dart'),
-        lint('conditional_uri_does_not_exist', 121, 16,
-            messageContains: 'missing_2.dart'),
+        lint(35, 16, messageContains: 'missing_1.dart'),
+        lint(121, 16, messageContains: 'missing_2.dart'),
       ],
     );
   }
@@ -68,10 +64,8 @@ import ''
 ''',
       [
         error(HintCode.UNUSED_IMPORT, 7, 2),
-        lint('conditional_uri_does_not_exist', 35, 29,
-            messageContains: 'missing_1.dart'),
-        lint('conditional_uri_does_not_exist', 142, 28,
-            messageContains: 'missing_2.dart'),
+        lint(35, 29, messageContains: 'missing_1.dart'),
+        lint(142, 28, messageContains: 'missing_2.dart'),
       ],
     );
   }

--- a/test/rules/constant_identifier_names_test.dart
+++ b/test/rules/constant_identifier_names_test.dart
@@ -25,7 +25,7 @@ class ConstantIdentifierNamesRecordsTest extends LintRuleTest {
     await assertDiagnostics(r'''
 const R = (x: 1);
 ''', [
-      lint('constant_identifier_names', 6, 1),
+      lint(6, 1),
     ]);
   }
 

--- a/test/rules/deprecated_consistency_test.dart
+++ b/test/rules/deprecated_consistency_test.dart
@@ -28,7 +28,7 @@ class B extends A {
   B({super.a});
 }
 ''', [
-      lint('deprecated_consistency', 20, 1),
+      lint(20, 1),
     ]);
   }
 }

--- a/test/rules/discarded_futures_test.dart
+++ b/test/rules/discarded_futures_test.dart
@@ -41,7 +41,7 @@ class A {
 
 Future<int> g() async => 0;
 ''', [
-      lint('discarded_futures', 22, 1),
+      lint(22, 1),
     ]);
   }
 
@@ -55,7 +55,7 @@ class A {
 
 Future<int> g() async => 0;
 ''', [
-      lint('discarded_futures', 29, 1),
+      lint(29, 1),
     ]);
   }
 
@@ -69,8 +69,8 @@ void recreateDir(String path) {
 Future<void> deleteDir(String path) async {}
 Future<void> createDir(String path) async {}
 ''', [
-      lint('discarded_futures', 34, 9),
-      lint('discarded_futures', 53, 9),
+      lint(34, 9),
+      lint(53, 9),
     ]);
   }
 
@@ -84,7 +84,7 @@ void f() {
 
 Future<void> createDir(String path) async {}
 ''', [
-      lint('discarded_futures', 22, 9),
+      lint(22, 9),
     ]);
   }
 
@@ -111,7 +111,7 @@ int h(Function f) => 0;
 
 Future<int> g() async => 0;
 ''', [
-      lint('discarded_futures', 29, 1),
+      lint(29, 1),
     ]);
   }
 
@@ -162,8 +162,8 @@ class Dir{
   Future<void> createDir(String path) async {}
 }
 ''', [
-      lint('discarded_futures', 49, 9),
-      lint('discarded_futures', 70, 9),
+      lint(49, 9),
+      lint(70, 9),
     ]);
   }
 
@@ -175,7 +175,7 @@ var a = () {
 
 Future<int> g() async => 0;
 ''', [
-      lint('discarded_futures', 15, 1),
+      lint(15, 1),
     ]);
   }
 
@@ -185,7 +185,7 @@ var a = () => g();
 
 Future<int> g() async => 0;
 ''', [
-      lint('discarded_futures', 14, 1),
+      lint(14, 1),
     ]);
   }
 
@@ -219,7 +219,7 @@ void ff(String command) {
 
 Future<int> g() async => 0;
 ''', [
-      lint('discarded_futures', 93, 1),
+      lint(93, 1),
     ]);
   }
 }

--- a/test/rules/file_names_test.dart
+++ b/test/rules/file_names_test.dart
@@ -25,7 +25,7 @@ class FileNamesInvalidTest extends LintRuleTest {
     await assertDiagnostics(r'''
 class A { }
 ''', [
-      lint('file_names', 0, 0),
+      lint(0, 0),
     ]);
   }
 }

--- a/test/rules/library_private_types_in_public_api_test.dart
+++ b/test/rules/library_private_types_in_public_api_test.dart
@@ -28,9 +28,9 @@ enum E {
   _O get ooo => o;
 }
 ''', [
-      lint('library_private_types_in_public_api', 40, 2),
-      lint('library_private_types_in_public_api', 63, 2),
-      lint('library_private_types_in_public_api', 75, 2),
+      lint(40, 2),
+      lint(63, 2),
+      lint(75, 2),
     ]);
   }
 }
@@ -51,7 +51,7 @@ class C {
   Object get x => _x;
 }
 ''', [
-      lint('library_private_types_in_public_api', 41, 2),
+      lint(41, 2),
     ]);
   }
 
@@ -65,7 +65,7 @@ class B extends _A {
   B(super.o);
 }
 ''', [
-      lint('library_private_types_in_public_api', 83, 1),
+      lint(83, 1),
     ]);
   }
 
@@ -81,7 +81,7 @@ class B extends A {
   B(_O super.o);
 }
 ''', [
-      lint('library_private_types_in_public_api', 89, 2),
+      lint(89, 2),
     ]);
   }
 }

--- a/test/rules/non_constant_identifier_names_test.dart
+++ b/test/rules/non_constant_identifier_names_test.dart
@@ -27,7 +27,7 @@ class NonConstantIdentifierNamesRecordsTest extends LintRuleTest {
 var a = (x: 1);
 var b = (X: 1);
 ''', [
-      lint('non_constant_identifier_names', 25, 1),
+      lint(25, 1),
     ]);
   }
 
@@ -37,7 +37,7 @@ var b = (X: 1);
 var A = (x: 1);
 const B = (x: 1);
 ''', [
-      lint('non_constant_identifier_names', 5, 1),
+      lint(5, 1),
     ]);
   }
 

--- a/test/rules/null_closures_test.dart
+++ b/test/rules/null_closures_test.dart
@@ -32,7 +32,7 @@ f() => <int>[2, 4, 6].firstWhere((e) => e.isEven, orElse: () => null);
 
 f() => List.generate(3, null);
 ''', [
-      lint('null_closures', 38, 4),
+      lint(38, 4),
     ]);
   }
 
@@ -42,7 +42,7 @@ f() => List.generate(3, null);
 
 f() => <int>[2, 4, 6].where(null);
 ''', [
-      lint('null_closures', 42, 4),
+      lint(42, 4),
     ]);
   }
 
@@ -56,7 +56,7 @@ f() {
   return map;
 }
 ''', [
-      lint('null_closures', 67, 4),
+      lint(67, 4),
     ]);
   }
 }

--- a/test/rules/omit_local_variable_types_test.dart
+++ b/test/rules/omit_local_variable_types_test.dart
@@ -28,7 +28,7 @@ String f() {
   return h;
 }
 ''', [
-      lint('omit_local_variable_types', 42, 26),
+      lint(42, 26),
     ]);
   }
 
@@ -54,7 +54,7 @@ String f() {
   return h;
 }
 ''', [
-      lint('omit_local_variable_types', 42, 26),
+      lint(42, 26),
     ]);
   }
 }

--- a/test/rules/overridden_fields_test.dart
+++ b/test/rules/overridden_fields_test.dart
@@ -115,20 +115,20 @@ class GC34 extends GC33 {
 }
 ''', [
       error(HintCode.OVERRIDE_ON_NON_OVERRIDING_FIELD, 120, 1),
-      lint('overridden_fields', 127, 5),
-      lint('overridden_fields', 202, 9),
+      lint(127, 5),
+      lint(202, 9),
       error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 281, 4),
-      lint('overridden_fields', 351, 5),
-      lint('overridden_fields', 426, 9),
+      lint(351, 5),
+      lint(426, 9),
       error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 480, 4),
-      lint('overridden_fields', 508, 9),
-      lint('overridden_fields', 550, 5),
-      lint('overridden_fields', 625, 9),
+      lint(508, 9),
+      lint(550, 5),
+      lint(625, 9),
       error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 759, 4),
-      lint('overridden_fields', 787, 9),
-      lint('overridden_fields', 829, 4),
-      lint('overridden_fields', 891, 1),
-      lint('overridden_fields', 920, 4),
+      lint(787, 9),
+      lint(829, 4),
+      lint(891, 1),
+      lint(920, 4),
     ]);
   }
 }

--- a/test/rules/prefer_asserts_in_initializer_lists_test.dart
+++ b/test/rules/prefer_asserts_in_initializer_lists_test.dart
@@ -31,7 +31,7 @@ class B extends A {
   }
 }
 ''', [
-      lint('prefer_asserts_in_initializer_lists', 80, 6),
+      lint(80, 6),
     ]);
   }
 }

--- a/test/rules/prefer_collection_literals_test.dart
+++ b/test/rules/prefer_collection_literals_test.dart
@@ -23,7 +23,7 @@ class PreferCollectionLiteralsPreNNBDTest extends LintRuleTest {
 // @dart=2.9    
 var list = List(); 
 ''', [
-      lint('prefer_collection_literals', 28, 6),
+      lint(28, 6),
     ]);
   }
 
@@ -32,7 +32,7 @@ var list = List();
 // @dart=2.9    
 var list = [[], List()];
 ''', [
-      lint('prefer_collection_literals', 33, 6),
+      lint(33, 6),
     ]);
   }
 
@@ -76,7 +76,7 @@ void c() {
   a(some: LinkedHashSet<Foo>());
 }
 ''', [
-      lint('prefer_collection_literals', 103, 20),
+      lint(103, 20),
     ]);
   }
 
@@ -106,7 +106,7 @@ void c() {
   b(LinkedHashSet<Foo>());
 }
 ''', [
-      lint('prefer_collection_literals', 86, 20),
+      lint(86, 20),
     ]);
   }
 

--- a/test/rules/prefer_contains_test.dart
+++ b/test/rules/prefer_contains_test.dart
@@ -43,7 +43,7 @@ bool b = '11'.indexOf('2', 1) == -1;
     await assertDiagnostics(r'''
 bool b = '11'.indexOf('2', 0) == -1;
 ''', [
-      lint('prefer_contains', 9, 26),
+      lint(9, 26),
     ]);
   }
 
@@ -51,7 +51,7 @@ bool b = '11'.indexOf('2', 0) == -1;
     await assertDiagnostics(r'''
 bool le3 = ([].indexOf(1) as int) > -1;
 ''', [
-      lint('prefer_contains', 11, 27),
+      lint(11, 27),
       error(HintCode.UNNECESSARY_CAST, 12, 20),
     ]);
   }

--- a/test/rules/prefer_equal_for_default_values_test.dart
+++ b/test/rules/prefer_equal_for_default_values_test.dart
@@ -28,7 +28,7 @@ class B extends A {
   B({super.a : ''});
 }
 ''', [
-      lint('prefer_equal_for_default_values', 74, 1),
+      lint(74, 1),
     ]);
   }
 }

--- a/test/rules/public_member_api_docs_test.dart
+++ b/test/rules/public_member_api_docs_test.dart
@@ -25,12 +25,12 @@ enum A {
   int get y => 1;
 }
 ''', [
-      lint('public_member_api_docs', 5, 1),
-      lint('public_member_api_docs', 11, 1),
-      lint('public_member_api_docs', 13, 1),
-      lint('public_member_api_docs', 15, 1),
-      lint('public_member_api_docs', 24, 1),
-      lint('public_member_api_docs', 44, 1),
+      lint(5, 1),
+      lint(11, 1),
+      lint(13, 1),
+      lint(15, 1),
+      lint(24, 1),
+      lint(44, 1),
     ]);
   }
 
@@ -41,8 +41,8 @@ extension E on Object {
   void f() { }
 }
 ''', [
-      lint('public_member_api_docs', 10, 1),
-      lint('public_member_api_docs', 31, 1),
+      lint(10, 1),
+      lint(31, 1),
     ]);
   }
 
@@ -52,7 +52,7 @@ extension E on Object {
 mixin M {
   String m() => '';
 }''', [
-      lint('public_member_api_docs', 34, 1),
+      lint(34, 1),
     ]);
   }
 

--- a/test/rules/sort_constructors_first.dart
+++ b/test/rules/sort_constructors_first.dart
@@ -35,7 +35,7 @@ enum A {
   const A();
 }
 ''', [
-      lint('sort_constructors_first', 42, 1),
+      lint(42, 1),
     ]);
   }
 }

--- a/test/rules/sort_unnamed_constructors_first.dart
+++ b/test/rules/sort_unnamed_constructors_first.dart
@@ -35,7 +35,7 @@ enum A {
   const A();
 }
 ''', [
-      lint('sort_unnamed_constructors_first', 47, 1),
+      lint(47, 1),
     ]);
   }
 }

--- a/test/rules/super_goes_last_test.dart
+++ b/test/rules/super_goes_last_test.dart
@@ -33,7 +33,7 @@ class C extends A {
 ''', [
       error(HintCode.UNUSED_FIELD, 61, 2),
       error(CompileTimeErrorCode.SUPER_INVOCATION_NOT_LAST, 84, 5),
-      lint('super_goes_last', 84, 8),
+      lint(84, 8),
     ]);
   }
 }

--- a/test/rules/tighten_type_of_initializing_formals_test.dart
+++ b/test/rules/tighten_type_of_initializing_formals_test.dart
@@ -32,7 +32,7 @@ class C extends A {
   C(super.a) : assert(a != null);
 }
 ''', [
-      lint('tighten_type_of_initializing_formals', 107, 7),
+      lint(107, 7),
     ]);
   }
 }

--- a/test/rules/type_init_formals_test.dart
+++ b/test/rules/type_init_formals_test.dart
@@ -29,7 +29,7 @@ class B extends A {
   B({String? super.a});
 }
 ''', [
-      lint('type_init_formals', 66, 7),
+      lint(66, 7),
     ]);
   }
 }

--- a/test/rules/unnecessary_const_test.dart
+++ b/test/rules/unnecessary_const_test.dart
@@ -31,7 +31,7 @@ const r = (a: 1);
     await assertDiagnostics(r'''
 const r = const (a: 1);
 ''', [
-      lint('unnecessary_const', 11, 4),
+      lint(11, 4),
     ]);
   }
 }

--- a/test/rules/unnecessary_overrides_test.dart
+++ b/test/rules/unnecessary_overrides_test.dart
@@ -25,7 +25,7 @@ enum A {
   Type get runtimeType => super.runtimeType;
 }
 ''', [
-      lint('unnecessary_overrides', 41, 11),
+      lint(41, 11),
     ]);
   }
 
@@ -37,7 +37,7 @@ enum A {
   String toString() => super.toString();
 }
 ''', [
-      lint('unnecessary_overrides', 39, 8),
+      lint(39, 8),
     ]);
   }
 }

--- a/test/rules/use_enums_test.dart
+++ b/test/rules/use_enums_test.dart
@@ -26,7 +26,7 @@ class A {
   const A._(this.value);
 }
 ''', [
-      lint('use_enums', 6, 1),
+      lint(6, 1),
     ]);
   }
 
@@ -38,7 +38,7 @@ class A extends Object {
   const A._();
 }
 ''', [
-      lint('use_enums', 6, 1),
+      lint(6, 1),
     ]);
   }
 
@@ -49,7 +49,7 @@ class A {
   const A._();
 }
 ''', [
-      lint('use_enums', 6, 1),
+      lint(6, 1),
     ]);
   }
 
@@ -321,7 +321,7 @@ class _E {
 
 _E e = _E.withValue(0);
 ''', [
-      lint('use_enums', 6, 2),
+      lint(6, 2),
       error(HintCode.UNUSED_FIELD, 57, 1),
     ]);
   }
@@ -338,7 +338,7 @@ class A {
   const A._();
 }
 ''', [
-      lint('use_enums', 21, 1),
+      lint(21, 1),
     ]);
   }
 
@@ -353,7 +353,7 @@ class _A {
       error(HintCode.UNUSED_ELEMENT, 6, 2),
       error(HintCode.UNUSED_FIELD, 29, 1),
       error(HintCode.UNUSED_FIELD, 57, 1),
-      lint('use_enums', 6, 2),
+      lint(6, 2),
     ]);
   }
 
@@ -365,7 +365,7 @@ class A {
   const A._();
 }
 ''', [
-      lint('use_enums', 6, 1),
+      lint(6, 1),
     ]);
   }
 
@@ -378,7 +378,7 @@ class A with M {
   const A._();
 }
 ''', [
-      lint('use_enums', 22, 1),
+      lint(22, 1),
     ]);
   }
 }

--- a/test/rules/use_string_in_part_of_directives.dart
+++ b/test/rules/use_string_in_part_of_directives.dart
@@ -39,7 +39,7 @@ part '$testFileName';
 part of lib;
 ''',
       [
-        lint(1, 12),
+        lint(0, 12),
       ],
     );
   }

--- a/test/rules/use_string_in_part_of_directives.dart
+++ b/test/rules/use_string_in_part_of_directives.dart
@@ -39,7 +39,7 @@ part '$testFileName';
 part of lib;
 ''',
       [
-        lint('use_string_in_part_of_directives', 0, 12),
+        lint(1, 12),
       ],
     );
   }

--- a/test/rules/use_super_parameters_test.dart
+++ b/test/rules/use_super_parameters_test.dart
@@ -26,7 +26,7 @@ class B extends A {
   B(int f(int i)) : super(f);
 }
 ''', [
-      lint('use_super_parameters', 53, 1),
+      lint(53, 1),
     ]);
   }
 
@@ -39,7 +39,7 @@ class B extends A {
   const B({int? x, int? y}) : super(x: x, y: y);
 }
 ''', [
-      lint('use_super_parameters', 69, 1),
+      lint(69, 1),
     ]);
   }
 
@@ -52,7 +52,7 @@ class B extends A {
   B({int? x, int? z}) : super(x: x, y: z);
 }
 ''', [
-      lint('use_super_parameters', 57, 1),
+      lint(57, 1),
     ]);
   }
 
@@ -67,8 +67,7 @@ class B extends A {
   }
 }
 ''', [
-      lint('use_super_parameters', 57, 1,
-          messageContains: "Convert 'y' to a super parameter"),
+      lint(57, 1, messageContains: "Convert 'y' to a super parameter"),
     ]);
   }
 
@@ -82,8 +81,7 @@ class B extends A {
   B({this.x, int? y}) : super(x:x, y:y);
 }
 ''', [
-      lint('use_super_parameters', 67, 1,
-          messageContains: "Convert 'y' to a super parameter."),
+      lint(67, 1, messageContains: "Convert 'y' to a super parameter."),
     ]);
   }
 
@@ -334,7 +332,7 @@ class B extends A {
   B(int x, {int? foo}) : super(x, foo: 0); 
 }
 ''', [
-      lint('use_super_parameters', 59, 1),
+      lint(59, 1),
     ]);
   }
 
@@ -347,7 +345,7 @@ class B extends A {
   B(int x) : super(x);
 }
 ''', [
-      lint('use_super_parameters', 56, 1),
+      lint(56, 1),
     ]);
   }
 
@@ -360,7 +358,7 @@ class B extends A {
   B([int x = 0]) : super(x);
 }
 ''', [
-      lint('use_super_parameters', 46, 1),
+      lint(46, 1),
     ]);
   }
 
@@ -391,7 +389,7 @@ class C extends B {
   C(int foo, int bar) : super(foo, bar);
 }
 ''', [
-      lint('use_super_parameters', 93, 1),
+      lint(93, 1),
     ]);
   }
 
@@ -404,7 +402,7 @@ class B extends A {
   B(int x, int y) : super(x, y: y);
 }
 ''', [
-      lint('use_super_parameters', 56, 1),
+      lint(56, 1),
     ]);
   }
 
@@ -419,7 +417,7 @@ class C extends B {
   C(int baz, int foo, int bar) : super(foo, bar);
 }
 ''', [
-      lint('use_super_parameters', 93, 1),
+      lint(93, 1),
     ]);
   }
 
@@ -432,7 +430,7 @@ class B extends A {
   B(int x, {int? y}) : super(x, y: y);
 }
 ''', [
-      lint('use_super_parameters', 56, 1),
+      lint(56, 1),
     ]);
   }
 }


### PR DESCRIPTION
The existing API duplicates information that's encoded in the `lintRule` getter which is annoying.

This does away with that.

/cc @bwilkerson 
