### PR TITLE
fix `use_build_context_synchronously` to check for `BuildContext`s in NamedExpressions

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -105,6 +105,9 @@ class _Visitor extends SimpleAstVisitor {
 
   bool accessesContext(ArgumentList argumentList) {
     for (var argument in argumentList.arguments) {
+      if (argument is NamedExpression) {
+        argument = argument.expression;
+      }
       if (argument is Identifier) {
         var element = argument.staticElement;
         if (element == null) {

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -114,9 +114,6 @@ class ExpectedLint extends ExpectedDiagnostic {
 abstract class LintRuleTest extends PubPackageResolutionTest {
   String? get lintRule;
 
-  ExpectedLint lint(int offset, int length, {Pattern? messageContains}) =>
-      ExpectedLint(lintRule!, offset, length, messageContains: messageContains);
-
   @override
   List<String> get _lintRules => [if (lintRule != null) lintRule!];
 
@@ -220,10 +217,15 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
   /// Assert that there are no diagnostics in the given [code].
   Future<void> assertNoDiagnostics(String code) async =>
       assertDiagnostics(code, const []);
+
+  ExpectedLint lint(int offset, int length, {Pattern? messageContains}) =>
+      ExpectedLint(lintRule!, offset, length, messageContains: messageContains);
 }
 
 class PubPackageResolutionTest extends _ContextResolutionTest {
   final List<String> _lintRules = const [];
+
+  bool get addFlutterPackageDep => false;
 
   bool get addJsPackageDep => false;
 
@@ -303,6 +305,14 @@ class PubPackageResolutionTest extends _ContextResolutionTest {
       languageVersion: testPackageLanguageVersion,
     );
 
+    if (addFlutterPackageDep) {
+      var flutterPath = '/packages/flutter';
+      addFlutterPackageFiles(
+        getFolder(flutterPath),
+      );
+      configCopy.add(name: 'flutter', rootPath: flutterPath);
+    }
+
     if (addJsPackageDep) {
       var jsPath = '/packages/js';
       MockPackages.addJsPackageFiles(
@@ -321,6 +331,27 @@ class PubPackageResolutionTest extends _ContextResolutionTest {
 
     var path = '$testPackageRootPath/.dart_tool/package_config.json';
     writePackageConfig(path, configCopy);
+  }
+
+  /// Create a fake 'flutter' package that can be used by tests.
+  static void addFlutterPackageFiles(Folder rootFolder) {
+    var libFolder = rootFolder.getChildAssumingFolder('lib');
+    libFolder.getChildAssumingFile('widgets.dart').writeAsStringSync(r'''
+export 'src/widgets/framework.dart';
+''');
+
+    libFolder
+        .getChildAssumingFolder('src')
+        .getChildAssumingFolder('widgets')
+        .getChildAssumingFile('framework.dart')
+        .writeAsStringSync(r'''   
+abstract class BuildContext {
+  Widget get widget;
+}
+
+class Widget {
+}
+''');
   }
 }
 
@@ -379,6 +410,8 @@ abstract class _ContextResolutionTest with ResourceProviderMixin {
 
   List<String> get collectionIncludedPaths;
 
+  bool get enableTestMode => false;
+
   /// The analysis errors that were computed during analysis.
   List<AnalysisError> get errors => result.errors;
 
@@ -410,7 +443,7 @@ abstract class _ContextResolutionTest with ResourceProviderMixin {
   @mustCallSuper
   void setUp() {
     if (!_lintRulesAreRegistered) {
-      registerLintRules();
+      registerLintRules(inTestMode: enableTestMode);
       _lintRulesAreRegistered = true;
     }
 

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -410,8 +410,6 @@ abstract class _ContextResolutionTest with ResourceProviderMixin {
 
   List<String> get collectionIncludedPaths;
 
-  bool get enableTestMode => false;
-
   /// The analysis errors that were computed during analysis.
   List<AnalysisError> get errors => result.errors;
 
@@ -443,7 +441,7 @@ abstract class _ContextResolutionTest with ResourceProviderMixin {
   @mustCallSuper
   void setUp() {
     if (!_lintRulesAreRegistered) {
-      registerLintRules(inTestMode: enableTestMode);
+      registerLintRules();
       _lintRulesAreRegistered = true;
     }
 

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -72,6 +72,8 @@ import 'unawaited_futures_test.dart' as unawaited_futures;
 import 'unnecessary_const_test.dart' as unnecessary_const;
 import 'unnecessary_null_checks_test.dart' as unnecessary_null_checks;
 import 'unnecessary_overrides_test.dart' as unnecessary_overrides;
+import 'use_build_context_synchronously_test.dart'
+    as use_build_context_synchronously;
 import 'use_enums_test.dart' as use_enums;
 import 'use_is_even_rather_than_modulo_test.dart'
     as use_is_even_rather_than_modulo;
@@ -128,6 +130,7 @@ void main() {
   unnecessary_const.main();
   unnecessary_null_checks.main();
   unnecessary_overrides.main();
+  use_build_context_synchronously.main();
   use_enums.main();
   use_is_even_rather_than_modulo.main();
   use_super_parameters.main();

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(UseBuildContextSynchronouslyTest);
+  });
+
+  Future.delayed(const Duration(seconds: 1));
+}
+
+@reflectiveTest
+class UseBuildContextSynchronouslyTest extends LintRuleTest {
+
+  @override
+  bool get addFlutterPackageDep => true;
+
+  @override
+  bool get enableTestMode  => true;
+
+  @override
+  String get lintRule => 'use_build_context_synchronously';
+
+  /// https://github.com/dart-lang/linter/issues/3676
+  test_contextPassedAsNamedParam() async {
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+Future<void> foo(BuildContext context) async {
+    await Future.value();
+    bar(context: context);
+}
+
+Future<void> bar({required BuildContext context}) async {}
+''', [
+      lint(117, 21),
+    ]);
+  }
+}

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -10,18 +10,15 @@ main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(UseBuildContextSynchronouslyTest);
   });
-
-  Future.delayed(const Duration(seconds: 1));
 }
 
 @reflectiveTest
 class UseBuildContextSynchronouslyTest extends LintRuleTest {
-
   @override
   bool get addFlutterPackageDep => true;
 
   @override
-  bool get enableTestMode  => true;
+  bool get enableTestMode => true;
 
   @override
   String get lintRule => 'use_build_context_synchronously';

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -18,10 +18,11 @@ class UseBuildContextSynchronouslyTest extends LintRuleTest {
   bool get addFlutterPackageDep => true;
 
   @override
-  bool get enableTestMode => true;
-
-  @override
   String get lintRule => 'use_build_context_synchronously';
+
+  /// Ensure we're not run in the test dir.
+  @override
+  String get testPackageRootPath => '$workspaceRootPath/lib';
 
   /// https://github.com/dart-lang/linter/issues/3676
   test_contextPassedAsNamedParam() async {


### PR DESCRIPTION
Fixes #3676

Also adds `package:flutter` mocking to reflective tests.

/cc @bwilkerson 
