### PR TITLE
Simplify logic in implicit_reopen

### DIFF
--- a/lib/src/rules/implicit_reopen.dart
+++ b/lib/src/rules/implicit_reopen.dart
@@ -87,35 +87,30 @@ class _Visitor extends SimpleAstVisitor {
 
   void checkElement(InterfaceElement? element, NamedCompilationUnitMember node,
       {required String type}) {
-    if (element == null) return;
+    if (element is! ClassElement) return;
     if (element.hasReopen) return;
     if (element.isSealed) return;
     if (element.isMixinClass) return;
 
     var library = element.library;
-    var supertype = element.superElement;
+    var supertype = element.supertype?.element;
+    if (supertype is! ClassElement) return;
     if (supertype.library != library) return;
 
     if (element.isBase) {
       if (supertype.isFinal) {
         reportLint(node,
-            target: element, other: supertype!, reason: 'final', type: type);
+            target: element, other: supertype, reason: 'final', type: type);
         return;
       } else if (supertype.isInterface) {
         reportLint(node,
-            target: element,
-            other: supertype!,
-            reason: 'interface',
-            type: type);
+            target: element, other: supertype, reason: 'interface', type: type);
         return;
       }
     } else if (element.hasNoModifiers) {
       if (supertype.isInterface) {
         reportLint(node,
-            target: element,
-            other: supertype!,
-            reason: 'interface',
-            type: type);
+            target: element, other: supertype, reason: 'interface', type: type);
         return;
       }
     }
@@ -138,41 +133,6 @@ class _Visitor extends SimpleAstVisitor {
   }
 }
 
-extension on InterfaceElement? {
+extension on ClassElement {
   bool get hasNoModifiers => !isInterface && !isBase && !isSealed && !isFinal;
-
-  bool get isBase {
-    var self = this;
-    if (self is ClassElement) return self.isBase;
-    if (self is MixinElement) return self.isBase;
-    return false;
-  }
-
-  bool get isFinal {
-    var self = this;
-    if (self is ClassElement) return self.isFinal;
-    return false;
-  }
-
-  bool get isInterface {
-    var self = this;
-    if (self is ClassElement) return self.isInterface;
-    return false;
-  }
-
-  bool get isSealed {
-    var self = this;
-    if (self is ClassElement) return self.isSealed;
-    return false;
-  }
-
-  bool get isMixinClass {
-    var self = this;
-    if (self is ClassElement) return self.isMixinClass;
-    return false;
-  }
-
-  LibraryElement? get library => this?.library;
-
-  InterfaceElement? get superElement => this?.supertype?.element;
 }


### PR DESCRIPTION
* Many of the extension getters on `InterfaceElement?` helped account for a `null` receiver, but it turns out we don't want to report any lint when the annotated element is `null`, or when it's supertype's element is `null` either (we we also null-checking `supertype` in a few positions already).
* We also don't want to report any lint when the annotated element is not a `ClassElement`, or when it's supertype is not a `ClassElement`, so when we promote those variables, a lot of the benefits of the extension getters fall away.