### PR TITLE
[flutter_style_todos] Only allow blank characters before `TODO`

### DIFF
--- a/lib/src/rules/flutter_style_todos.dart
+++ b/lib/src/rules/flutter_style_todos.dart
@@ -50,7 +50,7 @@ class FlutterStyleTodos extends LintRule {
 }
 
 class _Visitor extends SimpleAstVisitor<void> {
-  static final _todoRegExp = RegExp(r'//+(.* )?TODO\b', caseSensitive: false);
+  static final _todoRegExp = RegExp(r'//+\s?TODO\b', caseSensitive: false);
 
   static final _todoExpectedRegExp =
       RegExp(r'// TODO\([a-zA-Z0-9][-a-zA-Z0-9]*\): ');

--- a/test/rules/flutter_style_todos_test.dart
+++ b/test/rules/flutter_style_todos_test.dart
@@ -20,6 +20,7 @@ class FlutterStyleTodosTest extends LintRuleTest {
   // TODO(srawlins): This test is called, "bad patterns", contains 10 TODO-like
   // comment lines, but then only expects 9 lints. Why?
   test_badPatterns() async {
+    // Test with comments that will be recognized as TODOs.
     await assertDiagnostics(
       r'''
 // TODO something
@@ -44,6 +45,12 @@ class FlutterStyleTodosTest extends LintRuleTest {
         lint(159, 28),
         lint(245, 64),
       ],
+    );
+    // Test with comments that will not be recognized as TODOs.
+    await assertNoDiagnostics(
+      r'''
+/// final todo = Todo(name: 'test todo', description: 'todo description');
+''',
     );
   }
 


### PR DESCRIPTION
# Description

The `flutter_style_todos` rule is used to allow any single character before `TODO`, this PR disallows it.

Fixes #3919
