### PR TITLE
Put `bad` examples before `good` in lint template

### DIFF
--- a/.github/ISSUE_TEMPLATE/lint-proposal.md
+++ b/.github/ISSUE_TEMPLATE/lint-proposal.md
@@ -23,13 +23,13 @@ assignees: ''
 
 *Does this enforce style advice?  Guard against errors?  Other?*
 
-## Good Examples 
-
-*Add a few examples that demonstrate a “good” adoption of this lint’s principle.*
-
 ## Bad Examples
 
 *Add a few examples that demonstrate where this lint should fire.*
+
+## Good Examples 
+
+*Add a few examples that demonstrate a “good” adoption of this lint’s principle.*
 
 ## Discussion
 


### PR DESCRIPTION
This changes the lint template, similar to the changes done in https://github.com/dart-lang/linter/commit/81ca8f2ccd14fbe172874b5cc1aeda10bf95be91