### PR TITLE
[use_build_context_synchronously] Fix for unprotected 'last' invocation.

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:collection/collection.dart';
 
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
@@ -346,7 +347,9 @@ extension on Statement {
   bool get terminatesControl {
     var self = this;
     if (self is Block) {
-      return self.statements.last.terminatesControl;
+      // TODO(scheglov) Stop using package:collection when SDK 3.0.0
+      var last = self.statements.lastOrNull;
+      return last != null && last.terminatesControl;
     }
     // TODO(srawlins): Make ExitDetector 100% functional for our needs. The
     // basic (only?) difference is that it doesn't consider a `break` statement

--- a/test/rule_test_support.dart
+++ b/test/rule_test_support.dart
@@ -39,20 +39,29 @@ typedef DiagnosticMatcher = bool Function(AnalysisError error);
 class AnalysisOptionsFileConfig {
   final List<String> experiments;
   final List<String> lints;
+  final bool propagateLinterExceptions;
 
   AnalysisOptionsFileConfig({
     this.experiments = const [],
     this.lints = const [],
+    this.propagateLinterExceptions = false,
   });
 
   String toContent() {
     var buffer = StringBuffer();
 
-    if (experiments.isNotEmpty) {
+    if (experiments.isNotEmpty || propagateLinterExceptions) {
       buffer.writeln('analyzer:');
       buffer.writeln('  enable-experiment:');
       for (var experiment in experiments) {
         buffer.writeln('    - $experiment');
+      }
+
+      if (propagateLinterExceptions) {
+        buffer.writeln('  strong-mode:');
+        buffer.writeln(
+          '    propagate-linter-exceptions: $propagateLinterExceptions',
+        );
       }
     }
 
@@ -378,6 +387,7 @@ class PubPackageResolutionTest extends _ContextResolutionTest {
       AnalysisOptionsFileConfig(
         experiments: experiments,
         lints: _lintRules,
+        propagateLinterExceptions: true,
       ),
     );
     writeTestPackageConfig(
@@ -456,6 +466,7 @@ export 'src/widgets/framework.dart';
         .writeAsStringSync(r'''   
 abstract class BuildContext {
   Widget get widget;
+  bool get mounted;
 }
 
 class Navigator {

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -428,6 +428,21 @@ Future<void> bar({required BuildContext context}) async {}
     ]);
   }
 
+  test_noAwaitBefore_ifEmptyThen_methodInvocation() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void f(BuildContext context) async {
+  if (true) {}
+  context.foo();
+}
+
+extension on BuildContext {
+  void foo() {}
+}
+''');
+  }
+
   /// https://github.com/dart-lang/linter/issues/3700
   test_propertyAccess_getter() async {
     await assertDiagnostics(r'''


### PR DESCRIPTION
Also enables `propagate-linter-exceptions`, so that we get the crash when resolving test code.

This issue started to happen quite often internally, there is a spike of crashes.