### PR TITLE
Define a lint code for package_names

### DIFF
--- a/lib/src/rules/pub/package_names.dart
+++ b/lib/src/rules/pub/package_names.dart
@@ -20,15 +20,10 @@ with digits and isn't a reserved word.
 ''';
 
 class PubPackageNames extends LintRule {
-  // TODO(brianwilkerson) Uncomment the following when `reportPubLint` supports
-  //  message arguments.
-  // static const LintCode code = LintCode('package_names',
-  //     "The package name '{0}' isn't a snake_case identifier.",
-  //     correctionMessage:
-  //     'Try changing the name to follow the snake_case style.');
-  //
-  // @override
-  // LintCode get lintCode => code;
+  static const LintCode code = LintCode(
+      'package_names', "The package name '{0}' isn't a snake_case identifier.",
+      correctionMessage:
+          'Try changing the name to follow the snake_case style.');
 
   PubPackageNames()
       : super(
@@ -36,6 +31,9 @@ class PubPackageNames extends LintRule {
             description: _desc,
             details: _details,
             group: Group.pub);
+
+  @override
+  LintCode get lintCode => code;
 
   @override
   PubspecVisitor getPubspecVisitor() => Visitor(this);
@@ -50,7 +48,7 @@ class Visitor extends PubspecVisitor {
   void visitPackageName(PSEntry name) {
     var packageName = name.value.text;
     if (packageName != null && !isValidPackageName(packageName)) {
-      rule.reportPubLint(name.value); // arguments: [packageName]
+      rule.reportPubLint(name.value, arguments: [packageName]);
     }
   }
 }


### PR DESCRIPTION
This code was commented out pending the publishing of a later version of the analyzer. That version has been published and moved to, so this code can now be uncommented.

There's no rush to merge this.