### PR TITLE
Fix unrelated_type_equality_checks when comparing enums

### DIFF
--- a/lib/src/util/dart_type_utilities.dart
+++ b/lib/src/util/dart_type_utilities.dart
@@ -290,10 +290,9 @@ extension on TypeSystem {
     } else {
       var sameSupertypes = leftElement.supertype == rightElement.supertype;
 
-      // Unrelated Enums or Mixins have the same supertype, but they are not the same element, so
+      // Unrelated Enums have the same supertype, but they are not the same element, so
       // they are unrelated.
-      if (sameSupertypes &&
-          (leftElement is EnumElement || leftElement is MixinElement)) {
+      if (sameSupertypes && leftElement is EnumElement) {
         return true;
       }
 

--- a/test_data/rules/unrelated_type_equality_checks.dart
+++ b/test_data/rules/unrelated_type_equality_checks.dart
@@ -196,18 +196,11 @@ void function32() {
   if (y == EnumImplements.a) print('a'); // LINT
 }
 
-void someFunction33(Mixin m1, Mixin2 m2) {
-  if (m1 == m1) print('someFunction32'); // OK
-  if (m1 == m2) print('someFunction32'); // LINT
-}
-
 class ClassBase {}
 
 class DerivedClass1 extends ClassBase {}
 
 mixin Mixin {}
-
-mixin Mixin2 {}
 
 class DerivedClass2 extends ClassBase with Mixin {}
 


### PR DESCRIPTION
# Description

Currently the `unrelated_type_equality_checks` doesn't work when comparing different enums. This can be a gotcha when comparing similar enums in terms of context.

```dart
enum EnumOpKind1 { insert, update, delete }
enum EnumOpKind2 { upsert, delete }

void fun() {
  var x = EnumOpKind1.delete;
  if (x == EnumOpKind1.delete) print('delete'); // OK
  if (x == EnumOpKind2.delete) print('delete'); // This should lint
}
```

Same thing happens when comparing different Mixins. Although this I've noticed when I looked into the source code of the lint.
