### PR TITLE
Detect doubled unnecessary_parenthesis, but allow ternary and equality

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -136,8 +136,11 @@ class _Visitor extends SimpleAstVisitor<void> {
         parent is InterpolationExpression ||
         (parent is ArgumentList && parent.arguments.length == 1) ||
         (parent is IfStatement && node == parent.condition) ||
+        (parent is IfElement && node == parent.condition) ||
         (parent is WhileStatement && node == parent.condition) ||
-        (parent is IfElement && node == parent.condition)) {
+        (parent is DoStatement && node == parent.condition) ||
+        (parent is SwitchStatement && node == parent.expression) ||
+        (parent is SwitchExpression && node == parent.expression)) {
       rule.reportLint(node);
       return;
     }
@@ -170,7 +173,8 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (parent is AssignmentExpression ||
           parent is VariableDeclaration ||
           parent is ReturnStatement ||
-          parent is YieldStatement) {
+          parent is YieldStatement ||
+          parent is ConstructorFieldInitializer) {
         return;
       }
     }

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -142,20 +142,32 @@ main() async {
   var a3 = (1 + 1); // LINT
 }
 
-bool test() {
+bool testTernaryAndEquality() {
   if ((1 == 1 ? true : false)) // LINT
   {
-    return true;
+    return (1 != 1); // OK
   } else if ((1 == 1 ? true : false)) // LINT
   {
-    return false;
-  }
-  if ((1 == 1)) // LINT
-  {
-    return (1 != 1); // OK
-  } else {
     return (1 > 1); // LINT
   }
+  while ((1 == 1)) // LINT
+  {
+    print('');
+  }
+  switch ((5 == 6)) // LINT
+  {
+    case true:
+      return false;
+    default:
+      return true;
+  }
+}
+
+class TestConstructorFieldInitializer {
+  bool _x, _y;
+  TestConstructorFieldInitializer()
+      : _x = (1 == 2), // OK
+        _y = (true && false); // LINT
 }
 
 int test2() => (1 == 1 ? 2 : 3); // OK

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -116,7 +116,40 @@ main() async {
   List<String> list = <String>[];
   (list[list.length]).toString(); // LINT
 
+  print(!({"a": "b"}["a"]!.isEmpty)); // LINT
+
+  print((1 + 2)); // LINT
+
+  print((1 == 1 ? 2 : 3)); // LINT
+  print('a'.substring((1 == 1 ? 2 : 3), 4)); // OK
+  var a1 = (1 == 1 ? 2 : 3); // OK
+  print('${(1 == 1 ? 2 : 3)}'); // LINT
+  print([(1 == 1 ? 2 : 3)]); // OK
+
+  var a2 = (1 == 1); // OK
+  a2 = (1 == 1); // OK
+  a2 = (1 == 1) || "".isEmpty; // OK
+  var a3 = (1 + 1); // LINT
 }
+
+bool test() {
+  if ((1 == 1 ? true : false)) // LINT
+  {
+    return true;
+  } else if ((1 == 1 ? true : false)) // LINT
+  {
+    return false;
+  }
+  if ((1 == 1)) // LINT
+  {
+    return (1 != 1); // OK
+  } else {
+    return (1 > 1); // LINT
+  }
+}
+
+int test2() => (1 == 1 ? 2 : 3); // OK
+bool test3() => (1 == 1); // LINT
 
 Invocation? invocation() => null;
 


### PR DESCRIPTION
* Fixes #3885
* Fixes #3886

---

This implements new rules for `unnecessary_parenthesis` lint:
* `${(  )}` and `((  ))` are never OK, drop the inner ones

else,
* `(a ? b : c)` is always OK
* `(a == b)` and `(a != b)` are OK in assignment-like and return-like statements.

---

This pull request addresses two seemingly completely separate changes, but I think it should be done all at once. That is because:

* Currently some cases where doubled parentheses *happen to be* dropped are cases of `((a == b))` etc. So I'd be introducing more false negatives if I remove the old reason to drop these but not add the new one.

* Removing doubled parentheses just misses one case of `ArgumentList` so it's unclear why I am adding all the other numerous cases here. But more rules are necessary *only because* they will become the only reason for some cases of `((a ? b : c))` to still be dropped.
