### PR TITLE
migrate `unnecessary_lambdas` from `traverseNodesInDFS()`

### DIFF
--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -42,10 +42,8 @@ bool _containsNullAwareInvocationInChain(AstNode? node) =>
         (node is IndexExpression &&
             _containsNullAwareInvocationInChain(node.target)));
 
-Iterable<Element?> _extractElementsOfSimpleIdentifiers(AstNode node) => node
-    .traverseNodesInDFS()
-    .whereType<SimpleIdentifier>()
-    .map((e) => e.staticElement);
+Iterable<Element?> _extractElementsOfSimpleIdentifiers(AstNode node) =>
+    _IdentifierVisitor().extractElements(node);
 
 class UnnecessaryLambdas extends LintRule {
   UnnecessaryLambdas()
@@ -108,6 +106,23 @@ class _FinalExpressionChecker {
     }
 
     return false;
+  }
+}
+
+class _IdentifierVisitor extends RecursiveAstVisitor {
+  final _elements = <Element?>[];
+
+  _IdentifierVisitor();
+
+  List<Element?> extractElements(AstNode node) {
+    node.accept(this);
+    return _elements;
+  }
+
+  @override
+  visitSimpleIdentifier(SimpleIdentifier node) {
+    _elements.add(node.staticElement);
+    super.visitSimpleIdentifier(node);
   }
 }
 

--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc = r"Don't create a lambda when a tear-off will do.";


### PR DESCRIPTION
A modest gain in the general case.

**BEFORE**

![image](https://user-images.githubusercontent.com/67586/191887480-a7d5726e-d21d-41e4-b7f3-33da286dcdbf.png)

**AFTER**

<img width="798" alt="image" src="https://user-images.githubusercontent.com/67586/191888317-ab21c455-424e-4dcb-93c8-638289f4b49f.png">

/cc @bwilkerson 
