### PR TITLE
New rule: library_annotations

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -83,6 +83,7 @@ linter:
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
+    - library_annotations
     - library_names
     - library_prefixes
     - library_private_types_in_public_api

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -86,6 +86,7 @@ import 'rules/invariant_booleans.dart';
 import 'rules/iterable_contains_unrelated_type.dart';
 import 'rules/join_return_with_assignment.dart';
 import 'rules/leading_newlines_in_multiline_strings.dart';
+import 'rules/library_annotations.dart';
 import 'rules/library_names.dart';
 import 'rules/library_prefixes.dart';
 import 'rules/library_private_types_in_public_api.dart';
@@ -307,6 +308,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(IterableContainsUnrelatedType())
     ..register(JoinReturnWithAssignment())
     ..register(LeadingNewlinesInMultilineStrings())
+    ..register(LibraryAnnotations())
     ..register(LibraryNames())
     ..register(LibraryPrefixes())
     ..register(LibraryPrivateTypesInPublicAPI())

--- a/lib/src/rules/library_annotations.dart
+++ b/lib/src/rules/library_annotations.dart
@@ -1,0 +1,156 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/extensions.dart';
+import 'package:meta/meta_meta.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Attach library annotations to library directives.';
+
+const _details = r'''
+Attach library annotations to library directives, rather than
+some other library-level element.
+
+**BAD:**
+```dart
+import 'package:test/test.dart';
+
+@TestOn('browser')
+void main() {}
+```
+
+**GOOD:**
+```dart
+@TestOn('browser')
+library;
+import 'package:test/test.dart';
+
+void main() {}
+```
+
+**NOTE:** An unnamed library, like `library;` above, is only supported in Dart
+2.19 and later. Code which might run in earlier versions of Dart will need to
+provide a name in the `library` directive.
+''';
+
+class LibraryAnnotations extends LintRule {
+  static const LintCode code = LintCode('library_annotations',
+      'This annotation must be attached to a library directive.',
+      correctionMessage: 'Attach library annotations to library directives.');
+
+  LibraryAnnotations()
+      : super(
+            name: 'library_annotations',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addClassDeclaration(this, visitor);
+    registry.addClassTypeAlias(this, visitor);
+    registry.addEnumDeclaration(this, visitor);
+    registry.addExportDirective(this, visitor);
+    registry.addExtensionDeclaration(this, visitor);
+    registry.addFunctionTypeAlias(this, visitor);
+    registry.addFunctionDeclaration(this, visitor);
+    registry.addGenericTypeAlias(this, visitor);
+    registry.addImportDirective(this, visitor);
+    registry.addMixinDeclaration(this, visitor);
+    registry.addTopLevelVariableDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LibraryAnnotations rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) => _check(node);
+
+  @override
+  void visitClassTypeAlias(ClassTypeAlias node) => _check(node);
+
+  @override
+  void visitEnumDeclaration(EnumDeclaration node) => _check(node);
+
+  @override
+  void visitExportDirective(ExportDirective node) => _check(node);
+
+  @override
+  void visitExtensionDeclaration(ExtensionDeclaration node) => _check(node);
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) => _check(node);
+
+  @override
+  void visitFunctionTypeAlias(FunctionTypeAlias node) => _check(node);
+
+  @override
+  void visitGenericTypeAlias(GenericTypeAlias node) => _check(node);
+
+  @override
+  void visitImportDirective(ImportDirective node) => _check(node);
+
+  @override
+  void visitMixinDeclaration(MixinDeclaration node) => _check(node);
+
+  @override
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) =>
+      _check(node);
+
+  void _check(AnnotatedNode node) {
+    for (var annotation in node.metadata) {
+      var elementAnnotation = annotation.elementAnnotation;
+      if (elementAnnotation == null) {
+        return;
+      }
+
+      if (elementAnnotation.targetKinds.contains(TargetKind.library) &&
+          (node.parent as CompilationUnit?)?.directives.first == node) {
+        rule.reportLint(annotation);
+        return;
+      }
+
+      if (elementAnnotation.isPragmaLateTrust) {
+        rule.reportLint(annotation);
+        return;
+      }
+    }
+  }
+}
+
+extension on ElementAnnotation {
+  /// Whether this is an annotation of the form `@pragma('dart2js:late:trust')`.
+  bool get isPragmaLateTrust {
+    if (_isConstructor(libraryName: 'dart.core', className: 'pragma')) {
+      var value = computeConstantValue();
+      var nameValue = value?.getField('name');
+      return nameValue?.toStringValue() == 'dart2js:late:trust';
+    }
+    return false;
+  }
+
+  // Copied from package:analyzer/src/dart/element/element.dart
+  bool _isConstructor({
+    required String libraryName,
+    required String className,
+  }) {
+    var element = this.element;
+    return element is ConstructorElement &&
+        element.enclosingElement.name == className &&
+        element.library.name == libraryName;
+  }
+}

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -37,6 +37,7 @@ import 'discarded_futures_test.dart' as discarded_futures;
 import 'file_names_test.dart' as file_names;
 import 'flutter_style_todos_test.dart' as flutter_style_todos;
 import 'hash_and_equals_test.dart' as hash_and_equals;
+import 'library_annotations_test.dart' as library_annotations;
 import 'library_names_test.dart' as library_names;
 import 'library_private_types_in_public_api_test.dart'
     as library_private_types_in_public_api;
@@ -116,6 +117,7 @@ void main() {
   file_names.main();
   flutter_style_todos.main();
   hash_and_equals.main();
+  library_annotations.main();
   library_names.main();
   library_private_types_in_public_api.main();
   literal_only_boolean_expressions.main();

--- a/test/rules/library_annotations_test.dart
+++ b/test/rules/library_annotations_test.dart
@@ -30,6 +30,26 @@ class C {}
     );
   }
 
+  test_classTypeAliasDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+abstract class C = Object with Future;
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_enumDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+enum E { one, two }
+''',
+      [lint(0, 29)],
+    );
+  }
+
   test_exportDeclaration() async {
     await assertDiagnostics(
       r'''
@@ -55,6 +75,16 @@ extension E on int {}
       r'''
 @pragma('dart2js:late:trust')
 void f() {}
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_genericTypedefDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+typedef Fn = void Function();
 ''',
       [lint(0, 29)],
     );
@@ -97,41 +127,11 @@ var i = 1;
     );
   }
 
-  test_classTypeAliasDeclaration() async {
-    await assertDiagnostics(
-      r'''
-@pragma('dart2js:late:trust')
-abstract class C = Object with Future;
-''',
-      [lint(0, 29)],
-    );
-  }
-
   test_typedefDeclaration() async {
     await assertDiagnostics(
       r'''
 @pragma('dart2js:late:trust')
 typedef void Fn();
-''',
-      [lint(0, 29)],
-    );
-  }
-
-  test_genericTypedefDeclaration() async {
-    await assertDiagnostics(
-      r'''
-@pragma('dart2js:late:trust')
-typedef Fn = void Function();
-''',
-      [lint(0, 29)],
-    );
-  }
-
-  test_enumDeclaration() async {
-    await assertDiagnostics(
-      r'''
-@pragma('dart2js:late:trust')
-enum E { one, two }
 ''',
       [lint(0, 29)],
     );

--- a/test/rules/library_annotations_test.dart
+++ b/test/rules/library_annotations_test.dart
@@ -1,0 +1,139 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(LibraryAnnotationsTest);
+  });
+}
+
+@reflectiveTest
+class LibraryAnnotationsTest extends LintRuleTest {
+  @override
+  bool get addMetaPackageDep => true;
+
+  @override
+  String get lintRule => 'library_annotations';
+
+  test_classDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+class C {}
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_exportDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+export 'dart:math';
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_extensionDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+extension E on int {}
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_functionDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+void f() {}
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_importDirective() async {
+    await assertDiagnostics(
+      r'''
+@TestOn('browser')
+import 'package:meta/meta_meta.dart';
+
+@Target({TargetKind.library})
+class TestOn {
+  const TestOn(String name);
+}
+
+class C {}
+''',
+      [lint(0, 18)],
+    );
+  }
+
+  test_mixinDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+mixin M {}
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_topLevelVariableDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+var i = 1;
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_classTypeAliasDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+abstract class C = Object with Future;
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_typedefDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+typedef void Fn();
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_genericTypedefDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+typedef Fn = void Function();
+''',
+      [lint(0, 29)],
+    );
+  }
+
+  test_enumDeclaration() async {
+    await assertDiagnostics(
+      r'''
+@pragma('dart2js:late:trust')
+enum E { one, two }
+''',
+      [lint(0, 29)],
+    );
+  }
+}


### PR DESCRIPTION
# Description

Report on annotations which should be attached to a library directive.

Basically this is just `@pragma('dart2js:late:trust')` and all `TargetKind.library` directives that are currently allowed by BestPracticesVisitor.

Fixes https://github.com/dart-lang/linter/issues/3790