### PR TITLE
fix `avoid_returning_this` false positive w/ conditional this returns

### DIFF
--- a/lib/src/rules/avoid_returning_this.dart
+++ b/lib/src/rules/avoid_returning_this.dart
@@ -72,6 +72,8 @@ class AvoidReturningThis extends LintRule {
 class _BodyVisitor extends RecursiveAstVisitor {
   List<ReturnStatement> returnStatements = [];
 
+  bool foundNonThisReturn = false;
+
   List<ReturnStatement> collectReturns(BlockFunctionBody body) {
     body.accept(this);
     return returnStatements;
@@ -84,9 +86,14 @@ class _BodyVisitor extends RecursiveAstVisitor {
 
   @override
   visitReturnStatement(ReturnStatement node) {
+    // Short-circuit if we've encountered a non-this return.
+    if (foundNonThisReturn) return;
     // Short-circuit if not returning this.
-    if (!_returnsThis(node)) return;
-
+    if (!_returnsThis(node)) {
+      foundNonThisReturn = true;
+      returnStatements.clear();
+      return;
+    }
     returnStatements.add(node);
     super.visitReturnStatement(node);
   }

--- a/test/rules/avoid_returning_this_test.dart
+++ b/test/rules/avoid_returning_this_test.dart
@@ -17,6 +17,36 @@ class AvoidReturningThisTest extends LintRuleTest {
   @override
   String get lintRule => 'avoid_returning_this';
 
+  /// https://github.com/dart-lang/linter/issues/3853
+  test_conditionalReturn() async {
+    await assertNoDiagnostics(r'''
+class C {
+  C getInstance(C? c) {
+    if (c == null) return this;
+    return c;
+  }
+}
+''');
+  }
+
+  test_conditionalReturn_expression_ternary() async {
+    await assertNoDiagnostics(r'''
+class C {
+  C getInstance(C? c) => c == null ? this : c;
+}
+''');
+  }
+
+  test_conditionalReturn_ternary() async {
+    await assertNoDiagnostics(r'''
+class C {
+  C getInstance(C? c) {
+    return c == null ? this : c;
+  }
+}
+''');
+  }
+
   test_method() async {
     await assertDiagnostics(r'''
 enum A {


### PR DESCRIPTION
Updates the semantics of `avoid_returning_this` to bail when a body has a return of anything non-`this`. This lint should only fire when `this` is returned unconditionally.


Fixes #3853


/cc @bwilkerson 