### PR TITLE
Add missed case for prefer_collection_literals

### DIFF
--- a/test/rules/prefer_collection_literals_test.dart
+++ b/test/rules/prefer_collection_literals_test.dart
@@ -122,4 +122,19 @@ void f() {
       error(CompileTimeErrorCode.UNDEFINED_FUNCTION, 44, 15),
     ]);
   }
+
+  @failingTest
+  test_closure_returns_linkedHashSet() async {
+    await assertDiagnostics(r'''
+import 'dart:collection';
+
+void a(Set<int> Function() f) {}
+
+void c() {
+  a(() => LinkedHashSet<int>());
+}
+''', [
+      lint(82, 20),
+    ]);
+  }
 }

--- a/test_data/rules/prefer_collection_literals.dart
+++ b/test_data/rules/prefer_collection_literals.dart
@@ -64,7 +64,6 @@ void main() {
   var sss = Set.from(iter); // OK
 
   LinkedHashSet<String> sss1 = <int, LinkedHashSet<String>>{}.putIfAbsent(3, () => LinkedHashSet<String>()); // OK
-  var sss2 = <int, Set<String>>{}.putIfAbsent(0, () => LinkedHashSet()); // LINT
 
   var lhs = LinkedHashSet(equals: (a, b) => false, hashCode: (o) => 13)..addAll({}); // OK
 

--- a/test_data/rules/prefer_collection_literals.dart
+++ b/test_data/rules/prefer_collection_literals.dart
@@ -64,6 +64,7 @@ void main() {
   var sss = Set.from(iter); // OK
 
   LinkedHashSet<String> sss1 = <int, LinkedHashSet<String>>{}.putIfAbsent(3, () => LinkedHashSet<String>()); // OK
+  var sss2 = <int, Set<String>>{}.putIfAbsent(0, () => LinkedHashSet()); // LINT
 
   var lhs = LinkedHashSet(equals: (a, b) => false, hashCode: (o) => 13)..addAll({}); // OK
 


### PR DESCRIPTION
Shows that the check for returning from a function literal is incorrect.

# Description

Please include a summary of the change and a reference to any corresponding issues.
If this is a fix to an existing lint rule or a proposed new one, please include
the name of the rule in the pull request.

If this is a new lint or feature and there is not an existing tracking bug, please
consider opening one to better facilitate conversation.

Fixes # (issue)
