### PR TITLE
simplify iteration in `avoid_escaping_inner_quotes`

### DIFF
--- a/lib/src/rules/avoid_escaping_inner_quotes.dart
+++ b/lib/src/rules/avoid_escaping_inner_quotes.dart
@@ -59,11 +59,15 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitStringInterpolation(StringInterpolation node) {
     if (node.isRaw || node.isMultiline) return;
 
-    var text = node.elements
-        .whereType<InterpolationString>()
-        .map((e) => e.value)
-        .reduce((a, b) => '$a$b');
-    if (isChangeable(text, isSingleQuoted: node.isSingleQuoted)) {
+    var text = StringBuffer();
+    for (var element in node.elements) {
+      if (element is InterpolationString) {
+        var value = element.value;
+        text.write(value);
+      }
+    }
+
+    if (isChangeable(text.toString(), isSingleQuoted: node.isSingleQuoted)) {
       rule.reportLint(node);
     }
   }

--- a/lib/src/rules/avoid_escaping_inner_quotes.dart
+++ b/lib/src/rules/avoid_escaping_inner_quotes.dart
@@ -62,8 +62,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     var text = StringBuffer();
     for (var element in node.elements) {
       if (element is InterpolationString) {
-        var value = element.value;
-        text.write(value);
+        text.write(element.value);
       }
     }
 


### PR DESCRIPTION
Modest improvement in benchmarks but I think worth it?

**BEFORE**

<img width="798" alt="image" src="https://user-images.githubusercontent.com/67586/191891940-cda173bb-ced9-4b82-bafc-21b307502092.png">

**AFTER**

<img width="755" alt="image" src="https://user-images.githubusercontent.com/67586/191892646-858543b2-c45a-40ff-9665-f818c415c07f.png">


/cc @a14n @bwilkerson 