### PR TITLE
Remove Iterable<Object?>-related methods from collection_methods_unrelated_type

### DIFF
--- a/lib/src/rules/collection_methods_unrelated_type.dart
+++ b/lib/src/rules/collection_methods_unrelated_type.dart
@@ -25,13 +25,8 @@ as follows:
 * an argument to `Map<K, V>.remove` should be related to `K`
 * an argument to `Map<K, V>.[]` should be related to `K`
 * an argument to `Queue<E>.remove` should be related to `E`
-* an argument to `Set<E>.containsAll` should be related to `Iterable<E>`
-* an argument to `Set<E>.difference` should be related to `Set<E>`
-* an argument to `Set<E>.intersection` should be related to `Set<E>`
 * an argument to `Set<E>.lookup` should be related to `E`
 * an argument to `Set<E>.remove` should be related to `E`
-* an argument to `Set<E>.removeAll` should be related to `Iterable<E>`
-* an argument to `Set<E>.retainAll` should be related to `Iterable<E>`
 
 **BAD:**
 ```dart
@@ -45,7 +40,7 @@ void someFunction() {
 ```dart
 void someFunction() {
   var set = <int>{};
-  set.removeAll({'1'}); // LINT
+  set.remove('1'); // LINT
 }
 ```
 
@@ -61,7 +56,7 @@ void someFunction() {
 ```dart
 void someFunction() {
   var set = <int>{};
-  set.removeAll({1}); // OK
+  set.remove(1); // OK
 }
 ```
 
@@ -133,24 +128,6 @@ class _Visitor extends UnrelatedTypesProcessors {
           'remove',
           ExpectedArgumentKind.assignableToCollectionTypeArgument,
         ),
-        // Argument to `Set<E>.containsAll` should be assignable to `Set<E>`.
-        MethodDefinitionForElement(
-          typeProvider.setElement,
-          'containsAll',
-          ExpectedArgumentKind.assignableToIterableOfTypeArgument,
-        ),
-        // Argument to `Set<E>.difference` should be assignable to `Set<E>`.
-        MethodDefinitionForElement(
-          typeProvider.setElement,
-          'difference',
-          ExpectedArgumentKind.assignableToCollection,
-        ),
-        // Argument to `Set<E>.intersection` should be assignable to `Set<E>`.
-        MethodDefinitionForElement(
-          typeProvider.setElement,
-          'intersection',
-          ExpectedArgumentKind.assignableToCollection,
-        ),
         // Argument to `Set<E>.lookup` should be assignable to `E`.
         MethodDefinitionForElement(
           typeProvider.setElement,
@@ -162,18 +139,6 @@ class _Visitor extends UnrelatedTypesProcessors {
           typeProvider.setElement,
           'remove',
           ExpectedArgumentKind.assignableToCollectionTypeArgument,
-        ),
-        // Argument to `Set<E>.removeAll` should be assignable to `Set<E>`.
-        MethodDefinitionForElement(
-          typeProvider.setElement,
-          'removeAll',
-          ExpectedArgumentKind.assignableToIterableOfTypeArgument,
-        ),
-        // Argument to `Set<E>.retainAll` should be assignable to `Set<E>`.
-        MethodDefinitionForElement(
-          typeProvider.setElement,
-          'retainAll',
-          ExpectedArgumentKind.assignableToIterableOfTypeArgument,
         ),
       ];
 

--- a/test/rules/collection_methods_unrelated_type_test.dart
+++ b/test/rules/collection_methods_unrelated_type_test.dart
@@ -234,56 +234,6 @@ class CollectionMethodsUnrelatedTypeSetTest extends LintRuleTest {
   @override
   String get lintRule => 'collection_methods_unrelated_type';
 
-  test_containsAll_related_subtype() async {
-    await assertNoDiagnostics('''
-void f(Set<num> set, Set<int> other) {
-  set.containsAll(other);
-}
-''');
-  }
-
-  test_containsAll_unrelated() async {
-    await assertDiagnostics('''
-void f(Set<num> set, Set<String> other) {
-  set.containsAll(other);
-}
-''', [lint(60, 5)]);
-  }
-
-  test_difference_related_subtype() async {
-    await assertNoDiagnostics(
-      '''
-void f(Set<num> set, Set<int> other) {
-  set.difference(other);
-}
-''',
-    );
-  }
-
-  test_difference_unrelated() async {
-    await assertDiagnostics('''
-void f(Set<num> set, Set<String> other) {
-  set.difference(other);
-}
-''', [lint(59, 5)]);
-  }
-
-  test_intersection_related_subtype() async {
-    await assertNoDiagnostics('''
-void f(Set<num> set, Set<int> other) {
-  set.intersection(other);
-}
-''');
-  }
-
-  test_intersection_unrelated() async {
-    await assertDiagnostics('''
-void f(Set<num> set, Set<String> other) {
-  set.intersection(other);
-}
-''', [lint(61, 5)]);
-  }
-
   test_lookup_related_subtype() async {
     await assertNoDiagnostics('var x = <num>{}.lookup(1);');
   }
@@ -304,37 +254,5 @@ void f(Set<num> set, Set<String> other) {
       '''var x = <num>{}.remove('1');''',
       [lint(23, 3)],
     );
-  }
-
-  test_removeAll_related_subtype() async {
-    await assertNoDiagnostics('''
-void f(Set<num> set, List<int> other) {
-  set.removeAll(other);
-}
-''');
-  }
-
-  test_removeAll_unrelated() async {
-    await assertDiagnostics('''
-void f(Set<num> set, List<String> other) {
-  set.removeAll(other);
-}
-''', [lint(59, 5)]);
-  }
-
-  test_retainAll_related_subtype() async {
-    await assertNoDiagnostics('''
-void f(Set<num> set, List<int> other) {
-  set.retainAll(other);
-}
-''');
-  }
-
-  test_retainAll_unrelated() async {
-    await assertDiagnostics('''
-void f(Set<num> set, List<String> other) {
-  set.retainAll(other);
-}
-''', [lint(59, 5)]);
   }
 }


### PR DESCRIPTION
This PR removes 5 methods from `collection_methods_unrelated_type`'s concern, as they are too hard to analyze given downwards inference.

Fixes #3833
