### PR TITLE
Fix for crash in prefer_const_constructors_in_immutables when firstWhere().

### DIFF
--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -119,9 +119,9 @@ class _Visitor extends SimpleAstVisitor<void> {
       return redirectInvocation.staticElement?.isConst ?? false;
     }
     // Constructor with implicit `super()` call.
-    var supertype = clazz.supertype;
-    return supertype != null &&
-        supertype.constructors.firstWhere((e) => e.name.isEmpty).isConst;
+    var unnamedSuperConstructor =
+        clazz.supertype?.constructors.firstWhereOrNull((e) => e.name.isEmpty);
+    return unnamedSuperConstructor != null && unnamedSuperConstructor.isConst;
   }
 
   /// Whether [clazz] or any of it's super-types are annotated with

--- a/test/rules/prefer_const_constructors_in_immutables_test.dart
+++ b/test/rules/prefer_const_constructors_in_immutables_test.dart
@@ -15,10 +15,10 @@ main() {
 @reflectiveTest
 class PreferConstConstructorsInImmutablesTest extends LintRuleTest {
   @override
-  String get lintRule => 'prefer_const_constructors_in_immutables';
+  bool get addMetaPackageDep => true;
 
   @override
-  bool get addMetaPackageDep => true;
+  String get lintRule => 'prefer_const_constructors_in_immutables';
 
   test_assertInitializer_canBeConst() async {
     await assertDiagnostics(r'''
@@ -42,6 +42,24 @@ class C {
   C.named(a) : assert(a.toString() == 'string');
 }
 ''');
+  }
+
+  test_implicitSuperConstructorInvocation_undefined() async {
+    await assertDiagnostics(r'''
+import 'package:meta/meta.dart';
+
+@immutable
+class A {
+  const A.named();
+}
+
+class B extends A {
+  B();
+}
+''', [
+      error(CompileTimeErrorCode.UNDEFINED_CONSTRUCTOR_IN_INITIALIZER_DEFAULT,
+          99, 1),
+    ]);
   }
 
   test_returnOfInvalidType() async {


### PR DESCRIPTION
Saw a crash in logs.
```
StateError: Bad state: No element
at ListBase.firstWhere    (dart:collection)
at _Visitor._hasConstConstructorInvocation    (prefer_const_constructors_in_immutables.dart:124)
at _Visitor.visitConstructorDeclaration    (prefer_const_constructors_in_immutables.dart:96)
```