### PR TITLE
Add rule 'override_void_return'

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -74,6 +74,7 @@ linter:
     - exhaustive_cases
     - file_names
     - flutter_style_todos
+    - future_return_overriding_void_return
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -74,7 +74,6 @@ linter:
     - exhaustive_cases
     - file_names
     - flutter_style_todos
-    - future_return_overriding_void_return
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs
@@ -105,6 +104,7 @@ linter:
     - one_member_abstracts
     - only_throw_errors
     - overridden_fields
+    - override_void_return
     - package_api_docs
     - package_names
     - package_prefixed_library_names

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -111,6 +111,7 @@ import 'rules/omit_local_variable_types.dart';
 import 'rules/one_member_abstracts.dart';
 import 'rules/only_throw_errors.dart';
 import 'rules/overridden_fields.dart';
+import 'rules/override_void_return.dart';
 import 'rules/package_api_docs.dart';
 import 'rules/package_prefixed_library_names.dart';
 import 'rules/parameter_assignments.dart';
@@ -305,6 +306,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(ExhaustiveCases())
     ..register(FileNames())
     ..register(FlutterStyleTodos())
+    ..register(OverrideVoidReturn())
     ..register(HashAndEquals())
     ..register(ImplementationImports())
     ..register(ImplicitCallTearoffs())

--- a/lib/src/rules/override_void_return.dart
+++ b/lib/src/rules/override_void_return.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Non-void return overriding void return.';
+
+const _details = r'''
+Do not override a `void`-returning method with a non-`void`-returning method.
+
+**BAD:**
+```dart
+abstract class One {
+  void m();
+}
+
+class One extends Two {
+  Future<void> m() async {
+    return Future.delayed(Duration(seconds: 3), () => print('Hello'));
+  }
+}
+```
+
+**GOOD:**
+```dart
+abstract class One {
+  void m();
+}
+
+class One extends Two {
+  void m() async {
+    return Future.delayed(Duration(seconds: 3), () => print('Hello'));
+  }
+}
+```
+
+''';
+
+class OverrideVoidReturn extends LintRule {
+  static const LintCode code = LintCode(
+      'override_void_return',
+      "The member '{0}' specifies a non-void return type, but overrides a "
+          'member with a void return type.',
+      correctionMessage: 'Try using a void return type.');
+
+  OverrideVoidReturn()
+      : super(
+            name: 'override_void_return',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this, context);
+    registry.addMethodDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+  final LinterContext context;
+
+  _Visitor(this.rule, this.context);
+
+  Element? getOverriddenMember(Element element) {
+    var classElement = element.thisOrAncestorOfType<InterfaceElement>();
+    if (classElement == null) {
+      return null;
+    }
+    var name = element.name;
+    if (name == null) {
+      return null;
+    }
+
+    var libraryUri = classElement.library.source.uri;
+    return context.inheritanceManager.getInherited(
+      classElement.thisType,
+      Name(libraryUri, name),
+    );
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    if (node.isStatic) return;
+    var element = node.declaredElement;
+    if (element == null) return;
+    if (!element.returnType.isVoid) {
+      var overriddenMember = getOverriddenMember(element);
+      if (overriddenMember is! MethodElement) return;
+      if (overriddenMember.returnType.isVoid) {
+        rule.reportLintForToken(node.name, arguments: [overriddenMember.name]);
+      }
+    }
+  }
+}

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -56,6 +56,7 @@ import 'null_closures_test.dart' as null_closures;
 import 'omit_local_variable_types_test.dart' as omit_local_variable_types;
 import 'only_throw_errors_test.dart' as only_throw_errors;
 import 'overridden_fields_test.dart' as overridden_fields;
+import 'override_void_return_test.dart' as override_void_return;
 import 'parameter_assignments_test.dart' as parameter_assignments;
 import 'prefer_asserts_in_initializer_lists_test.dart'
     as prefer_asserts_in_initializer_lists;
@@ -139,6 +140,7 @@ void main() {
   omit_local_variable_types.main();
   only_throw_errors.main();
   overridden_fields.main();
+  override_void_return.main();
   parameter_assignments.main();
   prefer_asserts_in_initializer_lists.main();
   prefer_collection_literals.main();

--- a/test/rules/override_void_return_test.dart
+++ b/test/rules/override_void_return_test.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(OverrideVoidReturnTest);
+  });
+}
+
+@reflectiveTest
+class OverrideVoidReturnTest extends LintRuleTest {
+  @override
+  String get lintRule => 'override_void_return';
+
+  test_abstract() async {
+    await assertDiagnostics(r'''
+abstract class A {
+  void m();
+}
+class B extends A {
+  Future<void> m() async {}
+}
+''', [
+      lint(68, 1),
+    ]);
+  }
+
+  test_extended() async {
+    await assertDiagnostics(r'''
+class A {
+  void m() {}
+}
+class B extends A {
+  int m() => 7;
+}
+''', [
+      lint(52, 1),
+    ]);
+  }
+
+  test_genericInstantiation() async {
+    await assertDiagnostics(r'''
+import 'dart:async';
+
+abstract class A<T> {
+  T m();
+}
+class B extends A<void> {
+  FutureOr<void> m() async {}
+}
+''', [
+      lint(98, 1),
+    ]);
+  }
+
+  test_implemented() async {
+    await assertDiagnostics(r'''
+class A {
+  void m() {}
+}
+class B implements A {
+  int m() => 7;
+}
+''', [
+      lint(55, 1),
+    ]);
+  }
+
+  test_mixedIn() async {
+    await assertDiagnostics(r'''
+mixin M {
+  void m() {}
+}
+class B with M {
+  Future<void> m() async {}
+}
+''', [
+      lint(58, 1),
+    ]);
+  }
+
+  @FailingTest(reason: 'Not implemented yet')
+  test_mixinApplication() async {
+    await assertDiagnostics(r'''
+class A {
+  void m() {}
+}
+mixin M {
+  Future<void> m() async {}
+}
+class B = A with M;
+''', [
+      lint(56, 1),
+    ]);
+  }
+
+  test_superConstraint() async {
+    await assertDiagnostics(r'''
+class A {
+  void m() {}
+}
+mixin M on A {
+  Future<void> m() async {}
+}
+''', [
+      lint(56, 1),
+    ]);
+  }
+
+  test_voidOverride() async {
+    await assertNoDiagnostics(r'''
+class A {
+  void m() {}
+}
+class B extends A {
+  void m() {}
+}
+''');
+  }
+}


### PR DESCRIPTION
# Description


Fixes https://github.com/dart-lang/linter/issues/1882


This rule prevents dangerous overrides, and helps to stay safe with [`unawaited_futures`](https://dart-lang.github.io/linter/lints/unawaited_futures.html).

Two things to maybe discuss:

* [ ] the name? I welcome suggestions :)
* [x] Are there edge cases to special-case? Overriding with `Future?`, `Future<Never>`, `Future<Null>`, FutureOr?`, ...? CC @eernstg 
