### PR TITLE
Update unnecessary_final.dart

### DIFF
--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -10,9 +10,13 @@ import '../analyzer.dart';
 const _desc = "Don't use `final` for local variables.";
 
 const _details = r'''
-**DON'T** use `final` for local variables.
+Use `var`, not `final`, when declaring local variables.
 
-`var` is shorter, and `final` does not change the meaning of the code.
+Per Effective Dart, there are two styles in wide use. This rule
+enforces the `var` style. For the alternative style that prefers `final`,
+enable `prefer_final_locals` and `prefer_final_in_for_each` instead.
+
+For fields, final is always recommended; see the rule `prefer_final_fields`.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -12,9 +12,10 @@ const _desc = "Don't use `final` for local variables.";
 const _details = r'''
 Use `var`, not `final`, when declaring local variables.
 
-Per Effective Dart, there are two styles in wide use. This rule
-enforces the `var` style. For the alternative style that prefers `final`,
-enable `prefer_final_locals` and `prefer_final_in_for_each` instead.
+Per [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables),
+there are two styles in wide use. This rule enforces the `var` style.
+For the alternative style that prefers `final`, enable `prefer_final_locals`
+and `prefer_final_in_for_each` instead.
 
 For fields, `final` is always recommended; see the rule `prefer_final_fields`.
 

--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -16,7 +16,7 @@ Per Effective Dart, there are two styles in wide use. This rule
 enforces the `var` style. For the alternative style that prefers `final`,
 enable `prefer_final_locals` and `prefer_final_in_for_each` instead.
 
-For fields, final is always recommended; see the rule `prefer_final_fields`.
+For fields, `final` is always recommended; see the rule `prefer_final_fields`.
 
 **BAD:**
 ```dart


### PR DESCRIPTION
Clarify this this is an opinionated lint, that there is a semantic difference between `final` and `var`, and what the alternatives are.

Fixes https://github.com/dart-lang/linter/issues/3825