### PR TITLE
filter UNUSED_LOCAL_VARIABLE diagnostics in test expectations

### DIFF
--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -476,7 +476,7 @@ abstract class _ContextResolutionTest with ResourceProviderMixin {
       .toList();
 
   /// Error codes that by default should be ignored in test expectations.
-  List<HintCode> get ignoredErrorCodes => [HintCode.UNUSED_LOCAL_VARIABLE];
+  List<HintCode> get ignoredErrorCodes => [WarningCode.UNUSED_LOCAL_VARIABLE];
 
   Folder get sdkRoot => newFolder('/sdk');
 

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -8,19 +8,18 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/src/dart/analysis/byte_store.dart';
 import 'package:analyzer/src/dart/analysis/driver_based_analysis_context.dart';
-import 'package:analyzer/src/dart/analysis/experiments.dart';
 import 'package:analyzer/src/lint/registry.dart';
 import 'package:analyzer/src/lint/util.dart';
 import 'package:analyzer/src/test_utilities/mock_packages.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
-import 'package:analyzer/src/test_utilities/package_config_file_builder.dart';
 import 'package:analyzer/src/test_utilities/resource_provider_mixin.dart';
-import 'package:linter/src/analyzer.dart';
+import 'package:collection/collection.dart';
 import 'package:linter/src/rules.dart';
 import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
+import 'rule_test_support.dart';
 
 export 'package:analyzer/src/dart/analysis/experiments.dart';
 export 'package:analyzer/src/dart/error/syntactic_errors.dart';
@@ -472,7 +471,12 @@ abstract class _ContextResolutionTest with ResourceProviderMixin {
   List<String> get collectionIncludedPaths;
 
   /// The analysis errors that were computed during analysis.
-  List<AnalysisError> get errors => result.errors;
+  List<AnalysisError> get errors => result.errors
+      .whereNot((e) => ignoredErrorCodes.any((c) => e.errorCode == c))
+      .toList();
+
+  /// Error codes that by default should be ignored in test expectations.
+  List<HintCode> get ignoredErrorCodes => [HintCode.UNUSED_LOCAL_VARIABLE];
 
   Folder get sdkRoot => newFolder('/sdk');
 

--- a/test/rules/cancel_subscriptions_test.dart
+++ b/test/rules/cancel_subscriptions_test.dart
@@ -49,7 +49,6 @@ void f(Stream stream) {
   StreamSubscription s = stream.listen((_) {});
 }
 ''', [
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 66, 1),
       lint(66, 25),
     ]);
   }
@@ -92,7 +91,7 @@ class A {
           'should be counted as canceled. However, that is not how an '
           'expectation is set in an integration test, and a Lint is indeed '
           'reported for this case. We have the test written here with what was '
-          'presumably the intention of the previoius test.')
+          'presumably the intention of the previous test.')
   test_privateField_canceled_outsideTheClass() async {
     await assertNoDiagnostics(r'''
 import 'dart:async';

--- a/test/rules/constant_identifier_names_test.dart
+++ b/test/rules/constant_identifier_names_test.dart
@@ -42,7 +42,6 @@ void f() {
   final (AA, ) = (1, );
 }
 ''', [
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 20, 2),
       lint(20, 2),
     ]);
   }

--- a/test/rules/join_return_with_assignment_test.dart
+++ b/test/rules/join_return_with_assignment_test.dart
@@ -205,13 +205,11 @@ int f(int a, int b) {
   }
 
   test_patternVariableDeclaration_multiple() async {
-    await assertDiagnostics(r'''
+    await assertNoDiagnostics(r'''
 int f() {
   var (a, b) = (0, 1);
   return a;
 }
-''', [
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 20, 1),
-    ]);
+''');
   }
 }

--- a/test/rules/non_constant_identifier_names_test.dart
+++ b/test/rules/non_constant_identifier_names_test.dart
@@ -35,9 +35,7 @@ void f() {
   if ([1,2] case [int AB, int c]) { }
 }
 ''', [
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 33, 2),
       lint(33, 2),
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 41, 1),
     ]);
   }
 
@@ -55,7 +53,6 @@ void f() {
   var (AB, ) = (1, );
 }
 ''', [
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 18, 2),
       lint(18, 2),
     ]);
   }

--- a/test/rules/null_check_on_nullable_type_parameter_test.dart
+++ b/test/rules/null_check_on_nullable_type_parameter_test.dart
@@ -24,9 +24,7 @@ void f<T>((T?, T?) p){
   var (x!, y) = p;
 }
 ''', [
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 30, 1),
       lint(31, 1),
-      error(HintCode.UNUSED_LOCAL_VARIABLE, 34, 1),
     ]);
   }
 }

--- a/test/rules/parameter_assignments_test.dart
+++ b/test/rules/parameter_assignments_test.dart
@@ -78,17 +78,14 @@ void f(String p) {
   }
 
   test_function_ok_shadow() async {
-    await assertDiagnostics(r'''
+    await assertNoDiagnostics(r'''
 void f(String? p) {
   if (p == null) {
     int p = 2;
     p = 3;
   }
 }
-''', [
-      // No lint.
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 47, 1),
-    ]);
+''');
   }
 
   test_function_positional_optional_assignedTwice() async {

--- a/test/rules/prefer_const_constructors_test.dart
+++ b/test/rules/prefer_const_constructors_test.dart
@@ -51,16 +51,13 @@ class A {
 }
 ''');
 
-    await assertDiagnostics(r'''
+    await assertNoDiagnostics(r'''
 import 'a.dart' deferred as a;
 
 void f() {
   var aa = a.A();
 }
-''', [
-      // No lint.
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 49, 2),
-    ]);
+''');
   }
 
   test_extraPositionalArgument() async {

--- a/test/rules/prefer_contains_test.dart
+++ b/test/rules/prefer_contains_test.dart
@@ -26,7 +26,6 @@ condition() {
 }
 ''', [
       // No lint
-      error(WarningCode.UNUSED_LOCAL_VARIABLE, 41, 4),
       error(CompileTimeErrorCode.ARGUMENT_TYPE_NOT_ASSIGNABLE, 77, 3),
     ]);
   }


### PR DESCRIPTION
These diagnostics are just noise and we need to do hokey things to ignore them.

In case we ever care a test can always override `ignoredErrorCodes`.

I'll take a pass to remove all the gross `print(..)` work-arounds next.

/cc @bwilkerson @srawlins 
