### PR TITLE
update test

### DIFF
--- a/test/rules/non_constant_identifier_names_test.dart
+++ b/test/rules/non_constant_identifier_names_test.dart
@@ -22,14 +22,13 @@ class NonConstantIdentifierNamesPatternsTest extends LintRuleTest {
   @override
   String get lintRule => 'non_constant_identifier_names';
 
-  @FailingTest(reason: 'Flow analysis fails w/ a Bad state exception')
   test_patternForStatement() async {
     await assertDiagnostics(r'''
 void f() {
-  for (var (AB, ) = (0, 1); AB <= 13; (AB, ) = ( , AB++)) { }
+  for (var (AB, c) = (0, 1); AB <= 13; (AB, c) = (c, AB + c)) { }
 }
 ''', [
-      lint(18, 2),
+      lint(23, 2),
     ]);
   }
 

--- a/test/rules/non_constant_identifier_names_test.dart
+++ b/test/rules/non_constant_identifier_names_test.dart
@@ -36,11 +36,12 @@ void f() {
   test_patternIfStatement() async {
     await assertDiagnostics(r'''
 void f() {
-  if ([1,2] case [int AB, int]) { }
+  if ([1,2] case [int AB, int c]) { }
 }
 ''', [
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 33, 2),
+      error(HintCode.UNUSED_LOCAL_VARIABLE, 33, 2),
       lint(33, 2),
+      error(HintCode.UNUSED_LOCAL_VARIABLE, 41, 1),
     ]);
   }
 

--- a/test/rules/non_constant_identifier_names_test.dart
+++ b/test/rules/non_constant_identifier_names_test.dart
@@ -39,9 +39,9 @@ void f() {
   if ([1,2] case [int AB, int c]) { }
 }
 ''', [
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 33, 2),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 33, 2),
       lint(33, 2),
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 41, 1),
+      error(WarningCode.UNUSED_LOCAL_VARIABLE, 41, 1),
     ]);
   }
 


### PR DESCRIPTION
With the new analyzer, this is producing a `CONSTANT_PATTERN_NEVER_MATCHES_VALUE_TYPE` warning code.

Also, with flow analysis improvements, this now fixes pattern-for tests.

Fixes #3669.

/cc @bwilkerson 