### PR TITLE
Fix unnecessary_parenthesis with as-expression

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -7,10 +7,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Unnecessary parenthesis can be removed.';
+const _desc = r'Unnecessary parentheses can be removed.';
 
 const _details = r'''
-**AVOID** using parenthesis when not needed.
+**AVOID** using parentheses when not needed.
 
 **GOOD:**
 ```dart
@@ -22,6 +22,21 @@ a = b;
 a = (b);
 ```
 
+Parentheses are considered unnecessary if they do not change the meaning of the
+code and they do not improve the readability of the code. The goal is not to
+force all developers to maintain the expression precedence table in their heads,
+which is why the second condition is included. Examples of this condition
+include:
+
+* cascade expressions - it is sometimes not clear what the target of a cascase
+  expression is, especially with assignments, or nested cascades. For example,
+  the expression `a.b = (c..d)`.
+* expressions with whitespace between tokens - it can look very strange to see
+  an expression like `!await foo` which is valid and equivalent to
+  `!(await foo)`.
+* logical expressions - parentheses can improve the readability of the implicit
+  grouping defined by precedence. For example, the expression
+  `(a && b) || c && d`.
 ''';
 
 class UnnecessaryParenthesis extends LintRule {
@@ -90,7 +105,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    // `a..b=(c..d)` is OK.
+    // `a..b = (c..d)` is OK.
     if (expression is CascadeExpression ||
         node.thisOrAncestorMatching(
                 (n) => n is Statement || n is CascadeExpression)
@@ -111,6 +126,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (parent is ConditionalExpression) return;
       if (parent is CascadeExpression) return;
       if (parent is FunctionExpressionInvocation) return;
+      if (parent is AsExpression) return;
+      if (parent is IsExpression) return;
 
       // A prefix expression (! or -) can have an argument wrapped in
       // "unnecessary" parens if that argument has potentially confusing

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -28,7 +28,7 @@ force all developers to maintain the expression precedence table in their heads,
 which is why the second condition is included. Examples of this condition
 include:
 
-* cascade expressions - it is sometimes not clear what the target of a cascase
+* cascade expressions - it is sometimes not clear what the target of a cascade
   expression is, especially with assignments, or nested cascades. For example,
   the expression `a.b = (c..d)`.
 * expressions with whitespace between tokens - it can look very strange to see

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -6,26 +6,25 @@
 
 import 'dart:async';
 
-
 /// https://github.com/dart-lang/linter/issues/2944
 void foo() {
   final items = [];
   (() => [].add('something')).compose(() {}); // OK
   (() => '').hashCode; // OK
   (() => '').f = 1; // OK
-  (() => '') +  1; // OK
+  (() => '') + 1; // OK
   (() => '')[0]; // OK
 }
 
 extension A on void Function() {
   void Function() compose(void Function() other) => () {
-    this();
-    other();
-  };
+        this();
+        other();
+      };
 
   set f(int f) {}
-  operator+(int x) {}
-  int operator[](int i) => 0;
+  operator +(int x) {}
+  int operator [](int i) => 0;
 }
 
 var func = (() => null); // LINT
@@ -58,6 +57,8 @@ main() async {
   (await new Future.value(1)).toString(); // OK
   ('' as String).toString(); // OK
   !(true as bool); // OK
+  (b - a) as num; // OK
+  (b - a) is num; // OK
   a = (a); // LINT
   (a) ? true : false; // LINT
   true ? (a) : false; // LINT
@@ -122,7 +123,8 @@ class ClassWithFunction {
   ClassWithFunction();
   ClassWithFunction.named(int a) : this.number = (a + 2); // LINT
   // https://github.com/dart-lang/linter/issues/1473
-  ClassWithFunction.named2(Function value) : this.f = (value ?? (_) => 42); // OK
+  ClassWithFunction.named2(Function value)
+      : this.f = (value ?? (_) => 42); // OK
 }
 
 class ClassWithClassWithFunction {
@@ -141,5 +143,5 @@ class UnnecessaryParenthesis {
 }
 
 extension<T> on Set<T> {
-  Set<T> operator+(Set<T> other) => {...this, ...other};
+  Set<T> operator +(Set<T> other) => {...this, ...other};
 }


### PR DESCRIPTION
# Description

Fixes unnecessary_parenthesis handling of an `as` expression and an `is` expression. Also adds documentation explaining the heuristics of the rule.

Also changes 'parenthesis' to 'parentheses' where grammatically necessary.

Fixes https://github.com/dart-lang/linter/issues/1843