### PR TITLE
migrate `avoid_returning_this` from `traverseNodesInDFS`

### DIFF
--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -43,8 +43,6 @@ var buffer = StringBuffer()
 
 ''';
 
-bool _isFunctionExpression(AstNode node) => node is FunctionExpression;
-
 bool _returnsThis(ReturnStatement node) => node.expression is ThisExpression;
 
 class AvoidReturningThis extends LintRule {
@@ -60,6 +58,29 @@ class AvoidReturningThis extends LintRule {
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
     registry.addMethodDeclaration(this, visitor);
+  }
+}
+
+class _BodyVisitor extends UnifyingAstVisitor {
+  List<ReturnStatement> returnStatements = [];
+
+  List<ReturnStatement> collectReturns(BlockFunctionBody body) {
+    body.accept(this);
+    return returnStatements;
+  }
+
+  @override
+  visitFunctionExpression(FunctionExpression node) {
+    // Short-circuit visiting on Function expressions.
+  }
+
+  @override
+  visitReturnStatement(ReturnStatement node) {
+    // Short-circuit if not returning this.
+    if (_returnsThis(node)) return;
+
+    returnStatements.add(node);
+    super.visitReturnStatement(node);
   }
 }
 
@@ -94,10 +115,8 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     var body = node.body;
     if (body is BlockFunctionBody) {
-      var returnStatements = body.block
-          .traverseNodesInDFS(excludeCriteria: _isFunctionExpression)
-          .whereType<ReturnStatement>();
-      if (returnStatements.isNotEmpty && returnStatements.every(_returnsThis)) {
+      var returnStatements = _BodyVisitor().collectReturns(body);
+      if (returnStatements.isNotEmpty) {
         rule.reportLint(returnStatements.first.expression);
       }
     } else if (body is ExpressionFunctionBody) {

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -61,7 +61,7 @@ class AvoidReturningThis extends LintRule {
   }
 }
 
-class _BodyVisitor extends UnifyingAstVisitor {
+class _BodyVisitor extends RecursiveAstVisitor {
   List<ReturnStatement> returnStatements = [];
 
   List<ReturnStatement> collectReturns(BlockFunctionBody body) {

--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -77,7 +77,7 @@ class _BodyVisitor extends UnifyingAstVisitor {
   @override
   visitReturnStatement(ReturnStatement node) {
     // Short-circuit if not returning this.
-    if (_returnsThis(node)) return;
+    if (!_returnsThis(node)) return;
 
     returnStatements.add(node);
     super.visitReturnStatement(node);


### PR DESCRIPTION
Minor improvement but one step closer to deprecating `traverseNodesInDFS`.

**BEFORE**

<img width="676" alt="image" src="https://user-images.githubusercontent.com/67586/193697508-d4286fb4-df36-40c6-94bc-e285988c135e.png">

**AFTER**

<img width="714" alt="image" src="https://user-images.githubusercontent.com/67586/193699941-c61f0a9a-7f92-4317-8999-3eb2f61e9977.png">


/cc @bwilkerson 
