### PR TITLE
Fix `unnecessary_parenthesis` with postfix bang operator.

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
@@ -104,6 +105,9 @@ class _Visitor extends SimpleAstVisitor<void> {
           // Code like `(String).noSuchMethod()` is allowed.
           return;
         }
+      } else if (parent is PostfixExpression &&
+          parent.operator.type == TokenType.BANG) {
+        return;
       }
       rule.reportLint(node);
       return;

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -120,6 +120,11 @@ main() async {
   (a?.abs()).hashCode;
   (a?..abs()).hashCode;
   (a?[0]).hashCode;
+
+  (a?.sign)!;
+  (a?.abs())!;
+  (a?..abs())!;
+  (a?[0])!;
 }
 
 Invocation? invocation() => null;


### PR DESCRIPTION
#3848

Add a fix for the `PostfixExpression` with `!`.

Please also note the Flutter code can be simplified as proposed in https://github.com/flutter/flutter/pull/117026