### PR TITLE
perf improvements for `recursive_getters`

### DIFF
--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -7,7 +7,6 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
-import '../extensions.dart';
 
 const _desc = r'Property getter recursively returns itself.';
 
@@ -54,65 +53,58 @@ class RecursiveGetters extends LintRule {
   }
 }
 
-/// Tests if a simple identifier is a recursive getter by looking at its parent.
-class _RecursiveGetterParentVisitor extends SimpleAstVisitor<bool> {
-  @override
-  bool visitPropertyAccess(PropertyAccess node) =>
-      node.target is ThisExpression;
+class _BodyVisitor extends RecursiveAstVisitor {
+  final LintRule rule;
+  final ExecutableElement element;
+  _BodyVisitor(this.element, this.rule);
 
   @override
-  bool? visitSimpleIdentifier(SimpleIdentifier node) {
-    var parent = node.parent;
-    if (parent is ArgumentList ||
-        parent is ConditionalExpression ||
-        parent is ExpressionFunctionBody ||
-        parent is ReturnStatement) {
-      return true;
+  visitListLiteral(ListLiteral node) {
+    if (node.isConst) return null;
+    return super.visitListLiteral(node);
+  }
+
+  @override
+  visitSetOrMapLiteral(SetOrMapLiteral node) {
+    if (node.isConst) return null;
+    return super.visitSetOrMapLiteral(node);
+  }
+
+  @override
+  visitSimpleIdentifier(SimpleIdentifier node) {
+    if (node.staticElement == element) {
+      if (node.parent is! PrefixedIdentifier) {
+        rule.reportLint(node);
+      }
     }
 
-    if (parent is PropertyAccess) {
-      return parent.accept(this);
-    }
-
-    return false;
+    return super.visitSimpleIdentifier(node);
   }
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
-  final visitor = _RecursiveGetterParentVisitor();
-
   _Visitor(this.rule);
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
     // getters have null arguments, methods have parameters, could be empty.
-    if (node.functionExpression.parameters != null) {
-      return;
-    }
+    if (node.functionExpression.parameters != null) return;
 
-    var element = node.declaredElement2;
-    _verifyElement(node.functionExpression, element);
+    _verifyElement(node.functionExpression, node.declaredElement2);
   }
 
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
     // getters have null arguments, methods have parameters, could be empty.
-    if (node.parameters != null) {
-      return;
-    }
+    if (node.parameters != null) return;
 
-    var element = node.declaredElement2;
-    _verifyElement(node.body, element);
+    _verifyElement(node.body, node.declaredElement2);
   }
 
   void _verifyElement(AstNode node, ExecutableElement? element) {
-    node
-        .traverseNodesInDFS()
-        .whereType<SimpleIdentifier>()
-        .where(
-            (n) => element == n.staticElement && (n.accept(visitor) ?? false))
-        .forEach(rule.reportLint);
+    if (element == null) return;
+    node.accept(_BodyVisitor(element, rule));
   }
 }

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -62,6 +62,7 @@ import 'prefer_generic_function_type_aliases_test.dart'
     as prefer_generic_function_type_aliases;
 import 'prefer_spread_collections_test.dart' as prefer_spread_collections;
 import 'public_member_api_docs_test.dart' as public_member_api_docs;
+import 'recursive_getters_test.dart' as recursive_getters;
 import 'sort_constructors_first_test.dart' as sort_constructors_first;
 import 'sort_unnamed_constructors_first_test.dart'
     as sort_unnamed_constructors_first;
@@ -125,6 +126,7 @@ void main() {
   prefer_generic_function_type_aliases.main();
   prefer_spread_collections.main();
   public_member_api_docs.main();
+  recursive_getters.main();
   sort_constructors_first.main();
   sort_unnamed_constructors_first.main();
   super_goes_last.main();

--- a/test/rules/recursive_getters_test.dart
+++ b/test/rules/recursive_getters_test.dart
@@ -1,0 +1,124 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(RecursiveGettersTest);
+  });
+}
+
+@reflectiveTest
+class RecursiveGettersTest extends LintRuleTest {
+  @override
+  String get lintRule => 'recursive_getters';
+
+  /// https://github.com/dart-lang/linter/issues/3706
+  test_constList_expressionFunctionBody() async {
+    var listContents = StringBuffer();
+    for (var i = 0; i < 100000; ++i) {
+      listContents.write('"foo", ');
+    }
+    await assertNoDiagnostics('''
+List<String> get strings => const <String>[$listContents];
+''');
+  }
+
+  test_constMap_expressionFunctionBody() async {
+    var mapContents = StringBuffer();
+    for (var i = 0; i < 100000; ++i) {
+      mapContents.write('$i : "foo", ');
+    }
+    await assertNoDiagnostics('''
+Map<int, String> get strings => const <int, String>{$mapContents};
+''');
+  }
+
+  /// https://github.com/dart-lang/linter/issues/3706
+  test_constSet_expressionFunctionBody() async {
+    var setContents = StringBuffer();
+    for (var i = 0; i < 100000; ++i) {
+      setContents.write('"foo$i", ');
+    }
+    await assertNoDiagnostics('''
+Set<String> get strings => const <String>{$setContents};
+''');
+  }
+
+  /// https://github.com/dart-lang/linter/issues/586
+  test_nestedReference() async {
+    await assertNoDiagnostics(r'''
+class Nested {
+  final Nested _parent;
+  Nested(this._parent);
+  Nested get ancestor => _parent.ancestor;
+}
+''');
+  }
+
+  test_referenceInListLiteral() async {
+    await assertDiagnostics(r'''
+class C {
+  List<int> get f => [1, 2, ...f];
+}
+''', [
+      lint(41, 1),
+    ]);
+  }
+
+  test_referenceInMapLiteral() async {
+    await assertDiagnostics(r'''
+class C {
+  Map<int, int> get f => {}..addAll(f);
+}
+''', [
+      lint(46, 1),
+    ]);
+  }
+
+  test_referenceInMethodCall() async {
+    await assertDiagnostics(r'''
+class C {
+  int get f {
+    print(f);
+    return 0;
+  }
+}
+''', [
+      lint(34, 1),
+    ]);
+  }
+
+  test_simpleGetter() async {
+    await assertDiagnostics(r'''
+class C {
+  int get f => f;
+}
+''', [
+      lint(25, 1),
+    ]);
+  }
+
+  test_simpleGetter_thisPrefix() async {
+    await assertDiagnostics(r'''
+class C {
+  int get f => this.f;
+}
+''', [
+      lint(30, 1),
+    ]);
+  }
+
+  test_staticMemberReference() async {
+    await assertNoDiagnostics(r'''
+class C {
+  static final c = C();
+  int get f => c.f;
+}
+''');
+  }
+}


### PR DESCRIPTION
Addresses the pathological case reported by @davidmorgan (see: `test_constList_expressionFunctionBody`) and makes the common case **_much_** faster.

Compare.

**BEFORE**

![image](https://user-images.githubusercontent.com/67586/191618073-9ea2bd27-dd02-40de-ab07-8459fe5c39c2.png)

**AFTER**

![image](https://user-images.githubusercontent.com/67586/191618083-3040cbdb-aabd-4c84-be70-cc7a2cfc6b2f.png)

Fixes: https://github.com/dart-lang/linter/issues/3706

/cc @bwilkerson 
