### PR TITLE
1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
+# 1.32.0
+
+- update `avoid_types_as_parameter_names` to handle type variables
+- update `avoid_positional_boolean_parameters` to handle typedefs
+- improve `unnecessary_parenthesis` support for property accesses and method invocations
+- update `avoid_redundant_argument_values` to check parameters of redirecting constructors
+- performance improvements for `prefer_const_literals_to_create_immutables`
+- update `use_build_context_synchronously` to check context properties
+- fix false positive for `avoid_private_typedef_functions` with generalized type aliases
+
 # 1.31.0
 
-- updated `prefer_equal_for_default_values` to not report for SDKs `>=2.19`,
+- update `prefer_equal_for_default_values` to not report for SDKs `>=2.19`,
   where this lint is now an analyzer diagnostic.
-- updated `unrelated_type_equality_checks` to support updated `package:fixnum`
+- update `unrelated_type_equality_checks` to support updated `package:fixnum`
   structure.
 
 # 1.30.0

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.31.0';
+const String version = '1.32.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.31.0
+version: 1.32.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
# 1.32.0

- update `avoid_types_as_parameter_names` to handle type variables
- update `avoid_positional_boolean_parameters` to handle typedefs
- improve `unnecessary_parenthesis` support for property accesses and method invocations
- update `avoid_redundant_argument_values` to check parameters of redirecting constructors
- performance improvements for `prefer_const_literals_to_create_immutables`
- update `use_build_context_synchronously` to check context properties
- fix false positive for `avoid_private_typedef_functions` with generalized type aliases

---

Closes: #3848 

RC being tested on https://dart-review.googlesource.com/c/sdk/+/275044.

/cc @bwilkerson @srawlins 
