### PR TITLE
add `replacedBy` info to point to `collection_methods_unrelated_type`

### DIFF
--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -131,7 +131,8 @@ class IterableContainsUnrelatedType extends LintRule {
           description: _desc,
           details: _details,
           group: Group.errors,
-          state: State.deprecated(),
+          state:
+              State.deprecated(replacedBy: 'collection_methods_unrelated_type'),
         );
 
   @override

--- a/lib/src/rules/list_remove_unrelated_type.dart
+++ b/lib/src/rules/list_remove_unrelated_type.dart
@@ -131,7 +131,8 @@ class ListRemoveUnrelatedType extends LintRule {
           description: _desc,
           details: _details,
           group: Group.errors,
-          state: State.deprecated(),
+          state:
+              State.deprecated(replacedBy: 'collection_methods_unrelated_type'),
         );
 
   @override


### PR DESCRIPTION
In preparation for: https://github.com/dart-lang/sdk/issues/52472.

/cc @srawlins 
