### PR TITLE
assigned variable support for `void_checks`

### DIFF
--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -49,9 +49,10 @@ class VoidChecks extends LintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this, context);
-    registry.addMethodInvocation(this, visitor);
-    registry.addInstanceCreationExpression(this, visitor);
+    registry.addAssignedVariablePattern(this, visitor);
     registry.addAssignmentExpression(this, visitor);
+    registry.addInstanceCreationExpression(this, visitor);
+    registry.addMethodInvocation(this, visitor);
     registry.addReturnStatement(this, visitor);
   }
 }
@@ -87,6 +88,14 @@ class _Visitor extends SimpleAstVisitor<void> {
       return true;
     }
     return false;
+  }
+
+  @override
+  void visitAssignedVariablePattern(AssignedVariablePattern node) {
+    var valueType = node.matchedValueType;
+    var element = node.element;
+    if (element is! VariableElement) return;
+    _check(element.type, valueType, node);
   }
 
   @override

--- a/test/rules/void_checks_test.dart
+++ b/test/rules/void_checks_test.dart
@@ -9,6 +9,7 @@ import '../rule_test_support.dart';
 main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(VoidChecksTest);
+    defineReflectiveTests(VoidChecksTestLanguage300);
   });
 }
 
@@ -49,6 +50,45 @@ void bug2813() {
 ''', [
       // No lint
       error(CompileTimeErrorCode.RETURN_OF_INVALID_TYPE_FROM_FUNCTION, 26, 1),
+    ]);
+  }
+}
+
+@reflectiveTest
+class VoidChecksTestLanguage300 extends LintRuleTest
+    with LanguageVersion300Mixin {
+  @override
+  String get lintRule => 'void_checks';
+
+  test_listPattern_local() async {
+    await assertDiagnostics(r'''
+void f() {
+  void p;
+  [p] = <int>[7];
+  return p;
+}
+''', [
+      lint(24, 1),
+    ]);
+  }
+
+  test_listPattern_param() async {
+    await assertDiagnostics(r'''
+void f(void p) {
+  [p] = <int>[7];
+}
+''', [
+      lint(20, 1),
+    ]);
+  }
+
+  test_recordPattern() async {
+    await assertDiagnostics(r'''
+void f(void p) {
+  (p, ) = (7, );
+}
+''', [
+      lint(20, 1),
     ]);
   }
 }


### PR DESCRIPTION
Fixes #4179

/cc @bwilkerson @srawlins 