### PR TITLE
Reference Effective Dart in avoid_classes_with_only_static_members

### DIFF
--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -11,6 +11,8 @@ import '../analyzer.dart';
 const _desc = r'Avoid defining a class that contains only static members.';
 
 const _details = r'''
+From [Effective Dart](https://dart.dev/guides/language/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members):
+
 **AVOID** defining a class that contains only static members.
 
 Creating classes with the sole purpose of providing utility or otherwise static


### PR DESCRIPTION
# Description

Reference Effective Dart in avoid_classes_with_only_static_members

This matches the formatting that @parlough recently standardized on.