### PR TITLE
1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
-# 1.29.0-dev
+# 1.29.0
 
+- new lint: `dangling_library_doc_comments`
+- fix `no_leading_underscores_for_local_identifiers` to not report super formals as local variables
+- fix `unnecessary_overrides` false negatives
+- fix `cancel_subscriptions` for nullable fields 
+- new lint: `collection_methods_unrelated_type`
+- update `library_names` to support unnamed libraries
+- fix `unnecessary_parenthesis` support for as-expressions
+- fix `use_build_context_synchronously` to check for context property accesses
+- fix false positive in `comment_references`
+- improved unrelated type checks to handle enums and cascades
+- fix `unnecessary_brace_in_string_interps` for `this` expressions 
+- update `use_build_context_synchronously` for `BuildContext.mounted`
+- improve `flutter_style_todos` to handle more cases
+- fix `use_build_context_synchronously` to check for `BuildContext`s in named expressions
+- fix `exhaustive_cases` to check parenthesized expressions
+- performance improvements for:
+  - `avoid_null_checks_in_equality_operators`
+  - `join_return_with_statement`
+  - `recursive_getters`
+  - `unnecessary_lambdas`
+  - `diagnostic_describe_all_properties`
+  - `prefer_foreach`
+  - `avoid_escaping_inner_quotes`
+  - `cascade_invocations`
+  - `tighten_type_of_initializing_formals`
+  - `prefer_interpolation_to_compose_strings`
+  - `prefer_constructors_over_static_methods`
+  - `avoid_returning_null`
+  - `parameter_assignments`
+  - `prefer_constructors_over_static_methods`
+  - `prefer_interpolation_to_compose_strings`
+  - `avoid_returning_null`
+  - `avoid_returning_this`
+  - `flutter_style_todos`
+  - `avoid_positional_boolean_parameters`
+  - `prefer_const_constructors`
 - new lint: `implicit_call_tearoffs`
 - new lint: `unnecessary_library_directive`
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.29.0-dev';
+const String version = '1.29.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.29.0-dev
+version: 1.29.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.29.0

- new lint: `dangling_library_doc_comments`
- fix `no_leading_underscores_for_local_identifiers` to not report super formals as local variables
- fix `unnecessary_overrides` false negatives
- fix `cancel_subscriptions` for nullable fields 
- new lint: `collection_methods_unrelated_type`
- update `library_names` to support unnamed libraries
- fix `unnecessary_parenthesis` support for as-expressions
- fix `use_build_context_synchronously` to check for context property accesses
- fix false positive in `comment_references`
- improved unrelated type checks to handle enums and cascades
- fix `unnecessary_brace_in_string_interps` for `this` expressions 
- update `use_build_context_synchronously` for `BuildContext.mounted`
- improve `flutter_style_todos` to handle more cases
- fix `use_build_context_synchronously` to check for `BuildContext`s in named expressions
- fix `exhaustive_cases` to check parenthesized expressions
- performance improvements for:
  - `avoid_null_checks_in_equality_operators`
  - `join_return_with_statement`
  - `recursive_getters`
  - `unnecessary_lambdas`
  - `diagnostic_describe_all_properties`
  - `prefer_foreach`
  - `avoid_escaping_inner_quotes`
  - `cascade_invocations`
  - `tighten_type_of_initializing_formals`
  - `prefer_interpolation_to_compose_strings`
  - `prefer_constructors_over_static_methods`
  - `avoid_returning_null`
  - `parameter_assignments`
  - `prefer_constructors_over_static_methods`
  - `prefer_interpolation_to_compose_strings`
  - `avoid_returning_null`
  - `avoid_returning_this`
  - `flutter_style_todos`
  - `avoid_positional_boolean_parameters`
  - `prefer_const_constructors`
- new lint: `implicit_call_tearoffs`
- new lint: `unnecessary_library_directive`



---


/cc @bwilkerson @srawlins 