### PR TITLE
Refer to new WarningCodes as such

### DIFF
--- a/test/rules/cancel_subscriptions_test.dart
+++ b/test/rules/cancel_subscriptions_test.dart
@@ -120,7 +120,7 @@ class A {
   }
 }
 ''', [
-      error(HintCode.UNUSED_FIELD, 57, 13),
+      error(WarningCode.UNUSED_FIELD, 57, 13),
       lint(57, 13),
     ]);
   }

--- a/test/rules/deprecated_member_use_from_same_package_test.dart
+++ b/test/rules/deprecated_member_use_from_same_package_test.dart
@@ -274,7 +274,7 @@ class C {}
 import 'lib.dart' hide C;
 ''', [
       // No lint.
-      error(HintCode.UNUSED_IMPORT, 7, 10),
+      error(WarningCode.UNUSED_IMPORT, 7, 10),
     ]);
   }
 
@@ -286,7 +286,7 @@ class C {}
     await assertDiagnostics(r'''
 import 'lib.dart' show C;
 ''', [
-      error(HintCode.UNUSED_IMPORT, 7, 10),
+      error(WarningCode.UNUSED_IMPORT, 7, 10),
       lint(23, 1),
     ]);
   }
@@ -535,7 +535,7 @@ library a;
 import 'lib.dart';
 ''', [
       lint(0, 18),
-      error(HintCode.UNUSED_IMPORT, 7, 10),
+      error(WarningCode.UNUSED_IMPORT, 7, 10),
     ]);
   }
 


### PR DESCRIPTION
The `HintCode`s are soft-deprecated. Removing them will cause these references to die.