### PR TITLE
support class mixins in `prefer_mixin`

### DIFF
--- a/lib/src/rules/prefer_mixin.dart
+++ b/lib/src/rules/prefer_mixin.dart
@@ -75,7 +75,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       var type = mixinNode.type;
       if (type is InterfaceType) {
         var element = type.element;
-        if (element is! MixinElement && !isAllowed(element)) {
+        if (element is MixinElement) continue;
+        if ((element is ClassElement && !element.isMixinClass) &&
+            !isAllowed(element)) {
           rule.reportLint(mixinNode, arguments: [mixinNode.name.name]);
         }
       }

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -72,6 +72,7 @@ import 'prefer_final_fields_test.dart' as prefer_final_fields;
 import 'prefer_final_parameters_test.dart' as prefer_final_parameters;
 import 'prefer_generic_function_type_aliases_test.dart'
     as prefer_generic_function_type_aliases;
+import 'prefer_mixin_test.dart' as prefer_mixin;
 import 'prefer_spread_collections_test.dart' as prefer_spread_collections;
 import 'public_member_api_docs_test.dart' as public_member_api_docs;
 import 'recursive_getters_test.dart' as recursive_getters;
@@ -154,6 +155,7 @@ void main() {
   prefer_generic_function_type_aliases.main();
   prefer_spread_collections.main();
   public_member_api_docs.main();
+  prefer_mixin.main();
   recursive_getters.main();
   sort_constructors_first.main();
   sort_unnamed_constructors_first.main();

--- a/test/rules/prefer_mixin_test.dart
+++ b/test/rules/prefer_mixin_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(PreferMixinTest);
+  });
+}
+
+@reflectiveTest
+class PreferMixinTest extends LintRuleTest {
+  @override
+  List<String> get experiments => ['sealed-classes', 'class-modifiers'];
+
+  @override
+  String get lintRule => 'prefer_mixin';
+
+  /// https://github.com/dart-lang/linter/issues/4065
+  test_mixinClass() async {
+    await assertNoDiagnostics(r'''
+mixin class M { }
+
+class Z with M { }
+''');
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/4065

/cc @bwilkerson 
