### PR TITLE
library_annotation: fix bad example

### DIFF
--- a/lib/src/rules/library_annotations.dart
+++ b/lib/src/rules/library_annotations.dart
@@ -19,9 +19,10 @@ some other library-level element.
 
 **BAD:**
 ```dart
+@TestOn('browser')
+
 import 'package:test/test.dart';
 
-@TestOn('browser')
 void main() {}
 ```
 
@@ -29,6 +30,7 @@ void main() {}
 ```dart
 @TestOn('browser')
 library;
+
 import 'package:test/test.dart';
 
 void main() {}


### PR DESCRIPTION
Should be at the top of the library file
