### PR TITLE
Fix use_build_context_synchronously in if conditions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ Felipe Morschel <fmorschel.contact@gmail.com>
 Nils Reichardt <hi@nils.re>
 Alex Li <alexv.525.li@gmail.com>
 Michail Smirnov <miva200267@gmail.com>
+Peter Leibiger <kuhnroyal@gmail.com>

--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -171,7 +171,8 @@ class _Visitor extends SimpleAstVisitor {
           return;
         }
       } else if (parent is IfStatement) {
-        if (parent.hasAsyncInCondition) {
+        // Only check the actual statement(s), not the IF condition
+        if (child is Statement && parent.hasAsyncInCondition) {
           rule.reportLint(node);
         }
 

--- a/test_data/rules/use_build_context_synchronously.dart
+++ b/test_data/rules/use_build_context_synchronously.dart
@@ -422,3 +422,9 @@ void awaitInIf3(BuildContext context, Future<bool> condition) async {
   if (await condition) return;
   Navigator.of(context).pushNamed('routeName'); // LINT
 }
+
+void awaitInIf4(BuildContext context, Future<bool> Function(BuildContext) condition) async {
+  if (await condition(context)) { // OK
+    Navigator.of(context).pushNamed('routeName'); // LINT
+  }
+}


### PR DESCRIPTION
# Description

Prevent false positives in IF statements, only check the IF statements.

Fixes false positives introduced in https://github.com/dart-lang/linter/pull/3458


