### PR TITLE
add a tool to get GH issue labels

### DIFF
--- a/tool/gh/get_labels.dart
+++ b/tool/gh/get_labels.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:args/args.dart';
+import 'package:github/github.dart';
+import 'package:http/http.dart' as http;
+
+import '../github.dart';
+
+/// Outputs a list of labels.
+Future<void> main(List<String> args) async {
+  var parser = ArgParser()
+    ..addOption('token', abbr: 't', help: 'Specifies a GitHub auth token.')
+    ..addOption('owner',
+        abbr: 'o', help: 'Specifies a GitHub repo owner (e.g., dart-lang).')
+    ..addOption('name',
+        abbr: 'n', help: 'Specifies a GitHub repo name (e.g., sdk).');
+
+  ArgResults options;
+  try {
+    options = parser.parse(args);
+  } on FormatException catch (err) {
+    printUsage(parser, err.message);
+    return;
+  }
+
+  var owner = options['owner'];
+  if (owner is! String) {
+    printUsage(parser, 'Must specify repo owner.');
+    return;
+  }
+  var name = options['name'];
+  if (name is! String) {
+    printUsage(parser, 'Must specify repo name.');
+    return;
+  }
+
+  var token = options['token'];
+  var auth = token is String ? Authentication.withToken(token) : null;
+  var labels = await getLabels(owner: owner, name: name, auth: auth);
+  for (var label in labels) {
+    print(label.name);
+  }
+}
+
+void printUsage(ArgParser parser, [String? error]) {
+  var message = error ?? 'Get labels for a given GitHub repo.';
+  print('''$message
+Usage: get_labels.dart rule_name
+${parser.usage}
+''');
+}

--- a/tool/gh/get_labels.dart
+++ b/tool/gh/get_labels.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:args/args.dart';
 import 'package:github/github.dart';
-import 'package:http/http.dart' as http;
 
 import '../github.dart';
 

--- a/tool/github.dart
+++ b/tool/github.dart
@@ -4,6 +4,20 @@
 
 import 'package:github/github.dart';
 
+Future<List<IssueLabel>> getLabels(
+    {required String owner, required String name, Authentication? auth}) async {
+  var github = GitHub(auth: auth);
+  var slug = RepositorySlug(owner, name);
+  try {
+    return github.issues.listLabels(slug).toList();
+  } on Exception catch (e) {
+    print('exception caught fetching GitHub labels');
+    print(e);
+    print('(defaulting to an empty list)');
+    return Future.value(<IssueLabel>[]);
+  }
+}
+
 Future<List<Issue>> getLinterIssues({Authentication? auth}) async {
   var github = GitHub(auth: auth);
   var slug = RepositorySlug('dart-lang', 'linter');


### PR DESCRIPTION
Adds a simple tool to fetch issue labels.

Sample run:

```
linter [main] ⚡  dart tool/gh/get_labels.dart -o dart-lang -n linter
area-build
cla: no
cla: yes
customer: flutter
customer: g3
customer: money (g3)
dependency: analyzer
effective dart
false negative
false positive
good first issue
help wanted
lint proposal
lint request
meta
needs internal testing
needs-info
new language feature
NNBD
P0
P1
P2
P3
P4
process
pub
set-core
set-flutter
set-flutter (dev)
set-internal
set-internal (available)
set-none
set-recommended
status: accepted
status: closed
status: in progress
status: pending
style
type-bug
type-code-health
type-documentation
type-enhancement
type-performance
type-question
type-task
type-test
ux
waiting for customer response
```

/cc @bwilkerson @srawlins 

/fyi @jcollins-g 