### PR TITLE
`use_build_context_synchronously`: check for context properties

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -113,6 +113,9 @@ class _Visitor extends SimpleAstVisitor {
       if (argument is NamedExpression) {
         argument = argument.expression;
       }
+      if (argument is PropertyAccess) {
+        argument = argument.propertyName;
+      }
       if (argument is Identifier) {
         var element = argument.staticElement;
         if (element == null) {

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -24,6 +24,27 @@ class UseBuildContextSynchronouslyTest extends LintRuleTest {
   @override
   String get testPackageRootPath => '$workspaceRootPath/lib';
 
+  /// https://github.com/dart-lang/linter/issues/3818
+  test_context_propertyAccess() async {
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+class W {
+  final BuildContext context;
+  W(this.context);
+
+  Future<void> f() async {
+    await Future.value();
+    g(this.context);
+  }
+
+  Future<void> g(BuildContext context) async {}
+}
+''', [
+      lint(157, 15),
+    ]);
+  }
+
   /// https://github.com/dart-lang/linter/issues/3676
   test_contextPassedAsNamedParam() async {
     await assertDiagnostics(r'''


### PR DESCRIPTION
Fixes #3818

/cc @bwilkerson 

(FWIW: this is not for immediate landing since we want to potentially hustle a low-risk release in after 1.29 sticks.)