### PR TITLE
Fix void_checks false positive: allow returning Never as void

### DIFF
--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -78,6 +78,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   bool isTypeAcceptableWhenExpectingVoid(DartType type) {
     if (type.isVoid) return true;
     if (type.isDartCoreNull) return true;
+    if (type is NeverType) return true;
     if (type.isDartAsyncFuture &&
         type is InterfaceType &&
         isTypeAcceptableWhenExpectingVoid(type.typeArguments.first)) {

--- a/test_data/rules/experiments/nnbd/rules/void_checks.dart
+++ b/test_data/rules/experiments/nnbd/rules/void_checks.dart
@@ -9,3 +9,20 @@ import 'dart:async';
 void emptyFunctionExpressionReturningFutureOrVoid(FutureOr<void> Function() f) {
   f = () {}; // OK
 }
+
+Never fail() { throw 'nope'; }
+
+void m1() async {
+  await Future.value(5).then<void>((x) { // OK
+    fail();
+  });
+}
+
+// https://github.com/dart-lang/linter/issues/3172
+void capture(FutureOr<void> Function() callback) {}
+
+void m2() {
+  capture(() { // OK
+    throw "oh no";
+  });
+}


### PR DESCRIPTION
* Fixes #3172

Note that the tests I'm adding *do* need to be in the nnbd folder, they don't fail in legacy Dart.
