### PR TITLE
when clause support for `literal_only_boolean_expressions`

### DIFF
--- a/lib/src/rules/literal_only_boolean_expressions.dart
+++ b/lib/src/rules/literal_only_boolean_expressions.dart
@@ -131,6 +131,7 @@ class LiteralOnlyBooleanExpressions extends LintRule {
     registry.addDoStatement(this, visitor);
     registry.addForStatement(this, visitor);
     registry.addIfStatement(this, visitor);
+    registry.addWhenClause(this, visitor);
     registry.addWhileStatement(this, visitor);
   }
 }
@@ -160,6 +161,13 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitIfStatement(IfStatement node) {
     if (_onlyLiterals(node.condition)) {
+      rule.reportLint(node);
+    }
+  }
+
+  @override
+  void visitWhenClause(WhenClause node) {
+    if (_onlyLiterals(node.expression)) {
       rule.reportLint(node);
     }
   }

--- a/test/rules/literal_only_boolean_expressions_test.dart
+++ b/test/rules/literal_only_boolean_expressions_test.dart
@@ -8,12 +8,14 @@ import '../rule_test_support.dart';
 
 main() {
   defineReflectiveSuite(() {
-    defineReflectiveTests(LiteralOnlyBooleanExpressionsTest);
+    defineReflectiveTests(LiteralOnlyBooleanExpressionsTestLanguage219);
+    defineReflectiveTests(LiteralOnlyBooleanExpressionsTestLanguage300);
   });
 }
 
 @reflectiveTest
-class LiteralOnlyBooleanExpressionsTest extends LintRuleTest {
+class LiteralOnlyBooleanExpressionsTestLanguage219 extends LintRuleTest
+    with LanguageVersion219Mixin {
   @override
   String get lintRule => 'literal_only_boolean_expressions';
 
@@ -25,5 +27,24 @@ void f() {
   }
 }
 ''');
+  }
+}
+
+@reflectiveTest
+class LiteralOnlyBooleanExpressionsTestLanguage300 extends LintRuleTest
+    with LanguageVersion300Mixin {
+  @override
+  String get lintRule => 'literal_only_boolean_expressions';
+
+  test_whenClause() async {
+    await assertDiagnostics(r'''
+void f() {
+  switch (1) {
+    case [int a] when true: print(a);
+  }
+}
+''', [
+      lint(43, 9),
+    ]);
   }
 }


### PR DESCRIPTION
Fixes #4122

/cc @bwilkerson 