### PR TITLE
Use WarningCodes over deprecated HintCodes

### DIFF
--- a/test/rules/avoid_final_parameters_test.dart
+++ b/test/rules/avoid_final_parameters_test.dart
@@ -27,8 +27,8 @@ class C {
 }
 ''', [
       // TODO(srawlins): Do not report this lint rule here, as it is redundant
-      // with the Hint.
-      error(HintCode.UNNECESSARY_FINAL, 23, 5),
+      // with the Warning.
+      error(WarningCode.UNNECESSARY_FINAL, 23, 5),
       lint(23, 12),
     ]);
   }
@@ -189,8 +189,8 @@ class B extends A {
 ''', [
       // TODO(srawlins): Do not report this lint rule here, as it is redundant
       // with the Hint.
-      error(HintCode.UNNECESSARY_FINAL, 83, 5),
-      error(HintCode.UNNECESSARY_FINAL, 98, 5),
+      error(WarningCode.UNNECESSARY_FINAL, 83, 5),
+      error(WarningCode.UNNECESSARY_FINAL, 98, 5),
       lint(83, 13),
       lint(98, 13),
     ]);

--- a/test/rules/conditional_uri_does_not_exist_test.dart
+++ b/test/rules/conditional_uri_does_not_exist_test.dart
@@ -29,7 +29,7 @@ import ''
     if (dart.library.async) 'dart:missing_2';
 ''',
       [
-        error(HintCode.UNUSED_IMPORT, 7, 2),
+        error(WarningCode.UNUSED_IMPORT, 7, 2),
         lint(35, 16, messageContains: 'dart:missing_1'),
         lint(120, 16, messageContains: 'dart:missing_2'),
       ],
@@ -47,7 +47,7 @@ import ''
     if (dart.library.async) 'missing_2.dart';
 ''',
       [
-        error(HintCode.UNUSED_IMPORT, 7, 2),
+        error(WarningCode.UNUSED_IMPORT, 7, 2),
         lint(35, 16, messageContains: 'missing_1.dart'),
         lint(121, 16, messageContains: 'missing_2.dart'),
       ],
@@ -63,7 +63,7 @@ import ''
     if (dart.library.io) 'package:foo/missing_2.dart';
 ''',
       [
-        error(HintCode.UNUSED_IMPORT, 7, 2),
+        error(WarningCode.UNUSED_IMPORT, 7, 2),
         lint(35, 29, messageContains: 'missing_1.dart'),
         lint(142, 28, messageContains: 'missing_2.dart'),
       ],

--- a/test/rules/constant_identifier_names_test.dart
+++ b/test/rules/constant_identifier_names_test.dart
@@ -45,7 +45,7 @@ void f() {
   final (AA, ) = (1, );
 }
 ''', [
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 20, 2),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 20, 2),
       lint(20, 2),
     ]);
   }

--- a/test/rules/invalid_case_patterns_test.dart
+++ b/test/rules/invalid_case_patterns_test.dart
@@ -50,7 +50,7 @@ void f(Object o) {
 }
 ''', [
       lint(43, 12),
-      error(HintCode.DEAD_CODE, 54, 1),
+      error(WarningCode.DEAD_CODE, 54, 1),
     ]);
   }
 
@@ -103,7 +103,7 @@ void f(Object o) {
   }
 }
 ''', [
-      error(HintCode.UNNECESSARY_TYPE_CHECK_TRUE, 43, 8),
+      error(WarningCode.UNNECESSARY_TYPE_CHECK_TRUE, 43, 8),
       lint(43, 8),
     ]);
   }
@@ -116,7 +116,7 @@ void f(Object o) {
   }
 }
 ''', [
-      error(HintCode.UNNECESSARY_TYPE_CHECK_FALSE, 43, 9),
+      error(WarningCode.UNNECESSARY_TYPE_CHECK_FALSE, 43, 9),
       lint(43, 9),
     ]);
   }

--- a/test/rules/non_constant_identifier_names_test.dart
+++ b/test/rules/non_constant_identifier_names_test.dart
@@ -39,7 +39,7 @@ void f() {
   if ([1,2] case [int AB, int]) { }
 }
 ''', [
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 33, 2),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 33, 2),
       lint(33, 2),
     ]);
   }
@@ -58,7 +58,7 @@ void f() {
   var (AB, ) = (1, );
 }
 ''', [
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 18, 2),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 18, 2),
       lint(18, 2),
     ]);
   }

--- a/test/rules/overridden_fields_test.dart
+++ b/test/rules/overridden_fields_test.dart
@@ -58,7 +58,7 @@ class B extends A {
   int? _private;
 }
 ''', [
-      error(HintCode.UNUSED_FIELD, 44, 8),
+      error(WarningCode.UNUSED_FIELD, 44, 8),
     ]);
   }
 
@@ -132,7 +132,7 @@ class GC34 extends GC33 {
   Object gc33 = 'yada';
 }
 ''', [
-      error(HintCode.OVERRIDE_ON_NON_OVERRIDING_FIELD, 120, 1),
+      error(WarningCode.OVERRIDE_ON_NON_OVERRIDING_FIELD, 120, 1),
       lint(127, 5),
       lint(202, 9),
       error(CompileTimeErrorCode.MIXIN_INHERITS_FROM_NOT_OBJECT, 281, 4),

--- a/test/rules/parameter_assignments_test.dart
+++ b/test/rules/parameter_assignments_test.dart
@@ -86,7 +86,7 @@ void f(String? p) {
 }
 ''', [
       // No lint.
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 47, 1),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 47, 1),
     ]);
   }
 

--- a/test/rules/prefer_const_constructors_test.dart
+++ b/test/rules/prefer_const_constructors_test.dart
@@ -59,7 +59,7 @@ void f() {
 }
 ''', [
       // No lint.
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 49, 2),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 49, 2),
     ]);
   }
 
@@ -78,7 +78,7 @@ K k() {
 }
 ''', [
       // No lint
-      error(HintCode.NON_CONST_CALL_TO_LITERAL_CONSTRUCTOR, 90, 3),
+      error(WarningCode.NON_CONST_CALL_TO_LITERAL_CONSTRUCTOR, 90, 3),
     ]);
   }
 }

--- a/test/rules/prefer_contains_test.dart
+++ b/test/rules/prefer_contains_test.dart
@@ -26,7 +26,7 @@ condition() {
 }
 ''', [
       // No lint
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 41, 4),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 41, 4),
       error(CompileTimeErrorCode.ARGUMENT_TYPE_NOT_ASSIGNABLE, 77, 3),
     ]);
   }
@@ -52,7 +52,7 @@ bool b = '11'.indexOf('2', 0) == -1;
 bool le3 = ([].indexOf(1) as int) > -1;
 ''', [
       lint(11, 27),
-      error(HintCode.UNNECESSARY_CAST, 12, 20),
+      error(WarningCode.UNNECESSARY_CAST, 12, 20),
     ]);
   }
 }

--- a/test/rules/unnecessary_breaks_test.dart
+++ b/test/rules/unnecessary_breaks_test.dart
@@ -105,7 +105,7 @@ f(bool c) {
 }
 ''', [
       // No lint.
-      error(HintCode.DEAD_CODE, 58, 8),
+      error(WarningCode.DEAD_CODE, 58, 8),
     ]);
   }
 }

--- a/test/rules/use_enums_test.dart
+++ b/test/rules/use_enums_test.dart
@@ -110,10 +110,10 @@ class _E {
 }
 ''', [
       // No lint.
-      error(HintCode.UNUSED_ELEMENT, 6, 2),
-      error(HintCode.UNUSED_FIELD, 29, 1),
-      error(HintCode.UNUSED_FIELD, 57, 1),
-      error(HintCode.UNUSED_ELEMENT_PARAMETER, 83, 1),
+      error(WarningCode.UNUSED_ELEMENT, 6, 2),
+      error(WarningCode.UNUSED_FIELD, 29, 1),
+      error(WarningCode.UNUSED_FIELD, 57, 1),
+      error(WarningCode.UNUSED_ELEMENT_PARAMETER, 83, 1),
     ]);
   }
 
@@ -129,8 +129,8 @@ class _E {
 _E get e => _E();
 ''', [
       // No lint.
-      error(HintCode.UNUSED_FIELD, 29, 1),
-      error(HintCode.UNUSED_FIELD, 57, 1),
+      error(WarningCode.UNUSED_FIELD, 29, 1),
+      error(WarningCode.UNUSED_FIELD, 57, 1),
     ]);
   }
 
@@ -170,8 +170,8 @@ class _E {
 }
 ''', [
       // No lint.
-      error(HintCode.UNUSED_ELEMENT, 6, 2),
-      error(HintCode.UNUSED_FIELD, 45, 1),
+      error(WarningCode.UNUSED_ELEMENT, 6, 2),
+      error(WarningCode.UNUSED_FIELD, 45, 1),
     ]);
   }
 
@@ -186,8 +186,8 @@ class _E {
 }
 ''', [
       // No lint.
-      error(HintCode.UNUSED_ELEMENT, 6, 2),
-      error(HintCode.UNUSED_FIELD, 48, 2),
+      error(WarningCode.UNUSED_ELEMENT, 6, 2),
+      error(WarningCode.UNUSED_FIELD, 48, 2),
     ]);
   }
 
@@ -202,8 +202,8 @@ class _E {
 class F implements _E  {}
 ''', [
       // No lint.
-      error(HintCode.UNUSED_FIELD, 29, 1),
-      error(HintCode.UNUSED_FIELD, 57, 1),
+      error(WarningCode.UNUSED_FIELD, 29, 1),
+      error(WarningCode.UNUSED_FIELD, 57, 1),
     ]);
   }
 
@@ -263,9 +263,9 @@ class _E {
       // No lint.
       // todo(pq):consider relaxing the lint to flag cases w/o a const
       // but all final fields.
-      error(HintCode.UNUSED_ELEMENT, 6, 2),
-      error(HintCode.UNUSED_FIELD, 29, 1),
-      error(HintCode.UNUSED_FIELD, 57, 1),
+      error(WarningCode.UNUSED_ELEMENT, 6, 2),
+      error(WarningCode.UNUSED_FIELD, 29, 1),
+      error(WarningCode.UNUSED_FIELD, 57, 1),
     ]);
   }
 
@@ -279,8 +279,8 @@ class _E {
 }
 ''', [
       // No lint.
-      error(HintCode.UNUSED_ELEMENT, 6, 2),
-      error(HintCode.UNUSED_FIELD, 57, 1),
+      error(WarningCode.UNUSED_ELEMENT, 6, 2),
+      error(WarningCode.UNUSED_FIELD, 57, 1),
     ]);
   }
 
@@ -322,7 +322,7 @@ class _E {
 _E e = _E.withValue(0);
 ''', [
       lint(6, 2),
-      error(HintCode.UNUSED_FIELD, 57, 1),
+      error(WarningCode.UNUSED_FIELD, 57, 1),
     ]);
   }
 
@@ -350,9 +350,9 @@ class _A {
   const _A();
 }
 ''', [
-      error(HintCode.UNUSED_ELEMENT, 6, 2),
-      error(HintCode.UNUSED_FIELD, 29, 1),
-      error(HintCode.UNUSED_FIELD, 57, 1),
+      error(WarningCode.UNUSED_ELEMENT, 6, 2),
+      error(WarningCode.UNUSED_FIELD, 29, 1),
+      error(WarningCode.UNUSED_FIELD, 57, 1),
       lint(6, 2),
     ]);
   }


### PR DESCRIPTION
The `HintCode` values are being deprecated for new `WarningCode` ones.

This is required to be pulled into the SDK and google3 before we can remove the HintCodes.
