### PR TITLE
Print the type names in unrelated_type_equality_checks

### DIFF
--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -5,12 +5,10 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 
 import '../analyzer.dart';
-import '../extensions.dart';
 import '../util/dart_type_utilities.dart';
 
 const _desc =
@@ -132,40 +130,19 @@ class DerivedClass2 extends ClassBase with Mixin {}
 
 ''';
 
-bool _hasNonComparableOperands(TypeSystem typeSystem, BinaryExpression node) {
-  var left = node.leftOperand;
-  var leftType = left.staticType;
-  var right = node.rightOperand;
-  var rightType = right.staticType;
-  if (leftType == null || rightType == null) {
-    return false;
-  }
-  return !left.isNullLiteral &&
-      !right.isNullLiteral &&
-      _nonComparable(typeSystem, leftType, rightType);
-}
-
-bool _isCoreInt(DartType? type) => type != null && type.isDartCoreInt;
-
-bool _isFixNumIntX(DartType type) {
-  // todo(pq): add tests that ensure this predicate works with fixnum >= 1.1.0-dev
-  // See: https://github.com/dart-lang/linter/issues/3868
-  if (type is! InterfaceType) return false;
-  InterfaceElement element = type.element;
-  if (element.name != 'Int32' && element.name != 'Int64') return false;
-  var uri = element.library.source.uri;
-  if (!uri.isScheme('package')) return false;
-  return uri.pathSegments.firstOrNull == 'fixnum';
-}
-
-bool _nonComparable(
-        TypeSystem typeSystem, DartType leftType, DartType? rightType) =>
-    typesAreUnrelated(typeSystem, leftType, rightType) &&
-    !(_isFixNumIntX(leftType) && _isCoreInt(rightType));
-
 class UnrelatedTypeEqualityChecks extends LintRule {
-  static const LintCode code = LintCode('unrelated_type_equality_checks',
-      "Neither type of the operands of '==' is a subtype of the other.",
+  static const LintCode expressionCode = LintCode(
+      'unrelated_type_equality_checks',
+      uniqueName: 'LintCode.unrelated_type_equality_checks_expression',
+      "The right operand type, '{0}', of the equality comparison is not a "
+          "subtype nor a supertype of the left operand type, '{1}'.",
+      correctionMessage: 'Try changing one or both of the operands.');
+
+  static const LintCode patternCode = LintCode(
+      'unrelated_type_equality_checks',
+      uniqueName: 'LintCode.unrelated_type_equality_checks_pattern',
+      "The operand type, '{0}', is not a subtype nor a supertype of the value "
+          "type, '{1}'.",
       correctionMessage: 'Try changing one or both of the operands.');
 
   UnrelatedTypeEqualityChecks()
@@ -176,7 +153,7 @@ class UnrelatedTypeEqualityChecks extends LintRule {
             group: Group.errors);
 
   @override
-  LintCode get lintCode => code;
+  List<LintCode> get lintCodes => [expressionCode, patternCode];
 
   @override
   void registerNodeProcessors(
@@ -196,12 +173,28 @@ class _Visitor extends SimpleAstVisitor<void> {
   @override
   void visitBinaryExpression(BinaryExpression node) {
     var isDartCoreBoolean = node.staticType?.isDartCoreBool ?? false;
-    if (!isDartCoreBoolean || !_isEqualityTest(node.operator)) {
+    if (!isDartCoreBoolean || !node.operator.isEqualityTest) {
       return;
     }
 
-    if (_hasNonComparableOperands(typeSystem, node)) {
-      rule.reportLint(node);
+    var leftOperand = node.leftOperand;
+    if (leftOperand is NullLiteral) return;
+    var rightOperand = node.rightOperand;
+    if (rightOperand is NullLiteral) return;
+    var leftType = leftOperand.staticType;
+    if (leftType == null) return;
+    var rightType = rightOperand.staticType;
+    if (rightType == null) return;
+
+    if (_nonComparable(leftType, rightType)) {
+      rule.reportLint(
+        node,
+        errorCode: UnrelatedTypeEqualityChecks.expressionCode,
+        arguments: [
+          rightType.getDisplayString(withNullability: true),
+          leftType.getDisplayString(withNullability: true),
+        ],
+      );
     }
   }
 
@@ -209,13 +202,43 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitRelationalPattern(RelationalPattern node) {
     var valueType = node.matchedValueType;
     if (valueType == null) return;
-    if (!_isEqualityTest(node.operator)) return;
+    if (!node.operator.isEqualityTest) return;
     var operandType = node.operand.staticType;
-    if (_nonComparable(typeSystem, valueType, operandType)) {
-      rule.reportLint(node);
+    if (operandType == null) return;
+    if (_nonComparable(valueType, operandType)) {
+      rule.reportLint(
+        node,
+        errorCode: UnrelatedTypeEqualityChecks.patternCode,
+        arguments: [
+          operandType.getDisplayString(withNullability: true),
+          valueType.getDisplayString(withNullability: true),
+        ],
+      );
     }
   }
 
-  bool _isEqualityTest(Token operator) =>
-      operator.type == TokenType.EQ_EQ || operator.type == TokenType.BANG_EQ;
+  bool _nonComparable(DartType leftType, DartType rightType) =>
+      typesAreUnrelated(typeSystem, leftType, rightType) &&
+      !(leftType.isFixnumIntX && rightType.isCoreInt);
+}
+
+extension on DartType? {
+  bool get isCoreInt => this != null && this!.isDartCoreInt;
+
+  bool get isFixnumIntX {
+    var self = this;
+    // todo(pq): add tests that ensure this predicate works with fixnum >= 1.1.0-dev
+    // See: https://github.com/dart-lang/linter/issues/3868
+    if (self is! InterfaceType) return false;
+    var element = self.element;
+    if (element.name != 'Int32' && element.name != 'Int64') return false;
+    var uri = element.library.source.uri;
+    if (!uri.isScheme('package')) return false;
+    return uri.pathSegments.firstOrNull == 'fixnum';
+  }
+}
+
+extension on Token {
+  bool get isEqualityTest =>
+      type == TokenType.EQ_EQ || type == TokenType.BANG_EQ;
 }

--- a/lib/src/rules/unrelated_type_equality_checks.dart
+++ b/lib/src/rules/unrelated_type_equality_checks.dart
@@ -134,15 +134,15 @@ class UnrelatedTypeEqualityChecks extends LintRule {
   static const LintCode expressionCode = LintCode(
       'unrelated_type_equality_checks',
       uniqueName: 'LintCode.unrelated_type_equality_checks_expression',
-      "The right operand type, '{0}', of the equality comparison is not a "
-          "subtype nor a supertype of the left operand type, '{1}'.",
+      "The type of the right operand ('{0}') isn't a subtype or a supertype of "
+          "the left operand ('{1}').",
       correctionMessage: 'Try changing one or both of the operands.');
 
   static const LintCode patternCode = LintCode(
       'unrelated_type_equality_checks',
       uniqueName: 'LintCode.unrelated_type_equality_checks_pattern',
-      "The operand type, '{0}', is not a subtype nor a supertype of the value "
-          "type, '{1}'.",
+      "The type of the operand ('{0}') isn't a subtype or a supertype of the "
+          "value being matched ('{1}').",
       correctionMessage: 'Try changing one or both of the operands.');
 
   UnrelatedTypeEqualityChecks()
@@ -187,8 +187,8 @@ class _Visitor extends SimpleAstVisitor<void> {
     if (rightType == null) return;
 
     if (_nonComparable(leftType, rightType)) {
-      rule.reportLint(
-        node,
+      rule.reportLintForToken(
+        node.operator,
         errorCode: UnrelatedTypeEqualityChecks.expressionCode,
         arguments: [
           rightType.getDisplayString(withNullability: true),

--- a/test/rules/unrelated_type_equality_checks_test.dart
+++ b/test/rules/unrelated_type_equality_checks_test.dart
@@ -22,7 +22,7 @@ class UnrelatedTypeEqualityChecksTestLanguage300 extends LintRuleTest
     await assertDiagnostics(r'''
 bool f((int, int) a, String b) => a == b;
 ''', [
-      lint(34, 6),
+      lint(36, 2),
     ]);
   }
 
@@ -36,7 +36,7 @@ bool f((int, int) a, (num, num) b) => a == b;
     await assertDiagnostics(r'''
 bool f((int, int) a, (String, String) b) => a == b;
 ''', [
-      lint(44, 6),
+      lint(46, 2),
     ]);
   }
 
@@ -50,7 +50,7 @@ bool f(({int one, int two}) a, ({num two, num one}) b) => a == b;
     await assertDiagnostics(r'''
 bool f(({int one, int two}) a, ({String one, String two}) b) => a == b;
 ''', [
-      lint(64, 6),
+      lint(66, 2),
     ]);
   }
 
@@ -64,7 +64,7 @@ bool f((int, {int two}) a, (num one, {num two}) b) => a == b;
     await assertDiagnostics(r'''
 bool f((int, {int two}) a, (String one, {String two}) b) => a == b;
 ''', [
-      lint(60, 6),
+      lint(62, 2),
     ]);
   }
 


### PR DESCRIPTION
# Description

This PR mainly splits the lint message into two, one appropriate for expressions (BinaryExpression with `==` or `!=`) and one appropriate for patterns. In each case, a conscious decision was made to write the "argument" type before the "target" type (approximate terms for the two cases). In particular for patterns, this produces messages like:

> The operand type, 'String', is not a subtype nor a supertype of the value type, 'int'.

I think this is much more readable than printing the target type (value type) first, as the problem likely does not lie with the value type, but with the operand type. But I'm still very open to word-smithing; this one is wordy 🙁 .

Also some tidying:

* Move some utility functions into the `_Visitor`, so as not to pass around the `TypeSystem`.
* Move some utility functions to extensions, for readability.
* Rename `fixNum` to `fixnum`.

Fixes https://github.com/dart-lang/linter/issues/4311