### PR TITLE
fix pattern constant detection

### DIFF
--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
@@ -52,8 +51,7 @@ class UnnecessaryConst extends LintRule {
   @override
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
-    var visitor =
-        _Visitor(this, patternsEnabled: context.isEnabled(Feature.patterns));
+    var visitor = _Visitor(this);
     registry.addInstanceCreationExpression(this, visitor);
     registry.addListLiteral(this, visitor);
     registry.addRecordLiteral(this, visitor);
@@ -63,8 +61,7 @@ class UnnecessaryConst extends LintRule {
 
 class _Visitor extends SimpleAstVisitor {
   final LintRule rule;
-  final bool patternsEnabled;
-  _Visitor(this.rule, {required this.patternsEnabled});
+  _Visitor(this.rule);
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
@@ -77,7 +74,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitListLiteral(ListLiteral node) {
-    if (patternsEnabled) return;
+    if (node.parent is ConstantPattern) return;
     _visitTypedLiteral(node);
   }
 
@@ -92,7 +89,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
-    if (patternsEnabled) return;
+    if (node.parent is ConstantPattern) return;
     _visitTypedLiteral(node);
   }
 

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -74,7 +74,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitListLiteral(ListLiteral node) {
-    if (node.parent is ConstantPattern) return;
+    if (node.unParenthesized.parent is ConstantPattern) return;
     _visitTypedLiteral(node);
   }
 
@@ -89,7 +89,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
-    if (node.parent is ConstantPattern) return;
+    if (node.unParenthesized.parent is ConstantPattern) return;
     _visitTypedLiteral(node);
   }
 

--- a/test/rules/unnecessary_const_test.dart
+++ b/test/rules/unnecessary_const_test.dart
@@ -64,6 +64,17 @@ void f(Object o) {
 ''');
   }
 
+  test_constConstructor() async {
+    await assertDiagnostics(r'''
+class C {
+  const C();
+}
+const c = const C();
+''', [
+      lint(35, 9),
+    ]);
+  }
+
   test_listLiteral() async {
     await assertDiagnostics(r'''
 const l = const [];

--- a/test/rules/unnecessary_const_test.dart
+++ b/test/rules/unnecessary_const_test.dart
@@ -63,6 +63,30 @@ void f(Object o) {
 }
 ''');
   }
+
+  test_listLiteral() async {
+    await assertDiagnostics(r'''
+const l = const [];
+''', [
+      lint(10, 8),
+    ]);
+  }
+
+  test_mapLiteral() async {
+    await assertDiagnostics(r'''
+const m = const {1: 1};
+''', [
+      lint(10, 12),
+    ]);
+  }
+
+  test_setLiteral() async {
+    await assertDiagnostics(r'''
+const s = const {1};
+''', [
+      lint(10, 9),
+    ]);
+  }
 }
 
 @reflectiveTest


### PR DESCRIPTION
Follow-up from https://github.com/dart-lang/linter/issues/4049

The previous fix silenced linting on all collection literals (not just ones in constant patterns). 😬 

/cc @bwilkerson 