### PR TITLE
null assert pattern support for `unnecessary_null_checks`

### DIFF
--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -175,6 +175,7 @@ class UnnecessaryNullChecks extends LintRule {
   void registerNodeProcessors(
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this, context);
+    registry.addNullAssertPattern(this, visitor);
     registry.addPostfixExpression(this, visitor);
   }
 }
@@ -184,6 +185,16 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   final LinterContext context;
   _Visitor(this.rule, this.context);
+
+  @override
+  void visitNullAssertPattern(NullAssertPattern node) {
+    if (node.operator.type != TokenType.BANG) return;
+
+    var expectedType = node.matchedValueType;
+    if (expectedType != null && context.typeSystem.isNullable(expectedType)) {
+      rule.reportLintForToken(node.operator);
+    }
+  }
 
   @override
   void visitPostfixExpression(PostfixExpression node) {

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -188,8 +188,6 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitNullAssertPattern(NullAssertPattern node) {
-    if (node.operator.type != TokenType.BANG) return;
-
     var expectedType = node.matchedValueType;
     if (expectedType != null && context.typeSystem.isNullable(expectedType)) {
       rule.reportLintForToken(node.operator);

--- a/test/rules/unnecessary_null_checks_test.dart
+++ b/test/rules/unnecessary_null_checks_test.dart
@@ -9,6 +9,7 @@ import '../rule_test_support.dart';
 main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(UnnecessaryNullChecksTest);
+    defineReflectiveTests(UnnecessaryNullChecksTestLanguage300);
   });
 }
 
@@ -38,6 +39,33 @@ f6(int? p) {
 ''', [
       // No lint
       error(CompileTimeErrorCode.UNDEFINED_FUNCTION, 22, 1),
+    ]);
+  }
+}
+
+@reflectiveTest
+class UnnecessaryNullChecksTestLanguage300 extends LintRuleTest
+    with LanguageVersion300Mixin {
+  @override
+  String get lintRule => 'unnecessary_null_checks';
+
+  test_listPattern() async {
+    await assertDiagnostics(r'''
+void f(int? a, int? b) {
+  [b!, ] = [a, ];
+}
+''', [
+      lint(29, 1),
+    ]);
+  }
+
+  test_recordPattern() async {
+    await assertDiagnostics(r'''
+void f(int? a, int? b) {
+  (b!, ) = (a, );
+}
+''', [
+      lint(29, 1),
     ]);
   }
 }


### PR DESCRIPTION
Fixes #4183

/cc @bwilkerson @srawlins 