### PR TITLE
Add notes about `always_put_control_body_on_new_line` and the formatter

### DIFF
--- a/lib/src/rules/always_put_control_body_on_new_line.dart
+++ b/lib/src/rules/always_put_control_body_on_new_line.dart
@@ -10,7 +10,7 @@ import '../analyzer.dart';
 const _desc = r'Separate the control structure expression from its statement.';
 
 const _details = r'''
-From the [flutter style guide](https://flutter.dev/style-guide/):
+From the [style guide for the flutter repo](https://flutter.dev/style-guide/):
 
 **DO** separate the control structure expression from its statement.
 
@@ -42,6 +42,10 @@ else print('ok')
 
 while (condition) i += 1;
 ```
+
+Note that this rule can conflict with the
+[Dart formatter](https://dart.dev/tools/dart-format), and should not be enabled
+when the Dart formatter is used.
 
 ''';
 

--- a/lib/src/rules/always_specify_types.dart
+++ b/lib/src/rules/always_specify_types.dart
@@ -13,7 +13,7 @@ import '../util/ascii_utils.dart';
 const _desc = r'Specify type annotations.';
 
 const _details = r'''
-From the [flutter style guide](https://flutter.dev/style-guide/):
+From the [style guide for the flutter repo](https://flutter.dev/style-guide/):
 
 **DO** specify type annotations.
 


### PR DESCRIPTION
# Description

Add a note. Also correct the name of the "style guide for the flutter repo".

Fixes #1847
