### PR TITLE
switch pattern support for `no_adjacent_strings_in_list`

### DIFF
--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -102,11 +102,10 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitSwitchPatternCase(SwitchPatternCase node) {
     var pattern = node.guardedPattern.pattern.unParenthesized;
-    if (pattern is ListPattern) {
-      for (var element in pattern.elements) {
-        if (element is ConstantPattern) {
-          check(element.expression.unParenthesized);
-        }
+    if (pattern is! ListPattern) return;
+    for (var element in pattern.elements) {
+      if (element is ConstantPattern) {
+        check(element.expression.unParenthesized);
       }
     }
   }

--- a/lib/src/rules/no_adjacent_strings_in_list.dart
+++ b/lib/src/rules/no_adjacent_strings_in_list.dart
@@ -57,6 +57,7 @@ class NoAdjacentStringsInList extends LintRule {
     registry.addIfElement(this, visitor);
     registry.addListLiteral(this, visitor);
     registry.addSetOrMapLiteral(this, visitor);
+    registry.addSwitchPatternCase(this, visitor);
   }
 }
 
@@ -65,10 +66,16 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   _Visitor(this.rule);
 
+  void check(AstNode? element) {
+    if (element is AdjacentStrings) {
+      rule.reportLint(element);
+    }
+  }
+
   @override
   void visitForElement(ForElement node) {
     if (node.body is AdjacentStrings) {
-      rule.reportLint(node.body);
+      check(node.body);
     }
   }
 
@@ -76,26 +83,30 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitIfElement(IfElement node) {
     if (node.elseElement == null && node.thenElement is AdjacentStrings) {
       rule.reportLint(node.thenElement);
-    } else if (node.elseElement is AdjacentStrings) {
-      rule.reportLint(node.elseElement);
+    } else {
+      check(node.elseElement);
     }
   }
 
   @override
   void visitListLiteral(ListLiteral node) {
-    for (var e in node.elements) {
-      if (e is AdjacentStrings) {
-        rule.reportLint(e);
-      }
-    }
+    node.elements.forEach(check);
   }
 
   @override
   void visitSetOrMapLiteral(SetOrMapLiteral node) {
     if (node.isMap) return;
-    for (var e in node.elements) {
-      if (e is AdjacentStrings) {
-        rule.reportLint(e);
+    node.elements.forEach(check);
+  }
+
+  @override
+  void visitSwitchPatternCase(SwitchPatternCase node) {
+    var pattern = node.guardedPattern.pattern.unParenthesized;
+    if (pattern is ListPattern) {
+      for (var element in pattern.elements) {
+        if (element is ConstantPattern) {
+          check(element.expression.unParenthesized);
+        }
       }
     }
   }

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -55,6 +55,7 @@ import 'literal_only_boolean_expressions_test.dart'
 import 'missing_whitespace_between_adjacent_strings_test.dart'
     as missing_whitespace_between_adjacent_strings;
 import 'no_duplicate_case_values_test.dart' as no_duplicate_case_values;
+import 'non_adjacent_strings_in_list_test.dart' as no_adjacent_strings_in_list;
 import 'non_constant_identifier_names_test.dart'
     as non_constant_identifier_names;
 import 'null_closures_test.dart' as null_closures;
@@ -149,6 +150,7 @@ void main() {
   library_private_types_in_public_api.main();
   literal_only_boolean_expressions.main();
   missing_whitespace_between_adjacent_strings.main();
+  no_adjacent_strings_in_list.main();
   no_duplicate_case_values.main();
   non_constant_identifier_names.main();
   null_closures.main();

--- a/test/rules/non_adjacent_strings_in_list_test.dart
+++ b/test/rules/non_adjacent_strings_in_list_test.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(NonAdjacentStringsInListTestLanguage300);
+  });
+}
+
+@reflectiveTest
+class NonAdjacentStringsInListTestLanguage300 extends LintRuleTest
+    with LanguageVersion300Mixin {
+  @override
+  bool get dumpAstOnFailures => true;
+
+  @override
+  String get lintRule => 'no_adjacent_strings_in_list';
+
+  test_switchPattern() async {
+    await assertDiagnostics(r'''
+void f() {
+  List<String?> row = [];
+  switch (row) {
+    case ['one' 'two', var name!]: print(name);
+  }
+}  
+''', [
+      lint(64, 11),
+    ]);
+  }
+}


### PR DESCRIPTION
Fixes #4119

/cc @srawlins @bwilkerson 