### PR TITLE
Fix reported range for undocumented mixin; re-implement public docs integration test

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -59,8 +59,55 @@ int? getIntValue(Expression expression, LinterContext? context) {
 
 /// Returns the most specific AST node appropriate for associating errors.
 SyntacticEntity getNodeToAnnotate(Declaration node) {
-  var mostSpecific = _getNodeToAnnotate(node);
-  return mostSpecific ?? node;
+  // TODO(srawlins): Convert to a switch expression over `Declaration` subtypes,
+  // assuming `Declaration` becomes an exhaustive type.
+  if (node is ClassDeclaration) {
+    return node.name;
+  }
+  if (node is ClassTypeAlias) {
+    return node.name;
+  }
+  if (node is ConstructorDeclaration) {
+    return node.name ?? node;
+  }
+  if (node is EnumConstantDeclaration) {
+    return node.name;
+  }
+  if (node is EnumDeclaration) {
+    return node.name;
+  }
+  if (node is ExtensionDeclaration) {
+    return node.name ?? node;
+  }
+  if (node is FieldDeclaration) {
+    return node.fields;
+  }
+  if (node is FunctionDeclaration) {
+    return node.name;
+  }
+  if (node is FunctionTypeAlias) {
+    return node.name;
+  }
+  if (node is GenericTypeAlias) {
+    return node.name;
+  }
+  if (node is MethodDeclaration) {
+    return node.name;
+  }
+  if (node is MixinDeclaration) {
+    return node.name;
+  }
+  if (node is TopLevelVariableDeclaration) {
+    return node.variables;
+  }
+  if (node is TypeParameter) {
+    return node.name;
+  }
+  if (node is VariableDeclaration) {
+    return node.name;
+  }
+  assert(false, "Unaccounted for Declaration subtype: '${node.runtimeType}'");
+  return node;
 }
 
 /// If the [node] is the finishing identifier of an assignment, return its
@@ -344,49 +391,6 @@ int? _getIntValue(Expression expression, LinterContext? context,
   if (value is! int) return null;
 
   return negated ? -value : value;
-}
-
-SyntacticEntity? _getNodeToAnnotate(Declaration node) {
-  if (node is MethodDeclaration) {
-    return node.name;
-  }
-  if (node is ConstructorDeclaration) {
-    return node.name;
-  }
-  if (node is FieldDeclaration) {
-    return node.fields;
-  }
-  if (node is ClassTypeAlias) {
-    return node.name;
-  }
-  if (node is FunctionTypeAlias) {
-    return node.name;
-  }
-  if (node is ClassDeclaration) {
-    return node.name;
-  }
-  if (node is EnumDeclaration) {
-    return node.name;
-  }
-  if (node is ExtensionDeclaration) {
-    return node.name;
-  }
-  if (node is FunctionDeclaration) {
-    return node.name;
-  }
-  if (node is TopLevelVariableDeclaration) {
-    return node.variables;
-  }
-  if (node is EnumConstantDeclaration) {
-    return node.name;
-  }
-  if (node is TypeParameter) {
-    return node.name;
-  }
-  if (node is VariableDeclaration) {
-    return node.name;
-  }
-  return null;
 }
 
 /// If the [node] is the target of a [CompoundAssignmentExpression],

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -61,8 +61,6 @@ setters inherit the docs from the getters.
 
 ''';
 
-// TODO(devoncarew): This lint is very slow - we should profile and optimize it.
-
 // TODO(devoncarew): Longer term, this lint could benefit from being more aware
 // of the actual API surface area of a package - including that defined by
 // exports - and linting against that.

--- a/test/integration/public_member_api_docs.dart
+++ b/test/integration/public_member_api_docs.dart
@@ -4,56 +4,61 @@
 
 import 'dart:io';
 
+import 'package:analyzer/src/lint/io.dart';
+import 'package:linter/src/cli.dart' as cli;
 import 'package:test/test.dart';
 
+import '../mocks.dart';
 import '../test_constants.dart';
 
 void main() {
   group('public_member_api_docs', () {
+    var currentOut = outSink;
+    var collectingOut = CollectingSink();
+    setUp(() {
+      exitCode = 0;
+      outSink = collectingOut;
+    });
+    tearDown(() {
+      collectingOut.buffer.clear();
+      outSink = currentOut;
+      exitCode = 0;
+    });
     test('lint lib/ sources and non-lib/ sources', () async {
-      var pubResult = Process.runSync(
-          'dart',
-          [
-            'pub',
-            'get',
-          ],
-          workingDirectory: '$integrationTestDir/public_member_api_docs');
-      expect(pubResult.exitCode, 0);
-
-      var result = Process.runSync(
-        'dart',
-        ['analyze', '$integrationTestDir/public_member_api_docs'],
-      );
+      await cli.run([
+        '$integrationTestDir/public_member_api_docs',
+        '--rules=public_member_api_docs'
+      ]);
       expect(
-          result.stdout.trim(),
+          collectingOut.trim(),
           stringContainsInOrder([
-            'a.dart:7:1',
-            'a.dart:9:11',
-            'a.dart:10:9',
-            'a.dart:14:16',
-            'a.dart:22:11',
-            'a.dart:26:16',
-            'a.dart:29:3',
-            'a.dart:30:5',
-            'a.dart:32:8',
-            'a.dart:34:8',
-            'a.dart:42:3',
-            'a.dart:44:3',
-            'a.dart:52:9',
-            'a.dart:60:14',
-            'a.dart:66:6',
-            'a.dart:68:3',
-            'a.dart:87:1',
-            'a.dart:92:5',
-            'a.dart:96:6',
-            'a.dart:111:1',
-            'a.dart:112:11',
-            'a.dart:119:14',
-            'a.dart:132:1',
-            'a.dart:134:7',
-            'a.dart:135:1',
+            'a.dart 7:7 [lint]',
+            'a.dart 9:11 [lint]',
+            'a.dart 10:9 [lint]',
+            'a.dart 14:16 [lint]',
+            'a.dart 22:11 [lint]',
+            'a.dart 26:16 [lint]',
+            'a.dart 29:3 [lint]',
+            'a.dart 30:5 [lint]',
+            'a.dart 32:8 [lint]',
+            'a.dart 34:8 [lint]',
+            'a.dart 42:3 [lint]',
+            'a.dart 44:3 [lint]',
+            'a.dart 52:9 [lint]',
+            'a.dart 60:14 [lint]',
+            'a.dart 66:6 [lint]',
+            'a.dart 68:3 [lint]',
+            'a.dart 87:1 [lint]',
+            'a.dart 92:5 [lint]',
+            'a.dart 96:6 [lint]',
+            'a.dart 111:11 [lint]',
+            'a.dart 112:11 [lint]',
+            'a.dart 119:14 [lint]',
+            'a.dart 132:9 [lint]',
+            'a.dart 134:7 [lint]',
+            'a.dart 135:9 [lint]',
           ]));
-      expect(result.exitCode, 0);
+      expect(exitCode, 1);
     });
   });
 }


### PR DESCRIPTION
Fixes #3987 and fixes #4116.

I went to fix #3987 but could not see any change in the results for `test/integration/public_member_api_docs.dart`. It turns out this test does not make any assertions on the code you're writing. It makes assertions on whatever `dart` binary exists in your `PATH`. So I filed #4116, and fix it here.

* Simplify `getNodeToAnnotate` and `_getNodeToAnnotate` by combining them into one method. It was split for nullability purposes, but that logic can be made more local in the ConstructorDeclaration and ExtensionDeclaration cases.
* Add MixinDeclaration case to `getNodeToAnnotate`.
* Sort the cases in `getNodeToAnnotate`.
* Re-implement `test/integration/public_member_api_docs.dart` with the `cli.dart` features that the other integration tests use.
  * Normally this would obfuscate the changed test expectations required for the fix to #3987, but GitHub's diff actually highlights nicely the few lines whose content really changes.
* Remove an outdated comment about performance. A [recent benchmark](https://github.com/dart-lang/linter/actions/runs/4355704004/jobs/7612683974) shows this rule to be one of the fastest.