### PR TITLE
Do not consider super formals as local variables

### DIFF
--- a/lib/src/rules/no_leading_underscores_for_local_identifiers.dart
+++ b/lib/src/rules/no_leading_underscores_for_local_identifiers.dart
@@ -109,8 +109,13 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (parameter is DefaultFormalParameter) {
         parameter = parameter.parameter;
       }
-      // Named parameters produce a `private_optional_parameter` diagnostic.
-      if (parameter is! FieldFormalParameter && !parameter.isNamed) {
+      if (parameter is FieldFormalParameter ||
+          parameter is SuperFormalParameter) {
+        // These are not local identifiers.
+        return;
+      }
+      if (!parameter.isNamed) {
+        // Named parameters produce a `private_optional_parameter` diagnostic.
         checkIdentifier(parameter.name);
       }
     }

--- a/test_data/rules/no_leading_underscores_for_local_identifiers.dart
+++ b/test_data/rules/no_leading_underscores_for_local_identifiers.dart
@@ -140,3 +140,12 @@ class TestClass {
 }
 
 typedef _OutputFunction = void Function(String msg); // OK
+
+class C {
+  int _i;
+  C(this._i);
+}
+
+class D extends C {
+  D(super._i); // OK
+}


### PR DESCRIPTION
# Description

When considering the names of local variables, do not consider super formals to be local variables.

Fixes https://github.com/dart-lang/linter/issues/3769.