### PR TITLE
Use more direct Effective Dart links

### DIFF
--- a/.github/ISSUE_TEMPLATE/lint-proposal.md
+++ b/.github/ISSUE_TEMPLATE/lint-proposal.md
@@ -45,6 +45,6 @@ assignees: ''
 
 <!-- Links -->
 [Writing Lints]: https://github.com/dart-lang/linter/blob/main/doc/writing-lints.md
-[Effective Dart]: https://dart.dev/guides/language/effective-dart
+[Effective Dart]: https://dart.dev/effective-dart
 [Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
 [SDK Tracker]: https://github.com/dart-lang/sdk/issues

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Please file feature requests and bugs in the [issue tracker][tracker].
 
 [analyzer_cli]: https://dart.dev/tools/dart-analyze
 [dart_cli]: https://dart.dev/tools/dart-tool
-[effective_dart]:https://dart.dev/guides/language/effective-dart
+[effective_dart]:https://dart.dev/effective-dart
 [lints]: https://dart-lang.github.io/linter/lints/
 [options_file]: https://dart.dev/guides/language/analysis-options#the-analysis-options-file
 [package-dart-lints]: https://github.com/dart-lang/lints
 [package-flutter-lints]: https://github.com/flutter/packages/tree/main/packages/flutter_lints
-[style_guide]:https://dart.dev/guides/language/effective-dart/style/
+[style_guide]:https://dart.dev/effective-dart/style/
 [tracker]: https://github.com/dart-lang/linter/issues

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Please file feature requests and bugs in the [issue tracker][tracker].
 
 [analyzer_cli]: https://dart.dev/tools/dart-analyze
 [dart_cli]: https://dart.dev/tools/dart-tool
-[effective_dart]:https://dart.dev/effective-dart
+[effective_dart]: https://dart.dev/effective-dart
 [lints]: https://dart-lang.github.io/linter/lints/
 [options_file]: https://dart.dev/guides/language/analysis-options#the-analysis-options-file
 [package-dart-lints]: https://github.com/dart-lang/lints
 [package-flutter-lints]: https://github.com/flutter/packages/tree/main/packages/flutter_lints
-[style_guide]:https://dart.dev/effective-dart/style/
+[style_guide]: https://dart.dev/effective-dart/style
 [tracker]: https://github.com/dart-lang/linter/issues

--- a/doc/writing-lints.md
+++ b/doc/writing-lints.md
@@ -160,7 +160,7 @@ Details are under active development.  Feedback is most [welcome][issues]!
 [adding new checks to errorprone]: https://github.com/google/error-prone/wiki/Criteria-for-new-checks
 [Dart package naming conventions]: https://dart.dev/tools/pub/pubspec#name
 [parallel construction]: https://en.wikipedia.org/wiki/Parallelism_(grammar)
-[style guide]: https://dart.dev/guides/language/effective-dart/style/
+[style guide]: https://dart.dev/effective-dart/style/
 [lints]: https://dart-lang.github.io/linter/lints/
 [lib/src/rules]: https://github.com/dart-lang/linter/tree/main/lib/src/rules
 [test_data/rules]: https://github.com/dart-lang/linter/tree/main/test_data/rules

--- a/lib/src/rules/avoid_classes_with_only_static_members.dart
+++ b/lib/src/rules/avoid_classes_with_only_static_members.dart
@@ -11,7 +11,7 @@ import '../analyzer.dart';
 const _desc = r'Avoid defining a class that contains only static members.';
 
 const _details = r'''
-From [Effective Dart](https://dart.dev/guides/language/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members):
+From [Effective Dart](https://dart.dev/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members):
 
 **AVOID** defining a class that contains only static members.
 

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -14,12 +14,12 @@ const _desc =
     r'Avoid overloading operator == and hashCode on classes not marked `@immutable`.';
 
 const _details = r'''
+From [Effective Dart](https://dart.dev/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes):
+
 **AVOID** overloading operator == and hashCode on classes not marked `@immutable`.
 
-If a class is not immutable, overloading operator == and hashCode can lead to
-unpredictable and undesirable behavior when used in collections. See
-https://dart.dev/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes
-for more information.
+If a class is not immutable, overloading `operator ==` and `hashCode` can
+lead to unpredictable and undesirable behavior when used in collections.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
+++ b/lib/src/rules/avoid_equals_and_hash_code_on_mutable_classes.dart
@@ -18,7 +18,7 @@ const _details = r'''
 
 If a class is not immutable, overloading operator == and hashCode can lead to
 unpredictable and undesirable behavior when used in collections. See
-https://dart.dev/guides/language/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes
+https://dart.dev/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes
 for more information.
 
 **BAD:**

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -14,7 +14,7 @@ import '../extensions.dart';
 const _desc = r"Don't explicitly initialize variables to null.";
 
 const _details = r'''
-From [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#dont-explicitly-initialize-variables-to-null):
+From [Effective Dart](https://dart.dev/effective-dart/usage#dont-explicitly-initialize-variables-to-null):
 
 **DON'T** explicitly initialize variables to `null`.
 

--- a/lib/src/rules/camel_case_extensions.dart
+++ b/lib/src/rules/camel_case_extensions.dart
@@ -11,7 +11,7 @@ import '../utils.dart';
 const _desc = r'Name extensions using UpperCamelCase.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
+From [Effective Dart](https://dart.dev/effective-dart/style#do-name-extensions-using-uppercamelcase):
 
 **DO** name extensions using `UpperCamelCase`.
 

--- a/lib/src/rules/camel_case_extensions.dart
+++ b/lib/src/rules/camel_case_extensions.dart
@@ -11,7 +11,7 @@ import '../utils.dart';
 const _desc = r'Name extensions using UpperCamelCase.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **DO** name extensions using `UpperCamelCase`.
 

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -12,7 +12,7 @@ import '../utils.dart';
 const _desc = r'Name types using UpperCamelCase.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **DO** name types using UpperCamelCase.
 

--- a/lib/src/rules/camel_case_types.dart
+++ b/lib/src/rules/camel_case_types.dart
@@ -12,7 +12,7 @@ import '../utils.dart';
 const _desc = r'Name types using UpperCamelCase.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
+From [Effective Dart](https://dart.dev/effective-dart/style#do-name-types-using-uppercamelcase):
 
 **DO** name types using UpperCamelCase.
 

--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -10,7 +10,7 @@ import '../analyzer.dart';
 const _desc = r'Adhere to Effective Dart Guide directives sorting conventions.';
 const _details = r'''
 **DO** follow the directive ordering conventions in
-[Effective Dart](https://dart.dev/guides/language/effective-dart/style#ordering):
+[Effective Dart](https://dart.dev/effective-dart/style#ordering):
 
 **DO** place `dart:` imports before other imports.
 

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -10,7 +10,7 @@ import '../analyzer.dart';
 const _desc = r'Use `;` instead of `{}` for empty constructor bodies.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **DO** use `;` instead of `{}` for empty constructor bodies.
 

--- a/lib/src/rules/empty_constructor_bodies.dart
+++ b/lib/src/rules/empty_constructor_bodies.dart
@@ -10,7 +10,7 @@ import '../analyzer.dart';
 const _desc = r'Use `;` instead of `{}` for empty constructor bodies.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
+From [Effective Dart](https://dart.dev/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies):
 
 **DO** use `;` instead of `{}` for empty constructor bodies.
 

--- a/lib/src/rules/no_literal_bool_comparisons.dart
+++ b/lib/src/rules/no_literal_bool_comparisons.dart
@@ -13,7 +13,7 @@ import '../analyzer.dart';
 const _desc = r"Don't compare booleans to boolean literals.";
 
 const _details = r'''
-From [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#dont-use-true-or-false-in-equality-operations):
+From [Effective Dart](https://dart.dev/effective-dart/usage#dont-use-true-or-false-in-equality-operations):
 
 **DON'T** use `true` or `false` in equality operations.
 

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -11,7 +11,7 @@ const _desc =
     r'Avoid defining a one-member abstract class when a simple function will do.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
+From [Effective Dart](https://dart.dev/effective-dart/design#avoid-defining-a-one-member-abstract-class-when-a-simple-function-will-do):
 
 **AVOID** defining a one-member abstract class when a simple function will do.
 

--- a/lib/src/rules/one_member_abstracts.dart
+++ b/lib/src/rules/one_member_abstracts.dart
@@ -11,7 +11,7 @@ const _desc =
     r'Avoid defining a one-member abstract class when a simple function will do.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **AVOID** defining a one-member abstract class when a simple function will do.
 

--- a/lib/src/rules/package_api_docs.dart
+++ b/lib/src/rules/package_api_docs.dart
@@ -53,7 +53,7 @@ abstract class Foo {
 ```
 
 Advice for writing good doc comments can be found in the
-[Doc Writing Guidelines](https://dart.dev/guides/language/effective-dart/documentation).
+[Doc Writing Guidelines](https://dart.dev/effective-dart/documentation).
 
 ''';
 

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -7,8 +7,6 @@ import '../analyzer.dart';
 const _desc = r'Use `=` to separate a named parameter from its default value.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/usage):
-
 **DO** use `=` to separate a named parameter from its default value.
 
 **BAD:**

--- a/lib/src/rules/prefer_equal_for_default_values.dart
+++ b/lib/src/rules/prefer_equal_for_default_values.dart
@@ -7,7 +7,7 @@ import '../analyzer.dart';
 const _desc = r'Use `=` to separate a named parameter from its default value.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/usage):
+From the [style guide](https://dart.dev/effective-dart/usage):
 
 **DO** use `=` to separate a named parameter from its default value.
 

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -10,7 +10,7 @@ import '../analyzer.dart';
 const _desc = r'Prefer using /// for doc comments.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style):
+From the [style guide](https://dart.dev/effective-dart/style):
 
 **PREFER** using `///` for doc comments.
 

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -10,9 +10,9 @@ import '../analyzer.dart';
 const _desc = r'Prefer using /// for doc comments.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style):
+From [Effective Dart](https://dart.dev/effective-dart/documentation#do-use--doc-comments-to-document-members-and-types):
 
-**PREFER** using `///` for doc comments.
+**DO** use `///` for documentation comments.
 
 Although Dart supports two syntaxes of doc comments (`///` and `/**`), we
 prefer using `///` for doc comments.

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -8,7 +8,7 @@ const _desc =
     r'Place the `super` call last in a constructor initialization list.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **DO** place the `super` call last in a constructor initialization list.
 

--- a/lib/src/rules/super_goes_last.dart
+++ b/lib/src/rules/super_goes_last.dart
@@ -8,8 +8,6 @@ const _desc =
     r'Place the `super` call last in a constructor initialization list.';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
-
 **DO** place the `super` call last in a constructor initialization list.
 
 Field initializers are evaluated in the order that they appear in the

--- a/lib/src/rules/type_annotate_public_apis.dart
+++ b/lib/src/rules/type_annotate_public_apis.dart
@@ -13,7 +13,7 @@ import '../util/ascii_utils.dart';
 const _desc = r'Type annotate public APIs.';
 
 const _details = r'''
-From [Effective Dart](https://dart.dev/guides/language/effective-dart/design#do-type-annotate-fields-and-top-level-variables-if-the-type-isnt-obvious):
+From [Effective Dart](https://dart.dev/effective-dart/design#do-type-annotate-fields-and-top-level-variables-if-the-type-isnt-obvious):
 
 **PREFER** type annotating public APIs.
 

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -11,7 +11,7 @@ import '../analyzer.dart';
 const _desc = "Don't type annotate initializing formals.";
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
+From [Effective Dart](https://dart.dev/effective-dart/design#dont-type-annotate-initializing-formals):
 
 **DON'T** type annotate initializing formals.
 

--- a/lib/src/rules/type_init_formals.dart
+++ b/lib/src/rules/type_init_formals.dart
@@ -11,7 +11,7 @@ import '../analyzer.dart';
 const _desc = "Don't type annotate initializing formals.";
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **DON'T** type annotate initializing formals.
 

--- a/lib/src/rules/unnecessary_final.dart
+++ b/lib/src/rules/unnecessary_final.dart
@@ -14,7 +14,7 @@ const _desc = "Don't use `final` for local variables.";
 const _details = r'''
 Use `var`, not `final`, when declaring local variables.
 
-Per [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables),
+Per [Effective Dart](https://dart.dev/effective-dart/usage#do-follow-a-consistent-rule-for-var-and-final-on-local-variables),
 there are two styles in wide use. This rule enforces the `var` style.
 For the alternative style that prefers `final`, enable `prefer_final_locals`
 and `prefer_final_in_for_each` instead.

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -12,7 +12,7 @@ const _desc =
     r'Avoid wrapping fields in getters and setters just to be "safe".';
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **AVOID** wrapping fields in getters and setters just to be "safe".
 

--- a/lib/src/rules/unnecessary_getters_setters.dart
+++ b/lib/src/rules/unnecessary_getters_setters.dart
@@ -12,7 +12,7 @@ const _desc =
     r'Avoid wrapping fields in getters and setters just to be "safe".';
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
+From [Effective Dart](https://dart.dev/effective-dart/usage#dont-wrap-a-field-in-a-getter-and-setter-unnecessarily):
 
 **AVOID** wrapping fields in getters and setters just to be "safe".
 

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -12,7 +12,7 @@ import '../ast.dart';
 const _desc = r"Don't access members with `this` unless avoiding shadowing.";
 
 const _details = r'''
-From the [style guide](https://dart.dev/effective-dart/style/):
+From [Effective Dart](https://dart.dev/effective-dart/usage#dont-use-this-when-not-needed-to-avoid-shadowing):
 
 **DON'T** use `this` when not needed to avoid shadowing.
 

--- a/lib/src/rules/unnecessary_this.dart
+++ b/lib/src/rules/unnecessary_this.dart
@@ -12,7 +12,7 @@ import '../ast.dart';
 const _desc = r"Don't access members with `this` unless avoiding shadowing.";
 
 const _details = r'''
-From the [style guide](https://dart.dev/guides/language/effective-dart/style/):
+From the [style guide](https://dart.dev/effective-dart/style/):
 
 **DON'T** use `this` when not needed to avoid shadowing.
 

--- a/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
+++ b/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
@@ -13,7 +13,7 @@ import '../analyzer.dart';
 const _desc = r'Use if-null operators to convert nulls to bools.';
 
 const _details = r'''
-From [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#prefer-using--to-convert-null-to-a-boolean-value):
+From [Effective Dart](https://dart.dev/effective-dart/usage#prefer-using--to-convert-null-to-a-boolean-value):
 
 Use if-null operators to convert nulls to bools.
 

--- a/lib/src/rules/use_string_in_part_of_directives.dart
+++ b/lib/src/rules/use_string_in_part_of_directives.dart
@@ -10,7 +10,7 @@ import '../analyzer.dart';
 const _desc = r'Use string in part of directives.';
 
 const _details = r'''
-From [Effective Dart](https://dart.dev/guides/language/effective-dart/usage#do-use-strings-in-part-of-directives):
+From [Effective Dart](https://dart.dev/effective-dart/usage#do-use-strings-in-part-of-directives):
 
 **DO** use strings in `part of` directives.
 

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -13,7 +13,7 @@ const _desc =
     r'Start the name of the method with to/_to or as/_as if applicable.';
 
 const _details = r'''
-From the [Effective Dart](https://dart.dev/effective-dart/design):
+From [Effective Dart](https://dart.dev/effective-dart/design#prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object):
 
 **PREFER** naming a method `to___()` if it copies the object's state to a new
 object.

--- a/lib/src/rules/use_to_and_as_if_applicable.dart
+++ b/lib/src/rules/use_to_and_as_if_applicable.dart
@@ -13,7 +13,7 @@ const _desc =
     r'Start the name of the method with to/_to or as/_as if applicable.';
 
 const _details = r'''
-From the [Effective Dart](https://dart.dev/guides/language/effective-dart/design):
+From the [Effective Dart](https://dart.dev/effective-dart/design):
 
 **PREFER** naming a method `to___()` if it copies the object's state to a new
 object.


### PR DESCRIPTION
This PR primary updates to the more concise `dart.dev/effective-dart` path we've [updated to](https://github.com/dart-lang/site-www/commit/176f6c58c204690fb5f421617b14f2eb99696f58) but also worked historically. It also updates multiple mentions of Effective Dart directly to the related rule for more relevant information. Also some linked to the wrong page completely, so updated those too.