### PR TITLE
Report avoid_returning_this on the return statement

### DIFF
--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -98,7 +98,7 @@ class _Visitor extends SimpleAstVisitor<void> {
           .traverseNodesInDFS(excludeCriteria: _isFunctionExpression)
           .whereType<ReturnStatement>();
       if (returnStatements.isNotEmpty && returnStatements.every(_returnsThis)) {
-        rule.reportLint(returnStatements.first);
+        rule.reportLint(returnStatements.first.expression);
       }
     } else if (body is ExpressionFunctionBody) {
       if (body.expression is ThisExpression) {

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -45,10 +45,7 @@ var buffer = StringBuffer()
 
 bool _isFunctionExpression(AstNode node) => node is FunctionExpression;
 
-bool _isReturnStatement(AstNode node) => node is ReturnStatement;
-
-bool _returnsThis(AstNode node) =>
-    (node as ReturnStatement).expression is ThisExpression;
+bool _returnsThis(ReturnStatement node) => node.expression is ThisExpression;
 
 class AvoidReturningThis extends LintRule {
   AvoidReturningThis()
@@ -99,9 +96,9 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (body is BlockFunctionBody) {
       var returnStatements = body.block
           .traverseNodesInDFS(excludeCriteria: _isFunctionExpression)
-          .where(_isReturnStatement);
+          .whereType<ReturnStatement>();
       if (returnStatements.isNotEmpty && returnStatements.every(_returnsThis)) {
-        rule.reportLintForToken(node.name2);
+        rule.reportLint(returnStatements.first);
       }
     } else if (body is ExpressionFunctionBody) {
       if (body.expression is ThisExpression) {

--- a/test_data/rules/avoid_returning_this.dart
+++ b/test_data/rules/avoid_returning_this.dart
@@ -8,9 +8,9 @@
 
 class A {
   int x = 0;
-  A badAddOne() { // LINT
+  A badAddOne() {
     x++;
-    return this;
+    return this; // LINT
   }
 
   Object goodAddOne1() { // OK it is ok because it does not return an A type.
@@ -22,8 +22,8 @@ class A {
     x++;
     return this.x;
   }
-  A getThing() { // LINT
-    return this;
+  A getThing() {
+    return this; // LINT
   }
 
   B doSomething() { // OK it is ok because it does not return an A type.
@@ -50,31 +50,31 @@ class B extends A{
     return this;
   }
 
-  B badAddOne2() { // LINT
+  B badAddOne2() {
     x++;
-    return this;
+    return this; // LINT
   }
 
-  B badOne3() { // LINT
+  B badOne3() {
     int a() {
       return 1;
     }
     x = a();
-    return this;
+    return this; // LINT
   }
 
-  B badOne4() { // LINT
+  B badOne4() {
     int a() => 1;
     x = a();
-    return this;
+    return this; // LINT
   }
 
-  B badOne5() { // LINT
+  B badOne5() {
     final a = () {
       return 1;
     };
     x = a();
-    return this;
+    return this; // LINT
   }
 }
 
@@ -94,8 +94,8 @@ class D implements C<D> {
     return this;
   }
 
-  D _m() { // LINT
-    return this;
+  D _m() {
+    return this; // LINT
   }
 }
 class E implements C<E> {


### PR DESCRIPTION
# Description

This just changes the lint report position to be the first `return this` statement.

Fixes #780
