### PR TITLE
prefer_void_to_null: not for variable declarations

### DIFF
--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -140,7 +140,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    if (parent is VariableDeclarationList && node == parent.type) {
+    if (parent is VariableDeclarationList &&
+        node == parent.type &&
+        parent.parent is! FieldDeclaration) {
       // We should not recommend to use `void` for local or top-level variables.
       return;
     }

--- a/lib/src/rules/prefer_void_to_null.dart
+++ b/lib/src/rules/prefer_void_to_null.dart
@@ -140,6 +140,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       return;
     }
 
+    if (parent is VariableDeclarationList && node == parent.type) {
+      // We should not recommend to use `void` for local or top-level variables.
+      return;
+    }
+
     // <Null>[] or <Null, Null>{}
     if (parent is TypeArgumentList) {
       var literal = parent.parent;

--- a/test/rules/prefer_void_to_null_test.dart
+++ b/test/rules/prefer_void_to_null_test.dart
@@ -37,4 +37,18 @@ void f(int a) {
 }
 ''');
   }
+
+  test_localVariable() async {
+    await assertNoDiagnostics(r'''
+void f() {
+  Null _;
+}
+''');
+  }
+
+  test_topLevelVariable() async {
+    await assertNoDiagnostics(r'''
+Null a;
+''');
+  }
 }

--- a/test_data/rules/prefer_void_to_null.dart
+++ b/test_data/rules/prefer_void_to_null.dart
@@ -52,8 +52,6 @@ class F implements E {
 }
 
 void void_; // OK
-Null null_; // LINT
-core.Null core_null; // LINT
 Future<void>? future_void; // OK
 Future<Null>? future_null; // LINT
 Future<core.Null>? future_core_null; // LINT
@@ -72,8 +70,6 @@ void Function(Future<Null>)? voidFunctionFutureNull; // LINT
 
 usage() {
   void void_; // OK
-  Null null_; // LINT
-  core.Null core_null; // LINT
   Future<void>? future_void; // OK
   Future<Null> future_null; // LINT
   Future<core.Null> future_core_null; // LINT
@@ -152,8 +148,6 @@ class AsMembers {
 
   void usage() {
     void void_; // OK
-    Null null_; // LINT
-    core.Null core_null; // LINT
     Future<void>? future_void; // OK
     Future<Null> future_null; // LINT
     Future<core.Null> future_core_null; // LINT


### PR DESCRIPTION
Fixes #3792  to not report `Null` as the type of a variable declaration.