### PR TITLE
null assert pattern support for `null_check_on_nullable_type_parameter`

### DIFF
--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -129,7 +129,7 @@ mixin LanguageVersion300Mixin on PubPackageResolutionTest {
 }
 
 abstract class LintRuleTest extends PubPackageResolutionTest {
-  bool get dumpAstOnFailures => false;
+  bool get dumpAstOnFailures => true;
 
   String? get lintRule;
 

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -58,6 +58,8 @@ import 'no_duplicate_case_values_test.dart' as no_duplicate_case_values;
 import 'non_adjacent_strings_in_list_test.dart' as no_adjacent_strings_in_list;
 import 'non_constant_identifier_names_test.dart'
     as non_constant_identifier_names;
+import 'null_check_on_nullable_type_parameter_test.dart'
+    as null_check_on_nullable_type_parameter;
 import 'null_closures_test.dart' as null_closures;
 import 'omit_local_variable_types_test.dart' as omit_local_variable_types;
 import 'one_member_abstracts_test.dart' as one_member_abstracts;
@@ -155,6 +157,7 @@ void main() {
   no_adjacent_strings_in_list.main();
   no_duplicate_case_values.main();
   non_constant_identifier_names.main();
+  null_check_on_nullable_type_parameter.main();
   null_closures.main();
   omit_local_variable_types.main();
   one_member_abstracts.main();

--- a/test/rules/null_check_on_nullable_type_parameter_test.dart
+++ b/test/rules/null_check_on_nullable_type_parameter_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(NullCheckOnNullableTypeParameterTestLanguage300);
+  });
+}
+
+@reflectiveTest
+class NullCheckOnNullableTypeParameterTestLanguage300 extends LintRuleTest with LanguageVersion300Mixin {
+  @override
+  String get lintRule => 'null_check_on_nullable_type_parameter';
+
+  test_nullAssertPattern() async {
+    await assertDiagnostics(r'''
+void f<T>((T?, T?) p){
+  var (x!, y) = p;
+}
+''', [
+      error(HintCode.UNUSED_LOCAL_VARIABLE, 30, 1),
+      lint(31, 1),
+      error(HintCode.UNUSED_LOCAL_VARIABLE, 34, 1),
+    ]);
+  }
+}

--- a/test/rules/null_check_on_nullable_type_parameter_test.dart
+++ b/test/rules/null_check_on_nullable_type_parameter_test.dart
@@ -13,7 +13,8 @@ main() {
 }
 
 @reflectiveTest
-class NullCheckOnNullableTypeParameterTestLanguage300 extends LintRuleTest with LanguageVersion300Mixin {
+class NullCheckOnNullableTypeParameterTestLanguage300 extends LintRuleTest
+    with LanguageVersion300Mixin {
   @override
   String get lintRule => 'null_check_on_nullable_type_parameter';
 


### PR DESCRIPTION
Fixes #4130

/cc @bwilkerson @srawlins 

/fyi @a14n 