### PR TITLE
avoid_redundant_argument_values: Check correct parameters of redirecting constructors

### DIFF
--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -4,14 +4,16 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:collection/collection.dart';
 
 import '../analyzer.dart';
 
 const _desc = r'Avoid redundant argument values.';
 
 const _details = r'''
-**DON'T** declare arguments with values that match the defaults for the
-corresponding parameter.
+**DON'T** pass an argument that matches the corresponding parameter's default
+value.
 
 **BAD:**
 ```dart
@@ -71,25 +73,31 @@ class _Visitor extends SimpleAstVisitor {
     for (var i = arguments.length - 1; i >= 0; --i) {
       var arg = arguments[i];
       var param = arg.staticParameterElement;
-      if (param == null ||
-          param.declaration.isRequired ||
-          param.hasRequired ||
-          !param.isOptional) {
-        continue;
+      if (arg is NamedExpression) {
+        arg = arg.expression;
       }
-      var value = param.computeConstantValue();
-      if (value != null && value.hasKnownValue) {
-        if (arg is NamedExpression) {
-          arg = arg.expression;
-        }
-        var expressionValue = context.evaluateConstant(arg).value;
-        if ((expressionValue?.hasKnownValue ?? false) &&
-            expressionValue == value) {
-          rule.reportLint(arg);
-        }
-      }
-      if (param.isOptionalPositional) {
+      checkArgument(arg, param);
+      if (param != null && param.isOptionalPositional) {
+        // Redundant arguments may be necessary to specify, in order to specify
+        // a non-redundant argument for the last optional positional parameter.
         break;
+      }
+    }
+  }
+
+  void checkArgument(Expression arg, ParameterElement? param) {
+    if (param == null ||
+        param.declaration.isRequired ||
+        param.hasRequired ||
+        !param.isOptional) {
+      return;
+    }
+    var value = param.computeConstantValue();
+    if (value != null && value.hasKnownValue) {
+      var expressionValue = context.evaluateConstant(arg).value;
+      if ((expressionValue?.hasKnownValue ?? false) &&
+          expressionValue == value) {
+        rule.reportLint(arg);
       }
     }
   }
@@ -100,13 +108,58 @@ class _Visitor extends SimpleAstVisitor {
   }
 
   @override
-  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+  visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
     check(node.argumentList);
   }
 
   @override
-  visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
-    check(node.argumentList);
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    var redirectedConstructor =
+        node.constructorName.staticElement?.redirectedConstructor;
+    while (redirectedConstructor?.redirectedConstructor != null) {
+      redirectedConstructor = redirectedConstructor?.redirectedConstructor;
+    }
+    if (redirectedConstructor == null) {
+      check(node.argumentList);
+      return;
+    }
+
+    var parameters = redirectedConstructor.parameters;
+
+    // If the constructor being called is a redirecting constructor, an argument
+    // is redundant if it is equal to the default value of the corresponding
+    // parameter on the _redirectied constructor_, not this constructor, which
+    // may be different.
+
+    var arguments = node.argumentList.arguments;
+    if (arguments.isEmpty) {
+      return;
+    }
+
+    for (var i = arguments.length - 1; i >= 0; --i) {
+      var arg = arguments[i];
+      ParameterElement? param;
+      if (arg is NamedExpression) {
+        param = parameters.firstWhereOrNull(
+            (p) => p.isNamed && p.name == arg.name.label.name);
+      } else {
+        // Count which positional argument we're at.
+        var positionalCount =
+            arguments.take(i + 1).where((a) => a is! NamedExpression).length;
+        var positionalIndex = positionalCount - 1;
+        if (positionalIndex < parameters.length) {
+          if (parameters[positionalIndex].isPositional) {
+            param = parameters[positionalIndex];
+          }
+        }
+      }
+      checkArgument(arg, param);
+      if (param != null && param.isOptionalPositional) {
+        // Redundant arguments may be necessary to specify, in order to specify
+        // a non-redundant argument for the last optional positional parameter.
+        break;
+      }
+    }
   }
 
   @override

--- a/test/rules/avoid_redundant_argument_values_test.dart
+++ b/test/rules/avoid_redundant_argument_values_test.dart
@@ -208,7 +208,6 @@ class C extends B {
 
   @override
   String toString() => '$value';
-  
 }
 void f() {
   A();

--- a/test/rules/avoid_redundant_argument_values_test.dart
+++ b/test/rules/avoid_redundant_argument_values_test.dart
@@ -86,6 +86,155 @@ void f() {
 ''');
   }
 
+  test_redirectingConstructor() async {
+    await assertNoDiagnostics(r'''
+class A {
+  factory A([int? value]) = B;
+  A._();
+}
+class B extends A {
+  B([int? value = 2]) : super._();
+}
+void f() {
+  A();
+  A(null);
+  A(1);
+}
+''');
+  }
+
+  test_redirectingConstructor_multipleOptional() async {
+    await assertNoDiagnostics(r'''
+class A {
+  factory A([int? one, int? two]) = B;
+  A._();
+}
+class B extends A {
+  int? one;
+  int? two;
+  B([this.one = 2, this.two = 2]) : super._();
+}
+void f() {
+  A();
+  A(null, null);
+  A(1, 1);
+}
+''');
+  }
+
+  test_redirectingConstructor_named() async {
+    await assertNoDiagnostics(r'''
+class A {
+  factory A({int? value}) = B;
+  A._();
+}
+class B extends A {
+  B({int? value = 2}) : super._();
+}
+void f() {
+  A();
+  A(value: null);
+  A(value: 1);
+}
+''');
+  }
+
+  test_redirectingConstructor_named_redundant() async {
+    await assertDiagnostics(r'''
+class A {
+  factory A({int? value}) = B;
+  A._();
+}
+class B extends A {
+  B({int? value = 2}) : super._();
+}
+void f() {
+  A(value: 2);
+}
+''', [
+      lint(124, 8),
+    ]);
+  }
+
+  test_redirectingConstructor_namedArgumentsAnywhere() async {
+    await assertNoDiagnostics(r'''
+class A {
+  factory A(int? one, int? two, {int? three}) = B;
+  A._();
+}
+class B extends A {
+  B(int? one, int? two, {int? three = 3}) : super._();
+}
+void f() {
+  A(1, 2);
+  A(1, three: null, 2);
+  A(1, 2, three: null);
+  A(1, three: 4, 2);
+  A(three: 4, 1, 2);
+}
+''');
+  }
+
+  test_redirectingConstructor_namedArgumentsAnywhere_redundant() async {
+    await assertDiagnostics(r'''
+class A {
+  factory A(int? one, int? two, {int? three}) = B;
+  A._();
+}
+class B extends A {
+  B(int? one, int? two, {int? three = 3}) : super._();
+}
+void f() {
+  A(1, three: 3, 2);
+}
+''', [
+      lint(167, 8),
+    ]);
+  }
+
+  test_redirectingConstructor_nested() async {
+    await assertNoDiagnostics(r'''
+class A {
+  factory A([num? value]) = B;
+  A._();
+}
+class B extends A {
+  factory B([num? value]) = C;
+  B._() : super._();
+}
+class C extends B {
+  num? value;
+  C([this.value = 2]) : super._();
+
+  @override
+  String toString() => '$value';
+  
+}
+void f() {
+  A();
+  A(null);
+  A(1);
+}
+''');
+  }
+
+  test_redirectingConstructor_redundant() async {
+    await assertDiagnostics(r'''
+class A {
+  factory A([int? value]) = B;
+  A._();
+}
+class B extends A {
+  B([int? value = 2]) : super._();
+}
+void f() {
+  A(2);
+}
+''', [
+      lint(124, 1),
+    ]);
+  }
+
   test_requiredNullable() async {
     await assertNoDiagnostics(r'''
 void f({required int? x}) { }


### PR DESCRIPTION
Redirecting constructors are not allowed to specify default values; instead they sort of "inherit" the default values of the redirectee (the target constructor).

One might thing a better fix would be to build this logic into `Expression.staticParameterElement`, but I think there are reasons that that should point to the redirecting constructor's parameters, rather than the redirectee's parameters. Specifically, the two lists of parameters _can_ have different parameter types.

Fixes #2217 
