### PR TITLE
`unnecessary_null_checks` to ignore `Future.value` and

### DIFF
--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -129,6 +129,27 @@ DartType? getExpectedType(PostfixExpression node) {
     parent = parent.parent;
   }
   if (parent is ArgumentList && realNode is Expression) {
+    var grandParent = parent.parent;
+    if (grandParent is InstanceCreationExpression) {
+      var constructor = grandParent.constructorName.staticElement;
+      if (constructor != null) {
+        if (constructor.returnType.isDartAsyncFuture &&
+            constructor.name == 'value') {
+          return null;
+        }
+      }
+    } else if (grandParent is MethodInvocation) {
+      var targetType = grandParent.realTarget?.staticType;
+      if (targetType is InterfaceType) {
+        var targetClass = targetType.element;
+
+        if (targetClass.library.isDartAsync &&
+            targetClass.name == 'Completer' &&
+            grandParent.methodName.name == 'complete') {
+          return null;
+        }
+      }
+    }
     return realNode.staticParameterElement?.type;
   }
   return null;

--- a/test/rules/unnecessary_null_checks_test.dart
+++ b/test/rules/unnecessary_null_checks_test.dart
@@ -17,6 +17,19 @@ class UnnecessaryNullChecksTest extends LintRuleTest {
   @override
   String get lintRule => 'unnecessary_null_checks';
 
+  test_completerComplete() async {
+    await assertNoDiagnostics(r'''
+import 'dart:async';
+void f(int? i) => Completer<int>().complete(i!);
+''');
+  }
+
+  test_futureValue() async {
+    await assertNoDiagnostics(r'''
+void f(int? i) => Future<int>.value(i!);
+''');
+  }
+
   test_undefinedFunction() async {
     await assertDiagnostics(r'''
 f6(int? p) {


### PR DESCRIPTION
 `Completer.complete`.

Fixes #4077
