### PR TITLE
Add tests for use_to_and_as_if_applicable inheritance

### DIFF
--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -12,11 +12,13 @@ const _desc =
     r'Start the name of the method with to/_to or as/_as if applicable.';
 
 const _details = r'''
-From the [design guide](https://dart.dev/guides/language/effective-dart/design):
+From the [Effective Dart](https://dart.dev/guides/language/effective-dart/design):
 
-**PREFER** naming a method to___() if it copies the object's state to a new object.
+**PREFER** naming a method `to___()` if it copies the object's state to a new
+object.
 
-**PREFER** naming a method as___() if it returns a different representation backed by the original object.
+**PREFER** naming a method `as___()` if it returns a different representation
+backed by the original object.
 
 **BAD:**
 ```dart

--- a/test_data/rules/use_to_and_as_if_applicable.dart
+++ b/test_data/rules/use_to_and_as_if_applicable.dart
@@ -5,7 +5,7 @@
 // test w/ `dart test -N use_to_and_as_if_applicable`
 
 class A {
-  A.from(B);
+  A.from(B _);
 }
 
 // Testing the regexp
@@ -71,4 +71,20 @@ class B {
     _asa();
     _functionWihParameter(0);
   }
+}
+
+abstract class C {
+  A getA();
+}
+
+class D1 extends C {
+  A getA() => A.from(B()); // OK
+}
+
+class D2 implements C {
+  A getA() => A.from(B()); // OK
+}
+
+mixin D3 on C {
+  A getA() => A.from(B()); // OK
 }


### PR DESCRIPTION
# Description

This issue is already fixed, but the tests are still lacking.

* Properly format the description text.
* Do not create a constructor parameter name that shadows a class name.
* Add inheritance tests.

Fixes #2080
