### PR TITLE
Fix documentation for `omit_local_variable_types`

### DIFF
--- a/lib/src/rules/omit_local_variable_types.dart
+++ b/lib/src/rules/omit_local_variable_types.dart
@@ -54,7 +54,7 @@ annotate the variable with the type you want.
 **GOOD:**
 ```dart
 Widget build(BuildContext context) {
-  [!Widget!] result = Text('You won!');
+  Widget result = Text('You won!');
   if (applyPadding) {
     result = Padding(padding: EdgeInsets.all(8.0), child: result);
   }


### PR DESCRIPTION
# Description

Not sure what was up with the old documentation, but that's definitely not how this lint works in its current state
