### PR TITLE
Fix `UnnecessaryParenthesis`

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -96,7 +96,6 @@ class _Visitor extends SimpleAstVisitor<void> {
           return;
         }
       } else if (parent is MethodInvocation) {
-        if (expression is CascadeExpression) return;
         var name = parent.methodName.name;
         if (name == 'noSuchMethod' || name == 'toString') {
           // Code like `(String).noSuchMethod()` is allowed.
@@ -239,10 +238,7 @@ class _Visitor extends SimpleAstVisitor<void> {
   /// Return `true` if the expression is null aware, or if one of its recursive
   /// targets is null aware.
   bool _isNullAware(Expression? expression) {
-    if (expression is CascadeExpression) {
-      // No need to check the target.
-      return expression.isNullAware;
-    } else if (expression is PropertyAccess) {
+    if (expression is PropertyAccess) {
       if (expression.isNullAware) return true;
       return _isNullAware(expression.target);
     } else if (expression is MethodInvocation) {

--- a/test/rules/unnecessary_parenthesis_test.dart
+++ b/test/rules/unnecessary_parenthesis_test.dart
@@ -23,10 +23,16 @@ class UnnecessaryParenthesisTest extends LintRuleTest {
 class A {
   var b = false;
   void m() {}
+  set setter(int i) {}
 }
 
 void f(A? a) {
   (a?..b = true)?.m();
+  (a?..b = true)?.setter = 1;
+}
+
+void g(List<int>? list) {
+  (list?..[0] = 1)?.length;
 }
 ''');
   }


### PR DESCRIPTION
This PR cover more cases for #4041

The fix in #4043 covers only the case of `parent is MethodInvocation`, but it should be generalized to be not based on the `parent` but rather that `expression is CascadeExpression`.

This PR removes the condition from `_isNullAware` and leaves the logic to reach line 150 to return without linting.