### PR TITLE
1.31.0 (cherry-pick release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.31.0
+
+- deprecated `prefer_equal_for_default_values`
+
 # 1.30.0
 
 - new lint: `enable_null_safety`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.31.0
 
-- deprecated `prefer_equal_for_default_values`
+- updated `prefer_equal_for_default_values` to not report for SDKs `>=2.19`,
+  where this lint is now an analyzer diagnostic.
 
 # 1.30.0
 

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -2,10 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/token.dart';
-import 'package:analyzer/dart/ast/visitor.dart';
-
 import '../analyzer.dart';
 
 const _desc = r'Use `=` to separate a named parameter from its default value.';
@@ -42,23 +38,6 @@ class PreferEqualForDefaultValues extends LintRule {
   @override
   LintCode get lintCode => code;
 
-  @override
-  void registerNodeProcessors(
-      NodeLintRegistry registry, LinterContext context) {
-    var visitor = _Visitor(this);
-    registry.addDefaultFormalParameter(this, visitor);
-  }
-}
-
-class _Visitor extends SimpleAstVisitor<void> {
-  final LintRule rule;
-
-  _Visitor(this.rule);
-
-  @override
-  void visitDefaultFormalParameter(DefaultFormalParameter node) {
-    if (node.isNamed && node.separator?.type == TokenType.COLON) {
-      rule.reportLintForToken(node.separator);
-    }
-  }
+  // As of 2.19, this is a warning so we don't want to double-report and so
+  // we don't register any processors.
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.30.0';
+const String version = '1.31.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.30.0
+version: 1.31.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.

--- a/test/rules/prefer_equal_for_default_values_test.dart
+++ b/test/rules/prefer_equal_for_default_values_test.dart
@@ -18,7 +18,8 @@ class PreferEqualForDefaultValuesTest extends LintRuleTest {
   String get lintRule => 'prefer_equal_for_default_values';
 
   test_super() async {
-    await assertDiagnostics(r'''
+    // As of 2.19, this is a warning and the lint is a no-op.
+    await assertNoDiagnostics(r'''
 class A {
   String? a;
   A({this.a});
@@ -27,8 +28,6 @@ class A {
 class B extends A {
   B({super.a : ''});
 }
-''', [
-      lint(74, 1),
-    ]);
+''');
   }
 }

--- a/test_data/rules/prefer_equal_for_default_values.dart
+++ b/test_data/rules/prefer_equal_for_default_values.dart
@@ -4,7 +4,9 @@
 
 // test w/ `dart test -N prefer_equal_for_default_values`
 
-f1({a: 1}) => null; // LINT
+// As of 2.19, this is a warning and the lint is a no-op.
+
+f1({a: 1}) => null; // OK
 f2({a = 1}) => null; // OK
 f3([a = 1]) => null; // OK
 f4([a]) => null; // OK


### PR DESCRIPTION
# 1.31.0

- updated `prefer_equal_for_default_values` to not report for SDKs `>=2.19`,
  where this lint is now an analyzer diagnostic.


Closes: #3864.

---

/cc @bwilkerson @srawlins @parlough 
