### PR TITLE
Loosen prefer_initializing_formals to not include different params vs fields types

### DIFF
--- a/test_data/rules/prefer_initializing_formals.dart
+++ b/test_data/rules/prefer_initializing_formals.dart
@@ -259,3 +259,35 @@ class GoodCaseWithDifferentNamedArgsInitializer {
       : this.x = a, // OK
         this.y = b; // OK
 }
+
+class GoodCaseWithDifferentType {
+  late Iterable<int> ids;
+  GoodCaseWithDifferentType(List<int> ids) {
+    this.ids = ids; // OK
+    ids.add(12);
+  }
+}
+
+class GoodCaseWithDifferentTypeNamedParam {
+  late Iterable<int>? ids;
+  GoodCaseWithDifferentTypeNamedParam({required List<int> ids}) {
+    this.ids = ids; // OK
+    ids.add(12);
+  }
+}
+
+class GoodCaseWithDifferentTypeInitializer {
+  Iterable<int>? ids;
+  GoodCaseWithDifferentTypeInitializer(List<int>? ids)
+      : this.ids = ids { // OK
+    ids?.add(12);
+  }
+}
+
+class GoodCaseWithDifferentTypeNamedParamInitializer {
+  Iterable<int> ids;
+  GoodCaseWithDifferentTypeNamedParamInitializer({required List<int> ids})
+      : this.ids = ids { // OK
+    ids.add(12);
+  }
+}


### PR DESCRIPTION
The code below triggers the lint:
```dart
class CaseWithDifferentType {
  Iterable<int> ids;
  CaseWithDifferentType(List<int> ids) : ids = ids { // LINT
    ids.add(1);
  }
}
```
The fixed code doesn't work:
```dart
class CaseWithDifferentType {
  Iterable<int> ids;
  CaseWithDifferentType(List<int> this.ids) {
    ids.add(1);  // Error: The method 'add' isn't defined for the class 'Iterable<int>'.
  }
}
```
This pull request will loosen this edge case to also match the type before linting so that this won't be an issue.

Closes #1605

I have revived that pull request from @dramos07 and adapted it to null-safe world. The tests all pass but I'm not so sure that I didn't do something wrong.