### PR TITLE
Add a test for a documented annotated enum value

### DIFF
--- a/test/rules/public_member_api_docs_test.dart
+++ b/test/rules/public_member_api_docs_test.dart
@@ -49,6 +49,20 @@ enum A {
 ''');
   }
 
+  test_annotatedEnumValue() async {
+    await assertNoDiagnostics(r'''
+/// Documented.
+enum A {
+  /// This represents 'a'.
+  @Deprecated("Use 'b'")
+  a,
+
+  /// This represents 'b'.
+  b;
+}
+''');
+  }
+
   /// https://github.com/dart-lang/linter/issues/3525
   test_extension() async {
     await assertDiagnostics(r'''


### PR DESCRIPTION
Closes #1396 (an analyzer bump, long ago, likely fixed the issue)