### PR TITLE
1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.30.0
+
+- new lint: `enable_null_safety`
+- new lint: `library_annotations`
+- miscellaneous documentation improvements
+
 # 1.29.0
 
 - new lint: `dangling_library_doc_comments`
@@ -38,7 +44,6 @@
   - `prefer_const_constructors`
 - new lint: `implicit_call_tearoffs`
 - new lint: `unnecessary_library_directive`
-- new lint: `enable_null_safety`
 
 # 1.28.0
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.29.0';
+const String version = '1.30.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.29.0
+version: 1.30.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.30.0

- new lint: `enable_null_safety`
- new lint: `library_annotations`
- miscellaneous documentation improvements

---

Closes: https://github.com/dart-lang/linter/issues/3828

/cc @bwilkerson @srawlins 

/fyi @parlough @mikairyuu 