### PR TITLE
Fix `unnecessary_parenthesis`

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -238,10 +238,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   /// Return `true` if the expression is null aware, or if one of its recursive
   /// targets is null aware.
   bool _isNullAware(Expression? expression) {
-    if (expression is CascadeExpression) {
-      // No need to check the target.
-      return expression.isNullAware;
-    } else if (expression is PropertyAccess) {
+    if (expression is PropertyAccess) {
       if (expression.isNullAware) return true;
       return _isNullAware(expression.target);
     } else if (expression is MethodInvocation) {

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -131,6 +131,10 @@ main() async {
   (a?..abs())!;
   (a?[0])!;
 
+  (a?..toString())?.abs();
+  (a?..field = true)?.setter;
+  (a?..[0] = 1)?.length;
+
   print(!({"a": "b"}["a"]!.isEmpty)); // LINT
 
   print((1 + 2)); // LINT

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -132,7 +132,7 @@ main() async {
   (a?[0])!;
 
   (a?..toString())?.abs();
-  (a?..field = true)?.setter;
+  (a?..field = true)?.setter = 1;
   (a?..[0] = 1)?.length;
 
   print(!({"a": "b"}["a"]!.isEmpty)); // LINT


### PR DESCRIPTION
Fixes #4041

`CascadeExpression` should be simply ignored in `_isNullAware` (which is done in a later part of the code).