### PR TITLE
New rule: dangling_library_doc_comments

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -62,6 +62,7 @@ linter:
     - conditional_uri_does_not_exist
     - constant_identifier_names
     - control_flow_in_finally
+    - dangling_library_doc_comments
     - curly_braces_in_flow_control_structures
     - depend_on_referenced_packages
     - deprecated_consistency

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -62,8 +62,8 @@ linter:
     - conditional_uri_does_not_exist
     - constant_identifier_names
     - control_flow_in_finally
-    - dangling_library_doc_comments
     - curly_braces_in_flow_control_structures
+    - dangling_library_doc_comments
     - depend_on_referenced_packages
     - deprecated_consistency
     - diagnostic_describe_all_properties

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -65,6 +65,7 @@ import 'rules/conditional_uri_does_not_exist.dart';
 import 'rules/constant_identifier_names.dart';
 import 'rules/control_flow_in_finally.dart';
 import 'rules/curly_braces_in_flow_control_structures.dart';
+import 'rules/dangling_library_doc_comments.dart';
 import 'rules/depend_on_referenced_packages.dart';
 import 'rules/deprecated_consistency.dart';
 import 'rules/diagnostic_describe_all_properties.dart';
@@ -282,6 +283,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(ConstantIdentifierNames())
     ..register(ControlFlowInFinally())
     ..register(CurlyBracesInFlowControlStructures())
+    ..register(DanglingLibraryDocComments())
     ..register(DependOnReferencedPackages())
     ..register(DeprecatedConsistency())
     ..register(DiagnosticsDescribeAllProperties())

--- a/lib/src/rules/dangling_library_doc_comments.dart
+++ b/lib/src/rules/dangling_library_doc_comments.dart
@@ -86,8 +86,9 @@ class _Visitor extends SimpleAstVisitor<void> {
         return;
       }
 
-      if (firstDirective.documentationComment != null) {
-        rule.reportLint(firstDirective.documentationComment);
+      var docComment = firstDirective.documentationComment;
+      if (docComment != null) {
+        rule.reportLintForToken(docComment.beginToken);
         return;
       }
 

--- a/lib/src/rules/dangling_library_doc_comments.dart
+++ b/lib/src/rules/dangling_library_doc_comments.dart
@@ -90,6 +90,8 @@ class _Visitor extends SimpleAstVisitor<void> {
         rule.reportLint(firstDirective.documentationComment);
         return;
       }
+
+      return;
     }
 
     if (node.declarations.isEmpty) {

--- a/lib/src/rules/dangling_library_doc_comments.dart
+++ b/lib/src/rules/dangling_library_doc_comments.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Attach library doc comments to library directives.';
+
+const _details = r'''
+Attach library doc comments (with `///`) to library directives, rather than
+leaving them dangling near the top of a library.
+
+**BAD:**
+```dart
+/// This is a great library.
+import 'package:math';
+```
+
+```dart
+/// This is a great library.
+
+class C {}
+```
+
+**GOOD:**
+```dart
+/// This is a great library.
+library;
+
+import 'package:math';
+
+class C {}
+```
+
+**NOTE:** An unnamed library, like `library;` above, is only supported in Dart
+2.19 and later. Code which might run in earlier versions of Dart need to provide
+a name in the `library` directive.
+''';
+
+class DanglingLibraryDocComments extends LintRule {
+  static const LintCode code = LintCode(
+      'dangling_library_doc_comments', 'Dangling library doc comment.',
+      correctionMessage: 'Attach library doc comments to library directives.');
+
+  DanglingLibraryDocComments()
+      : super(
+            name: 'dangling_library_doc_comments',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addCompilationUnit(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final DanglingLibraryDocComments rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    if (node.directives.isNotEmpty) {
+      // Only consider a doc comment on the first directive. Doc comments on
+      // other directives do not have the appearance of documenting the library.
+      var firstDirective = node.directives.first;
+      if (firstDirective is LibraryDirective) {
+        // Given the presense of library directive, don't worry about later doc
+        // comments in the library.
+        return;
+      }
+      if (firstDirective is PartOfDirective) {
+        // Don't worry about possible "library doc comments" in a part.
+        return;
+      }
+
+      if (firstDirective.documentationComment != null) {
+        rule.reportLint(firstDirective.documentationComment);
+        return;
+      }
+    }
+
+    if (node.declarations.isEmpty) {
+      // Without any declarations, we only need to check for a doc comment as
+      // the last thing in a file.
+      var endComment = node.endToken.precedingComments;
+      if (endComment is DocumentationCommentToken) {
+        rule.reportLintForToken(endComment);
+      }
+      return;
+    }
+
+    var firstDeclaration = node.declarations.first;
+    var docComment = firstDeclaration.documentationComment;
+    if (docComment == null) {
+      return;
+    }
+    var lineInfo = node.lineInfo;
+
+    // We must walk through the comments following the doc comment, tracking
+    // pairs of consecutive comments so as to check whether any two are
+    // separated by a blank line.
+    var commentToken = docComment.endToken;
+    var followingCommentToken = docComment.endToken.next;
+    while (followingCommentToken != null) {
+      // Any blank line between the doc comment and following comments makes
+      // the doc comment look dangling.
+      var commentEndLine = lineInfo.getLocation(commentToken.end).lineNumber;
+      var followingCommentEndLine =
+          lineInfo.getLocation(followingCommentToken.offset).lineNumber;
+      if (followingCommentEndLine > commentEndLine + 1) {
+        // There is a blank line between the declaration's doc comment and the
+        // declaration.
+        rule.reportLint(docComment);
+        return;
+      }
+
+      commentToken = followingCommentToken;
+      followingCommentToken = followingCommentToken.next;
+    }
+
+    var commentEndLine = lineInfo.getLocation(commentToken.end).lineNumber;
+    // The syntactic entity to which a comment is "attached" is the
+    // [Comment]'s `parent`, not it's `endToken`'s `next` [Token].
+    var tokenAfterDocComment =
+        (docComment.endToken as DocumentationCommentToken).parent;
+    if (tokenAfterDocComment == null) {
+      // We shouldn't get here as the doc comment is attached to
+      // [firstDeclaration].
+      return;
+    }
+    var declarationStartLine =
+        lineInfo.getLocation(tokenAfterDocComment.offset).lineNumber;
+    if (declarationStartLine > commentEndLine + 1) {
+      // There is a blank line between the declaration's doc comment and the
+      // declaration.
+      rule.reportLint(docComment);
+    }
+  }
+}

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -30,6 +30,8 @@ import 'collection_methods_unrelated_type_test.dart'
 import 'conditional_uri_does_not_exist_test.dart'
     as conditional_uri_does_not_exist;
 import 'constant_identifier_names_test.dart' as constant_identifier_names;
+import 'dangling_library_doc_comments_test.dart'
+    as dangling_library_doc_comments;
 import 'deprecated_consistency_test.dart' as deprecated_consistency;
 import 'discarded_futures_test.dart' as discarded_futures;
 import 'file_names_test.dart' as file_names;
@@ -108,6 +110,7 @@ void main() {
   collection_methods_unrelated_type.main();
   conditional_uri_does_not_exist.main();
   constant_identifier_names.main();
+  dangling_library_doc_comments.main();
   deprecated_consistency.main();
   discarded_futures.main();
   file_names.main();

--- a/test/rules/dangling_library_doc_comments_test.dart
+++ b/test/rules/dangling_library_doc_comments_test.dart
@@ -1,0 +1,127 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(DanglingLibraryDocCommentsTest);
+  });
+}
+
+@reflectiveTest
+class DanglingLibraryDocCommentsTest extends LintRuleTest {
+  @override
+  String get lintRule => 'dangling_library_doc_comments';
+
+  test_doc_comment_above_declaration() async {
+    await assertDiagnostics(
+      r'''
+/// Doc comment.
+
+class C {}
+''',
+      [lint(0, 16)],
+    );
+  }
+
+  test_doc_comment_above_declaration_ending_in_reference() async {
+    await assertNoDiagnostics(r'''
+/// Doc comment [C]
+class C {}
+''');
+  }
+
+  test_doc_comment_above_declaration_with_annotation() async {
+    await assertNoDiagnostics(r'''
+/// Doc comment.
+@deprecated
+class C {}
+''');
+  }
+
+  test_doc_comment_above_declaration_with_other_comment1() async {
+    await assertNoDiagnostics(r'''
+/// Doc comment.
+// Comment.
+class C {}
+''');
+  }
+
+  test_doc_comment_above_declaration_with_other_comment2() async {
+    await assertDiagnostics(
+      r'''
+/// Doc comment.
+
+// Comment.
+class C {}
+''',
+      [lint(0, 16)],
+    );
+  }
+
+  test_doc_comment_above_declaration_with_other_comment3() async {
+    await assertDiagnostics(
+      r'''
+/// Doc comment.
+// Comment.
+
+class C {}
+''',
+      [lint(0, 16)],
+    );
+  }
+
+  test_doc_comment_above_declaration_with_other_comment4() async {
+    await assertNoDiagnostics(r'''
+/// Doc comment.
+// Comment.
+/* Comment 2. */
+class C {}
+''');
+  }
+
+  test_doc_comment_at_end_of_file() async {
+    await assertDiagnostics(
+      r'''
+/// Doc comment with [int].
+''',
+      [lint(0, 27)],
+    );
+  }
+
+  test_doc_comment_attached_to_declaration() async {
+    await assertNoDiagnostics(r'''
+/// Doc comment.
+class C {}
+''');
+  }
+
+  test_doc_comment_on_first_directive() async {
+    await assertDiagnostics(
+      r'''
+/// Doc comment.
+export 'dart:math';
+''',
+      [lint(0, 16)],
+    );
+  }
+
+  test_doc_comment_on_later_directive() async {
+    await assertNoDiagnostics(r'''
+export 'dart:math';
+/// Doc comment for some reason.
+export 'dart:io';
+''');
+  }
+
+  test_doc_comment_on_library_directive() async {
+    await assertNoDiagnostics(r'''
+/// Doc comment.
+library l;
+''');
+  }
+}

--- a/test/rules/dangling_library_doc_comments_test.dart
+++ b/test/rules/dangling_library_doc_comments_test.dart
@@ -17,7 +17,7 @@ class DanglingLibraryDocCommentsTest extends LintRuleTest {
   @override
   String get lintRule => 'dangling_library_doc_comments';
 
-  test_doc_comment_above_declaration() async {
+  test_docComment_aboveDeclaration() async {
     await assertDiagnostics(
       r'''
 /// Doc comment.
@@ -28,14 +28,14 @@ class C {}
     );
   }
 
-  test_doc_comment_above_declaration_ending_in_reference() async {
+  test_docComment_aboveDeclaration_endingInReference() async {
     await assertNoDiagnostics(r'''
 /// Doc comment [C]
 class C {}
 ''');
   }
 
-  test_doc_comment_above_declaration_with_annotation() async {
+  test_docComment_aboveDeclarationWithAnnotation() async {
     await assertNoDiagnostics(r'''
 /// Doc comment.
 @deprecated
@@ -43,7 +43,19 @@ class C {}
 ''');
   }
 
-  test_doc_comment_above_declaration_with_other_comment1() async {
+  test_docComment_aboveDeclarationWithDocComment() async {
+    await assertDiagnostics(
+      r'''
+/// Library comment.
+
+/// Class comment.
+class C {}
+''',
+      [lint(0, 20)],
+    );
+  }
+
+  test_docComment_aboveDeclarationWithOtherComment1() async {
     await assertNoDiagnostics(r'''
 /// Doc comment.
 // Comment.
@@ -51,7 +63,7 @@ class C {}
 ''');
   }
 
-  test_doc_comment_above_declaration_with_other_comment2() async {
+  test_docComment_aboveDeclarationWithOtherComment2() async {
     await assertDiagnostics(
       r'''
 /// Doc comment.
@@ -63,7 +75,7 @@ class C {}
     );
   }
 
-  test_doc_comment_above_declaration_with_other_comment3() async {
+  test_docComment_aboveDeclarationWithOtherComment3() async {
     await assertDiagnostics(
       r'''
 /// Doc comment.
@@ -75,7 +87,7 @@ class C {}
     );
   }
 
-  test_doc_comment_above_declaration_with_other_comment4() async {
+  test_docComment_aboveDeclarationWithOtherComment4() async {
     await assertNoDiagnostics(r'''
 /// Doc comment.
 // Comment.
@@ -84,7 +96,7 @@ class C {}
 ''');
   }
 
-  test_doc_comment_at_end_of_file() async {
+  test_docComment_atEndOfFile() async {
     await assertDiagnostics(
       r'''
 /// Doc comment with [int].
@@ -93,14 +105,25 @@ class C {}
     );
   }
 
-  test_doc_comment_attached_to_declaration() async {
+  test_docComment_atEndOfFile_precededByComment() async {
+    await assertDiagnostics(
+      r'''
+// Copyright something.
+
+/// Doc comment with [int].
+''',
+      [lint(25, 27)],
+    );
+  }
+
+  test_docComment_attachedToDeclaration() async {
     await assertNoDiagnostics(r'''
 /// Doc comment.
 class C {}
 ''');
   }
 
-  test_doc_comment_on_first_directive() async {
+  test_docComment_onFirstDirective() async {
     await assertDiagnostics(
       r'''
 /// Doc comment.
@@ -110,7 +133,7 @@ export 'dart:math';
     );
   }
 
-  test_doc_comment_on_later_directive() async {
+  test_docComment_onLaterDirective() async {
     await assertNoDiagnostics(r'''
 export 'dart:math';
 /// Doc comment for some reason.
@@ -118,7 +141,7 @@ export 'dart:io';
 ''');
   }
 
-  test_doc_comment_on_library_directive() async {
+  test_docComment_onLibraryDirective() async {
     await assertNoDiagnostics(r'''
 /// Doc comment.
 library l;


### PR DESCRIPTION
# Description

Fixes https://github.com/dart-lang/linter/issues/3789

The issue states the intent of the rule well, but the devil is, as usual, in the details.

I have implemented this rule specifically to use a heuristic of which doc comments _might_ be trying to document a library. Here are the criteria:

* `///`-style comments only.
* comments above the first directive, unless the first directive is a `library` or `part` directive, so doc comments mixed _within_ directives (imports, exports) are not considered.
* comments above the first declaration, which are not physically attached to the declaration; that is, there exists at least one blank line between the doc comment and the first non-comment token of the declaration. The tests cover this case well, as it is tricky to get right.
* comments at the end of a library, in which there are no declarations. This should cover public libraries whose function is to export private libraries; they may contain no declarations, and may contain a comment intended to be a library doc comment.