### PR TITLE
`recursive_getters`: fix false-positive w/ property accesses

### DIFF
--- a/lib/src/rules/recursive_getters.dart
+++ b/lib/src/rules/recursive_getters.dart
@@ -64,6 +64,16 @@ class _BodyVisitor extends RecursiveAstVisitor {
   final ExecutableElement element;
   _BodyVisitor(this.element, this.rule);
 
+  bool isSelfReference(SimpleIdentifier node) {
+    if (node.staticElement != element) return false;
+    var parent = node.parent;
+    if (parent is PrefixedIdentifier) return false;
+    if (parent is PropertyAccess && parent.target is! ThisExpression) {
+      return false;
+    }
+    return true;
+  }
+
   @override
   visitListLiteral(ListLiteral node) {
     if (node.isConst) return null;
@@ -78,13 +88,11 @@ class _BodyVisitor extends RecursiveAstVisitor {
 
   @override
   visitSimpleIdentifier(SimpleIdentifier node) {
-    if (node.staticElement == element) {
-      if (node.parent is! PrefixedIdentifier) {
-        rule.reportLint(node, arguments: [node.name]);
-      }
+    if (isSelfReference(node)) {
+      rule.reportLint(node, arguments: [node.name]);
     }
 
-    return super.visitSimpleIdentifier(node);
+    // No need to call super visit (SimpleIdentifiers have no children).
   }
 }
 

--- a/test/rules/recursive_getters_test.dart
+++ b/test/rules/recursive_getters_test.dart
@@ -60,6 +60,19 @@ class Nested {
 ''');
   }
 
+  test_nestedReference_property() async {
+    await assertNoDiagnostics(r'''
+class Nested {
+  final Nested target;
+  Nested(this.target);
+  bool get isFoo {
+    var self = this;
+    return self.target.isFoo;
+  }
+}
+''');
+  }
+
   test_referenceInListLiteral() async {
     await assertDiagnostics(r'''
 class C {


### PR DESCRIPTION
See: https://dart-review.googlesource.com/c/sdk/+/264961

/cc @bwilkerson 
