### PR TITLE
don't overreport `prefer_equal_for_default_values` when it's a warning

### DIFF
--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -48,33 +48,6 @@ class PreferEqualForDefaultValues extends LintRule {
   @override
   LintCode get lintCode => code;
 
-  @override
-  void registerNodeProcessors(
-      NodeLintRegistry registry, LinterContext context) {
-    var libraryVersion = context
-        .currentUnit.unit.declaredElement?.library.languageVersion.effective;
-    if (libraryVersion != null) {
-      // As of 2.19, this is a warning so we don't want to double-report.
-      if (libraryVersion.major > 2 ||
-          (libraryVersion.major == 2 && libraryVersion.minor >= 19)) {
-        return;
-      }
-    }
-
-    var visitor = _Visitor(this);
-    registry.addDefaultFormalParameter(this, visitor);
-  }
-}
-
-class _Visitor extends SimpleAstVisitor<void> {
-  final LintRule rule;
-
-  _Visitor(this.rule);
-
-  @override
-  void visitDefaultFormalParameter(DefaultFormalParameter node) {
-    if (node.isNamed && node.separator?.type == TokenType.COLON) {
-      rule.reportLintForToken(node.separator);
-    }
-  }
+  // As of 2.19, this is a warning so we don't want to double-report and so
+  // we don't register any processors.
 }

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -56,7 +56,7 @@ class PreferEqualForDefaultValues extends LintRule {
     if (libraryVersion != null) {
       // As of 2.19, this is a warning so we don't want to double-report.
       if (libraryVersion.major > 2 ||
-          (libraryVersion.major == 2 && libraryVersion.minor == 19)) {
+          (libraryVersion.major == 2 && libraryVersion.minor >= 19)) {
         return;
       }
     }

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -2,10 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/dart/ast/visitor.dart';
-
 import '../analyzer.dart';
 
 const _desc = r'Use `=` to separate a named parameter from its default value.';

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -51,6 +51,16 @@ class PreferEqualForDefaultValues extends LintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
+    var libraryVersion = context
+        .currentUnit.unit.declaredElement?.library.languageVersion.effective;
+    if (libraryVersion != null) {
+      // As of 2.19, this is a warning so we don't want to double-report.
+      if (libraryVersion.major > 2 ||
+          (libraryVersion.major == 2 && libraryVersion.minor == 19)) {
+        return;
+      }
+    }
+
     var visitor = _Visitor(this);
     registry.addDefaultFormalParameter(this, visitor);
   }

--- a/test/rules/prefer_equal_for_default_values_test.dart
+++ b/test/rules/prefer_equal_for_default_values_test.dart
@@ -17,9 +17,9 @@ class PreferEqualForDefaultValuesTest extends LintRuleTest {
   @override
   String get lintRule => 'prefer_equal_for_default_values';
 
-  test_disabled_in_219() async {
+  test_super() async {
+    // As of 2.19, this is a warning and the lint is a no-op.
     await assertNoDiagnostics(r'''
-// @dart = 2.19   
 class A {
   String? a;
   A({this.a});
@@ -29,21 +29,5 @@ class B extends A {
   B({super.a : ''});
 }
 ''');
-  }
-
-  test_super() async {
-    await assertDiagnostics(r'''
-// @dart = 2.18    
-class A {
-  String? a;
-  A({this.a});
-}
-
-class B extends A {
-  B({super.a : ''});
-}
-''', [
-      lint(94, 1),
-    ]);
   }
 }

--- a/test/rules/prefer_equal_for_default_values_test.dart
+++ b/test/rules/prefer_equal_for_default_values_test.dart
@@ -17,8 +17,23 @@ class PreferEqualForDefaultValuesTest extends LintRuleTest {
   @override
   String get lintRule => 'prefer_equal_for_default_values';
 
+  test_disabled_in_219() async {
+    await assertNoDiagnostics(r'''
+// @dart = 2.19   
+class A {
+  String? a;
+  A({this.a});
+}
+
+class B extends A {
+  B({super.a : ''});
+}
+''');
+  }
+
   test_super() async {
     await assertDiagnostics(r'''
+// @dart = 2.18    
 class A {
   String? a;
   A({this.a});
@@ -28,7 +43,7 @@ class B extends A {
   B({super.a : ''});
 }
 ''', [
-      lint(74, 1),
+      lint(94, 1),
     ]);
   }
 }

--- a/test_data/rules/prefer_equal_for_default_values.dart
+++ b/test_data/rules/prefer_equal_for_default_values.dart
@@ -4,6 +4,8 @@
 
 // test w/ `dart test -N prefer_equal_for_default_values`
 
+// @dart = 2.18
+
 f1({a: 1}) => null; // LINT
 f2({a = 1}) => null; // OK
 f3([a = 1]) => null; // OK

--- a/test_data/rules/prefer_equal_for_default_values.dart
+++ b/test_data/rules/prefer_equal_for_default_values.dart
@@ -4,9 +4,9 @@
 
 // test w/ `dart test -N prefer_equal_for_default_values`
 
-// @dart = 2.18
+// As of 2.19, this is a warning and the lint is a no-op.
 
-f1({a: 1}) => null; // LINT
+f1({a: 1}) => null; // OK
 f2({a = 1}) => null; // OK
 f3([a = 1]) => null; // OK
 f4([a]) => null; // OK


### PR DESCRIPTION
See also: https://github.com/dart-lang/linter/pull/3855.


/cc @bwilkerson 