### PR TITLE
migrate `diagnostic_describe_all_properties` from `traverseNodesInDFS()`

### DIFF
--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -101,10 +101,10 @@ class _IdentifierVisitor extends RecursiveAstVisitor {
     } else {
       name = node.name;
       debugName =
-      '$debugPrefix${node.name[0].toUpperCase()}${node.name.substring(1)}';
+          '$debugPrefix${node.name[0].toUpperCase()}${node.name.substring(1)}';
     }
-    properties.removeWhere((property) =>
-    property.lexeme == debugName || property.lexeme == name);
+    properties.removeWhere(
+        (property) => property.lexeme == debugName || property.lexeme == name);
 
     super.visitSimpleIdentifier(node);
   }

--- a/lib/src/rules/diagnostic_describe_all_properties.dart
+++ b/lib/src/rules/diagnostic_describe_all_properties.dart
@@ -84,6 +84,32 @@ class DiagnosticsDescribeAllProperties extends LintRule {
   }
 }
 
+class _IdentifierVisitor extends RecursiveAstVisitor {
+  final List<Token> properties;
+  _IdentifierVisitor(this.properties);
+
+  @override
+  visitSimpleIdentifier(SimpleIdentifier node) {
+    String debugName;
+    String name;
+    const debugPrefix = 'debug';
+    if (node.name.startsWith(debugPrefix) &&
+        node.name.length > debugPrefix.length) {
+      debugName = node.name;
+      name = '${node.name[debugPrefix.length].toLowerCase()}'
+          '${node.name.substring(debugPrefix.length + 1)}';
+    } else {
+      name = node.name;
+      debugName =
+      '$debugPrefix${node.name[0].toUpperCase()}${node.name.substring(1)}';
+    }
+    properties.removeWhere((property) =>
+    property.lexeme == debugName || property.lexeme == name);
+
+    super.visitSimpleIdentifier(node);
+  }
+}
+
 class _Visitor extends SimpleAstVisitor {
   final LintRule rule;
   final LinterContext context;
@@ -91,27 +117,7 @@ class _Visitor extends SimpleAstVisitor {
   _Visitor(this.rule, this.context);
 
   void removeReferences(MethodDeclaration? method, List<Token> properties) {
-    if (method == null) {
-      return;
-    }
-    for (var p
-        in method.body.traverseNodesInDFS().whereType<SimpleIdentifier>()) {
-      String debugName;
-      String name;
-      const debugPrefix = 'debug';
-      if (p.name.startsWith(debugPrefix) &&
-          p.name.length > debugPrefix.length) {
-        debugName = p.name;
-        name = '${p.name[debugPrefix.length].toLowerCase()}'
-            '${p.name.substring(debugPrefix.length + 1)}';
-      } else {
-        name = p.name;
-        debugName =
-            '$debugPrefix${p.name[0].toUpperCase()}${p.name.substring(1)}';
-      }
-      properties.removeWhere((property) =>
-          property.lexeme == debugName || property.lexeme == name);
-    }
+    method?.body.accept(_IdentifierVisitor(properties));
   }
 
   bool skipForDiagnostic({Element? element, DartType? type, Token? name}) =>


### PR DESCRIPTION
Another modest gain (for the general case) and another step closer to deprecating `traverseNodesInDFS()` 🎉 .

**BEFORE**

<img width="739" alt="image" src="https://user-images.githubusercontent.com/67586/191885710-61e4b56d-cb77-4fc4-8786-5faafe951aaf.png">


**AFTER**

![image](https://user-images.githubusercontent.com/67586/191886465-51a56fa3-0445-42ec-873b-2712d6f52d41.png)


/cc @bwilkerson @srawlins 