### PR TITLE
Refactor "mounted check" computation in `use_build_context_synchronously`

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -186,7 +186,6 @@ class _MountedCheckVisitor extends SimpleAstVisitor<_MountedCheck> {
     }
     var conditionMountedCheck = node.expression.accept(this);
 
-    if (conditionMountedCheck == null) return null;
     if (child == node.thenStatement) {
       return conditionMountedCheck == _MountedCheck.positive
           ? _MountedCheck.positive
@@ -196,6 +195,12 @@ class _MountedCheckVisitor extends SimpleAstVisitor<_MountedCheck> {
           ? _MountedCheck.positive
           : null;
     } else {
+      if (conditionMountedCheck == null) {
+        var thenMountedCheck = node.thenStatement.accept(this);
+        var elseMountedCheck = node.elseStatement?.accept(this);
+        return thenMountedCheck == elseMountedCheck ? thenMountedCheck : null;
+      }
+
       if (conditionMountedCheck == _MountedCheck.positive) {
         // `child` is (or is a child of) a statement that comes after `node`
         // in a NodeList.

--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -349,12 +349,14 @@ class _Visitor extends SimpleAstVisitor {
     /// Checks each of the [statements] before [child] for a `mounted` check,
     /// and returns whether it did not find one (and the caller should keep
     /// looking).
-    bool checkStatements(Statement child, NodeList<Statement> statements) {
+    bool checkStatements(AstNode child, NodeList<Statement> statements) {
+      if (child is! Statement) {
+        assert(false, 'child must be a Statement, but is ${child.runtimeType}');
+        return true;
+      }
       var index = statements.indexOf(child);
       for (var i = index - 1; i >= 0; i--) {
         var s = statements[i];
-        // `s` is a sufficient mounted check if it causes control flow to exit
-        // the current function body, so we specify [ _MountedCheck.negative].
         if (s.isMountedCheckFor(child)) {
           return false;
         } else if (s.isAsync) {
@@ -371,22 +373,19 @@ class _Visitor extends SimpleAstVisitor {
     while (child != null && child is! FunctionBody) {
       var parent = child.parent;
       if (parent is Block) {
-        var keepChecking =
-            checkStatements(child as Statement, parent.statements);
+        var keepChecking = checkStatements(child, parent.statements);
         if (!keepChecking) {
           return;
         }
       } else if (parent is SwitchCase) {
         // Necessary for Dart 2.19 code.
-        var keepChecking =
-            checkStatements(child as Statement, parent.statements);
+        var keepChecking = checkStatements(child, parent.statements);
         if (!keepChecking) {
           return;
         }
       } else if (parent is SwitchPatternCase) {
         // Necessary for Dart 3.0 code.
-        var keepChecking =
-            checkStatements(child as Statement, parent.statements);
+        var keepChecking = checkStatements(child, parent.statements);
         if (!keepChecking) {
           return;
         }

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -136,6 +136,28 @@ bool get c => true;
 ''');
   }
 
+  test_awaitBeforeIf_mountedExitGuardInIf_beforeReferenceToContext4() async {
+    // Await, then an unrelated if/else, with a proper "exit if not mounted"
+    // guard in the then-statement, and another in the else-statement, then use
+    // of BuildContext, is OK.
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await f();
+  if (1 == 2) {
+    if (!mounted) return;
+  } else {
+    if (!mounted) return;
+  }
+  Navigator.of(context);
+}
+
+bool mounted = false;
+Future<void> f() async {}
+''');
+  }
+
   test_awaitBeforeIf_mountedExitGuardInIf_beforeReferenceToContext2() async {
     // Await, then a proper "exit if not mounted" guard in an if-condition,
     // then use of BuildContext, is OK.

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -54,6 +54,70 @@ Future<void> f() async {}
     ]);
   }
 
+  test_awaitBeforeConditional_mountedGuard() async {
+    // Await, then an "if mounted" guard in a conditional expression, and use of
+    // BuildContext in the conditional-then, is OK.
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await c();
+  mounted ? Navigator.of(context) : null;
+}
+Future<void> c() async => true;
+bool mounted = false;
+''');
+  }
+
+  test_awaitBeforeConditional_mountedGuard2() async {
+    // Await, then an "if not mounted" guard in a conditional expression, and
+    // use of BuildContext in the conditional-else, is OK.
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await c();
+  !mounted ? null : Navigator.of(context);
+}
+Future<void> c() async => true;
+bool mounted = false;
+''');
+  }
+
+  test_awaitBeforeConditional_mountedGuard3() async {
+    // Await, then an "if mounted" guard in a conditional expression, and
+    // use of BuildContext in the conditional-else, is REPORTED.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await c();
+  mounted ? null : Navigator.of(context);
+}
+Future<void> c() async => true;
+bool mounted = false;
+''', [
+      lint(111, 21),
+    ]);
+  }
+
+  test_awaitBeforeConditional_mountedGuard4() async {
+    // Await, then an "if not mounted" guard in a conditional expression, and
+    // use of BuildContext in the conditional-then, is REPORTED.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await c();
+  !mounted ? Navigator.of(context) : null;
+}
+Future<void> c() async => true;
+bool mounted = false;
+''', [
+      lint(105, 21),
+    ]);
+  }
+
   test_awaitBeforeIf_mountedExitGuardInIf_beforeReferenceToContext() async {
     // Await, then a proper "exit if not mounted" guard in an if-condition (or'd
     // with another bool), then use of BuildContext, is OK.
@@ -141,6 +205,27 @@ bool mounted = false;
 Future<void> f() async {}
 bool get c => true;
 ''');
+  }
+
+  test_awaitBeforeIf_mountedGuardInIf3() async {
+    // Await, then a proper "if mounted" guard in an if-condition, then use of
+    // BuildContext in the else-body, is OK.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await f();
+  if (mounted) {
+  } else {
+    Navigator.of(context);
+  }
+}
+
+bool mounted = false;
+Future<void> f() async {}
+''', [
+      lint(124, 21),
+    ]);
   }
 
   test_awaitBeforeIfStatement_withReferenceToContext() async {
@@ -231,6 +316,37 @@ void foo(BuildContext context) async {
 Future<bool> c() async => true;
 ''', [
       lint(106, 21),
+    ]);
+  }
+
+  test_awaitInIfCondition_beforeReferenceToContext2() async {
+    // Await in an if-condition, and use of BuildContext in single-statement
+    // if-then, is REPORTED.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  if (await c()) Navigator.of(context);
+}
+Future<bool> c() async => true;
+''', [
+      lint(96, 21),
+    ]);
+  }
+
+  test_awaitInIfCondition_beforeReferenceToContext3() async {
+    // Await in an if-condition, and use of BuildContext in single-statement
+    // if-else, is REPORTED.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  if (await c()) print(1);
+  else Navigator.of(context);
+}
+Future<bool> c() async => true;
+''', [
+      lint(113, 21),
     ]);
   }
 
@@ -423,6 +539,21 @@ Future<bool> c() async => true;
       // No lint.
       error(WarningCode.DEAD_CODE, 166, 22),
     ]);
+  }
+
+  test_conditionalOperator() async {
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+Future<String> foo(BuildContext context, bool condition) async {
+  await Future<void>.delayed(Duration());
+  return mounted ? bar(context) : 'no';
+}
+
+bool get mounted => true;
+
+String bar(BuildContext context) => 'bar';
+''');
   }
 
   /// https://github.com/dart-lang/linter/issues/3818


### PR DESCRIPTION
# Description

This is a sizable refactoring of `use_build_context_synchronously` which I think makes it more robust for future improvements, and solves one bug as a demonstration of this.

I learned a lot about this rule while poking around, and this refactoring is not a slam dunk (the code is certainly longer), so I'm including a big explanation of what is going on (and the code itself has many comments).

**Quick description of the rule**: In a method, you should not access a BuildContext (named `context`) after any `await` expression, _unless_ you "guard" that BuildContext access with a proper "mounted check", which is a call to `mounted.check` in some control-flow-affecting position, _between_ the `await` and the BuildContext access.

The devil is really in the details of what defines a proper "mounted check." Some basic examples:

* `if (context.mounted)` guards a BuildContext access in the then-statement, but not one in the else-statement.
* `if (!context.mounted)` guards a BuildContext access in the else-statement, but not one in the then-statement.
* `if (!context.mounted) return;` guards a BuildContext access in any statement following the statement.

So the check itself has a polarity, and the syntax nodes for the BuildContext access and the mounted check have a relationship. In some cases only a positive check properly guards, and in other cases only a negative check properly guards. If a positive check is required, this guards that the BuildContext can only ever be accessed if a mounted check came back positive. If a negative check is required, this guards that the BuildContext can only ever be accessed if a mounted check came back negative; in this case, what must be proven is that the code execution branches away from the BuildContext, like in the 3rd example above.

And you can imagine how real code uses much more complicated syntax. Parentheses, logical operators, conditional operators, block statements which may or may not always "exit", conditions or block statements which may themselves contain `await`s.

### Current impl

The current implementation of "is this a mounted check" (lines 202 through 277 in the left diff) is a function, `isMountedCheck`, which consists of a series of if/else-if/else-ifs checking what type of node we're looking at (a for-loop? an if-statement?) which has a nested function (`checkMounted`), and the code recurses into `isMountedCheck` and `checksMounted` as appropriate.

I found this function difficult to reason about and extend to account for conditional-expressions (#3465). The code must account for the polarity of mounted checks in child nodes, and whether code exits, etc. It seems so much like an ad-hoc visitor system, I thought it would be more maintainable and extensible as an actual visitor.

### New impl

The new implementation (the `_MountedCheckVisitor` class starting on line 119 and an entrypoint for the visitor, `isMountedCheckFor`, on line 430 which has the documentation) is a `SimpleAstVisitor<_MountedCheck>` where each visit method returns a nullable `_MountedCheck` value. The visitor is given the "child" node whose guarded-ness is in question, so that it can take node relationships into account. `_MountedCheck` is a binary enum defined just above. The nullability (required for `SimpleAstVisitor<T>` fits nicely into this model:

* A visit method returning `null` means the visited node does not definitely guard `child` with a mounted check.
* A visit method returning `_MountedCheck.positive` definitely guards `child` with a positive mounted check.
* A visit method returning `_MountedCheck.negative` definitely guards `child` with a negative mounted check.

See the new test cases, e.g. `test_awaitBeforeIf_mountedExitGuardInIf_beforeReferenceToContext4` for how a mounted check can be derived from complicated child nodes.

### Not a slam dunk

As I mentioned, this isn't a massive win or anything, but I do think the new code is more readable and maintainable. I don't think I can easily conceive of a test case that _cannot pass_ using the current implementation; it's just that I found the current implementation hard to extend. But I'd love love feedback. In particular:

* I'm not in love with the enum name `_MountedCheck` but couldn't think of anything much shorter. We could drop the underscore.
* I'm not in love with the enum value names `_MountedCheck.positive` and `_MountedCheck.negative`, so maybe we can think of something shorter... I still like them over simple `true` and `false` because it makes the code more readable, I think, to include some semantic meaning, over just `true` and `false`.

The code does seem to be as performant as the current impl by using the benchmark tool (and the time complexity shouldn't be different).

CC @pq @bwilkerson 

Fixes #3465 