### PR TITLE
update `unrelated_type_equality_checks` w/ 3.0-safe mixin

### DIFF
--- a/test_data/rules/unrelated_type_equality_checks.dart
+++ b/test_data/rules/unrelated_type_equality_checks.dart
@@ -182,7 +182,7 @@ class ClassBase {}
 
 class DerivedClass1 extends ClassBase {}
 
-abstract class Mixin {}
+mixin Mixin {}
 
 class DerivedClass2 extends ClassBase with Mixin {}
 


### PR DESCRIPTION
Another simple one.

/cc @scheglov 