### PR TITLE
Lint about comparing booleans to boolean literals

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -97,6 +97,7 @@ linter:
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    - no_literal_bool_comparisons
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -100,6 +100,7 @@ import 'rules/no_default_cases.dart';
 import 'rules/no_duplicate_case_values.dart';
 import 'rules/no_leading_underscores_for_library_prefixes.dart';
 import 'rules/no_leading_underscores_for_local_identifiers.dart';
+import 'rules/no_literal_bool_comparisons.dart';
 import 'rules/no_logic_in_create_state.dart';
 import 'rules/no_runtimeType_toString.dart';
 import 'rules/non_constant_identifier_names.dart';
@@ -321,6 +322,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(NoAdjacentStringsInList())
     ..register(NoDefaultCases())
     ..register(NoDuplicateCaseValues())
+    ..register(NoLiteralBoolComparisons())
     ..register(NonConstantIdentifierNames())
     ..register(NoLeadingUnderscoresForLibraryPrefixes())
     ..register(NoLeadingUnderscoresForLocalIdentifiers())

--- a/lib/src/rules/no_literal_bool_comparisons.dart
+++ b/lib/src/rules/no_literal_bool_comparisons.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+import '../analyzer.dart';
+
+const _desc = r"Don't compare booleans to boolean literals.";
+
+const _details = r'''
+From [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#dont-use-true-or-false-in-equality-operations):
+
+**DON'T** use `true` or `false` in equality operations.
+
+**BAD:**
+```dart
+if (someBool == true) {
+}
+while (someBool == false) {
+}
+```
+
+**GOOD:**
+```dart
+if (someBool) {
+}
+while (!someBool) {
+}
+```
+''';
+
+class NoLiteralBoolComparisons extends LintRule {
+  NoLiteralBoolComparisons()
+      : super(
+          name: 'no_literal_bool_comparisons',
+          description: _desc,
+          details: _details,
+          group: Group.style,
+        );
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    if (!context.isEnabled(Feature.non_nullable)) return;
+
+    var visitor = _Visitor(this, context);
+    registry.addBinaryExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
+
+  @override
+  void visitBinaryExpression(BinaryExpression node) {
+    var left = node.leftOperand;
+    var right = node.rightOperand;
+    if (right is BooleanLiteral && isBool(left.staticType)) {
+      rule.reportLint(right);
+    } else if (left is BooleanLiteral && isBool(right.staticType)) {
+      rule.reportLint(left);
+    }
+  }
+
+  bool isBool(DartType? type) =>
+      type != null &&
+      type.isDartCoreBool &&
+      context.typeSystem.isNonNullable(type);
+}

--- a/lib/src/rules/no_literal_bool_comparisons.dart
+++ b/lib/src/rules/no_literal_bool_comparisons.dart
@@ -17,7 +17,7 @@ From [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#dont
 
 **DON'T** use `true` or `false` in equality operations.
 
-This lint applies only if the variable is of a non-nullable `bool` type.
+This lint applies only if the expression is of a non-nullable `bool` type.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/no_literal_bool_comparisons.dart
+++ b/lib/src/rules/no_literal_bool_comparisons.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
@@ -15,6 +16,8 @@ const _details = r'''
 From [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#dont-use-true-or-false-in-equality-operations):
 
 **DON'T** use `true` or `false` in equality operations.
+
+This lint applies only if the variable is of a non-nullable `bool` type.
 
 **BAD:**
 ```dart
@@ -60,12 +63,15 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitBinaryExpression(BinaryExpression node) {
-    var left = node.leftOperand;
-    var right = node.rightOperand;
-    if (right is BooleanLiteral && isBool(left.staticType)) {
-      rule.reportLint(right);
-    } else if (left is BooleanLiteral && isBool(right.staticType)) {
-      rule.reportLint(left);
+    if (node.operator.type == TokenType.EQ_EQ ||
+        node.operator.type == TokenType.BANG_EQ) {
+      var left = node.leftOperand;
+      var right = node.rightOperand;
+      if (right is BooleanLiteral && isBool(left.staticType)) {
+        rule.reportLint(right);
+      } else if (left is BooleanLiteral && isBool(right.staticType)) {
+        rule.reportLint(left);
+      }
     }
   }
 

--- a/test_data/rules/no_literal_bool_comparisons.dart
+++ b/test_data/rules/no_literal_bool_comparisons.dart
@@ -1,0 +1,26 @@
+class TestClass {
+  bool x = false;
+}
+
+void foo() {
+  var x = false;
+  if (x == true) // LINT
+  {
+    print('oh');
+  }
+  var f = true;
+  while (true == f) { // LINT
+    print('oh');
+    f = false;
+  }
+
+  var c = TestClass();
+  if (c.x == true) { // LINT
+    print('oh');
+  }
+}
+
+void bar(bool x, bool? y) {
+  print(x == true); // LINT
+  print(y == true); // OK
+}

--- a/test_data/rules/no_literal_bool_comparisons.dart
+++ b/test_data/rules/no_literal_bool_comparisons.dart
@@ -9,18 +9,23 @@ void foo() {
     print('oh');
   }
   var f = true;
-  while (true == f) { // LINT
+  while (true == f) // LINT
+  {
     print('oh');
     f = false;
   }
 
   var c = TestClass();
-  if (c.x == true) { // LINT
+  if (c.x == true) // LINT
+  {
     print('oh');
   }
 }
 
 void bar(bool x, bool? y) {
   print(x == true); // LINT
+  print(x != true); // LINT
   print(y == true); // OK
+
+  if (x && true) print('oh'); // OK
 }

--- a/test_data/rules/no_literal_bool_comparisons.dart
+++ b/test_data/rules/no_literal_bool_comparisons.dart
@@ -20,6 +20,9 @@ void foo() {
   {
     print('oh');
   }
+
+  print((x && f) != true); // LINT
+  print(x && (f != true)); // LINT
 }
 
 void bar(bool x, bool? y) {


### PR DESCRIPTION
This lints against any expression like `x == true` or `false == x`.
It kicks in only if the variable is of type `bool`, non-nullable.

Fixes #3005
Ref https://github.com/dart-lang/linter/issues/3005#issuecomment-941293191
Ref https://github.com/dart-lang/linter/issues/3908#issuecomment-1352445021