### PR TITLE
Tidy up null_closures for null safety

### DIFF
--- a/lib/src/rules/null_closures.dart
+++ b/lib/src/rules/null_closures.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
-import '../extensions.dart';
 
 const _desc = r'Do not pass `null` as an argument where a closure is expected.';
 
@@ -22,51 +21,19 @@ result in an exception being thrown.
 This rule only catches null literals being passed where closures are expected
 in the following locations:
 
-#### Constructors
-
-* From `dart:async`
-  * `Future` at the 0th positional parameter
-  * `Future.microtask` at the 0th positional parameter
-  * `Future.sync` at the 0th positional parameter
-  * `Timer` at the 0th positional parameter
-  * `Timer.periodic` at the 1st positional parameter
-* From `dart:core`
-  * `List.generate` at the 1st positional parameter
-
 #### Static functions
 
 * From `dart:async`
-  * `scheduleMicrotask` at the 0th positional parameter
-  * `Future.doWhile` at the 0th positional parameter
-  * `Future.forEach` at the 0th positional parameter
   * `Future.wait` at the named parameter `cleanup`
-  * `Timer.run` at the 0th positional parameter
 
 #### Instance methods
 
 * From `dart:async`
-  * `Future.then` at the 0th positional parameter
-  * `Future.complete` at the 0th positional parameter
-* From `dart:collection`
-  * `Queue.removeWhere` at the 0th positional parameter
-  * `Queue.retain
-  * `Iterable.firstWhere` at the 0th positional parameter, and the named
-    parameter `orElse`
-  * `Iterable.forEach` at the 0th positional parameter
-  * `Iterable.fold` at the 1st positional parameter
-  * `Iterable.lastWhere` at the 0th positional parameter, and the named
-    parameter `orElse`
-  * `Iterable.map` at the 0th positional parameter
-  * `Iterable.reduce` at the 0th positional parameter
-  * `Iterable.singleWhere` at the 0th positional parameter, and the named
-    parameter `orElse`
-  * `Iterable.skipWhile` at the 0th positional parameter
-  * `Iterable.takeWhile` at the 0th positional parameter
-  * `Iterable.where` at the 0th positional parameter
-  * `List.removeWhere` at the 0th positional parameter
-  * `List.retainWhere` at the 0th positional parameter
-  * `String.replaceAllMapped` at the 1st positional parameter
-  * `String.replaceFirstMapped` at the 1st positional parameter
+  * `Future.then` at the named parameter `onError`
+* From `dart:core`
+  * `Iterable.firstWhere` at the named parameter `orElse`
+  * `Iterable.lastWhere` at the named parameter `orElse`
+  * `Iterable.singleWhere` at the named parameter `orElse`
   * `String.splitMapJoin` at the named parameters `onMatch` and `onNonMatch`
 
 **BAD:**
@@ -81,104 +48,31 @@ in the following locations:
 
 ''';
 
-List<NonNullableFunction> _constructorsWithNonNullableArguments =
-    <NonNullableFunction>[
-  NonNullableFunction('dart.async', 'Future', null, positional: [0]),
-  NonNullableFunction('dart.async', 'Future', 'microtask', positional: [0]),
-  NonNullableFunction('dart.async', 'Future', 'sync', positional: [0]),
-  NonNullableFunction('dart.async', 'Timer', null, positional: [1]),
-  NonNullableFunction('dart.async', 'Timer', 'periodic', positional: [1]),
-  NonNullableFunction('dart.core', 'List', 'generate', positional: [1]),
-];
-
 final Map<String, Set<NonNullableFunction>>
     _instanceMethodsWithNonNullableArguments = {
-  'any': {
-    NonNullableFunction('dart.core', 'Iterable', 'any', positional: [0]),
-  },
-  'complete': {
-    NonNullableFunction('dart.async', 'Future', 'complete', positional: [0]),
-  },
-  'every': {
-    NonNullableFunction('dart.core', 'Iterable', 'every', positional: [0]),
-  },
-  'expand': {
-    NonNullableFunction('dart.core', 'Iterable', 'expand', positional: [0]),
-  },
   'firstWhere': {
     NonNullableFunction('dart.core', 'Iterable', 'firstWhere',
-        positional: [0], named: ['orElse']),
-  },
-  'forEach': {
-    NonNullableFunction('dart.core', 'Iterable', 'forEach', positional: [0]),
-    NonNullableFunction('dart.core', 'Map', 'forEach', positional: [0]),
-  },
-  'fold': {
-    NonNullableFunction('dart.core', 'Iterable', 'fold', positional: [1]),
+        named: ['orElse']),
   },
   'lastWhere': {
     NonNullableFunction('dart.core', 'Iterable', 'lastWhere',
-        positional: [0], named: ['orElse']),
-  },
-  'map': {
-    NonNullableFunction('dart.core', 'Iterable', 'map', positional: [0]),
-  },
-  'putIfAbsent': {
-    NonNullableFunction('dart.core', 'Map', 'putIfAbsent', positional: [1]),
-  },
-  'reduce': {
-    NonNullableFunction('dart.core', 'Iterable', 'reduce', positional: [0]),
-  },
-  'removeWhere': {
-    NonNullableFunction('dart.collection', 'Queue', 'removeWhere',
-        positional: [0]),
-    NonNullableFunction('dart.core', 'List', 'removeWhere', positional: [0]),
-    NonNullableFunction('dart.core', 'Set', 'removeWhere', positional: [0]),
-  },
-  'replaceAllMapped': {
-    NonNullableFunction('dart.core', 'String', 'replaceAllMapped',
-        positional: [1]),
-  },
-  'replaceFirstMapped': {
-    NonNullableFunction('dart.core', 'String', 'replaceFirstMapped',
-        positional: [1]),
-  },
-  'retainWhere': {
-    NonNullableFunction('dart.collection', 'Queue', 'retainWhere',
-        positional: [0]),
-    NonNullableFunction('dart.core', 'List', 'retainWhere', positional: [0]),
-    NonNullableFunction('dart.core', 'Set', 'retainWhere', positional: [0]),
+        named: ['orElse']),
   },
   'singleWhere': {
     NonNullableFunction('dart.core', 'Iterable', 'singleWhere',
-        positional: [0], named: ['orElse']),
-  },
-  'skipWhile': {
-    NonNullableFunction('dart.core', 'Iterable', 'skipWhile', positional: [0]),
+        named: ['orElse']),
   },
   'splitMapJoin': {
     NonNullableFunction('dart.core', 'String', 'splitMapJoin',
         named: ['onMatch', 'onNonMatch']),
   },
-  'takeWhile': {
-    NonNullableFunction('dart.core', 'Iterable', 'takeWhile', positional: [0]),
-  },
   'then': {
-    NonNullableFunction('dart.async', 'Future', 'then',
-        positional: [0], named: ['onError']),
-  },
-  'where': {
-    NonNullableFunction('dart.core', 'Iterable', 'where', positional: [0]),
+    NonNullableFunction('dart.async', 'Future', 'then', named: ['onError']),
   },
 };
 
-List<NonNullableFunction> _staticFunctionsWithNonNullableArguments =
-    <NonNullableFunction>[
-  NonNullableFunction('dart.async', null, 'scheduleMicrotask', positional: [0]),
-  NonNullableFunction('dart.async', 'Future', 'doWhile', positional: [0]),
-  NonNullableFunction('dart.async', 'Future', 'forEach', positional: [1]),
+List<NonNullableFunction> _staticFunctionsWithNonNullableArguments = [
   NonNullableFunction('dart.async', 'Future', 'wait', named: ['cleanUp']),
-  NonNullableFunction('dart.async', 'Timer', 'run', positional: [0]),
 ];
 
 /// Function with closure parameters that cannot accept null arguments.
@@ -186,11 +80,10 @@ class NonNullableFunction {
   final String library;
   final String? type;
   final String? name;
-  final List<int> positional;
   final List<String> named;
 
   NonNullableFunction(this.library, this.type, this.name,
-      {this.positional = const <int>[], this.named = const <String>[]});
+      {this.named = const <String>[]});
 
   @override
   int get hashCode =>
@@ -223,7 +116,6 @@ class NullClosures extends LintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
-    registry.addInstanceCreationExpression(this, visitor);
     registry.addMethodInvocation(this, visitor);
   }
 }
@@ -232,20 +124,6 @@ class _Visitor extends SimpleAstVisitor<void> {
   final LintRule rule;
 
   _Visitor(this.rule);
-
-  @override
-  void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    var constructorName = node.constructorName;
-    var type = node.staticType;
-    for (var constructor in _constructorsWithNonNullableArguments) {
-      if (constructorName.name?.name == constructor.name) {
-        if (type.extendsClass(constructor.type, constructor.library)) {
-          _checkNullArgForClosure(
-              node.argumentList, constructor.positional, constructor.named);
-        }
-      }
-    }
-  }
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
@@ -257,8 +135,7 @@ class _Visitor extends SimpleAstVisitor<void> {
       for (var function in _staticFunctionsWithNonNullableArguments) {
         if (methodName == function.name) {
           if (element.name == function.type) {
-            _checkNullArgForClosure(
-                node.argumentList, function.positional, function.named);
+            _checkNullArgForClosure(node.argumentList, function.named);
           }
         }
       }
@@ -269,13 +146,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (method == null) {
         return;
       }
-      _checkNullArgForClosure(
-          node.argumentList, method.positional, method.named);
+      _checkNullArgForClosure(node.argumentList, method.named);
     }
   }
 
-  void _checkNullArgForClosure(
-      ArgumentList node, List<int> positions, List<String> names) {
+  void _checkNullArgForClosure(ArgumentList node, List<String> names) {
     var args = node.arguments;
     for (var i = 0; i < args.length; i++) {
       var arg = args[i];
@@ -283,10 +158,6 @@ class _Visitor extends SimpleAstVisitor<void> {
       if (arg is NamedExpression) {
         if (arg.expression is NullLiteral &&
             names.contains(arg.name.label.name)) {
-          rule.reportLint(arg);
-        }
-      } else {
-        if (arg is NullLiteral && positions.contains(i)) {
           rule.reportLint(arg);
         }
       }

--- a/test_data/rules/null_closures.dart
+++ b/test_data/rules/null_closures.dart
@@ -16,24 +16,14 @@ void list_firstWhere() {
 void iterable_singleWhere() {
   // singleWhere has a _named_ closure argument.
   <int>{2, 4, 6}.singleWhere((e) => e.isEven, orElse: null); // LINT
-  <int?>[2, 4, 6].singleWhere((e) => e?.isEven ?? false, orElse: () => null); // OK
-}
-
-void map_putIfAbsent() {
-  // putIfAbsent has a _required_ closure argument.
-  var map = <int, int?>{};
-  map.putIfAbsent(7, () => null); // OK
+  <int?>[2, 4, 6]
+      .singleWhere((e) => e?.isEven ?? false, orElse: () => null); // OK
 }
 
 void future_wait() {
   // Future.wait is a _static_ function with a _named_ argument.
   Future.wait([], cleanUp: null); // LINT
   Future.wait([], cleanUp: (_) => print('clean')); // OK
-}
-
-void list_generate() {
-  // List.generate is a _constructor_ with a _positional_ argument.
-  new List.generate(3, (_) => null); // OK
 }
 
 void map_otherMethods() {


### PR DESCRIPTION
# Description

`null_closures` was written before null safety for guarding against sending `null` where it was not expected, in Dart SDK APIs. For _most cases_, this has been solved by null safety 🎉 🎉 🎉 🎉 🎉 . In fact, every single positional closure parameter was made non-nullable, so this rule no longer applies to any positional parameters.

The named parameters however are all still relevant, and were the primary motivation for the rule (before the rule, I cleaned up many cases of `list.firstWhere(..., orElse: null)`).