### PR TITLE
update unrelated_type_equality_checks for fixnum restructuring

### DIFF
--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:collection/collection.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
@@ -153,7 +154,9 @@ bool _isFixNumIntX(DartType type) {
   if (type is! InterfaceType) return false;
   InterfaceElement element = type.element;
   if (element.name != 'Int32' && element.name != 'Int64') return false;
-  return element.library.source.uri.path.startsWith('fixnum/');
+  var uri = element.library.source.uri;
+  if (!uri.isScheme('package')) return false;
+  return uri.pathSegments.firstOrNull == 'fixnum';
 }
 
 class UnrelatedTypeEqualityChecks extends LintRule {

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -7,8 +7,6 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
@@ -153,13 +151,9 @@ bool _isFixNumIntX(DartType type) {
   // todo(pq): add tests that ensure this predicate works with fixnum >= 1.1.0-dev
   // See: https://github.com/dart-lang/linter/issues/3868
   if (type is! InterfaceType) return false;
-  Element element = type.element;
+  InterfaceElement element = type.element;
   if (element.name != 'Int32' && element.name != 'Int64') return false;
-  var libraryElement = element.library;
-  if (libraryElement is! LibraryElementImpl) return false;
-  var reference = libraryElement.reference;
-  if (reference == null) return false;
-  return reference.name.startsWith('package:fixnum/');
+  return element.library.source.uri.path.startsWith('fixnum/');
 }
 
 class UnrelatedTypeEqualityChecks extends LintRule {

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -7,6 +7,8 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/element.dart';
 
 import '../analyzer.dart';
 import '../extensions.dart';
@@ -148,12 +150,16 @@ bool _hasNonComparableOperands(TypeSystem typeSystem, BinaryExpression node) {
 bool _isCoreInt(DartType type) => type.isDartCoreInt;
 
 bool _isFixNumIntX(DartType type) {
-  if (type is! InterfaceType) {
-    return false;
-  }
+  // todo(pq): add tests that ensure this predicate works with fixnum >= 1.1.0-dev
+  // See: https://github.com/dart-lang/linter/issues/3868
+  if (type is! InterfaceType) return false;
   Element element = type.element;
-  return (element.name == 'Int32' || element.name == 'Int64') &&
-      element.library?.name == 'fixnum';
+  if (element.name != 'Int32' && element.name != 'Int64') return false;
+  var libraryElement = element.library;
+  if (libraryElement is! LibraryElementImpl) return false;
+  var reference = libraryElement.reference;
+  if (reference == null) return false;
+  return reference.name.startsWith('package:fixnum/');
 }
 
 class UnrelatedTypeEqualityChecks extends LintRule {


### PR DESCRIPTION
Fixes #3868 

(Note that we'll want to hustle this into a cherry-pick release for 2.19.)

/cc @bwilkerson 
