### PR TITLE
add relational pattern support to `unrelated_type_equality_checks`

### DIFF
--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -104,6 +104,8 @@ import 'unnecessary_overrides_test.dart' as unnecessary_overrides;
 import 'unnecessary_parenthesis_test.dart' as unnecessary_parenthesis;
 import 'unnecessary_string_escapes_test.dart' as unnecessary_string_escapes;
 import 'unreachable_from_main_test.dart' as unreachable_from_main;
+import 'unrelated_type_equality_checks_test.dart'
+    as unrelated_type_equality_checks;
 import 'use_build_context_synchronously_test.dart'
     as use_build_context_synchronously;
 import 'use_enums_test.dart' as use_enums;
@@ -191,6 +193,7 @@ void main() {
   unnecessary_parenthesis.main();
   unnecessary_string_escapes.main();
   unreachable_from_main.main();
+  unrelated_type_equality_checks.main();
   use_build_context_synchronously.main();
   use_enums.main();
   use_is_even_rather_than_modulo.main();

--- a/test/rules/unrelated_type_equality_checks_test.dart
+++ b/test/rules/unrelated_type_equality_checks_test.dart
@@ -50,6 +50,21 @@ String f(String char) {
     ]);
   }
 
+  test_switchExpression_notEq() async {
+    await assertDiagnostics(r'''    
+const space = 32;
+
+String f(int char) {
+  return switch (char) {
+    != 'space' => 'space',
+  };
+}
+''', [
+      error(CompileTimeErrorCode.NON_EXHAUSTIVE_SWITCH, 49, 6),
+      lint(69, 10),
+    ]);
+  }
+
   test_switchExpression_ok() async {
     await assertDiagnostics(r'''
 String f(String char) {

--- a/test/rules/unrelated_type_equality_checks_test.dart
+++ b/test/rules/unrelated_type_equality_checks_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(UnrelatedTypeEqualityChecksTestLanguage300);
+  });
+}
+
+@reflectiveTest
+class UnrelatedTypeEqualityChecksTestLanguage300 extends LintRuleTest
+    with LanguageVersion300Mixin {
+  @override
+  bool get dumpAstOnFailures => true;
+
+  @override
+  String get lintRule => 'unrelated_type_equality_checks';
+
+  test_switchExpression() async {
+    await assertDiagnostics(r'''    
+const space = 32;
+
+String f(int char) {
+  return switch (char) {
+    == 'space' => 'space',
+  };
+}
+''', [
+      error(CompileTimeErrorCode.NON_EXHAUSTIVE_SWITCH, 49, 6),
+      lint(69, 10),
+    ]);
+  }
+
+  test_switchExpression_lessEq_ok() async {
+    await assertDiagnostics(r'''
+String f(String char) {
+  return switch (char) {
+    <= 1 => 'space',
+  };
+}
+''', [
+      // No lint.
+      error(CompileTimeErrorCode.NON_EXHAUSTIVE_SWITCH, 33, 6),
+      error(CompileTimeErrorCode.UNDEFINED_OPERATOR, 53, 2),
+    ]);
+  }
+
+  test_switchExpression_ok() async {
+    await assertDiagnostics(r'''
+String f(String char) {
+  return switch (char) {
+    == 'space' => 'space',
+  };
+}
+''', [
+      // No lint.
+      error(CompileTimeErrorCode.NON_EXHAUSTIVE_SWITCH, 33, 6),
+    ]);
+  }
+}


### PR DESCRIPTION
Fixes #4123

/cc @bwilkerson 