### PR TITLE
don't overreport `cast_nullable_to_non_nullable` on undefined classes

### DIFF
--- a/lib/src/rules/cast_nullable_to_non_nullable.dart
+++ b/lib/src/rules/cast_nullable_to_non_nullable.dart
@@ -80,6 +80,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (expressionType != null &&
         type != null &&
         expressionType is! DynamicType &&
+        expressionType is! InvalidType &&
         context.typeSystem.isNullable(expressionType) &&
         context.typeSystem.isNonNullable(type)) {
       rule.reportLint(node);

--- a/lib/src/rules/cast_nullable_to_non_nullable.dart
+++ b/lib/src/rules/cast_nullable_to_non_nullable.dart
@@ -77,11 +77,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitAsExpression(AsExpression node) {
     var expressionType = node.expression.staticType;
     var type = node.type.type;
-    if (expressionType != null &&
-        type != null &&
-        expressionType is! DynamicType &&
+    if (expressionType is! DynamicType &&
         expressionType is! InvalidType &&
+        expressionType != null &&
         context.typeSystem.isNullable(expressionType) &&
+        type != null &&
         context.typeSystem.isNonNullable(type)) {
       rule.reportLint(node);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: ^3.0.0-0
 
 dependencies:
-  analyzer: ^5.11.1
+  analyzer: ^5.13.0
   args: ^2.1.0
   collection: ^1.15.0
   http: ^0.13.0

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -32,6 +32,8 @@ import 'avoid_unused_constructor_parameters_test.dart'
     as avoid_unused_constructor_parameters;
 import 'avoid_void_async_test.dart' as avoid_void_async;
 import 'cancel_subscriptions_test.dart' as cancel_subscriptions;
+import 'cast_nullable_to_non_nullable_test.dart'
+    as cast_nullable_to_non_nullable;
 import 'collection_methods_unrelated_type_test.dart'
     as collection_methods_unrelated_type;
 import 'conditional_uri_does_not_exist_test.dart'
@@ -167,6 +169,7 @@ void main() {
   avoid_unused_constructor_parameters.main();
   avoid_void_async.main();
   cancel_subscriptions.main();
+  cast_nullable_to_non_nullable.main();
   collection_methods_unrelated_type.main();
   conditional_uri_does_not_exist.main();
   constant_identifier_names.main();

--- a/test/rules/cast_nullable_to_non_nullable_test.dart
+++ b/test/rules/cast_nullable_to_non_nullable_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(CastNullableToNonNullableTest);
+  });
+}
+
+@reflectiveTest
+class CastNullableToNonNullableTest extends LintRuleTest {
+  @override
+  String get lintRule => 'cast_nullable_to_non_nullable';
+
+  test_castNullable() async {
+    await assertDiagnostics(r'''
+String? s;
+var a = s as String; 
+''', [
+      lint(19, 11),
+    ]);
+  }
+
+  @soloTest
+  test_castNullable_unresolvedType() async {
+    await assertDiagnostics(r'''
+Undefined? s;
+var a = s! as String; 
+''', [
+      // No lint.
+      error(CompileTimeErrorCode.UNDEFINED_CLASS, 0, 9),
+    ]);
+  }
+}

--- a/test/rules/cast_nullable_to_non_nullable_test.dart
+++ b/test/rules/cast_nullable_to_non_nullable_test.dart
@@ -26,7 +26,6 @@ var a = s as String;
     ]);
   }
 
-  @soloTest
   test_castNullable_unresolvedType() async {
     await assertDiagnostics(r'''
 Undefined? s;


### PR DESCRIPTION
See also: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8780744067138629361/+/u/analyze_flutter_flutter/stdout

/cc @scheglov 
