### PR TITLE
🔦 optionally dump ASTs on reflective test failures

### DIFF
--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/file_system/file_system.dart';

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:analyzer/file_system/file_system.dart';
@@ -10,6 +11,7 @@ import 'package:analyzer/src/dart/analysis/byte_store.dart';
 import 'package:analyzer/src/dart/analysis/driver_based_analysis_context.dart';
 import 'package:analyzer/src/dart/analysis/experiments.dart';
 import 'package:analyzer/src/lint/registry.dart';
+import 'package:analyzer/src/lint/util.dart';
 import 'package:analyzer/src/test_utilities/mock_packages.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:analyzer/src/test_utilities/package_config_file_builder.dart';
@@ -18,6 +20,8 @@ import 'package:linter/src/analyzer.dart';
 import 'package:linter/src/rules.dart';
 import 'package:meta/meta.dart';
 import 'package:test/test.dart';
+
+import 'mocks.dart';
 
 export 'package:analyzer/src/dart/analysis/experiments.dart';
 export 'package:analyzer/src/dart/error/syntactic_errors.dart';
@@ -113,6 +117,8 @@ class ExpectedLint extends ExpectedDiagnostic {
 }
 
 abstract class LintRuleTest extends PubPackageResolutionTest {
+  bool get dumpAstOnFailures => false;
+
   String? get lintRule;
 
   @override
@@ -203,6 +209,17 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
       }
     }
     if (buffer.isNotEmpty) {
+      if (dumpAstOnFailures) {
+        buffer.writeln();
+        buffer.writeln();
+        var astSink = CollectingSink();
+        StringSpelunker(result.unit.toSource(),
+                sink: astSink, featureSet: result.unit.featureSet)
+            .spelunk();
+        buffer.write(astSink.buffer);
+        buffer.writeln();
+      }
+
       errors.sort((first, second) => first.offset.compareTo(second.offset));
       buffer.writeln();
       buffer.writeln('To accept the current state, expect:');


### PR DESCRIPTION
Helpful especially for folks stumbling around in the dark supporting new language features with unfamiliar ASTs. 🔦 

Sample output:

```
package:test_api                               fail
test/rule_test_support.dart 252:7              LintRuleTest.assertDiagnosticsIn
test/rule_test_support.dart 143:11             LintRuleTest.assertDiagnostics
===== asynchronous gap ===========================
test/rules/prefer_final_locals_test.dart 42:5  PreferFinalLocalsPatternsTest.test_destructured_recordPattern_list

Expected but did not find:
  prefer_final_locals [13, 1]
  prefer_final_locals [16, 1]


CompilationUnitImpl [f() {var [a, b] = ['a', 'b']; print('$a$b');}] 
  FunctionDeclarationImpl [f() {var [a, b] = ['a', 'b']; print('$a$b');}] 
    FunctionExpressionImpl [() {var [a, b] = ['a', 'b']; print('$a$b');}] 
      FormalParameterListImpl [()] 
      BlockFunctionBodyImpl [{var [a, b] = ['a', 'b']; print('$a$b');}] 
        BlockImpl [{var [a, b] = ['a', 'b']; print('$a$b');}] 
          PatternVariableDeclarationStatementImpl [var [a, b] = ['a', 'b'];] 
            PatternVariableDeclarationImpl [var [a, b] = ['a', 'b']] 
              ListPatternImpl [[a, b]] 
                DeclaredVariablePatternImpl [a] 
                DeclaredVariablePatternImpl [b] 
              ListLiteralImpl [['a', 'b']] 
                SimpleStringLiteralImpl ['a'] 
                SimpleStringLiteralImpl ['b'] 
          ExpressionStatementImpl [print('$a$b');] 
            MethodInvocationImpl [print('$a$b')] 
              SimpleIdentifierImpl [print] 
              ArgumentListImpl [('$a$b')] 
                StringInterpolationImpl ['$a$b'] 
                  InterpolationStringImpl ['] 
                  InterpolationExpressionImpl [$a] 
                    SimpleIdentifierImpl [a] 
                  InterpolationStringImpl [] 
                  InterpolationExpressionImpl [$b] 
                    SimpleIdentifierImpl [b] 
                  InterpolationStringImpl ['] 


To accept the current state, expect:

```


@bwilkerson 