### PR TITLE
fix `prefer_const_declarations` failing test (WAI)

### DIFF
--- a/test/rules/prefer_const_declarations_test.dart
+++ b/test/rules/prefer_const_declarations_test.dart
@@ -20,12 +20,11 @@ class PreferConstDeclarationsTest extends LintRuleTest {
   @override
   String get lintRule => 'prefer_const_declarations';
 
-  @FailingTest(issue: 'https://github.com/dart-lang/linter/issues/3626')
   test_recordLiteral() async {
     await assertDiagnostics(r'''
-final tuple = ("first", 2, true);
+final tuple = const ("first", 2, true);
 ''', [
-      lint(14, 18),
+      lint(0, 38),
     ]);
   }
 


### PR DESCRIPTION
As per our discussion (and looking at how list literals are supported), this is actually WAI.

Closes: #3626

/cc @bwilkerson 