### PR TITLE
fix use_build_context_synchronously description error

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -17,11 +17,13 @@ const _details = r'''
 **DON'T** use BuildContext across asynchronous gaps.
 
 Storing `BuildContext` for later usage can easily lead to difficult to diagnose
-crashes. Asynchronous gaps are implicitly storing `BuildContext` and are some of
-the easiest to overlook when writing code.
+crashes, because it can change its state during the async gap and no longer be 
+asociated to an `Element`. Asynchronous gaps are implicitly storing 
+`BuildContext` and are some of the easiest to overlook when writing code.
 
-When a `BuildContext` is used, its `mounted` property must be checked after an
-asynchronous gap.
+
+In any `Widget` it is possible to store the data related to the `BuildContext`
+before the async gap.
 
 **BAD:**
 ```dart
@@ -37,6 +39,20 @@ void onButtonTapped(BuildContext context) {
   Navigator.of(context).pop();
 }
 ```
+
+**GOOD:**
+```dart
+void onButtonTapped() async {
+  final navigator = Navigator.of(context);
+  await Future.delayed(const Duration(seconds: 1));
+
+  navigator.pop();
+}
+```
+
+**EXCEPTION:**
+In a `StatefulWidget` it is possible to check the `State`'s `mounted` property, after an
+asynchronous gap and before using `BuildContext`.
 
 **GOOD:**
 ```dart


### PR DESCRIPTION
This PR is trying to address this issue: https://github.com/dart-lang/linter/issues/3943 use_build_context_synchronously lint is pointing out the issue of using a `BuildContext` after an sync gap when its state can become defunct.  The first problem was that the description and the example were incorrect. Because calling `if (!context.mounted) return` is not possible as `mounted` is not a property of `BuildContext` rather of `State`.  So fixing that is one thing by emphasizing that you can only check `mounted` on a `StatefulWidget`.  The more general advice I feel we can give the devs at this point is (without getting to technical in the lint description) is to store the "state" that would be part of `BuildContext`'s tree before the async gap. Acting on that state would be ok even after an async gap, even if the `BuildContext` is `defunct` at that point because the state that we expect to affect after an async gap is still that state that was referenced before the async gap. In other words we expect that we would still affect the `Navigator`/`ScaffoldMessenger`/`Provider`/etc. that we got before the async gap.  To look at it from another direction. Even if we assume the risk of the `BuildContext` being defunct after an async gap, and call `Navigator.of(context)`, in the case where the context is now part of a different location in the tree we actually don't want the "new" `Navigator` but rather the "old" one which we would have gotten before the async gap.

IMO this whole thing is a caused by a limitation of the framework. What I mean by that is, if we know that `BuildContext` can have a state where it is not supposed to be used for certain calls it would be best to have a way to check that on the `BuildContext` itself (like `BuildContext.mounted` would have done if it existed)

Fixes # (issue)
https://github.com/dart-lang/linter/issues/3943