### PR TITLE
unnecessary_lambdas: Do not report when expression has late final variables

### DIFF
--- a/lib/src/rules/unnecessary_lambdas.dart
+++ b/lib/src/rules/unnecessary_lambdas.dart
@@ -72,11 +72,15 @@ class _FinalExpressionChecker {
 
   _FinalExpressionChecker(this.parameters);
 
+  /// Returns whether [element] is a `final` variable or property and not
+  /// `late`.
   bool isFinalElement(Element? element) {
     if (element is PropertyAccessorElement) {
-      return element.isSynthetic && element.variable.isFinal;
+      return element.isSynthetic &&
+          element.variable.isFinal &&
+          !element.variable.isLate;
     } else if (element is VariableElement) {
-      return element.isFinal;
+      return element.isFinal && !element.isLate;
     }
     return true;
   }

--- a/test/rules/unnecessary_lambdas_test.dart
+++ b/test/rules/unnecessary_lambdas_test.dart
@@ -156,6 +156,16 @@ void f() {
     ]);
   }
 
+  test_methodCallOnLateFinalLocal_matchingArg() async {
+    await assertNoDiagnostics(r'''
+void f() {
+  late final List<int> l;
+  if (1 == 2) l = [];
+  [].where((e) => l.contains(e));
+}
+''');
+  }
+
   test_methodCallOnFinalLocal_closureParameterIsTarget() async {
     await assertNoDiagnostics(r'''
 void f() {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/2182

Final properties and variables are understood by this rule to be "safe for tearing off" as they shouldn't change. While this is not true for final fields, it is the understanding. This change also requires the property or variable to not be late, so that it is definitely initialized when it is torn off.