### PR TITLE
Report unrelated types on implicit receiver calls from extension

### DIFF
--- a/lib/src/util/unrelated_types_visitor.dart
+++ b/lib/src/util/unrelated_types_visitor.dart
@@ -105,6 +105,8 @@ abstract class UnrelatedTypesProcessors extends SimpleAstVisitor<void> {
           targetType = parent.declaredElement2?.thisType;
         } else if (parent is EnumDeclaration) {
           targetType = parent.declaredElement2?.thisType;
+        } else if (parent is ExtensionDeclaration) {
+          targetType = parent.extendedType.type;
         }
       }
     }

--- a/test_data/rules/iterable_contains_unrelated_type.dart
+++ b/test_data/rules/iterable_contains_unrelated_type.dart
@@ -192,3 +192,11 @@ enum E implements List<int> {
     contains(1); // OK
   }
 }
+
+extension on List<int> {
+  void f() {
+    contains('string'); // LINT
+    this.contains('string'); // LINT
+    contains(1); // OK
+  }
+}

--- a/test_data/rules/list_remove_unrelated_type.dart
+++ b/test_data/rules/list_remove_unrelated_type.dart
@@ -196,3 +196,11 @@ enum E implements List<int> {
     remove(1); // OK
   }
 }
+
+extension on List<int> {
+  void f() {
+    remove('string'); // LINT
+    this.remove('string'); // LINT
+    remove(1); // OK
+  }
+}


### PR DESCRIPTION
# Description

This allows some rules to track an implicit receiver from within an extension method.

Fixes https://github.com/dart-lang/linter/issues/3702
