### PR TITLE
Use deps.dev for OpenSSF scorecard results link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ analysis server and the `dart analyze` command in the [Dart command-line tool][d
 [![Coverage Status](https://coveralls.io/repos/dart-lang/linter/badge.svg)](https://coveralls.io/r/dart-lang/linter)
 [![Pub](https://img.shields.io/pub/v/linter.svg)](https://pub.dev/packages/linter)
 [![package publisher](https://img.shields.io/pub/publisher/linter.svg)](https://pub.dev/packages/linter/publisher)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/dart-lang/linter/badge)](https://api.securityscorecards.dev/projects/github.com/dart-lang/linter)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/dart-lang/linter/badge)](https://deps.dev/project/github/dart-lang%2Flinter)
 
 ## Installing
 


### PR DESCRIPTION
This is linked to by the OpenSSF scorecard badge at the top of the README. The previous link was to unformatted JSON. Instead, this links to [deps.dev](https://deps.dev) which formats the results and in the future may include other information.

Previous link: https://api.securityscorecards.dev/projects/github.com/dart-lang/linter
New link: https://deps.dev/project/github/dart-lang%2Flinter