### PR TITLE
"removed" rule doc codegen WIP

### DIFF
--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -60,7 +60,7 @@ class AvoidAs extends LintRule {
           description: _desc,
           details: _details,
           group: Group.style,
-          state: State.deprecated(), //State.removed(since: dart3),
+          state: State.removed(since: dart3),
         );
 
   @override

--- a/lib/src/rules/avoid_as.dart
+++ b/lib/src/rules/avoid_as.dart
@@ -60,7 +60,7 @@ class AvoidAs extends LintRule {
           description: _desc,
           details: _details,
           group: Group.style,
-          state: State.removed(since: dart3),
+          state: State.deprecated(), //State.removed(since: dart3),
         );
 
   @override

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -583,8 +583,8 @@ class RuleHtmlGenerator {
   String get detailsHeader {
     if (state.isRemoved) {
       var since = state.since;
-      var sinceDetail = since != null ? 'in Dart $since.' : '';
-      return 'Removed $sinceDetail';
+      var sinceDetail = since != null ? ' in Dart $since.' : '';
+      return '<p style="font-size:30px"><strong>Removed$sinceDetail</strong></p>';
     }
     return '';
   }

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -580,6 +580,15 @@ class RuleHtmlGenerator {
 
   String get details => rule.details;
 
+  String get detailsHeader {
+    if (state.isRemoved) {
+      var since = state.since;
+      var sinceDetail = since != null ? 'in Dart $since.' : '';
+      return 'Removed $sinceDetail';
+    }
+    return '';
+  }
+
   String get group => rule.group.name;
 
   String get humanReadableName => rule.name;
@@ -603,18 +612,6 @@ class RuleHtmlGenerator {
     return sb.toString();
   }
 
-  State get state => rule.state;
-
-  String get stateString {
-    if (state.isDeprecated) {
-      return '<span style="color:orangered;font-weight:bold;" >${state.label}</span>';
-    }
-    if (state.isExperimental) {
-      return '<span style="color:hotpink;font-weight:bold;" >${state.label}</span>';
-    }
-    return state.label;
-  }
-
   String get name => rule.name;
 
   String get since {
@@ -626,6 +623,21 @@ class RuleHtmlGenerator {
         ? 'v${info.sinceLinter}'
         : '<strong>Unreleased</strong>';
     return 'Dart SDK: $sdkVersion • <small>(Linter $linterVersion)</small>';
+  }
+
+  State get state => rule.state;
+
+  String get stateString {
+    if (state.isDeprecated) {
+      return '<span style="color:orangered;font-weight:bold;" >${state.label}</span>';
+    }
+    if (state.isRemoved) {
+      return '<span style="color:darkgray;font-weight:bold;" >${state.label}</span>';
+    }
+    if (state.isExperimental) {
+      return '<span style="color:hotpink;font-weight:bold;" >${state.label}</span>';
+    }
+    return state.label;
   }
 
   void generate([String? filePath]) {
@@ -670,7 +682,7 @@ class RuleHtmlGenerator {
             <p><a class="overflow-link" href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></p>
          </header>
          <section>
-
+            $detailsHeader
             ${markdownToHtml(details)}
             $incompatibleRuleDetails
          </section>

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -270,7 +270,11 @@ ${parser.usage}
 ''');
 }
 
-String qualify(LintRule r) => r.name + describeState(r);
+String qualify(LintRule r) {
+  var name = r.name;
+  var label = r.state.isRemoved ? '<s>$name</s>' : name;
+  return label + describeState(r);
+}
 
 class CountBadger {
   Iterable<LintRule> rules;
@@ -705,8 +709,6 @@ class RuleMarkdownGenerator {
 
   String get group => rule.group.name;
 
-  String get maturity => describeState(rule);
-
   String get name => rule.name;
 
   String get since {
@@ -719,13 +721,15 @@ class RuleMarkdownGenerator {
     return 'Dart SDK: $sdkVersion • _(Linter $linterVersion)_';
   }
 
+  String get state => describeState(rule);
+
   void generate({String? filePath, String? fixStatus}) {
     var buffer = StringBuffer();
 
     buffer.writeln('# Rule $name');
     buffer.writeln();
     buffer.writeln('**Group**: $group\\');
-    buffer.writeln('**Maturity**: $maturity\\');
+    buffer.writeln('**State**: $state\\');
     buffer.writeln('**Since**: $since\\');
     buffer.writeln();
 

--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -634,14 +634,13 @@ class RuleHtmlGenerator {
   String get stateString {
     if (state.isDeprecated) {
       return '<span style="color:orangered;font-weight:bold;" >${state.label}</span>';
-    }
-    if (state.isRemoved) {
+    } else if (state.isRemoved) {
       return '<span style="color:darkgray;font-weight:bold;" >${state.label}</span>';
-    }
-    if (state.isExperimental) {
+    } else if (state.isExperimental) {
       return '<span style="color:hotpink;font-weight:bold;" >${state.label}</span>';
+    } else {
+      return state.label;
     }
-    return state.label;
   }
 
   void generate([String? filePath]) {


### PR DESCRIPTION
Room for improvement but a start.  

Adds "removed" state context to generated rule docs.

**Example:**

![image](https://user-images.githubusercontent.com/67586/214164964-d4043fce-ebe8-4c2e-bd17-7096779f4a52.png)

@parlough: I'm curious if you have some thoughts here.

We'd like to keep generating docs for removed lints (to keep backlinks working) but would like it to be clear at a glance that a rule has been removed.

Any ideas most welcome!

See: #3880 

/cc @bwilkerson @parlough 

