### PR TITLE
Add lint codes for the remaining core lints

### DIFF
--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -33,12 +33,20 @@ align(clearItems) {
 ''';
 
 class NonConstantIdentifierNames extends LintRule {
+  static const LintCode code = LintCode('non_constant_identifier_names',
+      "The variable name '{0}' isn't a lowerCamelCase identifier.",
+      correctionMessage:
+          'Try changing the name to follow the lowerCamelCase style.');
+
   NonConstantIdentifierNames()
       : super(
             name: 'non_constant_identifier_names',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(
@@ -66,12 +74,13 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (id == null) {
       return;
     }
-    if (underscoresOk && id.lexeme.isJustUnderscores) {
+    var name = id.lexeme;
+    if (underscoresOk && name.isJustUnderscores) {
       // For example, `___` is OK in a callback.
       return;
     }
-    if (!isLowerCamelCase(id.lexeme)) {
-      rule.reportLintForToken(id);
+    if (!isLowerCamelCase(name)) {
+      rule.reportLintForToken(id, arguments: [name]);
     }
   }
 

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -44,6 +44,12 @@ T run<T>(T callback()) {
 ''';
 
 class NullCheckOnNullableTypeParameter extends LintRule {
+  static const LintCode code = LintCode(
+      'null_check_on_nullable_type_parameter',
+      "The null check operator shouldn't be used on a variable whose type is a "
+          'potentially nullable type parameter.',
+      correctionMessage: "Try explicitly testing for 'null'.");
+
   NullCheckOnNullableTypeParameter()
       : super(
           name: 'null_check_on_nullable_type_parameter',
@@ -52,6 +58,9 @@ class NullCheckOnNullableTypeParameter extends LintRule {
           maturity: Maturity.stable,
           group: Group.style,
         );
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(
@@ -66,10 +75,10 @@ class NullCheckOnNullableTypeParameter extends LintRule {
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  _Visitor(this.rule, this.context);
-
   final LintRule rule;
+
   final LinterContext context;
+  _Visitor(this.rule, this.context);
 
   @override
   void visitPostfixExpression(PostfixExpression node) {

--- a/lib/src/rules/package_prefixed_library_names.dart
+++ b/lib/src/rules/package_prefixed_library_names.dart
@@ -51,12 +51,21 @@ bool matchesOrIsPrefixedBy(String name, String prefix) =>
     name == prefix || name.startsWith('$prefix.');
 
 class PackagePrefixedLibraryNames extends LintRule {
+  static const LintCode code = LintCode(
+      'package_prefixed_library_names',
+      'The library name is not prefixed by the package name and a '
+          'dot-separated path.',
+      correctionMessage: "Try changing the name to '{0}'.");
+
   PackagePrefixedLibraryNames()
       : super(
             name: 'package_prefixed_library_names',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(
@@ -98,7 +107,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     //
     // var name = element.name;
     // if (name == null || !matchesOrIsPrefixedBy(name, prefix)) {
-    //   rule.reportLint(node.name);
+    //   rule.reportLint(node.name, arguments: ['$prefix.$name']);
     // }
   }
 }

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -33,12 +33,19 @@ typedef F = void Function();
 ''';
 
 class PreferGenericFunctionTypeAliases extends LintRule {
+  static const LintCode code = LintCode('prefer_generic_function_type_aliases',
+      "Use the generic function type syntax in 'typedef's.",
+      correctionMessage: "Try using the generic function type syntax ('{0}').");
+
   PreferGenericFunctionTypeAliases()
       : super(
             name: 'prefer_generic_function_type_aliases',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(
@@ -58,6 +65,16 @@ class _Visitor extends SimpleAstVisitor<void> {
     //https://github.com/dart-lang/linter/issues/2777
     if (node.semicolon.isSynthetic) return;
 
-    rule.reportLintForToken(node.name);
+    var returnType = node.returnType;
+    var typeParameters = node.typeParameters;
+    var parameters = node.parameters;
+    var returnTypeSource =
+        returnType == null ? '' : '${returnType.toSource()} ';
+    var typeParameterSource =
+        typeParameters == null ? '' : typeParameters.toSource();
+    var parameterSource = parameters.toSource();
+    var replacement =
+        '${returnTypeSource}Function$typeParameterSource$parameterSource';
+    rule.reportLintForToken(node.name, arguments: [replacement]);
   }
 }

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -37,17 +37,30 @@ if (words.length != 0) return words.join(' ');
 ''';
 
 class PreferIsEmpty extends LintRule {
-  static const LintCode alwaysFalse = LintCode('prefer_is_empty',
-      'Always false because length is always greater or equal 0.');
+  // TODO(brianwilkerson) Both `alwaysFalse` and `alwaysTrue` should be warnings
+  //  rather than lints because they represent a bug rather than a style
+  //  preference.
+  static const LintCode alwaysFalse = LintCode(
+      'prefer_is_empty',
+      "The comparison is always 'false' because the length is always greater "
+          'than or equal to 0.');
 
-  static const LintCode alwaysTrue = LintCode('prefer_is_empty',
-      'Always true because length is always greater or equal 0.');
+  static const LintCode alwaysTrue = LintCode(
+      'prefer_is_empty',
+      "The comparison is always 'true' because the length is always greater "
+          'than or equal to 0.');
 
-  static const LintCode useIsEmpty =
-      LintCode('prefer_is_empty', 'Use isEmpty instead of length');
+  static const LintCode useIsEmpty = LintCode(
+      'prefer_is_empty',
+      "Use 'isEmpty' instead of 'length' to test whether the collection is "
+          'empty.',
+      correctionMessage: "Try rewriting the expression to use 'isEmpty'.");
 
-  static const LintCode useIsNotEmpty =
-      LintCode('prefer_is_empty', 'Use isNotEmpty instead of length');
+  static const LintCode useIsNotEmpty = LintCode(
+      'prefer_is_empty',
+      "Use 'isNotEmpty' instead of 'length' to test whether the collection is "
+          'empty.',
+      correctionMessage: "Try rewriting the expression to use 'isNotEmpty'.");
 
   PreferIsEmpty()
       : super(
@@ -55,6 +68,10 @@ class PreferIsEmpty extends LintRule {
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  List<LintCode> get lintCodes =>
+      [alwaysFalse, alwaysTrue, useIsEmpty, useIsNotEmpty];
 
   @override
   void registerNodeProcessors(

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -35,12 +35,19 @@ if (!sources.isEmpty) {
 ''';
 
 class PreferIsNotEmpty extends LintRule {
+  static const LintCode code = LintCode('prefer_is_not_empty',
+      "Use 'isNotEmpty' rather than negating the result of 'isEmpty'.",
+      correctionMessage: "Try rewriting the expression to use 'isNotEmpty'.");
+
   PreferIsNotEmpty()
       : super(
             name: 'prefer_is_not_empty',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -27,12 +27,19 @@ iterable.whereType<MyClass>();
 ''';
 
 class PreferIterableWhereType extends LintRule {
+  static const LintCode code = LintCode('prefer_iterable_whereType',
+      "Use 'whereType' to select elements of a given type.",
+      correctionMessage: "Try rewriting the expression to use 'whereType'.");
+
   PreferIterableWhereType()
       : super(
             name: 'prefer_iterable_whereType',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(

--- a/lib/src/rules/prefer_typing_uninitialized_variables.dart
+++ b/lib/src/rules/prefer_typing_uninitialized_variables.dart
@@ -56,6 +56,16 @@ class GoodClass {
 ''';
 
 class PreferTypingUninitializedVariables extends LintRule {
+  static const LintCode forField = LintCode(
+      'prefer_typing_uninitialized_variables',
+      'An uninitialized field should have an explicit type annotation.',
+      correctionMessage: 'Try adding a type annotation.');
+
+  static const LintCode forVariable = LintCode(
+      'prefer_typing_uninitialized_variables',
+      'An uninitialized variable should have an explicit type annotation.',
+      correctionMessage: 'Try adding a type annotation.');
+
   PreferTypingUninitializedVariables()
       : super(
             name: 'prefer_typing_uninitialized_variables',
@@ -82,9 +92,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
+    var code = node.parent is FieldDeclaration
+        ? PreferTypingUninitializedVariables.forField
+        : PreferTypingUninitializedVariables.forVariable;
+
     for (var v in node.variables) {
       if (v.initializer == null) {
-        rule.reportLint(v);
+        rule.reportLint(v, errorCode: code);
       }
     }
   }

--- a/lib/src/rules/provide_deprecation_message.dart
+++ b/lib/src/rules/provide_deprecation_message.dart
@@ -32,12 +32,20 @@ void oldFunction(arg1, arg2) {}
 ''';
 
 class ProvideDeprecationMessage extends LintRule {
+  static const LintCode code = LintCode(
+      'provide_deprecation_message', 'Missing a deprecation message.',
+      correctionMessage:
+          "Try using the constructor to provide a message ('@Deprecated(\"message\")').");
+
   ProvideDeprecationMessage()
       : super(
             name: 'provide_deprecation_message',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(

--- a/lib/src/rules/unnecessary_overrides.dart
+++ b/lib/src/rules/unnecessary_overrides.dart
@@ -51,12 +51,20 @@ It's valid to override a member in the following cases:
 ''';
 
 class UnnecessaryOverrides extends LintRule {
+  static const LintCode code = LintCode(
+      'unnecessary_overrides', 'Unnecessary override.',
+      correctionMessage:
+          'Try adding behavior in the overriding member or removing the override.');
+
   UnnecessaryOverrides()
       : super(
             name: 'unnecessary_overrides',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(
@@ -156,20 +164,6 @@ abstract class _AbstractUnnecessaryOverrideVisitor extends SimpleAstVisitor {
     return false;
   }
 
-  /// Returns true if [_inheritedMethod] is `@protected` and [declaration] is
-  /// not `@protected`, and false otherwise.
-  ///
-  /// This indicates that [_inheritedMethod] may have been overridden in order
-  /// to expand its visibility.
-  bool _makesPublicFromProtected() {
-    var declaredElement = declaration.declaredElement;
-    if (declaredElement == null) return false;
-    if (declaredElement.hasProtected) {
-      return false;
-    }
-    return _inheritedMethod.hasProtected;
-  }
-
   bool _haveSameDeclaration() {
     var declaredElement = declaration.declaredElement;
     if (declaredElement == null) {
@@ -192,6 +186,20 @@ abstract class _AbstractUnnecessaryOverrideVisitor extends SimpleAstVisitor {
       if (param.defaultValueCode != superParam.defaultValueCode) return false;
     }
     return true;
+  }
+
+  /// Returns true if [_inheritedMethod] is `@protected` and [declaration] is
+  /// not `@protected`, and false otherwise.
+  ///
+  /// This indicates that [_inheritedMethod] may have been overridden in order
+  /// to expand its visibility.
+  bool _makesPublicFromProtected() {
+    var declaredElement = declaration.declaredElement;
+    if (declaredElement == null) return false;
+    if (declaredElement.hasProtected) {
+      return false;
+    }
+    return _inheritedMethod.hasProtected;
   }
 
   bool _sameKind(ParameterElement first, ParameterElement second) {

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -30,12 +30,20 @@ void main() {
 ''';
 
 class VoidChecks extends LintRule {
+  static const LintCode code = LintCode(
+      'void_checks', "Assignment to a variable of type 'void'.",
+      correctionMessage:
+          'Try removing the assignment or changing the type of the variable.');
+
   VoidChecks()
       : super(
             name: 'void_checks',
             description: _desc,
             details: _details,
             group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   void registerNodeProcessors(
@@ -55,17 +63,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule, LinterContext context) : typeSystem = context.typeSystem;
 
-  bool isTypeAcceptableWhenExpectingVoid(DartType type) {
-    if (type.isVoid) return true;
-    if (type.isDartCoreNull) return true;
-    if (type.isDartAsyncFuture &&
-        type is InterfaceType &&
-        isTypeAcceptableWhenExpectingVoid(type.typeArguments.first)) {
-      return true;
-    }
-    return false;
-  }
-
   bool isTypeAcceptableWhenExpectingFutureOrVoid(DartType type) {
     if (type.isDynamic) return true;
     if (isTypeAcceptableWhenExpectingVoid(type)) return true;
@@ -75,6 +72,17 @@ class _Visitor extends SimpleAstVisitor<void> {
       return true;
     }
 
+    return false;
+  }
+
+  bool isTypeAcceptableWhenExpectingVoid(DartType type) {
+    if (type.isVoid) return true;
+    if (type.isDartCoreNull) return true;
+    if (type.isDartAsyncFuture &&
+        type is InterfaceType &&
+        isTypeAcceptableWhenExpectingVoid(type.typeArguments.first)) {
+      return true;
+    }
     return false;
   }
 


### PR DESCRIPTION
Continuing some ongoing work to improve the messages for lints by adding explicit `LintCode`s.