### PR TITLE
migrate `prefer_foreach` from `traverseNodesInDFS()`

### DIFF
--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -116,7 +116,7 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
   }
 }
 
-class _ReferenceFinder extends GeneralizingAstVisitor {
+class _ReferenceFinder extends UnifyingAstVisitor {
   bool found = false;
   final LocalVariableElement? element;
   _ReferenceFinder(this.element);

--- a/lib/src/rules/prefer_foreach.dart
+++ b/lib/src/rules/prefer_foreach.dart
@@ -105,12 +105,7 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
     var target = node.target;
     if (arguments.length == 1 &&
         arguments.first.canonicalElement == element &&
-        (target == null ||
-            target.canonicalElement != element &&
-                !target
-                    .traverseNodesInDFS()
-                    .map((e) => e.canonicalElement)
-                    .contains(element))) {
+        (target == null || !_ReferenceFinder(element).references(target))) {
       rule.reportLint(forEachStatement);
     }
   }
@@ -118,6 +113,29 @@ class _PreferForEachVisitor extends SimpleAstVisitor {
   @override
   void visitParenthesizedExpression(ParenthesizedExpression node) {
     node.unParenthesized.accept(this);
+  }
+}
+
+class _ReferenceFinder extends GeneralizingAstVisitor {
+  bool found = false;
+  final LocalVariableElement? element;
+  _ReferenceFinder(this.element);
+
+  bool references(Expression target) {
+    if (target.canonicalElement == element) return true;
+
+    target.accept(this);
+    return found;
+  }
+
+  @override
+  visitNode(AstNode node) {
+    if (found) return;
+
+    found = node.canonicalElement == element;
+    if (!found) {
+      super.visitNode(node);
+    }
   }
 }
 


### PR DESCRIPTION
Surprisingly big gain in the general case (and we all know this can get quadratic in the pathological one). 🏁 

**BEFORE**


<img width="687" alt="image" src="https://user-images.githubusercontent.com/67586/191882217-2a6686da-2e0d-496b-8fc3-0164dbe79f77.png">

**AFTER**

<img width="648" alt="image" src="https://user-images.githubusercontent.com/67586/191882826-5ce9490f-bb71-4307-b96f-28d10d820614.png">

/cc @srawlins @bwilkerson 