### PR TITLE
Add scorecards badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ analysis server and the `dart analyze` command in the [Dart command-line tool][d
 [![Coverage Status](https://coveralls.io/repos/dart-lang/linter/badge.svg)](https://coveralls.io/r/dart-lang/linter)
 [![Pub](https://img.shields.io/pub/v/linter.svg)](https://pub.dev/packages/linter)
 [![package publisher](https://img.shields.io/pub/publisher/linter.svg)](https://pub.dev/packages/linter/publisher)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/dart-lang/linter/badge)](https://api.securityscorecards.dev/projects/github.com/dart-lang/linter)
 
 ## Installing
 


### PR DESCRIPTION
Bug: https://github.com/dart-lang/.github/issues/31

# Description
Adds the scorecards badge to the linter repository. This badge shows the current security score for the repository.
