### PR TITLE
1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+1.35.0
+
+- add new lints: 
+  - `explicit_reopen`
+  - `unnecessary_breaks`
+  - `type_literal_in_constant_pattern`
+- updates to existing lints to support patterns and class modifiers
+- remove support for:
+  - `enable_null_safety`
+  - `invariant_booleans`
+  - `prefer_bool_in_asserts`
+  - `prefer_equal_for_default_values`
+  - `super_goes_last`
+- fix `unnecessary_parenthesis` false-positives with null-aware expressions
+- fix `void_checks` to allow assignments of `Future<dynamic>?` to parameters
+  typed `FutureOr<void>?`
+- fix `use_build_context_synchronously` in if conditions
+- fix a false positive for `avoid_private_typedef_functions` with generalized
+  type aliases
+- update `unnecessary_parenthesis` to detect some doubled parens
+- update `void_checks` to allow returning `Never` as void
+- update `no_adjacent_strings_in_list` to support set literals and for- and
+  if-elements
+- update `avoid_types_as_parameter_names` to handle type variables
+- update `avoid_positional_boolean_parameters` to handle typedefs
+- update `avoid_redundant_argument_values` to check parameters of redirecting
+  constructors
+- improve performance for `prefer_const_literals_to_create_immutables`
+- update `use_build_context_synchronously` to check context properties
+- improve `unnecessary_parenthesis` support for property accesses and method
+  invocations
+- improve `unreachable_from_main` to report unreachable constructors
+
 # 1.34.0
 
 - update `only_throw_errors` to not report on values of type `Never`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@
 - update `use_build_context_synchronously` to check context properties
 - improve `unnecessary_parenthesis` support for property accesses and method
   invocations
-- improve `unreachable_from_main` to report unreachable constructors
 
 # 1.34.0
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Package version.  Synchronized w/ pubspec.yaml.
-const String version = '1.34.0';
+const String version = '1.35.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: linter
-version: 1.34.0
+version: 1.35.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
1.35.0

- add new lints: 
  - `explicit_reopen`
  - `unnecessary_breaks`
  - `type_literal_in_constant_pattern`
- updates to existing lints to support patterns and class modifiers
- remove support for:
  - `enable_null_safety`
  - `invariant_booleans`
  - `prefer_bool_in_asserts`
  - `prefer_equal_for_default_values`
  - `super_goes_last`
- fix `unnecessary_parenthesis` false-positives with null-aware expressions
- fix `void_checks` to allow assignments of `Future<dynamic>?` to parameters
  typed `FutureOr<void>?`
- fix `use_build_context_synchronously` in if conditions
- fix a false positive for `avoid_private_typedef_functions` with generalized
  type aliases
- update `unnecessary_parenthesis` to detect some doubled parens
- update `void_checks` to allow returning `Never` as void
- update `no_adjacent_strings_in_list` to support set literals and for- and
  if-elements
- update `avoid_types_as_parameter_names` to handle type variables
- update `avoid_positional_boolean_parameters` to handle typedefs
- update `avoid_redundant_argument_values` to check parameters of redirecting
  constructors
- improve performance for `prefer_const_literals_to_create_immutables`
- update `use_build_context_synchronously` to check context properties
- improve `unnecessary_parenthesis` support for property accesses and method
  invocations

---

/cc @bwilkerson @srawlins 