### PR TITLE
migrate `prefer_constructors_over_static_methods` from `traverseNodesInDFS`

### DIFF
--- a/lib/src/rules/prefer_constructors_over_static_methods.dart
+++ b/lib/src/rules/prefer_constructors_over_static_methods.dart
@@ -44,24 +44,6 @@ class Point {
 bool _hasNewInvocation(DartType returnType, FunctionBody body) =>
     _BodyVisitor(returnType).containsInstanceCreation(body);
 
-class _BodyVisitor extends RecursiveAstVisitor {
-  bool found = false;
-  final DartType returnType;
-  _BodyVisitor(this.returnType);
-  @override
-  visitInstanceCreationExpression(InstanceCreationExpression node) {
-    found = node.staticType == returnType;
-    if (!found) {
-      super.visitInstanceCreationExpression(node);
-    }
-  }
-
-  bool containsInstanceCreation(FunctionBody body) {
-    body.accept(this);
-    return found;
-  }
-}
-
 class PreferConstructorsInsteadOfStaticMethods extends LintRule {
   PreferConstructorsInsteadOfStaticMethods()
       : super(
@@ -75,6 +57,26 @@ class PreferConstructorsInsteadOfStaticMethods extends LintRule {
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this, context);
     registry.addMethodDeclaration(this, visitor);
+  }
+}
+
+class _BodyVisitor extends RecursiveAstVisitor {
+  bool found = false;
+
+  final DartType returnType;
+  _BodyVisitor(this.returnType);
+
+  bool containsInstanceCreation(FunctionBody body) {
+    body.accept(this);
+    return found;
+  }
+
+  @override
+  visitInstanceCreationExpression(InstanceCreationExpression node) {
+    found = node.staticType == returnType;
+    if (!found) {
+      super.visitInstanceCreationExpression(node);
+    }
   }
 }
 


### PR DESCRIPTION
A modest gain in the common case.

**BEFORE**

<img width="641" alt="image" src="https://user-images.githubusercontent.com/67586/193937665-96ffebe9-dcb4-468c-9813-b79b2b1cc280.png">

**AFTER**

<img width="838" alt="image" src="https://user-images.githubusercontent.com/67586/193937582-b58db7d1-5cb6-4366-9dd2-447399c351a8.png">

/cc @bwilkerson 
