### PR TITLE
validate rule descriptions don't have needless leading whitespace

### DIFF
--- a/lib/src/rules/avoid_final_parameters.dart
+++ b/lib/src/rules/avoid_final_parameters.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid final for parameter declarations';
+const _desc = r'Avoid final for parameter declarations.';
 
 const _details = r'''
 **AVOID** declaring parameters as final.

--- a/lib/src/rules/leading_newlines_in_multiline_strings.dart
+++ b/lib/src/rules/leading_newlines_in_multiline_strings.dart
@@ -10,7 +10,6 @@ import '../analyzer.dart';
 const _desc = r'Start multiline strings with a newline.';
 
 const _details = r"""
-
 Multiline strings are easier to read when they start with a newline (a newline
 starting a multiline string is ignored).
 

--- a/lib/src/rules/prefer_const_literals_to_create_immutables.dart
+++ b/lib/src/rules/prefer_const_literals_to_create_immutables.dart
@@ -13,7 +13,6 @@ const desc =
     'Prefer const literals as parameters of constructors on @immutable classes.';
 
 const details = '''
-
 **PREFER** using `const` for instantiating list, map and set literals used as
 parameters in immutable class instantiations.
 

--- a/lib/src/rules/prefer_double_quotes.dart
+++ b/lib/src/rules/prefer_double_quotes.dart
@@ -9,7 +9,6 @@ const _desc =
     r"Prefer double quotes where they won't require escape sequences.";
 
 const _details = '''
-
 **DO** use double quotes where they wouldn't require additional escapes.
 
 That means strings with a double quote may use apostrophes so that the double

--- a/lib/src/rules/prefer_int_literals.dart
+++ b/lib/src/rules/prefer_int_literals.dart
@@ -11,7 +11,6 @@ import '../analyzer.dart';
 const _desc = 'Prefer int literals over double literals.';
 
 const _details = '''
-
 **DO** use int literals rather than the corresponding double literal.
 
 **BAD:**

--- a/lib/src/rules/prefer_single_quotes.dart
+++ b/lib/src/rules/prefer_single_quotes.dart
@@ -10,7 +10,6 @@ import '../analyzer.dart';
 const _desc = r'Only use double quotes for strings containing single quotes.';
 
 const _details = '''
-
 **DO** use single quotes where they wouldn't require additional escapes.
 
 That means strings with an apostrophe may use double quotes so that the

--- a/lib/src/rules/unnecessary_null_aware_operator_on_extension_on_nullable.dart
+++ b/lib/src/rules/unnecessary_null_aware_operator_on_extension_on_nullable.dart
@@ -9,7 +9,7 @@ import 'package:analyzer/dart/element/element.dart';
 import '../analyzer.dart';
 
 const _desc =
-    r'Unnecessary null aware operator on extension on a nullable type';
+    r'Unnecessary null aware operator on extension on a nullable type.';
 
 const _details = r'''
 Avoid null aware operators for members defined in an extension on a nullable type.

--- a/test/all.dart
+++ b/test/all.dart
@@ -19,6 +19,8 @@ import 'validate_headers_test.dart' as validate_headers;
 import 'validate_incompatible_rules.dart' as validate_incompatible_rules;
 import 'validate_no_rule_description_references.dart'
     as validate_no_rule_description_references;
+import 'validate_rule_description_format_test.dart'
+    as validate_rule_description_format;
 import 'verify_reflective_test_suites.dart' as verify_reflective_test_suites;
 import 'version_test.dart' as version_test;
 
@@ -39,6 +41,7 @@ void main() {
   validate_headers.main();
   validate_incompatible_rules.main();
   validate_no_rule_description_references.main();
+  validate_rule_description_format.main();
   verify_reflective_test_suites.main();
   version_test.main();
 }

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -68,15 +68,6 @@ void defineRuleTests() {
         }
       }
     });
-    group('format', () {
-      for (var rule in Registry.ruleRegistry.rules) {
-        test('`${rule.name}` description', () {
-          expect(rule.description.endsWith('.'), isTrue,
-              reason:
-                  "Rule description for ${rule.name} should end with a '.'");
-        });
-      }
-    });
   });
 }
 

--- a/test/validate_rule_description_format_test.dart
+++ b/test/validate_rule_description_format_test.dart
@@ -10,8 +10,15 @@ import 'package:analyzer/src/lint/registry.dart';
 
 void main() {
   group('rule doc format', () {
+    var rules = Registry.ruleRegistry.rules;
+    test('(setup)', () {
+      expect(rules, isNotEmpty,
+          reason:
+              'Ensure `registerLintRules()` is called before running this suite.');
+    });
+
     group('description - trailing periods', () {
-      for (var rule in Registry.ruleRegistry.rules) {
+      for (var rule in rules) {
         test('`${rule.name}` description', () {
           expect(rule.description.endsWith('.'), isTrue,
               reason:
@@ -20,14 +27,13 @@ void main() {
       }
     });
     group('details - no leading whitespace', () {
-      for (var rule in Registry.ruleRegistry.rules) {
+      for (var rule in rules) {
         test('`${rule.name}` details', () {
           expect(rule.details.startsWith(RegExp(r'\s+')), isFalse,
               reason:
-              'Rule details for ${rule.name} should not have leading whitespace.');
+                  'Rule details for ${rule.name} should not have leading whitespace.');
         });
       }
     });
-
   });
 }

--- a/test/validate_rule_description_format_test.dart
+++ b/test/validate_rule_description_format_test.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
-import 'package:linter/src/rules.dart';
-import 'package:test/test.dart';
 import 'package:analyzer/src/lint/registry.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('rule doc format', () {

--- a/test/validate_rule_description_format_test.dart
+++ b/test/validate_rule_description_format_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:linter/src/rules.dart';
+import 'package:test/test.dart';
+import 'package:analyzer/src/lint/registry.dart';
+
+void main() {
+  group('rule doc format', () {
+    group('description - trailing periods', () {
+      for (var rule in Registry.ruleRegistry.rules) {
+        test('`${rule.name}` description', () {
+          expect(rule.description.endsWith('.'), isTrue,
+              reason:
+                  "Rule description for ${rule.name} should end with a '.'");
+        });
+      }
+    });
+    group('details - no leading whitespace', () {
+      for (var rule in Registry.ruleRegistry.rules) {
+        test('`${rule.name}` details', () {
+          expect(rule.details.startsWith(RegExp(r'\s+')), isFalse,
+              reason:
+              'Rule details for ${rule.name} should not have leading whitespace.');
+        });
+      }
+    });
+
+  });
+}


### PR DESCRIPTION
Validates that rule descriptions don't have needless leading whitespace.

Catches a few spots missed in https://github.com/dart-lang/linter/pull/2764.

Also ensures description checking is run (by ensuring the list of lints is not empty).

Catches a few spots that were going undetected.

Fixes #3709

/fyi @asashour 

/cc @bwilkerson 