### PR TITLE
Do not trigger use_build_context_synchronously on context.mounted

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -314,7 +314,9 @@ class _Visitor extends SimpleAstVisitor {
   visitPrefixedIdentifier(PrefixedIdentifier node) {
     // Getter access.
     if (isBuildContext(node.prefix.staticType, skipNullable: true)) {
-      check(node);
+      if (node.identifier.name != 'mounted') {
+        check(node);
+      }
     }
   }
 }

--- a/test_data/rules/use_build_context_synchronously.dart
+++ b/test_data/rules/use_build_context_synchronously.dart
@@ -295,6 +295,12 @@ class _MyState extends State<MyWidget> {
     Navigator.of(context).pushNamed('routeName'); // OK
   }
 
+  void methodWithBuildContextParameter4(BuildContext context) async {
+    await Future<void>.delayed(Duration());
+    if (!context.mounted) return;
+    await Navigator.of(context).pushNamed('routeName'); // OK
+  }
+
   void methodWithMountedFieldCheck(
       BuildContext context, WidgetStateContext stateContext) async {
     await Future<void>.delayed(Duration());


### PR DESCRIPTION
# Description

Do not trigger use_build_context_synchronously on `context.mounted`.

Fixes #4007 partially.

## Fixed

```dart
class AsyncContextTestWidget extends StatelessWidget {
  const AsyncContextTestWidget({super.key});

  @override
  Widget build(BuildContext context) {
    return ElevatedButton(
      onPressed: () async {
        await Future<void>.delayed(Duration.zero);

        // This line is marked as using context across async gaps
        if (!context.mounted) {
          return;
        }
      },
      child: const Text('Test'),
    );
  }
}
```

## Not fixed

```dart
// This line triggers a warning too
final isMounted = context.mounted;

if (!isMounted) {
  return;
}
```
