### PR TITLE
Fix avoid_redundant_argument_values for redirecting generative constructors

### DIFF
--- a/lib/src/rules/avoid_redundant_argument_values.dart
+++ b/lib/src/rules/avoid_redundant_argument_values.dart
@@ -123,8 +123,13 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    var redirectedConstructor =
-        node.constructorName.staticElement?.redirectedConstructor;
+    var constructor = node.constructorName.staticElement;
+    if (constructor != null && !constructor.isFactory) {
+      check(node.argumentList);
+      return;
+    }
+
+    var redirectedConstructor = constructor?.redirectedConstructor;
     while (redirectedConstructor?.redirectedConstructor != null) {
       redirectedConstructor = redirectedConstructor?.redirectedConstructor;
     }
@@ -135,10 +140,10 @@ class _Visitor extends SimpleAstVisitor {
 
     var parameters = redirectedConstructor.parameters;
 
-    // If the constructor being called is a redirecting constructor, an argument
-    // is redundant if it is equal to the default value of the corresponding
-    // parameter on the _redirectied constructor_, not this constructor, which
-    // may be different.
+    // If the constructor being called is a redirecting factory constructor, an
+    // argument is redundant if it is equal to the default value of the
+    // corresponding parameter on the _redirectied constructor_, not this
+    // constructor, which may be different.
 
     var arguments = node.argumentList.arguments;
     if (arguments.isEmpty) {

--- a/test/rules/avoid_redundant_argument_values_test.dart
+++ b/test/rules/avoid_redundant_argument_values_test.dart
@@ -86,7 +86,7 @@ void f() {
 ''');
   }
 
-  test_redirectingConstructor() async {
+  test_redirectingFactoryConstructor() async {
     await assertNoDiagnostics(r'''
 class A {
   factory A([int? value]) = B;
@@ -103,7 +103,7 @@ void f() {
 ''');
   }
 
-  test_redirectingConstructor_multipleOptional() async {
+  test_redirectingFactoryConstructor_multipleOptional() async {
     await assertNoDiagnostics(r'''
 class A {
   factory A([int? one, int? two]) = B;
@@ -122,7 +122,7 @@ void f() {
 ''');
   }
 
-  test_redirectingConstructor_named() async {
+  test_redirectingFactoryConstructor_named() async {
     await assertNoDiagnostics(r'''
 class A {
   factory A({int? value}) = B;
@@ -139,7 +139,7 @@ void f() {
 ''');
   }
 
-  test_redirectingConstructor_named_redundant() async {
+  test_redirectingFactoryConstructor_named_redundant() async {
     await assertDiagnostics(r'''
 class A {
   factory A({int? value}) = B;
@@ -156,7 +156,7 @@ void f() {
     ]);
   }
 
-  test_redirectingConstructor_namedArgumentsAnywhere() async {
+  test_redirectingFactoryConstructor_namedArgumentsAnywhere() async {
     await assertNoDiagnostics(r'''
 class A {
   factory A(int? one, int? two, {int? three}) = B;
@@ -175,7 +175,7 @@ void f() {
 ''');
   }
 
-  test_redirectingConstructor_namedArgumentsAnywhere_redundant() async {
+  test_redirectingFactoryConstructor_namedArgumentsAnywhere_redundant() async {
     await assertDiagnostics(r'''
 class A {
   factory A(int? one, int? two, {int? three}) = B;
@@ -192,7 +192,7 @@ void f() {
     ]);
   }
 
-  test_redirectingConstructor_nested() async {
+  test_redirectingFactoryConstructor_nested() async {
     await assertNoDiagnostics(r'''
 class A {
   factory A([num? value]) = B;
@@ -217,7 +217,7 @@ void f() {
 ''');
   }
 
-  test_redirectingConstructor_redundant() async {
+  test_redirectingFactoryConstructor_redundant() async {
     await assertDiagnostics(r'''
 class A {
   factory A([int? value]) = B;
@@ -231,6 +231,58 @@ void f() {
 }
 ''', [
       lint(124, 1),
+    ]);
+  }
+
+  test_redirectingGenerativeConstructor() async {
+    await assertNoDiagnostics(r'''
+class A {
+  A([int? value]) : this._(value);
+  A._([int? value = 2]);
+}
+void f() {
+  A(2);
+}
+''');
+  }
+
+  test_redirectingGenerativeConstructor_named() async {
+    await assertNoDiagnostics(r'''
+class A {
+  A({int? value}) : this._(value: value);
+  A._({int? value = 2});
+}
+void f() {
+  A(value: 2);
+}
+''');
+  }
+
+  test_redirectingGenerativeConstructor_named_redundant() async {
+    await assertDiagnostics(r'''
+class A {
+  A({int? value}) : this._(value: value);
+  A._({int? value = 2});
+}
+void f() {
+  A(value: null);
+}
+''', [
+      lint(101, 4),
+    ]);
+  }
+
+  test_redirectingGenerativeConstructor_redundant() async {
+    await assertDiagnostics(r'''
+class A {
+  A([int? value]) : this._(value);
+  A._([int? value = 2]);
+}
+void f() {
+  A(null);
+}
+''', [
+      lint(87, 4),
     ]);
   }
 


### PR DESCRIPTION
Fixes #3850