### PR TITLE
`prefer_const_constructors`: constant check re-ordering

### DIFF
--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -84,16 +84,14 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    if (node.constructorName.type.isDeferred) {
-      return;
-    }
+    if (node.constructorName.type.isDeferred) return;
 
     var element = node.constructorName.staticElement;
-    if (!node.isConst && element != null && element.isConst) {
+    if (element == null) return;
+
+    if (element.isConst && !node.isConst) {
       // Handled by analyzer hint.
-      if (element.hasLiteral) {
-        return;
-      }
+      if (element.hasLiteral) return;
 
       var enclosingElement = element.enclosingElement3;
       if (enclosingElement is ClassElement &&


### PR DESCRIPTION
Delay more expensive node `isConst` check.

A pretty minor bump but a few runs suggest some relative improvement (and objectively this shouldn't **_hurt_** and is no less clear).

**Before**

![image](https://user-images.githubusercontent.com/67586/197284246-91a43800-89b8-4c81-b81c-66eb28815ee8.png)

**After**

![image](https://user-images.githubusercontent.com/67586/197285844-25950d5b-f43d-4200-a95f-e73f18f53a0c.png)
