### PR TITLE
Deprecate iterable_contains_unrelated_type and list_remove_unrelated_types

### DIFF
--- a/example/all.yaml
+++ b/example/all.yaml
@@ -80,7 +80,6 @@ linter:
     - implicit_call_tearoffs
     - implicit_reopen
     - invalid_case_patterns
-    - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -88,7 +87,6 @@ linter:
     - library_prefixes
     - library_private_types_in_public_api
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - matching_super_parameters
     - missing_whitespace_between_adjacent_strings

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -115,6 +115,10 @@ abstract class Mixin {}
 class DerivedClass3 extends ClassBase implements Mixin {}
 ```
 
+**DEPRECATED:** This rule is deprecated in favor of
+`collection_methods_unrelated_type`.
+The rule will be removed in a future Dart release.
+
 ''';
 
 class IterableContainsUnrelatedType extends LintRule {
@@ -123,10 +127,12 @@ class IterableContainsUnrelatedType extends LintRule {
 
   IterableContainsUnrelatedType()
       : super(
-            name: 'iterable_contains_unrelated_type',
-            description: _desc,
-            details: _details,
-            group: Group.errors);
+          name: 'iterable_contains_unrelated_type',
+          description: _desc,
+          details: _details,
+          group: Group.errors,
+          state: State.deprecated(),
+        );
 
   @override
   LintCode get lintCode => code;

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -115,6 +115,10 @@ abstract class Mixin {}
 class DerivedClass3 extends ClassBase implements Mixin {}
 ```
 
+**DEPRECATED:** This rule is deprecated in favor of
+`collection_methods_unrelated_type`.
+The rule will be removed in a future Dart release.
+
 ''';
 
 class ListRemoveUnrelatedType extends LintRule {
@@ -123,10 +127,12 @@ class ListRemoveUnrelatedType extends LintRule {
 
   ListRemoveUnrelatedType()
       : super(
-            name: 'list_remove_unrelated_type',
-            description: _desc,
-            details: _details,
-            group: Group.errors);
+          name: 'list_remove_unrelated_type',
+          description: _desc,
+          details: _details,
+          group: Group.errors,
+          state: State.deprecated(),
+        );
 
   @override
   LintCode get lintCode => code;


### PR DESCRIPTION
Fixes #3893