### PR TITLE
Add use_build_context_synchronously tests for context-in-await

### DIFF
--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -308,7 +308,7 @@ Future<void> f() async {}
 ''');
   }
 
-  test_awaitExpressionContainsReferenceToContext() async {
+  test_await_expressionContainsReferenceToContext() async {
     // Await expression contains use of BuildContext, is OK.
     await assertNoDiagnostics(r'''
 import 'package:flutter/widgets.dart';
@@ -382,6 +382,20 @@ Future<bool> c() async => true;
 ''', [
       lint(113, 21),
     ]);
+  }
+
+  test_awaitInIfCondition_expressionContainsReferenceToContext() async {
+    // Await expression contains use of BuildContext, is OK.
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(
+    BuildContext context, Future<bool> Function(BuildContext) condition) async {
+  if (await condition(context)) {
+    return;
+  }
+}
+''');
   }
 
   test_awaitInIfReferencesContext_beforeReferenceToContext() async {

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -308,6 +308,18 @@ Future<void> f() async {}
 ''');
   }
 
+  test_awaitExpressionContainsReferenceToContext() async {
+    // Await expression contains use of BuildContext, is OK.
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(
+    BuildContext context, Future<bool> Function(BuildContext) condition) async {
+  await condition(context);
+}
+''');
+  }
+
   // https://github.com/dart-lang/linter/issues/3457
   test_awaitInIfCondition_aboveReferenceToContext() async {
     // Await in an if-condition, then use of BuildContext in the if-body, is
@@ -373,18 +385,19 @@ Future<bool> c() async => true;
   }
 
   test_awaitInIfReferencesContext_beforeReferenceToContext() async {
-    // Await in an if-condition, then use of BuildContext, is REPORTED.
+    // Await in an if-condition, then use of BuildContext in if-then statement,
+    // is REPORTED.
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
-void foo(
-    BuildContext context, Future<bool> Function(BuildContext) condition) async {
-  if (await condition(context)) {
+void foo(BuildContext context) async {
+  if (await c()) {
     Navigator.of(context);
   }
 }
+Future<bool> c() async => true;
 ''', [
-      lint(169, 21),
+      lint(102, 21),
     ]);
   }
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/linter/issues/4027

I think this was fixed by the recent refactoring. Just adding test cases here.