### PR TITLE
bump gh pages build to dev SDK

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
         with:
-          sdk: stable
+          sdk: dev
       - name: Get dependencies
         run: dart pub get
       - name: Generate docs


### PR DESCRIPTION
This should fix our broken gh-pages deployment.

<img width="929" alt="image" src="https://user-images.githubusercontent.com/67586/231600210-22be9164-d7b8-4f5e-9dae-8cac07849b14.png">


/cc @srawlins @bwilkerson 