### PR TITLE
New rule: Use matching super parameter names

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -90,6 +90,7 @@ linter:
     - lines_longer_than_80_chars
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
+    - matching_super_parameters
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -97,6 +97,7 @@ import 'rules/library_private_types_in_public_api.dart';
 import 'rules/lines_longer_than_80_chars.dart';
 import 'rules/list_remove_unrelated_type.dart';
 import 'rules/literal_only_boolean_expressions.dart';
+import 'rules/matching_super_parameters.dart';
 import 'rules/missing_whitespace_between_adjacent_strings.dart';
 import 'rules/no_adjacent_strings_in_list.dart';
 import 'rules/no_default_cases.dart';
@@ -325,6 +326,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(LinesLongerThan80Chars())
     ..register(ListRemoveUnrelatedType())
     ..register(LiteralOnlyBooleanExpressions())
+    ..register(MatchingSuperParameters())
     ..register(MissingWhitespaceBetweenAdjacentStrings())
     ..register(NoAdjacentStringsInList())
     ..register(NoDefaultCases())

--- a/lib/src/rules/matching_super_parameters.dart
+++ b/lib/src/rules/matching_super_parameters.dart
@@ -92,10 +92,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
-    var positionalSuperParameters = node.parameters.parameters
-        .whereType<SuperFormalParameter>()
-        .where((p) => p.isPositional)
-        .toList();
+    var positionalSuperParameters = <SuperFormalParameter>[];
+    for (var parameter in node.parameters.parameters) {
+      if (parameter is SuperFormalParameter && parameter.isPositional) {
+        positionalSuperParameters.add(parameter);
+      }
+    }
     if (positionalSuperParameters.isEmpty) {
       // We are only concerned with positional super-parameters.
       return;

--- a/lib/src/rules/matching_super_parameters.dart
+++ b/lib/src/rules/matching_super_parameters.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:collection/collection.dart';
+
+import '../analyzer.dart';
+
+const _desc = r'Use matching super parameter names.';
+
+const _details = r'''
+**DO** use super parameter names that match their corresponding super
+constructor's parameter names.
+
+**BAD:**
+
+```dart
+class Rectangle {
+  final int width;
+  final int height;
+  
+  Rectangle(this.width, this.height);
+}
+
+class ColoredRectangle extends Rectangle {
+  final Color color;
+  
+  ColoredRectangle(
+    this.color,
+    super.height, // Bad, actually corresponds to the `width` parameter.
+    super.width, // Bad, actually corresponds to the `height` parameter.
+  ); 
+}
+```
+
+**GOOD:**
+
+```dart
+class Rectangle {
+  final int width;
+  final int height;
+  
+  Rectangle(this.width, this.height);
+}
+
+class ColoredRectangle extends Rectangle {
+  final Color color;
+  
+  ColoredRectangle(
+    this.color,
+    super.width,
+    super.height, 
+  ); 
+}
+```
+''';
+
+class MatchingSuperParameters extends LintRule {
+  static const LintCode code = LintCode(
+      'matching_super_parameters',
+      "The super parameter named '{0}'' does not share the same name as the "
+          "corresponding parameter in the super constructor, '{1}'.",
+      correctionMessage:
+          'Try using the name of the corresponding parameter in the super '
+          'constructor.');
+
+  MatchingSuperParameters()
+      : super(
+            name: 'matching_super_parameters',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addConstructorDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final LintRule rule;
+
+  const _Visitor(this.rule);
+
+  @override
+  void visitConstructorDeclaration(ConstructorDeclaration node) {
+    var positionalSuperParameters = node.parameters.parameters
+        .whereType<SuperFormalParameter>()
+        .where((p) => p.isPositional)
+        .toList();
+    if (positionalSuperParameters.isEmpty) {
+      // We are only concerned with positional super-parameters.
+      return;
+    }
+    var superInvocation =
+        node.initializers.whereType<SuperConstructorInvocation>().firstOrNull;
+    var superConstructor = superInvocation?.staticElement;
+    if (superConstructor == null) {
+      var class_ = node.parent;
+      if (class_ is ClassDeclaration) {
+        superConstructor =
+            class_.declaredElement?.supertype?.element.unnamedConstructor;
+      }
+    }
+    if (superConstructor is! ConstructorElement) {
+      return;
+    }
+    var positionalParametersOfSuper =
+        superConstructor.parameters.where((p) => p.isPositional).toList();
+    if (positionalParametersOfSuper.length < positionalSuperParameters.length) {
+      // More positional parameters are passed to super constructor than it
+      // has positional parameters, an error.
+      return;
+    }
+    for (var i = 0; i < positionalSuperParameters.length; i++) {
+      var superParameter = positionalSuperParameters[i];
+      var superParameterName = superParameter.name.lexeme;
+      var parameterOfSuperName = positionalParametersOfSuper[i].name;
+      if (superParameterName != parameterOfSuperName) {
+        rule.reportLint(superParameter,
+            arguments: [superParameterName, parameterOfSuperName]);
+      }
+    }
+  }
+}

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -61,6 +61,7 @@ import 'library_private_types_in_public_api_test.dart'
 import 'lines_longer_than_80_chars_test.dart' as lines_longer_than_80_chars;
 import 'literal_only_boolean_expressions_test.dart'
     as literal_only_boolean_expressions;
+import 'matching_super_parameters_test.dart' as matching_super_parameters;
 import 'missing_whitespace_between_adjacent_strings_test.dart'
     as missing_whitespace_between_adjacent_strings;
 import 'no_duplicate_case_values_test.dart' as no_duplicate_case_values;
@@ -181,6 +182,7 @@ void main() {
   library_private_types_in_public_api.main();
   lines_longer_than_80_chars.main();
   literal_only_boolean_expressions.main();
+  matching_super_parameters.main();
   missing_whitespace_between_adjacent_strings.main();
   no_adjacent_strings_in_list.main();
   no_duplicate_case_values.main();

--- a/test/rules/matching_super_parameters_test.dart
+++ b/test/rules/matching_super_parameters_test.dart
@@ -1,0 +1,224 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(MatchingSuperParametersTest);
+  });
+}
+
+@reflectiveTest
+class MatchingSuperParametersTest extends LintRuleTest {
+  @override
+  String get lintRule => 'matching_super_parameters';
+
+  test_explicitSuperInvocation_matchingWithOffset() async {
+    await assertNoDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.x,
+    super.y,
+  ) : super.named(); 
+}
+
+class C {
+  final int x;
+  final int y;
+  
+  C.named(this.x, this.y);
+}
+''');
+  }
+
+  test_explicitSuperInvocation_matchingWithOffset_withNamedSuper() async {
+    await assertNoDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.x,
+    super.y, {
+    required super.z,
+  }) : super.named(); 
+}
+
+class C {
+  final int x;
+  final int y;
+  final int z;
+  
+  C.named(this.x, this.y, {required this.z});
+}
+''');
+  }
+
+  test_explicitSuperInvocation_matchingWithOffset_withNamedExplicit() async {
+    await assertNoDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.x,
+    super.y,
+  ) : super.named(z: 1); 
+}
+
+class C {
+  final int x;
+  final int y;
+  final int z;
+  
+  C.named(this.x, this.y, {required this.z});
+}
+''');
+  }
+
+  test_explicitSuperInvocation_nonMatching() async {
+    await assertDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.y,
+    super.x,
+  ) : super.named(); 
+}
+
+class C {
+  final int x;
+  final int y;
+  
+  C.named(this.x, this.y);
+}
+''', [
+      lint(62, 7),
+      lint(75, 7),
+    ]);
+  }
+
+  test_implicitSuperInvocation_matchingWithGap() async {
+    await assertNoDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    super.x,
+    this.w,
+    super.y,
+  ); 
+}
+
+class C {
+  final int x;
+  final int y;
+  
+  C(this.x, this.y);
+}
+''');
+  }
+
+  test_implicitSuperInvocation_matchingWithOffset() async {
+    await assertNoDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.x,
+    super.y,
+  ); 
+}
+
+class C {
+  final int x;
+  final int y;
+  
+  C(this.x, this.y);
+}
+''');
+  }
+
+  test_implicitSuperInvocation_nonMatching() async {
+    await assertDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.y,
+    super.x,
+  ); 
+}
+
+class C {
+  final int x;
+  final int y;
+  
+  C(this.x, this.y);
+}
+''', [
+      lint(62, 7),
+      lint(75, 7),
+    ]);
+  }
+
+  test_implicitSuperInvocation_nonMatching_omittedOptional() async {
+    await assertDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.y,
+  ); 
+}
+
+class C {
+  final int x;
+  final int? y;
+  
+  C(this.x, [this.y]);
+}
+''', [
+      lint(62, 7),
+    ]);
+  }
+
+  test_implicitSuperInvocation_nonMatching_tooMany() async {
+    await assertDiagnostics(r'''
+class D extends C {
+  final String w;
+  
+  D(
+    this.w,
+    super.y,
+    super.x,
+  ); 
+}
+
+class C {
+  final int x;
+  
+  C(this.x);
+}
+''', [
+      // No lint.
+      error(
+          CompileTimeErrorCode
+              .SUPER_FORMAL_PARAMETER_WITHOUT_ASSOCIATED_POSITIONAL,
+          81,
+          1),
+    ]);
+  }
+}


### PR DESCRIPTION
Implements the proposal at https://github.com/dart-lang/linter/issues/4259