### PR TITLE
check for context property accesses in `use_build_context_synchronously`

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -70,6 +70,7 @@ class UseBuildContextSynchronously extends LintRule {
       registry.addMethodInvocation(this, visitor);
       registry.addInstanceCreationExpression(this, visitor);
       registry.addFunctionExpressionInvocation(this, visitor);
+      registry.addPrefixedIdentifier(this, visitor);
     }
   }
 }
@@ -292,6 +293,14 @@ class _Visitor extends SimpleAstVisitor {
   void visitMethodInvocation(MethodInvocation node) {
     if (isBuildContext(node.target?.staticType, skipNullable: true) ||
         accessesContext(node.argumentList)) {
+      check(node);
+    }
+  }
+
+  @override
+  visitPrefixedIdentifier(PrefixedIdentifier node) {
+    // Getter access.
+    if (isBuildContext(node.prefix.staticType, skipNullable: true)) {
       check(node);
     }
   }

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -39,4 +39,39 @@ Future<void> bar({required BuildContext context}) async {}
       lint(117, 21),
     ]);
   }
+
+  /// https://github.com/dart-lang/linter/issues/3700
+  test_propertyAccess_getter() async {
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+extension on BuildContext {
+  BuildContext get foo => this;
+}
+
+Future<void> f(BuildContext context) async {
+  await Future.value();
+  context.foo;
+}
+''', [
+      lint(174, 11),
+    ]);
+  }
+
+  test_propertyAccess_setter() async {
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+extension on BuildContext {
+  set foo(int x){ }
+}
+
+Future<void> f(BuildContext context) async {
+  await Future.value();
+  context.foo = 1;
+}
+''', [
+      lint(162, 11),
+    ]);
+  }
 }


### PR DESCRIPTION
Fixes #3700

/cc @bwilkerson 