### PR TITLE
skip undefined classes in `await_only_futures`

### DIFF
--- a/lib/src/rules/await_only_futures.dart
+++ b/lib/src/rules/await_only_futures.dart
@@ -72,6 +72,7 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (!(type == null ||
         type.isDartAsyncFuture ||
         type is DynamicType ||
+        type is InvalidType ||
         type.extendsClass('Future', 'dart.async') ||
         type.implementsInterface('Future', 'dart.async') ||
         type.isDartAsyncFutureOr)) {

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'await_only_futures_test.dart' as await_only_futures;
 import 'always_specify_types_test.dart' as always_specify_types;
 import 'always_use_package_imports_test.dart' as always_use_package_imports;
 import 'annotate_overrides_test.dart' as annotate_overrides;
@@ -32,6 +31,7 @@ import 'avoid_types_as_parameter_names_test.dart'
 import 'avoid_unused_constructor_parameters_test.dart'
     as avoid_unused_constructor_parameters;
 import 'avoid_void_async_test.dart' as avoid_void_async;
+import 'await_only_futures_test.dart' as await_only_futures;
 import 'cancel_subscriptions_test.dart' as cancel_subscriptions;
 import 'cast_nullable_to_non_nullable_test.dart'
     as cast_nullable_to_non_nullable;

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'await_only_futures_test.dart' as await_only_futures;
 import 'always_specify_types_test.dart' as always_specify_types;
 import 'always_use_package_imports_test.dart' as always_use_package_imports;
 import 'annotate_overrides_test.dart' as annotate_overrides;
@@ -168,6 +169,7 @@ void main() {
   avoid_types_as_parameter_names.main();
   avoid_unused_constructor_parameters.main();
   avoid_void_async.main();
+  await_only_futures.main();
   cancel_subscriptions.main();
   cast_nullable_to_non_nullable.main();
   collection_methods_unrelated_type.main();

--- a/test/rules/await_only_futures_test.dart
+++ b/test/rules/await_only_futures_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AwaitOnlyFuturesTest);
+  });
+}
+
+@reflectiveTest
+class AwaitOnlyFuturesTest extends LintRuleTest {
+  @override
+  String get lintRule => 'await_only_futures';
+
+  test_undefinedClass() async {
+    await assertDiagnostics(r'''
+Undefined f() async => await f();
+''', [
+      // No lint
+      error(CompileTimeErrorCode.UNDEFINED_CLASS, 0, 9),
+    ]);
+  }
+}


### PR DESCRIPTION
(This is breaking internally.)

See also: https://github.com/dart-lang/linter/pull/4371

/cc @scheglov 
