### PR TITLE
Move more use_build_context_synchronously tests

### DIFF
--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -39,6 +39,26 @@ void foo(BuildContext context, Future<bool> condition) async {
     ]);
   }
 
+  test_awaitBeforeSwitch_mountedExitGuardInCase_beforeReferenceToContext() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context, Future<void> future) async {
+  await future;
+
+  switch ('') {
+    case 'a':
+      if (!mounted) {
+        break;
+      }
+      Navigator.of(context);
+  }
+}
+
+bool mounted = false;
+''');
+  }
+
   test_awaitBeforeReferenceToContext_inClosure() async {
     // todo (pq): what about closures?
     await assertNoDiagnostics(r'''

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -24,27 +24,123 @@ class UseBuildContextSynchronouslyTest extends LintRuleTest {
   @override
   String get testPackageRootPath => '$workspaceRootPath/lib';
 
+  test_await_afterReferenceToContextInBody() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  Navigator.of(context);
+  await f();
+}
+
+Future<void> f() async {}
+''');
+  }
+
+  test_await_beforeReferenceToContextInBody() async {
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await f();
+  Navigator.of(context);
+}
+
+Future<void> f() async {}
+''', [
+      lint(94, 21),
+    ]);
+  }
+
+  test_awaitBeforeIf_mountedExitGuardInIfConditionWithOr_beforeReferenceToContext() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await f();
+  if (c || !mounted) return;
+  Navigator.of(context);
+}
+
+bool mounted = false;
+Future<void> f() async {}
+bool get c => true;
+''');
+  }
+
+  test_awaitBeforeIf_mountedGuardInIfCondition_referenceToContextInIfBody() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await f();
+  if (mounted) {
+    Navigator.of(context);
+  }
+}
+
+bool mounted = false;
+Future<void> f() async {}
+''');
+  }
+
+  test_awaitBeforeIf_mountedGuardInIfConditionWithAnd_referenceToContextInIfBody() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await f();
+  if (c && mounted) {
+    Navigator.of(context);
+  }
+}
+
+bool mounted = false;
+Future<void> f() async {}
+bool get c => true;
+''');
+  }
+
   test_awaitBeforeIfStatement_beforeReferenceToContext() async {
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
-  var b = await condition;
+void foo(BuildContext context) async {
+  var b = await c();
   if (b) {
     Navigator.of(context);
   }
 }
+Future<bool> c() async => true;
 ''', [
-      lint(145, 21),
+      lint(115, 21),
     ]);
+  }
+
+  test_awaitBeforeReferenceToContext_inClosure() async {
+    // todo (pq): what about closures?
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await c();
+  f1(() {
+    f2(context);
+  });
+}
+
+void f1(Function f) {}
+void f2(BuildContext c) {}
+Future<bool> c() async => true;
+''');
   }
 
   test_awaitBeforeSwitch_mountedExitGuardInCase_beforeReferenceToContext() async {
     await assertNoDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<void> future) async {
-  await future;
+void foo(BuildContext context) async {
+  await f();
 
   switch ('') {
     case 'a':
@@ -54,25 +150,8 @@ void foo(BuildContext context, Future<void> future) async {
       Navigator.of(context);
   }
 }
-
 bool mounted = false;
-''');
-  }
-
-  test_awaitBeforeReferenceToContext_inClosure() async {
-    // todo (pq): what about closures?
-    await assertNoDiagnostics(r'''
-import 'package:flutter/widgets.dart';
-
-void foo(BuildContext context, Future<bool> condition) async {
-  await condition;
-  f1(() {
-    f2(context);
-  });
-}
-
-void f1(Function f) {}
-void f2(BuildContext c) {}
+Future<void> f() async {}
 ''');
   }
 
@@ -81,14 +160,14 @@ void f2(BuildContext c) {}
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
-  if (await condition) {
+void foo(BuildContext context) async {
+  if (await c()) {
     Navigator.of(context);
   }
 }
-
+Future<bool> c() async => true;
 ''', [
-      lint(132, 21),
+      lint(102, 21),
     ]);
   }
 
@@ -96,12 +175,13 @@ void foo(BuildContext context, Future<bool> condition) async {
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
-  if (await condition) return;
+void foo(BuildContext context) async {
+  if (await c()) return;
   Navigator.of(context);
 }
+Future<bool> c() async => true;
 ''', [
-      lint(136, 21),
+      lint(106, 21),
     ]);
   }
 
@@ -124,13 +204,14 @@ void foo(
     await assertNoDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
+void foo(BuildContext context) async {
   Navigator.of(context);
   if (1 == 2) {
-    await condition;
+    await c();
     return;
   }
 }
+Future<bool> c() async => true;
 ''');
   }
 
@@ -140,13 +221,14 @@ void foo(BuildContext context, Future<bool> condition) async {
     await assertNoDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
+void foo(BuildContext context) async {
   if (1 == 2) {
-    await condition;
+    await c();
     return;
   }
   Navigator.of(context);
 }
+Future<bool> c() async => true;
 ''');
   }
 
@@ -154,15 +236,16 @@ void foo(BuildContext context, Future<bool> condition) async {
     await assertNoDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
+void foo(BuildContext context) async {
   Navigator.of(context);
   if (1 == 2) {
-    await condition;
+    await c();
   } else {
-    await condition;
+    await c();
     return;
   }
 }
+Future<bool> c() async => true;
 ''');
   }
 
@@ -170,31 +253,53 @@ void foo(BuildContext context, Future<bool> condition) async {
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
+void foo(BuildContext context) async {
   if (1 == 2) {
-    await condition;
+    await c();
   } else {
-    await condition;
+    await c();
     return;
   }
   Navigator.of(context);
 }
+Future<bool> c() async => true;
 ''', [
-      lint(190, 21),
+      lint(154, 21),
     ]);
   }
 
+  @FailingTest(reason: 'Logic not implemented yet.')
   test_awaitInWhileBody_afterReferenceToContext() async {
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  while (true) {
+    // OK the first time only!
+    Navigator.of(context);
+    await f();
+  }
+}
+
+bool mounted = false;
+Future<void> f() async {}
+''', [
+      lint(149, 21),
+    ]);
+  }
+
+  test_awaitInWhileBody_afterReferenceToContextOutsideWait() async {
     await assertNoDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<void> condition) async {
+void foo(BuildContext context) async {
   Navigator.of(context);
   while (true) {
-    await condition;
+    await f();
     break;
   }
 }
+Future<void> f() async {}
 ''');
   }
 
@@ -202,15 +307,16 @@ void foo(BuildContext context, Future<void> condition) async {
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<void> condition) async {
+void foo(BuildContext context) async {
   while (true) {
-    await condition;
+    await f();
     break;
   }
   Navigator.of(context);
 }
+Future<void> f() async {}
 ''', [
-      lint(158, 21),
+      lint(128, 21),
     ]);
   }
 
@@ -218,16 +324,17 @@ void foo(BuildContext context, Future<void> condition) async {
     await assertNoDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
+void foo(BuildContext context) async {
   Navigator.of(context);
   if (1 == 2) {
-    await condition;
+    await c();
     return;
   } else {
-    await condition;
+    await c();
     return;
   }
 }
+Future<bool> c() async => true;
 ''');
   }
 
@@ -235,19 +342,20 @@ void foo(BuildContext context, Future<bool> condition) async {
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(BuildContext context, Future<bool> condition) async {
+void foo(BuildContext context) async {
   if (1 == 2) {
-    await condition;
+    await c();
     return;
   } else {
-    await condition;
+    await c();
     return;
   }
   Navigator.of(context);
 }
+Future<bool> c() async => true;
 ''', [
       // No lint.
-      error(WarningCode.DEAD_CODE, 202, 22),
+      error(WarningCode.DEAD_CODE, 166, 22),
     ]);
   }
 

--- a/test_data/rules/use_build_context_synchronously.dart
+++ b/test_data/rules/use_build_context_synchronously.dart
@@ -7,19 +7,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-void mountedBinOpAnd(BuildContext context, bool condition) async {
-  await Future<void>.delayed(Duration());
-  if (condition && context.mounted) {
-    await Navigator.of(context).pushNamed('routeName'); // OK
-  }
-}
-
-void mountedBinOpAOr(BuildContext context, bool condition) async {
-  await Future<void>.delayed(Duration());
-  if (condition || !mounted) return;
-  await Navigator.of(context).pushNamed('routeName'); // OK
-}
-
 void awaitInSwitchCase(BuildContext context) async {
   await Future<void>.delayed(Duration());
   switch (1) {
@@ -306,13 +293,6 @@ class _MyState extends State<MyWidget> {
   Widget build(BuildContext context) => Placeholder();
 }
 
-void topLevel(BuildContext context) async {
-  Navigator.of(context).pushNamed('routeName'); // OK
-
-  await Future<void>.delayed(Duration());
-  Navigator.of(context).pushNamed('routeName'); // LINT
-}
-
 void topLevel2(BuildContext context) async {
   Navigator.of(context).pushNamed('routeName'); // OK
 
@@ -320,21 +300,5 @@ void topLevel2(BuildContext context) async {
   // todo (pq): consider other conditionals (for, while, do, ...)
   if (true) {
     Navigator.of(context).pushNamed('routeName'); // LINT
-  }
-}
-
-void topLevel3(BuildContext context) async {
-  while (true) {
-    // OK the first time only!
-    Navigator.of(context).pushNamed('routeName'); // TODO: LINT
-    await Future<void>.delayed(Duration());
-  }
-}
-
-void topLevel4(BuildContext context) async {
-  Navigator.of(context).pushNamed('routeName');
-  await Future<void>.delayed(Duration());
-  if (mounted) {
-    Navigator.of(context).pushNamed('routeName'); // OK
   }
 }

--- a/test_data/rules/use_build_context_synchronously.dart
+++ b/test_data/rules/use_build_context_synchronously.dart
@@ -338,18 +338,3 @@ void topLevel4(BuildContext context) async {
     Navigator.of(context).pushNamed('routeName'); // OK
   }
 }
-
-void topLevel5(BuildContext context) async {
-  Navigator.of(context).pushNamed('routeName');
-  await Future<void>.delayed(Duration());
-
-  switch ('') {
-    case 'a':
-      if (!mounted) {
-        break;
-      }
-      Navigator.of(context).pushNamed('routeName222'); // OK
-      break;
-    default: //nothing.
-  }
-}


### PR DESCRIPTION
This also makes some of the existing tests more compact, allowing for the reported range to have a smaller offset (like `lint(115, 21)` vs `lint(145, 21)`).