### PR TITLE
Add new rule: deprecated_member_use_from_same_package

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -63,6 +63,7 @@ linter:
     - dangling_library_doc_comments
     - depend_on_referenced_packages
     - deprecated_consistency
+    - deprecated_member_use_from_same_package
     - diagnostic_describe_all_properties
     - directives_ordering
     - discarded_futures

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -68,6 +68,7 @@ import 'rules/curly_braces_in_flow_control_structures.dart';
 import 'rules/dangling_library_doc_comments.dart';
 import 'rules/depend_on_referenced_packages.dart';
 import 'rules/deprecated_consistency.dart';
+import 'rules/deprecated_member_use_from_same_package.dart';
 import 'rules/diagnostic_describe_all_properties.dart';
 import 'rules/directives_ordering.dart';
 import 'rules/discarded_futures.dart';
@@ -293,6 +294,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(DanglingLibraryDocComments())
     ..register(DependOnReferencedPackages())
     ..register(DeprecatedConsistency())
+    ..register(DeprecatedMemberUseFromSamePackage())
     ..register(DiagnosticsDescribeAllProperties())
     ..register(DirectivesOrdering())
     ..register(DiscardedFutures())

--- a/lib/src/rules/deprecated_member_use_from_same_package.dart
+++ b/lib/src/rules/deprecated_member_use_from_same_package.dart
@@ -1,0 +1,458 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/error/deprecated_member_use_verifier.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/workspace/workspace.dart';
+
+import '../analyzer.dart';
+
+const _desc =
+    'Avoid using deprecated elements from within the package in which they are '
+    'declared.';
+
+const _details = r'''
+Elements which are annotated with `@deprecated` should not be referenced from
+within the package in which they are declared.
+
+**AVOID** using deprecated elements.
+
+...
+
+**BAD:**
+```dart
+// Declared in one library:
+class Foo {
+  @Deprecated("Use 'm2' instead")
+  void m1() {}
+
+  void m2({
+      @Deprecated('This is an old parameter') int? p,
+  })
+}
+
+@Deprecated('Do not use')
+int x = 0;
+
+// In the same or another library, but within the same package:
+void m(Foo foo) {
+  foo.m1();
+  foo.m2(p: 7);
+  x = 1;
+}
+```
+
+Deprecated elements can be used from within _other_ deprecated elements, in
+order to allow for the deprecation of a collection of APIs together as one unit.
+
+**GOOD:**
+```dart
+// Declared in one library:
+class Foo {
+  @Deprecated("Use 'm2' instead")
+  void m1() {}
+
+  void m2({
+      @Deprecated('This is an old parameter') int? p,
+  })
+}
+
+@Deprecated('Do not use')
+int x = 0;
+
+// In the same or another library, but within the same package:
+@Deprecated('Do not use')
+void m(Foo foo) {
+  foo.m1();
+  foo.m2(p: 7);
+  x = 1;
+}
+```
+''';
+
+class DeprecatedMemberUseFromSamePackage extends LintRule {
+  static const LintCode code = LintCode(
+    'deprecated_member_use_from_same_package',
+    "'{0}' is deprecated and shouldn't be used.",
+    correctionMessage:
+        'Try replacing the use of the deprecated member with the replacement, '
+        'if a replacement is specified.',
+  );
+
+  static const LintCode codeWithMessage = LintCode(
+    'deprecated_member_use_from_same_package',
+    "'{0}' is deprecated and shouldn't be used. {1}",
+    correctionMessage:
+        'Try replacing the use of the deprecated member with the replacement, '
+        'if a replacement is specified.',
+    uniqueName: 'LintCode.deprecated_member_use_from_same_package_with_message',
+  );
+
+  DeprecatedMemberUseFromSamePackage()
+      : super(
+            name: 'deprecated_member_use_from_same_package',
+            description: _desc,
+            details: _details,
+            group: Group.errors);
+
+  @override
+  List<LintCode> get lintCodes => [code, codeWithMessage];
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this, context);
+    registry.addCompilationUnit(this, visitor);
+  }
+}
+
+class _DeprecatedMemberUseVerifier extends BaseDeprecatedMemberUseVerifier {
+  final LintRule _rule;
+  final WorkspacePackage _workspacePackage;
+
+  _DeprecatedMemberUseVerifier(this._rule, this._workspacePackage);
+
+  @override
+  void reportError(
+      AstNode errorNode, Element element, String displayName, String? message) {
+    var library = element is LibraryElement ? element : element.library;
+    if (library == null || !_workspacePackage.contains(library.source)) {
+      // In this case, `DEPRECATED_MEMBER_USE` is reported by the analyzer.
+      return;
+    }
+
+    var normalizedMessage = message?.trim();
+    if (normalizedMessage == null ||
+        normalizedMessage.isEmpty ||
+        normalizedMessage == '.') {
+      _rule.reportLint(
+        errorNode,
+        arguments: [displayName],
+        errorCode: DeprecatedMemberUseFromSamePackage.code,
+      );
+    } else {
+      if (!normalizedMessage.endsWith('.') &&
+          !normalizedMessage.endsWith('?') &&
+          !normalizedMessage.endsWith('!')) {
+        normalizedMessage = '$message.';
+      }
+      _rule.reportLint(
+        errorNode,
+        arguments: [displayName, normalizedMessage],
+        errorCode: DeprecatedMemberUseFromSamePackage.codeWithMessage,
+      );
+    }
+  }
+}
+
+/// This visitor uses a [DeprecatedMemberUseVerifier] to both report uses of
+/// deprecated elements, and to track the deprecated-ness of ancestor
+/// declaration nodes.
+class _RecursiveVisitor extends RecursiveAstVisitor<void> {
+  final _DeprecatedMemberUseVerifier _deprecatedVerifier;
+
+  _RecursiveVisitor(LintRule rule, WorkspacePackage package)
+      : _deprecatedVerifier = _DeprecatedMemberUseVerifier(rule, package);
+
+  @override
+  void visitAssignmentExpression(AssignmentExpression node) {
+    _deprecatedVerifier.assignmentExpression(node);
+    super.visitAssignmentExpression(node);
+  }
+
+  @override
+  void visitBinaryExpression(BinaryExpression node) {
+    _deprecatedVerifier.binaryExpression(node);
+    super.visitBinaryExpression(node);
+  }
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitClassDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitClassTypeAlias(ClassTypeAlias node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitClassTypeAlias(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    var library = node.declaredElement?.library;
+    if (library == null) {
+      return;
+    }
+    _deprecatedVerifier.pushInDeprecatedValue(library.hasDeprecated);
+
+    super.visitCompilationUnit(node);
+  }
+
+  @override
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitConstructorDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitConstructorName(ConstructorName node) {
+    _deprecatedVerifier.constructorName(node);
+    super.visitConstructorName(node);
+  }
+
+  @override
+  void visitDefaultFormalParameter(DefaultFormalParameter node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitDefaultFormalParameter(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitEnumDeclaration(EnumDeclaration node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitEnumDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitExportDirective(ExportDirective node) {
+    _deprecatedVerifier.exportDirective(node);
+    super.visitExportDirective(node);
+  }
+
+  @override
+  void visitExtensionDeclaration(ExtensionDeclaration node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitExtensionDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitFieldDeclaration(FieldDeclaration node) {
+    _deprecatedVerifier.pushInDeprecatedMetadata(node.metadata);
+
+    try {
+      super.visitFieldDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitFieldFormalParameter(FieldFormalParameter node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitFieldFormalParameter(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitFunctionDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    _deprecatedVerifier.functionExpressionInvocation(node);
+    super.visitFunctionExpressionInvocation(node);
+  }
+
+  @override
+  void visitFunctionTypeAlias(FunctionTypeAlias node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitFunctionTypeAlias(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitGenericTypeAlias(GenericTypeAlias node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitGenericTypeAlias(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitImportDirective(ImportDirective node) {
+    _deprecatedVerifier.importDirective(node);
+    super.visitImportDirective(node);
+  }
+
+  @override
+  void visitIndexExpression(IndexExpression node) {
+    _deprecatedVerifier.indexExpression(node);
+    super.visitIndexExpression(node);
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    _deprecatedVerifier.instanceCreationExpression(node);
+    super.visitInstanceCreationExpression(node);
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitMethodDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    _deprecatedVerifier.methodInvocation(node);
+    super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitMixinDeclaration(MixinDeclaration node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitMixinDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitPostfixExpression(PostfixExpression node) {
+    _deprecatedVerifier.postfixExpression(node);
+    super.visitPostfixExpression(node);
+  }
+
+  @override
+  void visitPrefixExpression(PrefixExpression node) {
+    _deprecatedVerifier.prefixExpression(node);
+    super.visitPrefixExpression(node);
+  }
+
+  @override
+  void visitRedirectingConstructorInvocation(
+      RedirectingConstructorInvocation node) {
+    _deprecatedVerifier.redirectingConstructorInvocation(node);
+    super.visitRedirectingConstructorInvocation(node);
+  }
+
+  @override
+  void visitSimpleFormalParameter(SimpleFormalParameter node) {
+    _deprecatedVerifier
+        .pushInDeprecatedValue(node.declaredElement?.hasDeprecated ?? false);
+
+    try {
+      super.visitSimpleFormalParameter(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    _deprecatedVerifier.simpleIdentifier(node);
+    super.visitSimpleIdentifier(node);
+  }
+
+  @override
+  void visitSuperConstructorInvocation(SuperConstructorInvocation node) {
+    _deprecatedVerifier.superConstructorInvocation(node);
+    super.visitSuperConstructorInvocation(node);
+  }
+
+  @override
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+    _deprecatedVerifier.pushInDeprecatedMetadata(node.metadata);
+
+    try {
+      super.visitTopLevelVariableDeclaration(node);
+    } finally {
+      _deprecatedVerifier.popInDeprecated();
+    }
+  }
+}
+
+/// This [SimpleAstVisitor] visits the [CompilationUnit], and forwards the
+/// remainder of visitations to [_RecursiveVisitor], which keeps track of
+/// the deprecated-ness of ancestor declaration nodes.
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule _rule;
+  final LinterContext _context;
+
+  _Visitor(this._rule, this._context);
+
+  @override
+  void visitCompilationUnit(CompilationUnit node) {
+    var package = _context.package;
+    if (package == null) {
+      // If we don't appear to be in any known package structure, then we can
+      // never report that a deprecated use is from the same package as the
+      // declaration.
+      return;
+    }
+    var visitor = _RecursiveVisitor(_rule, package);
+    node.accept(visitor);
+  }
+}

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -38,6 +38,8 @@ import 'constant_identifier_names_test.dart' as constant_identifier_names;
 import 'dangling_library_doc_comments_test.dart'
     as dangling_library_doc_comments;
 import 'deprecated_consistency_test.dart' as deprecated_consistency;
+import 'deprecated_member_use_from_same_package_test.dart'
+    as deprecated_member_use_from_same_package;
 import 'directives_ordering_test.dart' as directives_ordering;
 import 'discarded_futures_test.dart' as discarded_futures;
 import 'eol_at_end_of_file_test.dart' as eol_at_end_of_file;
@@ -146,6 +148,7 @@ void main() {
   constant_identifier_names.main();
   dangling_library_doc_comments.main();
   deprecated_consistency.main();
+  deprecated_member_use_from_same_package.main();
   directives_ordering.main();
   discarded_futures.main();
   eol_at_end_of_file.main();

--- a/test/rules/deprecated_member_use_from_same_package_test.dart
+++ b/test/rules/deprecated_member_use_from_same_package_test.dart
@@ -1,0 +1,786 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(DeprecatedMemberUseFromSamePackageTest);
+  });
+}
+
+@reflectiveTest
+class DeprecatedMemberUseFromSamePackageTest extends LintRuleTest {
+  @override
+  String get lintRule => 'deprecated_member_use_from_same_package';
+
+  @override
+  Future<void> assertDiagnostics(
+      String code, List<ExpectedDiagnostic> expectedDiagnostics) async {
+    addTestFile(code);
+    await resolveTestFile();
+    var filteredErrors = errors
+        .whereNot((e) =>
+            e.errorCode == HintCode.DEPRECATED_MEMBER_USE_FROM_SAME_PACKAGE ||
+            e.errorCode ==
+                HintCode.DEPRECATED_MEMBER_USE_FROM_SAME_PACKAGE_WITH_MESSAGE)
+        .toList();
+    await assertDiagnosticsIn(filteredErrors, expectedDiagnostics);
+  }
+
+  test_deprecatedCallMethod() async {
+    await assertDiagnostics(r'''
+class C {
+  @deprecated
+  void call() {}
+}
+
+void f(C c) => c();
+''', [
+      lint(59, 3),
+    ]);
+  }
+
+  test_deprecatedClass() async {
+    await assertDiagnostics(r'''
+@deprecated
+class C {}
+
+void f(C c) {}
+''', [
+      lint(31, 1),
+    ]);
+  }
+
+  test_deprecatedClass_usedInClassTypeAlias() async {
+    await assertDiagnostics(r'''
+@deprecated
+class C {}
+
+class D = Object with C;
+''', [
+      lint(46, 1),
+    ]);
+  }
+
+  test_deprecatedClass_usedInDeprecatedClassTypeAlias() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+@deprecated
+class D = Object with C;
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedDefaultParameter() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+void f({@deprecated C? c = null}) {}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedEnum() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+@deprecated
+enum E {
+  one, two;
+
+  void f(C c) {}
+}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedExtension() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+@deprecated
+extension E on C {}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedField_initializer() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+class D {
+  @deprecated
+  Object f = C;
+}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedField_typeAnnotation() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+class D {
+  @deprecated
+  C? f;
+}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedFieldFormalParameter() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+class D {
+  Object c;
+  D({@deprecated required C this.c});
+}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedFunctionTypeAlias() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+@deprecated
+typedef void Callback(C c);
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedFunctionTypedParameter() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+void f({@deprecated required void p(C c)}) {}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedLibrary() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+library a;
+
+@deprecated
+class C {}
+
+C? x;
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedMixin() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+@deprecated
+mixin M {
+  C? x;
+}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedSimpleParameter() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+void f({@deprecated C? c}) {}
+''');
+  }
+
+  test_deprecatedClass_usedInDeprecatedTopLevelVariable() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+@deprecated
+C? x;
+''');
+  }
+
+  test_deprecatedClass_usedInFieldFormalParameter() async {
+    await assertDiagnostics(r'''
+@deprecated
+class C {}
+
+class D {
+  Object c;
+  D({required C this.c});
+}
+''', [
+      lint(60, 1),
+    ]);
+  }
+
+  test_deprecatedClass_usedInFunctionTypeAlias() async {
+    await assertDiagnostics(r'''
+@deprecated
+class C {}
+
+typedef void Callback(C c);
+''', [
+      lint(46, 1),
+    ]);
+  }
+
+  test_deprecatedClass_usedInFunctionTypedParameter() async {
+    await assertDiagnostics(r'''
+@deprecated
+class C {}
+
+void f({void p(C c)?}) {}
+''', [
+      lint(39, 1),
+    ]);
+  }
+
+  test_deprecatedClass_usedInGenericFunctionTypeAlias() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+class C {}
+
+@deprecated
+typedef Callback = void Function(C);
+''');
+  }
+
+  test_deprecatedClass_usedInGenericTypeAlias() async {
+    await assertDiagnostics(r'''
+@deprecated
+class C {}
+
+typedef Callback = void Function(C);
+''', [
+      lint(57, 1),
+    ]);
+  }
+
+  test_deprecatedClass_usedInHideCombinator() async {
+    newFile('$testPackageLibPath/lib.dart', r'''
+@deprecated
+class C {}
+''');
+    await assertDiagnostics(r'''
+import 'lib.dart' hide C;
+''', [
+      // No lint.
+      error(HintCode.UNUSED_IMPORT, 7, 10),
+    ]);
+  }
+
+  test_deprecatedClass_usedInShowCombinator() async {
+    newFile('$testPackageLibPath/lib.dart', r'''
+@deprecated
+class C {}
+''');
+    await assertDiagnostics(r'''
+import 'lib.dart' show C;
+''', [
+      error(HintCode.UNUSED_IMPORT, 7, 10),
+      lint(23, 1),
+    ]);
+  }
+
+  test_deprecatedConstructor_usedInSuperConstructorCall() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  A();
+}
+class B extends A {
+  B() : super();
+}
+''', [
+      lint(61, 7),
+    ]);
+  }
+
+  test_deprecatedDefaultParameterOfFunction() async {
+    await assertDiagnostics(r'''
+void f({@deprecated int p = 1}) {}
+
+void g() => f(p: 1);
+''', [
+      lint(50, 1),
+    ]);
+  }
+
+  test_deprecatedEnum() async {
+    await assertDiagnostics(r'''
+@deprecated
+enum E {
+  one, two;
+}
+late E e;
+''', [
+      lint(40, 1),
+    ]);
+  }
+
+  test_deprecatedEnumValue() async {
+    await assertDiagnostics(r'''
+enum E {
+  one, @deprecated two;
+}
+late E e = E.two;
+''', [
+      lint(48, 3),
+    ]);
+  }
+
+  test_deprecatedExtension_usedInExtensionOverride() async {
+    await assertDiagnostics(r'''
+@deprecated
+extension E on int {
+  void f() {}
+}
+
+var x = E(0).f();
+''', [
+      lint(58, 1),
+    ]);
+  }
+
+  test_deprecatedExtension_usedInOverride() async {
+    await assertDiagnostics(r'''
+@deprecated
+extension E on int {
+  int get foo => 1;
+}
+
+var x = E(0).foo;
+''', [
+      lint(64, 1),
+    ]);
+  }
+
+  test_deprecatedField_usedAsGetter() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  int f = 0;
+}
+
+void f(A a) {
+  a.f;
+}
+''', [
+      lint(58, 1),
+    ]);
+  }
+
+  test_deprecatedField_usedAsSetter() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  int f = 0;
+}
+
+void f(A a) {
+  a.f = 1;
+}
+''', [
+      lint(58, 1),
+    ]);
+  }
+
+  test_deprecatedField_usedInDeprecatedClass() async {
+    await assertNoDiagnostics(r'''
+class A {
+  @deprecated
+  int f = 0;
+}
+
+@deprecated
+class B {
+  void f(A a) {
+    a.f;
+    a.f = 1;
+  }
+}
+''');
+  }
+
+  test_deprecatedField_usedInDeprecatedFunction() async {
+    await assertNoDiagnostics(r'''
+class A {
+  @deprecated
+  int f = 0;
+}
+
+@deprecated
+void f(A a) {
+  a.f;
+  a.f = 1;
+}
+''');
+  }
+
+  test_deprecatedField_usedInPostfix() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  int f = 0;
+}
+
+void f(A a) {
+  a.f++;
+}
+''', [
+      lint(56, 3),
+    ]);
+  }
+
+  test_deprecatedField_usedInPrefix() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  int f = 0;
+}
+
+void f(A a) {
+  ++a.f;
+}
+''', [
+      lint(58, 3),
+    ]);
+  }
+
+  test_deprecatedField_usedInSuper() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  int f = 0;
+}
+
+class B extends A {
+  int get g => super.f;
+}
+''', [
+      lint(81, 1),
+    ]);
+  }
+
+  test_deprecatedGetter_usedInAssignment() async {
+    await assertNoDiagnostics(r'''
+@deprecated
+int get x => 1;
+
+set x(int value) {}
+
+void f() {
+  x = 1;
+}
+''');
+  }
+
+  test_deprecatedGetter_usedInCompoundAssignment() async {
+    await assertDiagnostics(r'''
+@deprecated
+int get x => 1;
+
+set x(int value) {}
+
+void f() {
+  x += 1;
+}
+''', [
+      lint(63, 1),
+    ]);
+  }
+
+  test_deprecatedIndexOperator() async {
+    await assertDiagnostics(r'''
+class C {
+  @deprecated
+  int operator[](int p) => 1;
+}
+
+void f(C c) {
+  c[1];
+}
+''', [
+      lint(73, 4),
+    ]);
+  }
+
+  test_deprecatedLibrary_export() async {
+    newFile('$testPackageLibPath/lib.dart', r'''
+@deprecated
+library a;
+''');
+    await assertDiagnostics(r'''
+export 'lib.dart';
+''', [
+      lint(0, 18),
+    ]);
+  }
+
+  test_deprecatedLibrary_import() async {
+    newFile('$testPackageLibPath/lib.dart', r'''
+@deprecated
+library a;
+''');
+    await assertDiagnostics(r'''
+import 'lib.dart';
+''', [
+      lint(0, 18),
+      error(HintCode.UNUSED_IMPORT, 7, 10),
+    ]);
+  }
+
+  test_deprecatedMethod() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  void m() {}
+
+  void m2() {
+    m();
+  }
+}
+''', [
+      lint(57, 1),
+    ]);
+  }
+
+  test_deprecatedMethod_usedInDeprecatedConstructor() async {
+    await assertNoDiagnostics(r'''
+class A {
+  @deprecated
+  void m() {}
+
+  @deprecated
+  A() {
+    m();
+  }
+}
+''');
+  }
+
+  test_deprecatedMethod_usedInDeprecatedSubclassConstructor() async {
+    await assertNoDiagnostics(r'''
+class A {
+  @deprecated
+  void m() {}
+}
+class B extends A {
+  @deprecated
+  B() {
+    m();
+  }
+}
+''');
+  }
+
+  test_deprecatedMethod_withMessage() async {
+    await assertDiagnostics(r'''
+class A {
+  @Deprecated('Message')
+  void m() {}
+
+  void m2() {
+    m();
+  }
+}
+''', [
+      lint(68, 1),
+    ]);
+  }
+
+  test_deprecatedNamedConstructor() async {
+    await assertDiagnostics(r'''
+class C {
+  @deprecated
+  C.named();
+}
+
+var x = C.named();
+''', [
+      lint(48, 7),
+    ]);
+  }
+
+  test_deprecatedNamedConstructor_usedInSuperConstructorCall() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  A.named();
+}
+class B extends A {
+  B() : super.named();
+}
+''', [
+      lint(67, 13),
+    ]);
+  }
+
+  test_deprecatedNamedParameterOfFunction() async {
+    await assertDiagnostics(r'''
+void f({@deprecated int? p}) {}
+
+void g() => f(p: 1);
+''', [
+      lint(47, 1),
+    ]);
+  }
+
+  test_deprecatedNamedParameterOfFunction_usedInDeclaringFunction() async {
+    await assertNoDiagnostics(r'''
+int? f({@deprecated int? p}) => p;
+''');
+  }
+
+  test_deprecatedNamedParameterOfMethod() async {
+    await assertDiagnostics(r'''
+class C {
+  void f({@deprecated int? p}) {}
+
+  void g() => f(p: 1);
+}
+''', [
+      lint(61, 1),
+    ]);
+  }
+
+  test_deprecatedOperator() async {
+    await assertDiagnostics(r'''
+class C {
+  @deprecated
+  C operator+(int other) => C();
+}
+void f(C c) {
+  c + 1;
+}
+''', [
+      lint(75, 5),
+    ]);
+  }
+
+  test_deprecatedOperator_usedInCompoundAssignment() async {
+    await assertDiagnostics(r'''
+class C {
+  @deprecated
+  C operator+(int other) => C();
+}
+void f(C c) {
+  c += 1;
+}
+''', [
+      lint(75, 6),
+    ]);
+  }
+
+  test_deprecatedParameterOfConstructor_usedInDeclaringConstructorBody() async {
+    await assertNoDiagnostics(r'''
+class C {
+  C({@deprecated int? p}) {
+    p;
+  }
+}
+''');
+  }
+
+  test_deprecatedParameterOfConstructor_usedInDeclaringConstructorInitializer() async {
+    await assertNoDiagnostics(r'''
+class C {
+  C({@deprecated int? p}) : assert(p == null || p > 0);
+}
+''');
+  }
+
+  test_deprecatedParameterOfConstructor_usedInRedirectingConstructor() async {
+    await assertDiagnostics(r'''
+class C {
+  C({@deprecated int? p});
+  C.two() : this(p: 0);
+}
+''', [
+      lint(54, 1),
+    ]);
+  }
+
+  test_deprecatedPositionalParameterOfFunction() async {
+    await assertDiagnostics(r'''
+void f([@deprecated int? p]) {}
+
+void g() => f(1);
+''', [
+      lint(47, 1),
+    ]);
+  }
+
+  test_deprecatedSetter() async {
+    await assertDiagnostics(r'''
+@deprecated set f(int value) {}
+
+void g() => f = 1;
+''', [
+      lint(45, 1),
+    ]);
+  }
+
+  test_deprecatedSetter_usedInCompoundAssignment() async {
+    await assertDiagnostics(r'''
+int get x => 1;
+
+@deprecated
+set x(int value) {}
+
+void f() {
+  x += 1;
+}
+''', [
+      lint(63, 1),
+    ]);
+  }
+
+  test_deprecatedStaticField() async {
+    await assertDiagnostics(r'''
+class A {
+  @deprecated
+  static int f = 0;
+}
+
+var a = A.f;
+''', [
+      lint(57, 1),
+    ]);
+  }
+
+  test_deprecatedTopLevelVariable_usedInAssignment() async {
+    await assertDiagnostics(r'''
+@deprecated
+int x = 1;
+
+void f() {
+  x = 1;
+}
+''', [
+      lint(37, 1),
+    ]);
+  }
+
+  test_deprecatedUnnamedConstructor() async {
+    await assertDiagnostics(r'''
+class C {
+  @deprecated
+  C();
+}
+
+var x = C();
+''', [
+      lint(42, 1),
+    ]);
+  }
+}


### PR DESCRIPTION
# Description

Fixes https://github.com/dart-lang/linter/issues/4118

This rule implements (more or less*) the same feature currently implemented in the analyzer `HintCode.DEPRECATED_MEMBER_USE_FROM_SAME_PACKAGE`.

See [this comment on the issue](https://github.com/dart-lang/linter/issues/4118#issuecomment-1460627011) for the steps to roll this to analyzer, which involve simultaneously removing `HintCode.DEPRECATED_MEMBER_USE_FROM_SAME_PACKAGE`.

*: The changes are improvements to the rule, which are similarly proposed and in-progress for `HintCode.DEPRECATED_MEMBER_USE`: https://github.com/dart-lang/sdk/issues/51664.