### PR TITLE
remove redundant getter declarations

### DIFF
--- a/test/rules/non_adjacent_strings_in_list_test.dart
+++ b/test/rules/non_adjacent_strings_in_list_test.dart
@@ -16,9 +16,6 @@ main() {
 class NonAdjacentStringsInListTestLanguage300 extends LintRuleTest
     with LanguageVersion300Mixin {
   @override
-  bool get dumpAstOnFailures => true;
-
-  @override
   String get lintRule => 'no_adjacent_strings_in_list';
 
   test_switchPattern() async {

--- a/test/rules/unrelated_type_equality_checks_test.dart
+++ b/test/rules/unrelated_type_equality_checks_test.dart
@@ -16,9 +16,6 @@ main() {
 class UnrelatedTypeEqualityChecksTestLanguage300 extends LintRuleTest
     with LanguageVersion300Mixin {
   @override
-  bool get dumpAstOnFailures => true;
-
-  @override
   String get lintRule => 'unrelated_type_equality_checks';
 
   test_switchExpression() async {


### PR DESCRIPTION
`dumpAstOnFailures` returns true in the base class so these declarations are needless.

/cc @bwilkerson @srawlins 