### PR TITLE
Disable invalid_case_patterns in Dart 3.0.0

### DIFF
--- a/lib/src/rules/invalid_case_patterns.dart
+++ b/lib/src/rules/invalid_case_patterns.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
@@ -267,6 +268,12 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   visitSwitchCase(SwitchCase node) {
+    var featureSet = node.thisOrAncestorOfType<CompilationUnit>()?.featureSet;
+    if (featureSet != null && featureSet.isEnabled(Feature.patterns)) {
+      // This lint rule is only meant for code which does not have 'patterns'
+      // enabled.
+      return;
+    }
     var expression = node.expression.unParenthesized;
     if (expression is SetOrMapLiteral) {
       if (expression.constKeyword == null) {

--- a/test/rules/invalid_case_patterns_test.dart
+++ b/test/rules/invalid_case_patterns_test.dart
@@ -13,14 +13,11 @@ main() {
 }
 
 @reflectiveTest
-class InvalidCasePatternsTest extends LintRuleTest {
+class InvalidCasePatternsTest extends LintRuleTest
+    with LanguageVersion219Mixin {
   @override
   String get lintRule => 'invalid_case_patterns';
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_binaryExpression_logicalAnd() async {
     await assertDiagnostics(r'''
 f(bool b) {
@@ -33,10 +30,6 @@ f(bool b) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_binaryExpression_plus() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -49,10 +42,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_conditionalExpression() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -66,10 +55,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'lint no longer produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_constConstructorCall() async {
     await assertDiagnostics(r'''
 class C {
@@ -99,10 +84,6 @@ f(C c) {
 ''');
   }
 
-  @FailingTest(
-    reason: 'error produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_identicalCall() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -115,10 +96,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_isExpression() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -132,10 +109,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_isNotExpression() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -149,10 +122,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_lengthCall() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -165,10 +134,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'lint no longer produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_listLiteral() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -191,10 +156,6 @@ void f(Object o) {
 ''');
   }
 
-  @FailingTest(
-    reason: 'lint no longer produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_listLiteral_typeArgs() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -207,10 +168,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'lint no longer produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_mapLiteral() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -233,10 +190,6 @@ void f(Object o) {
 ''');
   }
 
-  @FailingTest(
-    reason: 'lint no longer produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_mapLiteral_parenthesized() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -249,10 +202,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'lint no longer produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_mapLiteral_parenthesized_twice() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -265,10 +214,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'lint no longer is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_mapLiteral_typeArgs() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -301,10 +246,6 @@ void f(Object o) {
 ''');
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_setLiteral() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -327,10 +268,6 @@ void f(Object o) {
 ''');
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_setLiteral_typeArgs() async {
     await assertDiagnostics(r'''
 void f(Object o) {
@@ -343,10 +280,6 @@ void f(Object o) {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_unaryOperator_minus() async {
     await assertDiagnostics(r'''
 void f() {
@@ -360,10 +293,6 @@ void f() {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_unaryOperator_not() async {
     await assertDiagnostics(r'''
   void f() {
@@ -377,10 +306,6 @@ void f() {
     ]);
   }
 
-  @FailingTest(
-    reason: 'error is produced with analyzer 5.8.0',
-    issue: 'https://github.com/dart-lang/linter/issues/4166',
-  )
   test_wildcard() async {
     await assertDiagnostics(r'''
 f(int n) {


### PR DESCRIPTION
Fixes #4166.

The tests just need to run with Dart 2.19. This lint rule is not intended for code which has the 'patterns' feature enabled.