### PR TITLE
don't report `unnecessary_parenthesis` for null-aware cascades

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -96,6 +96,7 @@ class _Visitor extends SimpleAstVisitor<void> {
           return;
         }
       } else if (parent is MethodInvocation) {
+        if (expression is CascadeExpression) return;
         var name = parent.methodName.name;
         if (name == 'noSuchMethod' || name == 'toString') {
           // Code like `(String).noSuchMethod()` is allowed.

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -88,6 +88,7 @@ import 'unnecessary_library_directive_test.dart'
     as unnecessary_library_directive;
 import 'unnecessary_null_checks_test.dart' as unnecessary_null_checks;
 import 'unnecessary_overrides_test.dart' as unnecessary_overrides;
+import 'unnecessary_parenthesis_test.dart' as unnecessary_parenthesis;
 import 'use_build_context_synchronously_test.dart'
     as use_build_context_synchronously;
 import 'use_enums_test.dart' as use_enums;
@@ -160,6 +161,7 @@ void main() {
   unnecessary_library_directive.main();
   unnecessary_null_checks.main();
   unnecessary_overrides.main();
+  unnecessary_parenthesis.main();
   use_build_context_synchronously.main();
   use_enums.main();
   use_is_even_rather_than_modulo.main();

--- a/test/rules/unnecessary_parenthesis_test.dart
+++ b/test/rules/unnecessary_parenthesis_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(UnnecessaryParenthesisTest);
+  });
+}
+
+@reflectiveTest
+class UnnecessaryParenthesisTest extends LintRuleTest {
+  @override
+  String get lintRule => 'unnecessary_parenthesis';
+
+  /// https://github.com/dart-lang/linter/issues/4041
+  test_nullAware_cascadeAssignment() async {
+    await assertNoDiagnostics(r'''    
+class A {
+  var b = false;
+  void m() {}
+}
+
+void f(A? a) {
+  (a?..b = true)?.m();
+}
+''');
+  }
+}


### PR DESCRIPTION
Fixes #4041

/cc @bwilkerson 