### PR TITLE
Correct Documentation Examples for avoid_equals_and_hash_code_on_mutable_classes

### DIFF
--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -30,7 +30,7 @@ class A {
   @override
   operator ==(other) => other is A && other.key == key;
   @override
-  int hashCode() => key.hashCode;
+  int get hashCode => key.hashCode;
 }
 ```
 
@@ -42,7 +42,7 @@ class B {
   @override
   operator ==(other) => other is B && other.key == key;
   @override
-  int hashCode() => key.hashCode;
+  int get hashCode => key.hashCode;
 }
 ```
 
@@ -55,9 +55,9 @@ class C {
   final String key;
   const C(this.key);
   @override
-  operator ==(other) => other is B && other.key == key;
+  operator ==(other) => other is C && other.key == key;
   @override
-  int hashCode() => key.hashCode;
+  int get hashCode => key.hashCode;
 }
 ```
 


### PR DESCRIPTION
# Description

The three examples for avoid_equals_and_hash_code_on_mutable_classes don't compile because `hashCode` is a getter and not a method. Also, the class `C` references `B` instead of itself.

You can now copy and paste these examples into a Dart app.

Just a note: the second example also violates [const_constructor_with_non_final_field](https://dart.dev/diagnostics/const_constructor_with_non_final_field) which could be a bit confusing.