### PR TITLE
`no_leading_underscores_for_local_identifiers` if-case tests

### DIFF
--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -218,24 +218,6 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
       }
     }
     if (buffer.isNotEmpty) {
-      if (dumpAstOnFailures) {
-        buffer.writeln();
-        buffer.writeln();
-        try {
-          var astSink = CollectingSink();
-
-          StringSpelunker(result.unit.toSource(),
-                  sink: astSink, featureSet: result.unit.featureSet)
-              .spelunk();
-          buffer.write(astSink.buffer);
-          buffer.writeln();
-          // I hereby choose to catch this type.
-          // ignore: avoid_catching_errors
-        } on ArgumentError catch (_) {
-          // Perhaps we encountered a parsing error while spelunking.
-        }
-      }
-
       errors.sort((first, second) => first.offset.compareTo(second.offset));
       buffer.writeln();
       buffer.writeln('To accept the current state, expect:');
@@ -258,6 +240,25 @@ abstract class LintRuleTest extends PubPackageResolutionTest {
         buffer.write(actual.length);
         buffer.writeln('),');
       }
+
+      if (dumpAstOnFailures) {
+        buffer.writeln();
+        buffer.writeln();
+        try {
+          var astSink = CollectingSink();
+
+          StringSpelunker(result.unit.toSource(),
+                  sink: astSink, featureSet: result.unit.featureSet)
+              .spelunk();
+          buffer.write(astSink.buffer);
+          buffer.writeln();
+          // I hereby choose to catch this type.
+          // ignore: avoid_catching_errors
+        } on ArgumentError catch (_) {
+          // Perhaps we encountered a parsing error while spelunking.
+        }
+      }
+
       fail(buffer.toString());
     }
   }

--- a/test/rules/no_leading_underscores_for_local_identifiers_test.dart
+++ b/test/rules/no_leading_underscores_for_local_identifiers_test.dart
@@ -17,6 +17,16 @@ class NoLeadingUnderscoresForLocalIdentifiersTest extends LintRuleTest {
   @override
   String get lintRule => 'no_leading_underscores_for_local_identifiers';
 
+  test_listPattern_ifCase() async {
+    await assertDiagnostics(r'''
+f(Object o) {
+  if (o case [int _x, int y]) print('$_x$y'); 
+}
+''', [
+      lint(32, 2),
+    ]);
+  }
+
   test_listPattern_switch() async {
     await assertDiagnostics(r'''
 f() {
@@ -52,6 +62,16 @@ f() {
     ]);
   }
 
+  test_mapPattern_ifCase() async {
+    await assertDiagnostics(r'''
+f(Object o) {
+  if (o case {'x': var _x, 'y' : var y}) print('$_x$y');
+}
+''', [
+      lint(37, 2),
+    ]);
+  }
+
   test_mapPattern_switch() async {
     await assertDiagnostics(r'''
 f() {
@@ -79,6 +99,22 @@ f() {
     ]);
   }
 
+  test_objectPattern_ifCase() async {
+    await assertDiagnostics(r'''
+class C {
+  int c;
+  int d;
+  C(this.c, this.d);
+}
+
+f(Object o) {
+  if (o case C(c: var _x, d: var y)) print('$_x$y');
+}
+''', [
+      lint(88, 2),
+    ]);
+  }
+
   test_objectPattern_switch() async {
     await assertDiagnostics(r'''
 class A {
@@ -103,6 +139,16 @@ f() {
 }
 ''', [
       lint(13, 2),
+    ]);
+  }
+
+  test_recordPattern_ifCase() async {
+    await assertDiagnostics(r'''
+f(Object o) {
+  if (o case (int _x, int y)) print('$_x$y');
+}
+''', [
+      lint(32, 2),
     ]);
   }
 


### PR DESCRIPTION
(The AST dump change just means you don't need to scroll to see the current state output.)

/cc @bwilkerson 
