### PR TITLE
update tests w/ 3.0-compatible mixins

### DIFF
--- a/test_data/rules/library_private_types_in_public_api.dart
+++ b/test_data/rules/library_private_types_in_public_api.dart
@@ -46,7 +46,7 @@ class Public1 {}
 
 class Public2 extends Public4<_Private1> {}
 
-class Public3 extends Object with _Private2<int> {}
+class Public3 extends Object with _PrivateMixin<int> {}
 
 class Public4<T> implements _Private2<T> {}
 
@@ -57,6 +57,8 @@ class _Private1 {
 }
 
 class _Private2<E> {}
+
+mixin _PrivateMixin<E> {}
 
 // Mixins
 

--- a/test_data/rules/overridden_fields.dart
+++ b/test_data/rules/overridden_fields.dart
@@ -10,6 +10,10 @@ class Base {
   Object something = 'change';
 }
 
+mixin BaseMixin {
+  Object something = 'change';
+}
+
 class Bad1 extends Base {
   final x = 1, field = 'ipsum'; // LINT
 }
@@ -19,7 +23,7 @@ class Bad2 extends Base {
   Object something = 'done'; // LINT
 }
 
-class Bad3 extends Object with Base {
+class Bad3 extends Object with BaseMixin {
   @override
   Object something = 'done'; // LINT
 }
@@ -115,13 +119,17 @@ abstract class BB {
   abstract String s;
 }
 
+mixin AbstractMixin {
+  abstract String s;
+}
+
 class AA extends BB {
   /// Overriding abstracts in NNBD is OK.
   @override
   String s = ''; // OK
 }
 
-class AAA with BB {
+class AAA with AbstractMixin {
   @override
   String s = ''; // OK
 }

--- a/test_data/rules/prefer_const_constructors_in_immutables.dart
+++ b/test_data/rules/prefer_const_constructors_in_immutables.dart
@@ -41,7 +41,7 @@ class D {
   D.c4(a) : _a = '${a ? a : ''}'; // LINT
 }
 
-class Mixin1 {}
+mixin Mixin1 {}
 
 class E extends A with Mixin1 {
   // no lint because const leads to error : Const constructor can't be declared for a class with a mixin.

--- a/test_data/rules/slash_for_doc_comments.dart
+++ b/test_data/rules/slash_for_doc_comments.dart
@@ -49,7 +49,7 @@ class C {}
 var D = String;
 
 /** Z */ //LINT
-class Z = B with C;
+class Z = B with M1;
 
 /** M1 */ //LINT
 mixin M1 {}


### PR DESCRIPTION
Running w/ 3.0 experiments enabled, these tests all fail.

I think they can all be migrated to `mixin` declarations and not lose any coverage.

9 tests remain that I think need coverage in both 3.0 and pre-3.0 worlds so I'll work on breaking out some reflective tests for those.

/cc @scheglov 
