### PR TITLE
migrate `parameter_assignments` from `traverseNodesInDFS()`

### DIFF
--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -3,11 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
-import '../extensions.dart';
 
 const _desc =
     r"Don't reassign references to parameters of functions or methods.";

--- a/lib/src/rules/parameter_assignments.dart
+++ b/lib/src/rules/parameter_assignments.dart
@@ -43,7 +43,7 @@ void badFunctionPositional(int required, [int optional = 42]) { // LINT
 **BAD:**
 ```dart
 class A {
-    void badMethod(int parameter) { // LINT
+  void badMethod(int parameter) { // LINT
     parameter = 4;
   }
 }
@@ -84,28 +84,12 @@ class A {
 bool _isDefaultFormalParameterWithDefaultValue(FormalParameter parameter) =>
     parameter is DefaultFormalParameter && parameter.defaultValue != null;
 
-bool _isDefaultFormalParameterWithoutDefaultValueReassigned(
-        FormalParameter parameter, AssignmentExpression assignment) =>
-    parameter is DefaultFormalParameter &&
-    parameter.defaultValue == null &&
-    _isFormalParameterReassigned(parameter, assignment);
-
 bool _isFormalParameterReassigned(
     FormalParameter parameter, AssignmentExpression assignment) {
   var leftHandSide = assignment.leftHandSide;
   return leftHandSide is SimpleIdentifier &&
       leftHandSide.staticElement == parameter.declaredElement;
 }
-
-bool _preOrPostFixExpressionMutation(FormalParameter parameter, AstNode n) =>
-    n is PrefixExpression &&
-        n.operand is SimpleIdentifier &&
-        (n.operand as SimpleIdentifier).staticElement ==
-            parameter.declaredElement ||
-    n is PostfixExpression &&
-        n.operand is SimpleIdentifier &&
-        (n.operand as SimpleIdentifier).staticElement ==
-            parameter.declaredElement;
 
 class ParameterAssignments extends LintRule {
   ParameterAssignments()
@@ -124,6 +108,66 @@ class ParameterAssignments extends LintRule {
   }
 }
 
+class _DeclarationVisitor extends RecursiveAstVisitor {
+  final FormalParameter parameter;
+  final LintRule rule;
+  final bool paramIsNotNullByDefault;
+  final bool paramDefaultsToNull;
+  bool hasBeenAssigned = false;
+
+  _DeclarationVisitor(this.parameter, this.rule)
+      : paramIsNotNullByDefault = parameter is SimpleFormalParameter ||
+            _isDefaultFormalParameterWithDefaultValue(parameter),
+        paramDefaultsToNull = parameter is DefaultFormalParameter &&
+            parameter.defaultValue == null;
+
+  @override
+  visitAssignmentExpression(AssignmentExpression node) {
+    if (paramIsNotNullByDefault) {
+      if (_isFormalParameterReassigned(parameter, node)) {
+        rule.reportLint(node);
+      }
+    } else {
+      if (paramDefaultsToNull) {
+        if (_isFormalParameterReassigned(parameter, node)) {
+          if (hasBeenAssigned) {
+            rule.reportLint(node);
+          }
+          hasBeenAssigned = true;
+        }
+      }
+    }
+
+    super.visitAssignmentExpression(node);
+  }
+
+  @override
+  visitPostfixExpression(PostfixExpression node) {
+    if (paramIsNotNullByDefault) {
+      var operand = node.operand;
+      if (operand is SimpleIdentifier &&
+          operand.staticElement == parameter.declaredElement) {
+        rule.reportLint(node);
+      }
+    }
+
+    super.visitPostfixExpression(node);
+  }
+
+  @override
+  visitPrefixExpression(PrefixExpression node) {
+    if (paramIsNotNullByDefault) {
+      var operand = node.operand;
+      if (operand is SimpleIdentifier &&
+          operand.staticElement == parameter.declaredElement) {
+        rule.reportLint(node);
+      }
+    }
+
+    super.visitPrefixExpression(node);
+  }
+}
+
 class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
@@ -131,16 +175,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
-    var parameters = node.functionExpression.parameters;
-    if (parameters != null) {
-      // Getter do not have formal parameters.
-      for (var e in parameters.parameters) {
-        var declaredElement = e.declaredElement;
-        if (declaredElement != null &&
-            node.functionExpression.body
-                .isPotentiallyMutatedInScope(declaredElement)) {
-          _reportIfSimpleParameterOrWithDefaultValue(e, node);
-        }
+    var parameterList = node.functionExpression.parameters;
+    if (parameterList == null) return;
+    for (var e in parameterList.parameters) {
+      var declaredElement = e.declaredElement;
+      if (declaredElement != null &&
+          node.functionExpression.body
+              .isPotentiallyMutatedInScope(declaredElement)) {
+        node.accept(_DeclarationVisitor(e, rule));
       }
     }
   }
@@ -148,51 +190,13 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
     var parameterList = node.parameters;
-    if (parameterList != null) {
-      // Getters don't have parameters.
-      for (var e in parameterList.parameters) {
-        var declaredElement = e.declaredElement;
-        if (declaredElement != null &&
-            node.body.isPotentiallyMutatedInScope(declaredElement)) {
-          _reportIfSimpleParameterOrWithDefaultValue(e, node);
-        }
+    if (parameterList == null) return;
+    for (var e in parameterList.parameters) {
+      var declaredElement = e.declaredElement;
+      if (declaredElement != null &&
+          node.body.isPotentiallyMutatedInScope(declaredElement)) {
+        node.accept(_DeclarationVisitor(e, rule));
       }
-    }
-  }
-
-  void _reportIfSimpleParameterOrWithDefaultValue(
-      FormalParameter parameter, AstNode functionOrMethodDeclaration) {
-    var nodes = functionOrMethodDeclaration.traverseNodesInDFS();
-
-    if (parameter is SimpleFormalParameter ||
-        _isDefaultFormalParameterWithDefaultValue(parameter)) {
-      var mutatedNodes = nodes.where((n) =>
-          (n is AssignmentExpression &&
-              _isFormalParameterReassigned(parameter, n)) ||
-          _preOrPostFixExpressionMutation(parameter, n));
-      mutatedNodes.forEach(rule.reportLint);
-      return;
-    }
-
-    var assignmentsNodes = nodes
-        .where((n) =>
-            n is AssignmentExpression &&
-            _isDefaultFormalParameterWithoutDefaultValueReassigned(
-                parameter, n))
-        .toList();
-
-    var nonNullCoalescingAssignments = assignmentsNodes.where((n) =>
-        (n as AssignmentExpression).operator.type !=
-        TokenType.QUESTION_QUESTION_EQ);
-
-    if (assignmentsNodes.length > 1 ||
-        nonNullCoalescingAssignments.isNotEmpty) {
-      var node = assignmentsNodes.length > 1
-          ? assignmentsNodes.last
-          : nonNullCoalescingAssignments.isNotEmpty
-              ? nonNullCoalescingAssignments.first
-              : parameter;
-      rule.reportLint(node);
     }
   }
 }

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -44,6 +44,7 @@ import 'non_constant_identifier_names_test.dart'
 import 'null_closures_test.dart' as null_closures;
 import 'omit_local_variable_types_test.dart' as omit_local_variable_types;
 import 'overridden_fields_test.dart' as overridden_fields;
+import 'parameter_assignments_test.dart' as parameter_assignments;
 import 'prefer_asserts_in_initializer_lists_test.dart'
     as prefer_asserts_in_initializer_lists;
 import 'prefer_collection_literals_test.dart' as prefer_collection_literals;
@@ -113,6 +114,7 @@ void main() {
   null_closures.main();
   omit_local_variable_types.main();
   overridden_fields.main();
+  parameter_assignments.main();
   prefer_asserts_in_initializer_lists.main();
   prefer_collection_literals.main();
   prefer_const_constructors.main();

--- a/test/rules/parameter_assignments_test.dart
+++ b/test/rules/parameter_assignments_test.dart
@@ -1,0 +1,168 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(ParameterAssignmentsTest);
+  });
+}
+
+
+@reflectiveTest
+class ParameterAssignmentsTest extends LintRuleTest {
+  @override
+  String get lintRule => 'parameter_assignments';
+
+  @FailingTest(reason: 'Closures implemented')
+  test_closure_assignment() async {
+    await assertDiagnostics(r'''
+void f() {
+  (int p) {
+    p = 2;
+  }(2);
+}
+''', [
+      lint(27, 5),
+    ]);
+  }
+
+
+  test_function_assignment() async {
+    await assertDiagnostics(r'''
+void f(int p) {
+  p = 4;
+}
+''', [
+      lint(18, 5),
+     ]);
+  }
+
+  test_member_setter() async {
+    await assertDiagnostics(r'''
+class A {
+  set x(int v) {
+    v = 5;
+  }
+}
+''', [
+      lint(31, 5),
+    ]);
+  }
+
+  test_function_incrementAssignment() async {
+    await assertDiagnostics(r'''
+void f(int p) {
+  p += 4;
+}
+''', [
+      lint(18, 6),
+    ]);
+  }
+
+  test_function_prefix() async {
+    await assertDiagnostics(r'''
+void f(int p) {
+  ++p;
+}
+''', [
+      lint(18, 3),
+    ]);
+  }
+
+  test_function_named_default() async {
+    await assertDiagnostics(r'''
+void f({int p: 5}) {
+  print(p++);
+}
+''', [
+      lint(29, 3),
+    ]);
+  }
+
+  test_function_named_optional_ok() async {
+    await assertNoDiagnostics(r'''
+void f({int? optional}) {
+  optional ??= 8;
+}
+''');
+  }
+
+  test_function_positional_optional_ok() async {
+    await assertNoDiagnostics(r'''
+void f([int? optional]) {
+  optional ??= 8;
+}
+''');
+  }
+
+  test_function_positional_optional_assignedTwice() async {
+    await assertDiagnostics(r'''
+void f([int? optional]) {
+  optional ??= 8;
+  optional ??= 16;
+}
+''', [
+    error(StaticWarningCode.DEAD_NULL_AWARE_EXPRESSION, 59, 2),
+      lint(46, 15),
+    ]);
+  }
+
+  test_function_positional_optional_reassigned() async {
+    await assertDiagnostics(r'''
+void f([int? optional]) {
+  optional ??= 8;
+  optional = 16;
+}
+''', [
+      lint(46, 13),
+    ]);
+  }
+
+  test_function_positional_optional_re_incremented() async {
+    await assertDiagnostics(r'''
+void f([int? optional]) {
+  optional ??= 8;
+  optional += 16;
+}
+''', [
+      lint(46, 14),
+    ]);
+  }
+
+  test_function_postfix() async {
+    await assertDiagnostics(r'''
+void f(int p) {
+  p++;
+}
+''', [
+      lint(18, 3),
+    ]);
+  }
+
+  test_function_ok_shadow() async {
+    await assertDiagnostics(r'''
+void f(String? p) {
+  if (p == null) {
+    int p = 2;
+    p = 3;
+  }
+}
+''', [
+  // No lint.
+      error(HintCode.UNUSED_LOCAL_VARIABLE, 47, 1),
+    ]);
+  }
+
+  test_function_ok() async {
+    await assertNoDiagnostics(r'''
+void f(String p) {
+  print(p);
+}
+''');
+  }
+}

--- a/test/rules/parameter_assignments_test.dart
+++ b/test/rules/parameter_assignments_test.dart
@@ -17,7 +17,7 @@ class ParameterAssignmentsTest extends LintRuleTest {
   @override
   String get lintRule => 'parameter_assignments';
 
-  @FailingTest(reason: 'Closures implemented')
+  @FailingTest(reason: 'Closures not implemented')
   test_closure_assignment() async {
     await assertDiagnostics(r'''
 void f() {

--- a/test/rules/parameter_assignments_test.dart
+++ b/test/rules/parameter_assignments_test.dart
@@ -12,7 +12,6 @@ main() {
   });
 }
 
-
 @reflectiveTest
 class ParameterAssignmentsTest extends LintRuleTest {
   @override
@@ -31,7 +30,6 @@ void f() {
     ]);
   }
 
-
   test_function_assignment() async {
     await assertDiagnostics(r'''
 void f(int p) {
@@ -39,18 +37,6 @@ void f(int p) {
 }
 ''', [
       lint(18, 5),
-     ]);
-  }
-
-  test_member_setter() async {
-    await assertDiagnostics(r'''
-class A {
-  set x(int v) {
-    v = 5;
-  }
-}
-''', [
-      lint(31, 5),
     ]);
   }
 
@@ -61,16 +47,6 @@ void f(int p) {
 }
 ''', [
       lint(18, 6),
-    ]);
-  }
-
-  test_function_prefix() async {
-    await assertDiagnostics(r'''
-void f(int p) {
-  ++p;
-}
-''', [
-      lint(18, 3),
     ]);
   }
 
@@ -92,12 +68,26 @@ void f({int? optional}) {
 ''');
   }
 
-  test_function_positional_optional_ok() async {
+  test_function_ok() async {
     await assertNoDiagnostics(r'''
-void f([int? optional]) {
-  optional ??= 8;
+void f(String p) {
+  print(p);
 }
 ''');
+  }
+
+  test_function_ok_shadow() async {
+    await assertDiagnostics(r'''
+void f(String? p) {
+  if (p == null) {
+    int p = 2;
+    p = 3;
+  }
+}
+''', [
+      // No lint.
+      error(HintCode.UNUSED_LOCAL_VARIABLE, 47, 1),
+    ]);
   }
 
   test_function_positional_optional_assignedTwice() async {
@@ -107,8 +97,27 @@ void f([int? optional]) {
   optional ??= 16;
 }
 ''', [
-    error(StaticWarningCode.DEAD_NULL_AWARE_EXPRESSION, 59, 2),
+      error(StaticWarningCode.DEAD_NULL_AWARE_EXPRESSION, 59, 2),
       lint(46, 15),
+    ]);
+  }
+
+  test_function_positional_optional_ok() async {
+    await assertNoDiagnostics(r'''
+void f([int? optional]) {
+  optional ??= 8;
+}
+''');
+  }
+
+  test_function_positional_optional_re_incremented() async {
+    await assertDiagnostics(r'''
+void f([int? optional]) {
+  optional ??= 8;
+  optional += 16;
+}
+''', [
+      lint(46, 14),
     ]);
   }
 
@@ -123,17 +132,6 @@ void f([int? optional]) {
     ]);
   }
 
-  test_function_positional_optional_re_incremented() async {
-    await assertDiagnostics(r'''
-void f([int? optional]) {
-  optional ??= 8;
-  optional += 16;
-}
-''', [
-      lint(46, 14),
-    ]);
-  }
-
   test_function_postfix() async {
     await assertDiagnostics(r'''
 void f(int p) {
@@ -144,25 +142,25 @@ void f(int p) {
     ]);
   }
 
-  test_function_ok_shadow() async {
+  test_function_prefix() async {
     await assertDiagnostics(r'''
-void f(String? p) {
-  if (p == null) {
-    int p = 2;
-    p = 3;
-  }
+void f(int p) {
+  ++p;
 }
 ''', [
-  // No lint.
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 47, 1),
+      lint(18, 3),
     ]);
   }
 
-  test_function_ok() async {
-    await assertNoDiagnostics(r'''
-void f(String p) {
-  print(p);
+  test_member_setter() async {
+    await assertDiagnostics(r'''
+class A {
+  set x(int v) {
+    v = 5;
+  }
 }
-''');
+''', [
+      lint(31, 5),
+    ]);
   }
 }

--- a/test/rules/parameter_assignments_test.dart
+++ b/test/rules/parameter_assignments_test.dart
@@ -68,7 +68,7 @@ void f({int? optional}) {
 ''');
   }
 
-  test_function_ok() async {
+  test_function_ok_noAssignment() async {
     await assertNoDiagnostics(r'''
 void f(String p) {
   print(p);
@@ -149,6 +149,19 @@ void f(int p) {
 }
 ''', [
       lint(18, 3),
+    ]);
+  }
+
+  test_localFunction() async {
+    await assertDiagnostics(r'''
+void f(int p) {
+  void g() {
+    p = 3;
+  }
+  g();
+}
+''', [
+      lint(33, 5),
     ]);
   }
 


### PR DESCRIPTION
**BEFORE**

![image](https://user-images.githubusercontent.com/67586/191858133-e88eb3fc-09fc-477d-8650-ce5a473208f7.png)

**AFTER**

<img width="636" alt="image" src="https://user-images.githubusercontent.com/67586/191858942-f5b3cb83-4d98-4eba-956b-dbf05cf2686a.png">

@bwilkerson: it's still a bit awkward but on the right track I think.  Comments welcome!

