### PR TITLE
(un)deprecate `prefer_equal_for_default_values`

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -123,6 +123,7 @@ linter:
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes
+    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_in_for_each

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -38,7 +38,8 @@ class PreferEqualForDefaultValues extends LintRule {
             name: 'prefer_equal_for_default_values',
             description: _desc,
             details: _details,
-            maturity: Maturity.deprecated,
+            // todo(pq): deprecate for 3.0 (https://github.com/dart-lang/linter/issues/3879)
+            maturity: Maturity.stable,
             group: Group.style);
 
   @override


### PR DESCRIPTION
This is blocking `1.32.0` (#3848) since it's in the recommended set and will be breaking until it's removed (https://github.com/dart-lang/lints/issues/92).

We'll re-deprecate for 3.0, dart-lang/sdk#58947.

/cc @srawlins @bwilkerson 

