### PR TITLE
[wip] Introduce DartDoc "Summary Line" lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.34.0
 
-- new lint: `dartdoc_summary_line_format`
+- new lint: `dartdoc_summary_line`
 
 # 1.33.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+# 1.34.0
+
+- new lint: `dartdoc_summary_line_format`
+
 # 1.33.0
 
 - fix `unnecessary_parenthesis` false-positive with null-aware expressions
-- fix `void_checks` to allow assignments of `Future<dynamic>?` to parameters 
+- fix `void_checks` to allow assignments of `Future<dynamic>?` to parameters
   typed `FutureOr<void>?`
 - removed support for:
   - `enable_null_safety`
@@ -13,7 +17,7 @@
 - update `void_checks` to allow returning `Never` as void
 - new lint: `unnecessary_breaks`
 - fix `use_build_context_synchronously` in if conditions
-- update `no_adjacent_strings_in_list` to support set literals and for- and 
+- update `no_adjacent_strings_in_list` to support set literals and for- and
   if-elements
 
 # 1.32.0
@@ -44,14 +48,14 @@
 - new lint: `dangling_library_doc_comments`
 - fix `no_leading_underscores_for_local_identifiers` to not report super formals as local variables
 - fix `unnecessary_overrides` false negatives
-- fix `cancel_subscriptions` for nullable fields 
+- fix `cancel_subscriptions` for nullable fields
 - new lint: `collection_methods_unrelated_type`
 - update `library_names` to support unnamed libraries
 - fix `unnecessary_parenthesis` support for as-expressions
 - fix `use_build_context_synchronously` to check for context property accesses
 - fix false positive in `comment_references`
 - improved unrelated type checks to handle enums and cascades
-- fix `unnecessary_brace_in_string_interps` for `this` expressions 
+- fix `unnecessary_brace_in_string_interps` for `this` expressions
 - update `use_build_context_synchronously` for `BuildContext.mounted`
 - improve `flutter_style_todos` to handle more cases
 - fix `use_build_context_synchronously` to check for `BuildContext`s in named expressions
@@ -89,7 +93,7 @@
 
 # 1.27.0
 
-- fix `avoid_redundant_argument_values` when referencing required 
+- fix `avoid_redundant_argument_values` when referencing required
   parameters in legacy libraries
 - performance improvements for `use_late_for_private_fields_and_variables`
 - new lint: `use_string_in_part_of_directives`
@@ -142,7 +146,7 @@
 # 1.23.0
 
 - fixed `no_leading_underscores_for_local_identifiers`
-  to lint local function declarations 
+  to lint local function declarations
 - fixed `avoid_init_to_null` to correctly handle super
   initializing defaults that are non-null
 - updated `no_leading_underscores_for_local_identifiers`
@@ -151,7 +155,7 @@
   start with a digit
 - updated `require_trailing_commas` to handle functions
   in asserts and multi-line strings
-- updated `unsafe_html` to allow assignments to 
+- updated `unsafe_html` to allow assignments to
   `img.src`
 - fixed `unnecessary_null_checks` to properly handle map
   literal entries
@@ -180,7 +184,7 @@
   with `key` super parameter initializers
 - fixed `use_super_parameters` false positive with field
   formal params
-- updated `unnecessary_null_checks` and 
+- updated `unnecessary_null_checks` and
   `null_check_on_nullable_type_parameter` to handle
   list/set/map literals, and `yield` and `await`
   expressions
@@ -198,7 +202,7 @@
 - new lint: `use_colored_box`
 - performance improvements for `sort_constructors`
 - doc improvements for `always_use_package_imports`,
-  `avoid_print`, and `avoid_relative_lib_imports` 
+  `avoid_print`, and `avoid_relative_lib_imports`
 - update `avoid_void_async` to skip `main` functions
 - update `prefer_final_parameters` to not super on super params
 - lint updates for enhanced-enums and super-initializer language
@@ -209,7 +213,7 @@
 # 1.18.0
 
 - extend `camel_case_types` to cover enums
-- fix `no_leading_underscores_for_local_identifiers` to not 
+- fix `no_leading_underscores_for_local_identifiers` to not
   mis-flag field formal parameters with default values
 - fix `prefer_function_declarations_over_variables` to not
   mis-flag non-final fields
@@ -233,7 +237,7 @@
 - updates to `secure_pubspec_urls` to check `issue_tracker` and
   `repository` entries
 - new lint: `conditional_uri_does_not_exist`
-- performance improvements for 
+- performance improvements for
   `missing_whitespace_between_adjacent_strings`
 
 # 1.15.0
@@ -248,13 +252,13 @@
 
 # 1.14.0
 
-- fix `omit_local_variable_types` to not flag a local type that is 
+- fix `omit_local_variable_types` to not flag a local type that is
   required for inference
 
 # 1.13.0
 
 - allow `while (true) { ...}` in `literal_only_boolean_expressions`
-- fixed `file_names` to report at the start of the file (not the entire 
+- fixed `file_names` to report at the start of the file (not the entire
   compilation unit)
 - fixed `prefer_collection_literals` named typed param false positive
 - control flow improvements for `use_build_context_synchronously`
@@ -268,19 +272,19 @@
 
 # 1.11.0
 
-- added support for constructor tear-offs to `avoid_redundant_argument_values`, 
+- added support for constructor tear-offs to `avoid_redundant_argument_values`,
   `unnecessary_lambdas`, and `unnecessary_parenthesis`
 - new lint: `unnecessary_constructor_name` to flag unnecessary uses of `.new`
 
 # 1.10.0
 
-- improved regular expression parsing performance for common checks 
+- improved regular expression parsing performance for common checks
   (`camel_case_types`, `file_names`, etc.)
 - (internal) migrated to analyzer 2.1.0 APIs
-- fixed false positive in `use_build_context_synchronously` in awaits inside 
+- fixed false positive in `use_build_context_synchronously` in awaits inside
   anonymous functions
 - fixed `overridden_fields` false positive w/ static fields
-- fixed false positive in `avoid_null_checks_in_equality_operators` w/ 
+- fixed false positive in `avoid_null_checks_in_equality_operators` w/
   non-nullable params
 - fixed false positive for deferred imports in `prefer_const_constructors`
 
@@ -312,7 +316,7 @@
 - fixed `curly_braces_in_flow_control_structures` to properly flag terminating `else-if`
   blocks
 - improved `always_specify_types` to support type aliases
-- fixed false positive in `unnecessary_string_interpolations` w/ nullable interpolated 
+- fixed false positive in `unnecessary_string_interpolations` w/ nullable interpolated
   strings
 - fixed false positive in `avoid_function_literals_in_foreach_calls` for nullable
   iterables
@@ -330,7 +334,7 @@
 # 1.7.0
 
 - fixed case-sensitive false positive in `use_full_hex_values_for_flutter_colors`
-- improved try-block and switch statement flow analysis for 
+- improved try-block and switch statement flow analysis for
   `use_build_context_synchronously`
 - updated `use_setters_to_change_properties` to only highlight a method name,
   not the entire body and doc comment
@@ -343,7 +347,7 @@
 
 # 1.6.1
 
-- reverted relaxation of `sort_child_properties_last` to allow for a 
+- reverted relaxation of `sort_child_properties_last` to allow for a
   trailing Widget in instance creations
 
 # 1.6.0
@@ -352,14 +356,14 @@
   underscore
 - fixed false negative in `prefer_final_parameters` where first parameter
   is final
-- improved `directives_ordering` sorting of directives with dot paths and 
+- improved `directives_ordering` sorting of directives with dot paths and
   dot-separated package names
 - relaxed `sort_child_properties_last` to allow for a trailing Widget in
   instance creations
 
 # 1.5.0
 
-- (internal) migrated to `SecurityLintCode` instead of deprecated 
+- (internal) migrated to `SecurityLintCode` instead of deprecated
   `SecurityLintCodeWithUniqueName`
 - (internal) fixed `avoid_types_as_parameter_names` to skip field formal
   parameters

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -66,6 +66,7 @@ import 'rules/constant_identifier_names.dart';
 import 'rules/control_flow_in_finally.dart';
 import 'rules/curly_braces_in_flow_control_structures.dart';
 import 'rules/dangling_library_doc_comments.dart';
+import 'rules/dartdoc_summary_line.dart';
 import 'rules/depend_on_referenced_packages.dart';
 import 'rules/deprecated_consistency.dart';
 import 'rules/diagnostic_describe_all_properties.dart';
@@ -227,6 +228,7 @@ import 'rules/void_checks.dart';
 void registerLintRules({bool inTestMode = false}) {
   Analyzer.facade.cacheLinterVersion();
   Analyzer.facade
+    ..register(DartdocSummaryLine())
     ..register(AlwaysDeclareReturnTypes())
     ..register(UnnecessaryLibraryDirective())
     ..register(AlwaysPutControlBodyOnNewLine())

--- a/lib/src/rules/dartdoc_summary_line.dart
+++ b/lib/src/rules/dartdoc_summary_line.dart
@@ -1,0 +1,181 @@
+// Copyright (c) 2016, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: slash_for_doc_comments
+
+import 'dart:convert';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+import '../analyzer.dart';
+
+/// The maximum allowed length for a summary line.
+const maxSummaryLength = 140;
+
+const _desc =
+    r'Start your DartDoc comment with a single, brief sentence that ends with a period.';
+
+const _details = r'''
+From [Effective Dart](https://dart.dev/guides/language/effective-dart/documentation#do-start-doc-comments-with-a-single-sentence-summary):
+
+**DO** start doc comments with a single-sentence summary.
+
+Start your doc comment with a brief, user-centric description ending with a
+period. A sentence fragment is often sufficient. Provide just enough context
+for the reader to orient themselves and decide if they should keep reading or
+look elsewhere for the solution to their problem.
+
+For example:
+
+**GOOD:**
+```dart
+/// Deletes the file at [path] from the file system.
+void delete(String path) {
+  ...
+}
+```
+
+**BAD:**
+```dart
+/// Depending on the state of the file system and the user's permissions,
+/// certain operations may or may not be possible. If there is no file at
+/// [path] or it can't be accessed, this function throws either [IOError]
+/// or [PermissionError], respectively. Otherwise, this deletes the file.
+void delete(String path) {
+  ...
+}
+```
+
+From [Effective Dart](https://dart.dev/guides/language/effective-dart/documentation#do-separate-the-first-sentence-of-a-doc-comment-into-its-own-paragraph):
+
+**DO** separate the first sentence of a doc comment into its own paragraph.
+
+Add a blank line after the first sentence to split it out into its own
+paragraph. If more than a single sentence of explanation is useful, put the
+rest in later paragraphs.
+
+This helps you write a tight first sentence that summarizes the documentation.
+Also, tools like dart doc use the first paragraph as a short summary in places
+like lists of classes and members.
+
+For example:
+
+**GOOD:**
+```dart
+/// Deletes the file at [path].
+///
+/// Throws an [IOError] if the file could not be found. Throws a
+/// [PermissionError] if the file is present but could not be deleted.
+void delete(String path) {
+  ...
+}
+```
+
+**BAD:**
+```dart
+/// Deletes the file at [path]. Throws an [IOError] if the file could not
+/// be found. Throws a [PermissionError] if the file is present but could
+/// not be deleted.
+void delete(String path) {
+  ...
+}
+```
+''';
+
+/// Enforces that DartDoc blocks start with a single, brief line that ends in a period.
+///
+/// (Like the one above!)
+class DartdocSummaryLine extends LintRule {
+  DartdocSummaryLine()
+      : super(
+            name: 'dartdoc_summary_line',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addComment(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  /**
+   * Visits a [Comment] node, and finds and validates its summary line.
+   */
+  @override
+  void visitComment(Comment node) {
+    if (!node.isDocumentation) {
+      // Skip things that may not be proper dartdoc (like a /** */ comment)
+      return;
+    }
+
+    List<String> summary = _getSummary(node).toList();
+
+    // Should we enforce that summary.length == 1?
+    if (!_endsWithPeriod(summary) ||
+        summary.join(' ').length > maxSummaryLength) {
+      // Highlight the offending comment
+      rule.reportLintForOffset(node.offset, 3);
+    }
+  }
+}
+
+// Some utility functions
+
+/**
+ * Detects if a Comment starts with slash-star-star.
+ *
+ * This is a less common style for Dart Docs, but still [valid](https://dart.dev/guides/language/language-tour#documentation-comments).
+ */
+bool _isSlashStarStar(Comment node) =>
+    node.tokens.first.lexeme.startsWith('/**');
+
+/// Removes the first appearance of `prefix` from `line`, and trims the output.
+String _trimPrefix(String line, String prefix) =>
+    line.replaceFirst(prefix, '').trim();
+
+/// Removes the first triple slash of a `line` and returns its trimmed value.
+String _trimSlashes(String line) => _trimPrefix(line, '///');
+
+/**
+ * Removes the first asterisk of a `line` and and returns its trimmed value.
+ *
+ * (Like the ones that make this comment!)
+ */
+String _trimStars(String line) => _trimPrefix(line, ' *');
+
+/// [String.isNotEmpty] so it can be torn off.
+bool _isNotEmpty(String line) => line.isNotEmpty;
+
+/// Retrieves the summary line of a [Comment] node.
+///
+/// This will take "lines" (tokens or actual strings) from the beginning of the
+/// node until an empty line is found.
+Iterable<String> _getSummary(Comment node) {
+  if (_isSlashStarStar(node)) {
+    // The first token contains the whole block comment... Split in lines, then
+    // take as many as needed...
+    LineSplitter splitter = LineSplitter();
+    List<String> lines = splitter.convert(node.tokens.first.lexeme);
+    return lines
+        .sublist(1, lines.length - 1)
+        .map(_trimStars)
+        .takeWhile(_isNotEmpty);
+  } else {
+    return node.tokens
+        .map((tk) => _trimSlashes(tk.lexeme))
+        .takeWhile(_isNotEmpty);
+  }
+}
+
+/// Checks that the last of the `lines` ends in a period.
+bool _endsWithPeriod(Iterable<String> lines) => lines.last.endsWith('.');

--- a/lib/src/rules/dartdoc_summary_line.dart
+++ b/lib/src/rules/dartdoc_summary_line.dart
@@ -170,6 +170,12 @@ RegExp _sentenceBreak = RegExp(r'[^\.]+\.\s+[^\.]+');
 /// Returns the offset of the token that contains a sentence break.
 int? _findSentenceBreak(Iterable<Token> tokens) {
   for (Token tk in tokens) {
+    // "Corner case": If token is not last, and ends with a period.
+    // This used to be accepted, but shouldn't.
+    if (tk != tokens.last && tk.lexeme.endsWith('.')) {
+      return tk.end - 1;
+    }
+    // Attempt to locate the period in the middle of the lexeme.
     RegExpMatch? match = _sentenceBreak.firstMatch(tk.lexeme);
     if (match != null) {
       return tk.offset + tk.lexeme.indexOf('.', match.start);

--- a/lib/src/rules/dartdoc_summary_line.dart
+++ b/lib/src/rules/dartdoc_summary_line.dart
@@ -126,10 +126,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
     Iterable<Token> summary = _getSummary(node);
 
-    if (summary.length > maxSummaryLines) {
-      // Highlight the extra lines.
-      summary.skip(maxSummaryLines).forEach(rule.reportLintForToken);
-    }
     if (!_endsWithPeriod(summary)) {
       Token last = summary.last;
       // Highlight the last character of the sentence...
@@ -139,6 +135,12 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (sentenceBreakOffset != null) {
       // Highlight the position of the period that is breaking the summary.
       rule.reportLintForOffset(sentenceBreakOffset, 1);
+    }
+    if (summary.length > maxSummaryLines) {
+      // Highlight the extra lines.
+      summary.skip(maxSummaryLines).forEach((token) {
+        rule.reportLintForOffset(token.offset, 3);
+      });
     }
   }
 }


### PR DESCRIPTION
This is a WIP lint to enforce that DartDoc comments start with a ~~brief (140 chars) paragraph~~ single line that ends in a period ('.').

If there's additional content on the DartDoc, it expects a blank line before continuing, so:

### OK:

```dart
/// This is a valid dartdoc comment.
```

### OK:

```dart
/// This is also a valid dartdoc comment.
///
/// With some extra information right below as the next paragraph.
/// The comment can now be as complex as needed here, but it's
/// important that the first line is single and ends in a period.
```

### BAD:

```dart
/// This is a bad comment, because it
/// spills over two lines.
```

### BAD:

```dart
/// This is a bad comment, because it doesn't end in a period!
```

### BAD:

```dart
/// This is a bad comment, because it doesn't leave a blank space.
/// Between the first line and the rest of the content, that may be
/// arbitrarily complicated.
```

### IGNORED:

```dart
/**
 * This is a JavaDoc style comment.
 *
 * And is ignored by the linter. This is discouraged, don't do it.
 */
```

This lint only validates that the first ~~"paragraph" exists, is brief, and~~ line is isolated and ends in a period. It doesn't attempt to do any extra validation, like measuring the length of the line. Additional validation is left to other linters.

This lint ~~supports both `///` and `/**`~~ only supports `\\\` comments.


### Manual testing

I've run this lint against this repo, here's the CLI output:

<details>

<summary><tt>dit@dit:~/github/dart-linter$ dart run bin/linter.dart --rules=dartdoc_summary_line ~/github/dart-linter/lib</tt></summary>

```console
/src/util/score_utils.dart 11:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// todo(pq): de-duplicate these fetches / URIs
^^^
/src/util/tested_expressions.dart 124:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// TODO: A truly smart implementation would detect
  ^^^
/src/util/flutter_utils.dart 57:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// See: analysis_server/lib/src/utilities/flutter.dart
^^^
/src/util/ascii_utils.dart 5:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// String utilities that use underlying ASCII codes for improved performance.
^^^
/src/util/condition_scope_visitor.dart 133:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// todo (pq): here and w/ getTrueExpressions, consider an empty iterable
  ^^^
/src/util/leak_detector_visitor.dart 40:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// Builds a function that reports the variable node if the set of nodes
^^^
/src/util/unrelated_types_visitor.dart 14:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// Base class for visitor used in rules where we want to lint about invoking
^^^
/src/util/unrelated_types_visitor.dart 110:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// Checks a [MethodInvocation] or [IndexExpression] which has a singular
  ^^^
/src/rules/package_api_docs.dart 110:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  ///  classMember ::=
  ^^^
/src/rules/package_api_docs.dart 119:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  ///  compilationUnitMember ::=
  ^^^
/src/rules/unnecessary_string_escapes.dart 55:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// The special escaped chars listed in language specification
  ^^^
/src/rules/use_super_parameters.dart 143:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// Check if all super positional parameters can be converted to use super-
  ^^^
/src/rules/invariant_booleans.dart 127:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// The only purpose of this rule is to report the second node on a contradictory
^^^
/src/rules/prefer_is_empty.dart 188:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// todo(pq): consider sharing
  ^^^
/src/rules/use_string_buffers.dart 49:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// The motivation of this rule is performance stuffs, and the explanation is
^^^
/src/rules/cascade_invocations.dart 162:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// This is necessary when you have a variable declaration so that element
  ^^^
/src/rules/prefer_single_quotes.dart 121:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// The only way to get immediate children in a unified, typesafe way, is to
^^^
/src/rules/prefer_single_quotes.dart 139:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// Do a top-down analysis to search for string nodes. Note, do not pass in
^^^
/src/rules/prefer_single_quotes.dart 146:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// Scan as little of the tree as possible, by bailing out on first match. For
  ^^^
/src/rules/prefer_final_parameters.dart 92:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// Report the lint for parameters in the [parameters] list that are not
  ^^^
/src/rules/control_flow_in_finally.dart 111:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// Do not extend this class, it is meant to be used from
^^^
/src/rules/use_enums.dart 97:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// A visitor used to visit the class being linted. This visitor throws an
^^^
/src/rules/use_enums.dart 135:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// A visitor that visits everything in the library other than the class being
^^^
/src/rules/null_closures.dart 199:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// Two [NonNullableFunction] objects are equal if their [library], [type],
  ^^^
/src/rules/avoid_web_libraries_in_flutter.dart 30:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// todo (pq): consider making a utility and sharing w/ `prefer_relative_imports`
^^^
/src/rules/prefer_mixin.dart 78:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// Check for "legacy" classes that cannot easily be made `mixin`s for
  ^^^
/src/formatter.dart 198:3 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
  /// Override to influence error sorting
  ^^^
/src/ast.dart 32:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// Return the compilation unit of a node
^^^
/src/ast.dart 47:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// Returns the value of an [IntegerLiteral] or [PrefixExpression] with a
^^^
/src/ast.dart 66:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// If the [node] is the finishing identifier of an assignment, return its
^^^
/src/ast.dart 128:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// Return `true` if this compilation unit [node] is declared within a public
^^^
/src/ast.dart 392:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// If the [node] is the target of a [CompoundAssignmentExpression],
^^^
/src/cli.dart 47:1 [lint] Start your DartDoc comment with a single, brief sentence that ends with a period.
/// todo (pq): consider using `dart analyze` where possible
^^^

238 files analyzed, 33 issues found, in 10833 ms.
```

</details>

### Testing

* Will write tests, if this looks worthy of merging.

### Issues

Fixes https://github.com/dart-lang/linter/issues/56
Fixes https://github.com/dart-lang/linter/issues/1433