### PR TITLE
Fix `unnecessary_parenthesis` with null aware expressions.

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -88,11 +88,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitParenthesizedExpression(ParenthesizedExpression node) {
     var parent = node.parent;
     var expression = node.expression;
-    if (expression is SimpleIdentifier ||
-        (expression is CascadeExpression && expression.isNullAware) ||
-        (expression is PropertyAccess && expression.isNullAware) ||
-        (expression is MethodInvocation && expression.isNullAware) ||
-        (expression is IndexExpression && expression.isNullAware)) {
+    if (expression is SimpleIdentifier || _isNullAware(expression)) {
       if (parent is PropertyAccess) {
         var name = parent.propertyName.name;
         if (name == 'hashCode' || name == 'runtimeType') {
@@ -237,6 +233,25 @@ class _Visitor extends SimpleAstVisitor<void> {
         _ContainsFunctionExpressionVisitor();
     node.accept(containsFunctionExpressionVisitor);
     return containsFunctionExpressionVisitor.hasFunctionExpression;
+  }
+
+  /// Return if the expression is null aware, or one of its recursive targets
+  /// is null aware.
+  bool _isNullAware(Expression? expression) {
+    if (expression is CascadeExpression) {
+      // No need to check the target.
+      return expression.isNullAware;
+    } else if (expression is PropertyAccess) {
+      if (expression.isNullAware) return true;
+      return _isNullAware(expression.target);
+    } else if (expression is MethodInvocation) {
+      if (expression.isNullAware) return true;
+      return _isNullAware(expression.target);
+    } else if (expression is IndexExpression) {
+      if (expression.isNullAware) return true;
+      return _isNullAware(expression.target);
+    }
+    return false;
   }
 }
 

--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -235,8 +235,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     return containsFunctionExpressionVisitor.hasFunctionExpression;
   }
 
-  /// Return if the expression is null aware, or one of its recursive targets
-  /// is null aware.
+  /// Return `true` if the expression is null aware, or if one of its recursive
+  /// targets is null aware.
   bool _isNullAware(Expression? expression) {
     if (expression is CascadeExpression) {
       // No need to check the target.

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -121,6 +121,11 @@ main() async {
   (a?..abs()).hashCode;
   (a?[0]).hashCode;
 
+  (a?.sign.sign).hashCode;
+  (a?.abs().abs()).hashCode;
+  (a?..abs()..abs()).hashCode;
+  (a?[0][1]).hashCode;
+
   (a?.sign)!;
   (a?.abs())!;
   (a?..abs())!;


### PR DESCRIPTION
Fixes #4028

# Description

`unnecessary_parenthesis` should check for an expression being `null aware` recursively, through the `target`.
