### PR TITLE
Deprecate prefer_equal_for_default_values

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -123,7 +123,6 @@ linter:
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes
-    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_in_for_each

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -25,6 +25,11 @@ m({a: 1})
 m({a = 1})
 ```
 
+**DEPRECATED:** In Dart 2.19, 
+the Dart analyzer reports the old `:` syntax as a warning
+and will report it as an error in Dart 3.0.
+
+The rule will be removed in a future Linter release.
 ''';
 
 class PreferEqualForDefaultValues extends LintRule {
@@ -37,6 +42,7 @@ class PreferEqualForDefaultValues extends LintRule {
             name: 'prefer_equal_for_default_values',
             description: _desc,
             details: _details,
+            maturity: Maturity.deprecated,
             group: Group.style);
 
   @override

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -11,6 +11,12 @@ import '../analyzer.dart';
 const _desc = r'Use `=` to separate a named parameter from its default value.';
 
 const _details = r'''
+**DEPRECATED:** In Dart 2.19, 
+the Dart analyzer reports the old `:` syntax as a warning
+and will report it as an error in Dart 3.0.
+As a result, this rule is unmaintained 
+and will be removed in a future Linter release.
+
 From the [style guide](https://dart.dev/guides/language/effective-dart/usage):
 
 **DO** use `=` to separate a named parameter from its default value.
@@ -24,12 +30,6 @@ m({a: 1})
 ```dart
 m({a = 1})
 ```
-
-**DEPRECATED:** In Dart 2.19, 
-the Dart analyzer reports the old `:` syntax as a warning
-and will report it as an error in Dart 3.0.
-
-The rule will be removed in a future Linter release.
 ''';
 
 class PreferEqualForDefaultValues extends LintRule {


### PR DESCRIPTION
This lint is no longer necessary with the analyzer reporting it as a warning in Dart 2.19(https://github.com/dart-lang/sdk/commit/289aa509cd4f078457faf50670bb2871c31b2718).

