### PR TITLE
Support unnamed libraries

### DIFF
--- a/lib/src/rules/library_names.dart
+++ b/lib/src/rules/library_names.dart
@@ -57,8 +57,9 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitLibraryDirective(LibraryDirective node) {
-    if (!isLowerCaseUnderScoreWithDots(node.name2.toString())) {
-      rule.reportLint(node.name2);
+    var name = node.name2;
+    if (name != null && !isLowerCaseUnderScoreWithDots(name.toString())) {
+      rule.reportLint(name);
     }
   }
 }


### PR DESCRIPTION
# Description

Support unnamed libraries across all lint rules. The only ones which use LibraryDirective are:

* `library_names`
* `package_prefixed_library_name` which is just a big comment. So, easy peasy.