### PR TITLE
bump cli_util dep

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
 dev_dependencies:
   benchmark_harness: ^2.0.0
-  cli_util: ^0.3.0
+  cli_util: ^0.4.0
   github: ^9.0.0
   grinder: ^0.9.0
   lints: ^2.0.0


### PR DESCRIPTION
See: #4204.

Some out of dates deps remain:

dev_dependencies:
grinder       *0.9.0    *0.9.0      *0.9.0      0.9.3    
matcher       *0.12.14  *0.12.14    *0.12.14    0.12.15  

But I haven't investigated causes...

/cc @bwilkerson @srawlins 
