### PR TITLE
`flutter_style_todos`: factor out sync*

### DIFF
--- a/lib/src/rules/flutter_style_todos.dart
+++ b/lib/src/rules/flutter_style_todos.dart
@@ -52,25 +52,25 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
+  void checkComments(Token token) {
+    Token? comment = token.precedingComments;
+    while (comment != null) {
+      _checkComment(comment);
+      comment = comment.next;
+    }
+  }
+
   @override
   void visitCompilationUnit(CompilationUnit node) {
     Token? token = node.beginToken;
     while (token != null) {
-      _getPrecedingComments(token).forEach(_visitComment);
+      checkComments(token);
       if (token == token.next) break;
       token = token.next;
     }
   }
 
-  Iterable<Token> _getPrecedingComments(Token token) sync* {
-    Token? comment = token.precedingComments;
-    while (comment != null) {
-      yield comment;
-      comment = comment.next;
-    }
-  }
-
-  void _visitComment(Token node) {
+  void _checkComment(Token node) {
     var content = node.lexeme;
     if (content.startsWith(_todoRegExp) &&
         !content.startsWith(_todoExpectedRegExp)) {


### PR DESCRIPTION
Refactoring the regular expressions (#3774) should get us another win but this addresses the known slowness in `sync*` (https://github.com/dart-lang/sdk/issues/32102) and speeds this up ~3x.

**Before**

![image](https://user-images.githubusercontent.com/67586/197285460-8b151d76-eaba-4244-b6e9-a573ae471ec7.png)


**After**

![image](https://user-images.githubusercontent.com/67586/197285470-948d842d-d42b-48d5-8185-8d5bc3049d0a.png)

/cc @bwilkerson @srawlins 
