### PR TITLE
mixin test data migrations for 3.0

### DIFF
--- a/test_data/rules/avoid_implementing_value_types.dart
+++ b/test_data/rules/avoid_implementing_value_types.dart
@@ -34,7 +34,7 @@ class EmptyFileSize2 implements SizeWithKilobytes { // LINT
   double get inKilobytes => 0.0;
 }
 
-abstract class SizeClassMixin { // OK
+mixin SizeClassMixin { // OK
   int get inBytes => 0;
 
   @override

--- a/test_data/rules/prefer_asserts_in_initializer_lists.dart
+++ b/test_data/rules/prefer_asserts_in_initializer_lists.dart
@@ -86,7 +86,7 @@ class C extends B {
 }
 
 // no lint for mixin attributes
-class Mixin {
+mixin Mixin {
   var a;
 }
 


### PR DESCRIPTION
Follow-up from https://github.com/dart-lang/linter/pull/4136.

A few I missed.

The rest I'll migrate to reflective tests.

/cc @scheglov 
