### PR TITLE
Fix broken markdown caused by unclosed code block

### DIFF
--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -46,7 +46,7 @@ class A {
 }
 ```
 
-NOTE: The lint checks the use of the @immutable annotation, and will trigger
+NOTE: The lint checks the use of the `@immutable` annotation, and will trigger
 even if the class is otherwise not mutable. Thus:
 
 **BAD:**

--- a/lib/src/rules/enable_null_safety.dart
+++ b/lib/src/rules/enable_null_safety.dart
@@ -24,6 +24,7 @@ a() {
 ```dart
 b() {
 }
+```
 ''';
 
 class EnableNullSafety extends LintRule implements NodeLintRule {


### PR DESCRIPTION
Also puts `@immutable` in code style.