### PR TITLE
update test to reflect removed `NoSuchMethodError` default cons

### DIFF
--- a/test/integration/only_throw_errors.dart
+++ b/test/integration/only_throw_errors.dart
@@ -36,7 +36,7 @@ void main() {
             "throw 'hello world!'; // LINT",
             'throw null; // LINT',
             'throw 7; // LINT',
-            'throw new Object(); // LINT',
+            'throw Object(); // LINT',
             'throw returnString(); // LINT',
             'throw error; // LINT',
             '1 file analyzed, 6 issues found, in'

--- a/test_data/integration/only_throw_errors/only_throw_errors.dart
+++ b/test_data/integration/only_throw_errors/only_throw_errors.dart
@@ -19,11 +19,11 @@ void throwNumber() {
 }
 
 void throwObject() {
-  throw new Object(); // LINT
+  throw Object(); // LINT
 }
 
 void throwError() {
-  throw new Error(); // OK
+  throw Error(); // OK
 }
 
 void throwDynamicPrebuiltError() {
@@ -32,17 +32,17 @@ void throwDynamicPrebuiltError() {
 }
 
 void throwStaticPrebuiltError() {
-  Error error = new Error();
+  Error error = Error();
   throw error; // OK
 }
 
 void throwArgumentError() {
-  Error error = new ArgumentError('oh!');
+  Error error = ArgumentError('oh!');
   throw error; // OK
 }
 
 void throwException() {
-  Exception exception = new Exception('oh!');
+  Exception exception = Exception('oh!');
   throw exception; // OK
 }
 
@@ -56,18 +56,17 @@ void throwExceptionFromFunction() {
   throw returnException();
 }
 
-Exception returnException() => new Exception('oh!');
+Exception returnException() => Exception('oh!');
 
 // TODO: Even though in the test this does not get linted, it does while
 // analyzing the SDK code. Find out why.
 dynamic noSuchMethod(Invocation invocation) {
-  throw new NoSuchMethodError(new Object(), invocation.memberName,
-      invocation.positionalArguments, invocation.namedArguments);
+  throw NoSuchMethodError.withInvocation(Object(), invocation);
 }
 
 class Err extends Object with Exception {
   static throws() {
-    throw new Err(); // OK
+    throw Err(); // OK
   }
 }
 


### PR DESCRIPTION
The `NoSuchMethodError` default constructor has been removed and is failing the CI (https://github.com/dart-lang/linter/actions/runs/3688573840/jobs/6243527428#step:5:207).

This fixes that.

/cc @bwilkerson @srawlins 
