### PR TITLE
Use asInstanceOf in unrelated type checks

### DIFF
--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/element/element.dart';
+
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
 import '../util/unrelated_types_visitor.dart';
 
 const _desc = r'Invocation of Iterable<E>.contains with references of unrelated'
@@ -136,18 +137,16 @@ class IterableContainsUnrelatedType extends LintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    var visitor = _Visitor(this, context.typeSystem);
+    var visitor = _Visitor(this, context.typeSystem, context.typeProvider);
     registry.addMethodInvocation(this, visitor);
   }
 }
 
 class _Visitor extends UnrelatedTypesProcessors {
-  static final _definition = InterfaceTypeDefinition('Iterable', 'dart.core');
-
-  _Visitor(super.rule, super.typeSystem);
+  _Visitor(super.rule, super.typeSystem, super.typeProvider);
 
   @override
-  InterfaceTypeDefinition get definition => _definition;
+  InterfaceElement get interface => typeProvider.iterableElement;
 
   @override
   String get methodName => 'contains';

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/element/element.dart';
+
 import '../analyzer.dart';
-import '../util/dart_type_utilities.dart';
 import '../util/unrelated_types_visitor.dart';
 
 const _desc = r'Invocation of `remove` with references of unrelated types.';
@@ -136,18 +137,16 @@ class ListRemoveUnrelatedType extends LintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    var visitor = _Visitor(this, context.typeSystem);
+    var visitor = _Visitor(this, context.typeSystem, context.typeProvider);
     registry.addMethodInvocation(this, visitor);
   }
 }
 
 class _Visitor extends UnrelatedTypesProcessors {
-  static final _definition = InterfaceTypeDefinition('List', 'dart.core');
-
-  _Visitor(super.rule, super.typeSystem);
+  _Visitor(super.rule, super.typeSystem, super.typeProvider);
 
   @override
-  InterfaceTypeDefinition get definition => _definition;
+  InterfaceElement get interface => typeProvider.listElement;
 
   @override
   String get methodName => 'remove';

--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -4,76 +4,28 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:collection/collection.dart' show IterableExtension;
+import 'package:analyzer/dart/element/type_provider.dart';
 
 import '../analyzer.dart';
 import '../util/dart_type_utilities.dart';
-
-typedef _InterfaceTypePredicate = bool Function(InterfaceType type);
-
-/// Returns a predicate which returns whether a given [InterfaceTypeDefinition]
-/// is equal to [definition].
-_InterfaceTypePredicate _buildImplementsDefinitionPredicate(
-        InterfaceTypeDefinition definition) =>
-    (InterfaceType interface) =>
-        interface.element2.name == definition.name &&
-        interface.element2.library.name == definition.library;
-
-/// Returns the first type argument on [definition], as implemented by [type].
-///
-/// In the simplest case, [type] is the same class as [definition]. For
-/// example, given the definition `List<E>` and the type `List<int>`,
-/// this function returns the DartType for `int`.
-///
-/// In a more complicated case, we must traverse [type]'s interfaces to find
-/// [definition]. For example, given the definition `Set<E>` and the type `A`
-/// where `A implements B<List, String>` and `B<E, F> implements Set<F>, C<E>`,
-/// this function returns the DartType for `String`.
-DartType? _findIterableTypeArgument(
-    InterfaceTypeDefinition definition, InterfaceType? type,
-    {List<InterfaceType> accumulator = const []}) {
-  if (type == null ||
-      type.isDartCoreObject ||
-      type.isDynamic ||
-      accumulator.contains(type)) {
-    return null;
-  }
-
-  var predicate = _buildImplementsDefinitionPredicate(definition);
-  if (predicate(type)) {
-    return type.typeArguments.first;
-  }
-
-  var implementedInterfaces = type.allSupertypes;
-  var interface = implementedInterfaces.firstWhereOrNull(predicate);
-  if (interface != null && interface.typeArguments.isNotEmpty) {
-    return interface.typeArguments.first;
-  }
-
-  return _findIterableTypeArgument(definition, type.superclass,
-      accumulator: [type, ...accumulator, ...implementedInterfaces]);
-}
-
-bool _isParameterizedMethodInvocation(
-        String methodName, MethodInvocation node) =>
-    node.methodName.name == methodName &&
-    node.argumentList.arguments.length == 1;
 
 /// Base class for visitor used in rules where we want to lint about invoking
 /// methods on generic classes where the type of the singular argument is
 /// unrelated to the singular type argument of the class. Extending this
 /// visitor is as simple as knowing the method, class and library that uniquely
-/// define the target, i.e. implement only [definition] and [methodName].
+/// define the target, i.e. implement only [interface] and [methodName].
 abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
   final LintRule rule;
   final TypeSystem typeSystem;
+  final TypeProvider typeProvider;
 
-  UnrelatedTypesProcessors(this.rule, this.typeSystem);
+  UnrelatedTypesProcessors(this.rule, this.typeSystem, this.typeProvider);
 
   /// The type definition which this [UnrelatedTypesProcessors] is concerned
   /// with.
-  InterfaceTypeDefinition get definition;
+  InterfaceElement get interface;
 
   /// The name of the method which this [UnrelatedTypesProcessors] is concerned
   /// with.
@@ -81,13 +33,16 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    if (!_isParameterizedMethodInvocation(methodName, node)) {
+    if (node.argumentList.arguments.length != 1) {
+      return;
+    }
+    if (node.methodName.name != methodName) {
       return;
     }
 
     // At this point, we know that [node] is an invocation of a method which
-    // has the same name as the method that this UnrelatedTypesProcessors] is
-    // concerned with, and that the method has a single parameter.
+    // has the same name as the method that this [UnrelatedTypesProcessors] is
+    // concerned with, and that the method call has a single argument.
     //
     // We've completed the "cheap" checks, and must now continue with the
     // arduous task of determining whether the method target implements
@@ -101,24 +56,34 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
       for (AstNode? parent = node; parent != null; parent = parent.parent) {
         if (parent is ClassDeclaration) {
           targetType = parent.declaredElement2?.thisType;
+          break;
         } else if (parent is MixinDeclaration) {
           targetType = parent.declaredElement2?.thisType;
+          break;
         } else if (parent is EnumDeclaration) {
           targetType = parent.declaredElement2?.thisType;
+          break;
         }
       }
     }
-    var argument = node.argumentList.arguments.first;
+
+    if (targetType is! InterfaceType) {
+      return;
+    }
+
+    var collectionType = targetType.asInstanceOf(interface);
+    if (collectionType == null) {
+      return;
+    }
 
     // Finally, determine whether the type of the argument is related to the
     // type of the method target.
-    if (targetType is InterfaceType) {
-      var typeArgument = _findIterableTypeArgument(definition, targetType);
-      if (typeArgument != null &&
-          typesAreUnrelated(typeSystem, argument.staticType, typeArgument)) {
-        rule.reportLint(node,
-            arguments: [typeArgument.getDisplayString(withNullability: true)]);
-      }
+    var argumentType = node.argumentList.arguments.first.staticType;
+
+    var typeArgument = collectionType.typeArguments.first;
+    if (typesAreUnrelated(typeSystem, argumentType, typeArgument)) {
+      rule.reportLint(node,
+          arguments: [typeArgument.getDisplayString(withNullability: true)]);
     }
   }
 }


### PR DESCRIPTION
# Description

UnrelatedTypesProcessors used a custom method of grabbing the type argument off of a type as an implementation of `List<T>` or `Iterable<T>` etc. This replaces that custom code with `InterfaceType.asInstanceOf`. It should not have a behavior difference, nor a performance difference.