### PR TITLE
Don't check if iterable is nullable, what matters is null-aware calls

### DIFF
--- a/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
+++ b/lib/src/rules/avoid_function_literals_in_foreach_calls.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
@@ -56,10 +55,8 @@ bool _isInsideCascade(AstNode node) =>
     node.thisOrAncestorMatching((n) => n is Statement || n is CascadeExpression)
         is CascadeExpression;
 
-bool _isNonNullableIterable(DartType? type) =>
-    type != null &&
-    type.nullabilitySuffix == NullabilitySuffix.none &&
-    type.implementsInterface('Iterable', 'dart.core');
+bool _isIterable(DartType? type) =>
+    type != null && type.implementsInterface('Iterable', 'dart.core');
 
 class AvoidFunctionLiteralInForeachMethod extends LintRule {
   static const LintCode code = LintCode(
@@ -97,7 +94,7 @@ class _Visitor extends SimpleAstVisitor<void> {
         node.methodName.token.value() == 'forEach' &&
         node.argumentList.arguments.isNotEmpty &&
         node.argumentList.arguments.first is FunctionExpression &&
-        _isNonNullableIterable(target.staticType) &&
+        _isIterable(target.staticType) &&
         !node.containsNullAwareInvocationInChain() &&
         !_hasMethodChaining(node) &&
         !_isInsideCascade(node)) {

--- a/test/rules/avoid_function_literals_in_foreach_calls_test.dart
+++ b/test/rules/avoid_function_literals_in_foreach_calls_test.dart
@@ -10,6 +10,7 @@ import '../rule_test_support.dart';
 main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(AvoidFunctionLiteralsInForeachCalls);
+    defineReflectiveTests(AvoidFunctionLiteralsInForeachCallsPreNNBDTest);
   });
 }
 
@@ -159,7 +160,16 @@ class AvoidFunctionLiteralsInForeachCallsPreNNBDTest extends LintRuleTest {
     noSoundNullSafety = true;
   }
 
-  test_functionExpression_nullableTarget() async {
+  test_functionExpression_basic() async {
+    await assertDiagnostics(r'''
+// @dart=2.9
+void f(List<String> people) {
+  people.forEach((person) => print('$person'));
+}
+''', [lint(52, 7)]);
+  }
+
+  test_functionExpression_nullAware() async {
     await assertNoDiagnostics(r'''
 // @dart=2.9
 void f(List<String> people) {


### PR DESCRIPTION
* Fixes #4328.

   Reverts #4039 that caused false negatives in non-null-safe mode. 

   And reverts #2752 along with it because it was not the exact right fix in the first place.

   Null-aware calls are since handled by #4305 and all the existing tests still pass.
