### PR TITLE
Add required scorecards id-token permission to fix build

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      id-token: write
       actions: read
       contents: read
 


### PR DESCRIPTION
This is required with the update to v2 in https://github.com/dart-lang/linter/commit/40f67411f4bd184175d2b2416818fe1f8bcac158. See [Breaking changes in v2](https://github.com/ossf/scorecard-action#breaking-changes-in-v2) for more information.