### PR TITLE
Align public_member_api_docs expectations with '// LINT' comments

### DIFF
--- a/test/integration/public_member_api_docs.dart
+++ b/test/integration/public_member_api_docs.dart
@@ -28,6 +28,7 @@ void main() {
           result.stdout.trim(),
           stringContainsInOrder([
             'a.dart:7:1',
+            'a.dart:8:16',
             'a.dart:9:11',
             'a.dart:10:9',
             'a.dart:14:16',


### PR DESCRIPTION
After manually reviewing the full expectations and comparing with the `// LINT` and `// OK` comments, this is the total fix for the misalignment.

Fixes #4114 