### PR TITLE
Account for records in type relatedness checks

### DIFF
--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -167,7 +167,7 @@ bool typesAreUnrelated(
     return false;
   }
   if (promotedLeftType is InterfaceType && promotedRightType is InterfaceType) {
-    return typeSystem._interfaceTypesAreUnrelated(
+    return typeSystem.interfaceTypesAreUnrelated(
         promotedLeftType, promotedRightType);
   } else if (promotedLeftType is TypeParameterType &&
       promotedRightType is TypeParameterType) {
@@ -262,7 +262,7 @@ class InterfaceTypeDefinition {
 }
 
 extension on TypeSystem {
-  bool _interfaceTypesAreUnrelated(InterfaceType type1, InterfaceType type2) {
+  bool interfaceTypesAreUnrelated(InterfaceType type1, InterfaceType type2) {
     // In this case, [leftElement] and [rightElement] each represent
     // the same class, like `int`, or `Iterable<String>`.
     var element1 = type1.element;

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -262,34 +262,34 @@ class InterfaceTypeDefinition {
 }
 
 extension on TypeSystem {
-  bool interfaceTypesAreUnrelated(InterfaceType type1, InterfaceType type2) {
-    // In this case, [leftElement] and [rightElement] each represent
-    // the same class, like `int`, or `Iterable<String>`.
-    var element1 = type1.element;
-    var element2 = type2.element;
-    if (element1 == element2) {
+  bool interfaceTypesAreUnrelated(
+      InterfaceType leftType, InterfaceType rightType) {
+    var leftElement = leftType.element;
+    var rightElement = rightType.element;
+    if (leftElement == rightElement) {
       // In this case, [leftElement] and [rightElement] represent the same
       // class, modulo generics, e.g. `List<int>` and `List<dynamic>`. Now we
       // need to check type arguments.
-      var typeArguments1 = type1.typeArguments;
-      var typeArguments2 = type2.typeArguments;
-      if (typeArguments1.length != typeArguments2.length) {
+      var leftTypeArguments = leftType.typeArguments;
+      var rightTypeArguments = rightType.typeArguments;
+      if (leftTypeArguments.length != rightTypeArguments.length) {
         // I cannot think of how we would enter this block, but it guards
         // against RangeError below.
         return false;
       }
-      for (var i = 0; i < typeArguments1.length; i++) {
+      for (var i = 0; i < leftTypeArguments.length; i++) {
         // If any of the pair-wise type arguments are unrelated, then
         // [leftType] and [rightType] are unrelated.
-        if (typesAreUnrelated(this, typeArguments1[i], typeArguments2[i])) {
+        if (typesAreUnrelated(
+            this, leftTypeArguments[i], rightTypeArguments[i])) {
           return true;
         }
       }
       // Otherwise, they might be related.
       return false;
     } else {
-      return (element1.supertype?.isDartCoreObject ?? false) ||
-          element1.supertype != element2.supertype;
+      return (leftElement.supertype?.isDartCoreObject ?? false) ||
+          leftElement.supertype != rightElement.supertype;
     }
   }
 }

--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -11,8 +11,6 @@ import '../analyzer.dart';
 import '../ast.dart';
 import '../extensions.dart';
 
-typedef AstNodePredicate = bool Function(AstNode node);
-
 bool argumentsMatchParameters(
     NodeList<Expression> arguments, NodeList<FormalParameter> parameters) {
   var namedParameters = <String, Element?>{};
@@ -145,7 +143,9 @@ bool canonicalElementsFromIdentifiersAreEqual(
 ///   * are related if their supertypes are equal, e.g. `List<dynamic>` and
 ///     `Set<dynamic>`.
 /// * Two type variables are related if their bounds are related.
-/// * Otherwise, the types are related.
+/// * A record type is unrelated to any other type except a record type of
+///   the same shape.
+/// * Otherwise, any two types are related.
 // TODO(srawlins): typedefs and functions in general.
 bool typesAreUnrelated(
     TypeSystem typeSystem, DartType? leftType, DartType? rightType) {
@@ -167,35 +167,8 @@ bool typesAreUnrelated(
     return false;
   }
   if (promotedLeftType is InterfaceType && promotedRightType is InterfaceType) {
-    // In this case, [leftElement] and [rightElement] each represent
-    // the same class, like `int`, or `Iterable<String>`.
-    var leftElement = promotedLeftType.element;
-    var rightElement = promotedRightType.element;
-    if (leftElement == rightElement) {
-      // In this case, [leftElement] and [rightElement] represent the same
-      // class, modulo generics, e.g. `List<int>` and `List<dynamic>`. Now we
-      // need to check type arguments.
-      var leftTypeArguments = promotedLeftType.typeArguments;
-      var rightTypeArguments = promotedRightType.typeArguments;
-      if (leftTypeArguments.length != rightTypeArguments.length) {
-        // I cannot think of how we would enter this block, but it guards
-        // against RangeError below.
-        return false;
-      }
-      for (var i = 0; i < leftTypeArguments.length; i++) {
-        // If any of the pair-wise type arguments are unrelated, then
-        // [leftType] and [rightType] are unrelated.
-        if (typesAreUnrelated(
-            typeSystem, leftTypeArguments[i], rightTypeArguments[i])) {
-          return true;
-        }
-      }
-      // Otherwise, they might be related.
-      return false;
-    } else {
-      return (leftElement.supertype?.isDartCoreObject ?? false) ||
-          leftElement.supertype != rightElement.supertype;
-    }
+    return typeSystem._interfaceTypesAreUnrelated(
+        promotedLeftType, promotedRightType);
   } else if (promotedLeftType is TypeParameterType &&
       promotedRightType is TypeParameterType) {
     return typesAreUnrelated(typeSystem, promotedLeftType.element.bound,
@@ -208,6 +181,10 @@ bool typesAreUnrelated(
     if (_isFunctionTypeUnrelatedToType(promotedRightType, promotedLeftType)) {
       return true;
     }
+  } else if (promotedLeftType is RecordType ||
+      promotedRightType is RecordType) {
+    return !typeSystem.isAssignableTo(promotedLeftType, promotedRightType) &&
+        !typeSystem.isAssignableTo(promotedRightType, promotedLeftType);
   }
   return false;
 }
@@ -225,6 +202,8 @@ bool _isFunctionTypeUnrelatedToType(FunctionType type1, DartType type2) {
   }
   return true;
 }
+
+typedef AstNodePredicate = bool Function(AstNode node);
 
 class DartTypeUtilities {
   @Deprecated('Replace with `type.extendsClass`')
@@ -279,6 +258,39 @@ class InterfaceTypeDefinition {
     return other is InterfaceTypeDefinition &&
         name == other.name &&
         library == other.library;
+  }
+}
+
+extension on TypeSystem {
+  bool _interfaceTypesAreUnrelated(InterfaceType type1, InterfaceType type2) {
+    // In this case, [leftElement] and [rightElement] each represent
+    // the same class, like `int`, or `Iterable<String>`.
+    var element1 = type1.element;
+    var element2 = type2.element;
+    if (element1 == element2) {
+      // In this case, [leftElement] and [rightElement] represent the same
+      // class, modulo generics, e.g. `List<int>` and `List<dynamic>`. Now we
+      // need to check type arguments.
+      var typeArguments1 = type1.typeArguments;
+      var typeArguments2 = type2.typeArguments;
+      if (typeArguments1.length != typeArguments2.length) {
+        // I cannot think of how we would enter this block, but it guards
+        // against RangeError below.
+        return false;
+      }
+      for (var i = 0; i < typeArguments1.length; i++) {
+        // If any of the pair-wise type arguments are unrelated, then
+        // [leftType] and [rightType] are unrelated.
+        if (typesAreUnrelated(this, typeArguments1[i], typeArguments2[i])) {
+          return true;
+        }
+      }
+      // Otherwise, they might be related.
+      return false;
+    } else {
+      return (element1.supertype?.isDartCoreObject ?? false) ||
+          element1.supertype != element2.supertype;
+    }
   }
 }
 

--- a/test/rules/collection_methods_unrelated_type_test.dart
+++ b/test/rules/collection_methods_unrelated_type_test.dart
@@ -71,6 +71,10 @@ var x = <M>[].contains(C());
     await assertNoDiagnostics('var x = <num>[].contains(Object());');
   }
 
+  test_contains_related_records() async {
+    await assertNoDiagnostics('var x = <(num, num)>[].contains((1, 2));');
+  }
+
   test_contains_related_subclassOfList() async {
     await assertNoDiagnostics('''
 abstract class C implements List<num> {}
@@ -116,6 +120,18 @@ abstract class C implements List<num> {
   }
 }
 ''', [lint(66, 3)]);
+  }
+
+  test_contains_unrelated_records() async {
+    await assertDiagnostics("var x = <(int, int)>[].contains(('hi', 'hey'));", [
+      lint(32, 13),
+    ]);
+  }
+
+  test_contains_unrelated_recordAndNonRecord() async {
+    await assertDiagnostics("var x = <(int, int)>[].contains('hi');", [
+      lint(32, 4),
+    ]);
   }
 
   test_contains_unrelated_subclassOfList() async {

--- a/test/rules/unrelated_type_equality_checks_test.dart
+++ b/test/rules/unrelated_type_equality_checks_test.dart
@@ -18,6 +18,28 @@ class UnrelatedTypeEqualityChecksTestLanguage300 extends LintRuleTest
   @override
   String get lintRule => 'unrelated_type_equality_checks';
 
+  test_recordAndInterfaceType_unrelated() async {
+    await assertDiagnostics(r'''
+bool f((int, int) a, String b) => a == b;
+''', [
+      lint(34, 6),
+    ]);
+  }
+
+  test_records_related() async {
+    await assertNoDiagnostics(r'''
+bool f((int, int) a, (num, num) b) => a == b;
+''');
+  }
+
+  test_records_unrelated() async {
+    await assertDiagnostics(r'''
+bool f((int, int) a, (String, String) b) => a == b;
+''', [
+      lint(44, 6),
+    ]);
+  }
+
   @FailingTest(
       reason: 'Error code refactoring',
       issue: 'https://github.com/dart-lang/linter/issues/4256')

--- a/test/rules/unrelated_type_equality_checks_test.dart
+++ b/test/rules/unrelated_type_equality_checks_test.dart
@@ -40,6 +40,34 @@ bool f((int, int) a, (String, String) b) => a == b;
     ]);
   }
 
+  test_recordsWithNamed_related() async {
+    await assertNoDiagnostics(r'''
+bool f(({int one, int two}) a, ({num two, num one}) b) => a == b;
+''');
+  }
+
+  test_recordsWithNamed_unrelated() async {
+    await assertDiagnostics(r'''
+bool f(({int one, int two}) a, ({String one, String two}) b) => a == b;
+''', [
+      lint(64, 6),
+    ]);
+  }
+
+  test_recordsWithNamedAndPositional_related() async {
+    await assertNoDiagnostics(r'''
+bool f((int, {int two}) a, (num one, {num two}) b) => a == b;
+''');
+  }
+
+  test_recordsWithNamedAndPositional_unrelated() async {
+    await assertDiagnostics(r'''
+bool f((int, {int two}) a, (String one, {String two}) b) => a == b;
+''', [
+      lint(60, 6),
+    ]);
+  }
+
   @FailingTest(
       reason: 'Error code refactoring',
       issue: 'https://github.com/dart-lang/linter/issues/4256')


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/4265

Uses `isAssignableTo` to handle relatedness, accounting for shape and subtypes.