### PR TITLE
unreachable_from_main: Do not consider type annotations when computing reachability

### DIFF
--- a/lib/src/rules/unreachable_from_main.dart
+++ b/lib/src/rules/unreachable_from_main.dart
@@ -142,27 +142,9 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   }
 
   @override
-  void visitAsExpression(AsExpression node) {
-    node.expression.accept(this);
-    // Intentionally do not visit `node.type`, as a reference in the type of an
-    // as-expression is not good enough to count as "reachable". Marking a type
-    // as reachable only because it was seen in an as-expression would be a
-    // miscategorization if the type is never instantiated or subtyped.
-  }
-
-  @override
   void visitAssignmentExpression(AssignmentExpression node) {
     _visitCompoundAssignmentExpression(node);
     super.visitAssignmentExpression(node);
-  }
-
-  @override
-  void visitCastPattern(CastPattern node) {
-    node.pattern.accept(this);
-    // Intentionally do not visit `node.type`, as a reference in the type in a
-    // cast pattern is not good enough to count as "reachable". Marking a type
-    // as reachable only because it was seen in a cast pattern would be a
-    // miscategorization if the type is never instantiated or subtyped.
   }
 
   @override
@@ -224,35 +206,25 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   }
 
   @override
-  void visitFormalParameterList(FormalParameterList node) {
-    for (var parameter in node.parameters) {
-      if (parameter is DefaultFormalParameter) {
-        parameter.defaultValue?.accept(this);
-      }
-      // Intentionally do not visit `node.type`, as a reference in a type
-      // annotation is not good enough to count as "reachable". Marking a type
-      // as reachable only because it was seen in a type annotation would be a
-      // miscategorization if the type is never instantiated or subtyped.
+  void visitNamedType(NamedType node) {
+    if (node.type?.alias != null) {
+      // Any reference to a typedef counts as "reachable", since structural
+      // typing is used to match against objects.
+      _addDeclaration(node.element!);
     }
-  }
 
-  @override
-  void visitIsExpression(IsExpression node) {
-    node.expression.accept(this);
-    // Intentionally do not visit `node.type`, as a reference in an
-    // is-expression is not good enough to count as "reachable".
-    // Marking a type as reachable only because it was seen in an is-expression
-    // would be a miscategorization if the type is never instantiated or
-    // subtyped.
-  }
+    // Intentionally do not add the declaration of non-alias named types, as a
+    // reference to such a type in a [TypeAnnnotation] is not good enough to
+    // count as "reachable". Marking a type as reachable only because it was
+    // seen in a type annotation would be a miscategorization if the type is
+    // never instantiated or subtyped.
 
-  @override
-  void visitObjectPattern(ObjectPattern node) {
-    node.fields.accept(this);
-    // Intentionally do not visit `node.type`, as a reference as the type in an
-    // object pattern is not good enough to count as "reachable". Marking a type
-    // as reachable only because it was seen in an object pattern would be a
-    // miscategorization if the type is never instantiated or subtyped.
+    var typeArguments = node.typeArguments;
+    if (typeArguments != null) {
+      for (var typeArgument in typeArguments.arguments) {
+        typeArgument.accept(this);
+      }
+    }
   }
 
   @override
@@ -298,12 +270,15 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   }
 
   @override
-  void visitVariableDeclarationList(VariableDeclarationList node) {
-    node.variables.accept(this);
-    // Intentionally do not visit `node.type`, as a reference in a type
-    // annotation is not good enough to count as "reachable". Marking a type as
-    // reachable only because it was seen in a type annotation would be a
-    // miscategorization if the type is never instantiated or subtyped.
+  void visitVariableDeclaration(VariableDeclaration node) {
+    var parent = node.parent;
+    if (parent is VariableDeclarationList) {
+      var type = parent.type;
+      if (type != null) {
+        type.accept(this);
+      }
+    }
+    super.visitVariableDeclaration(node);
   }
 
   /// Adds the declaration of the top-level element which contains [element] to

--- a/test/rules/unreachable_from_main_test.dart
+++ b/test/rules/unreachable_from_main_test.dart
@@ -1009,7 +1009,7 @@ int x = 1;
     ]);
   }
 
-  test_typedef_reachable_eferencedInObjectPattern() async {
+  test_typedef_reachable_referencedInObjectPattern() async {
     await assertNoDiagnostics(r'''
 typedef T = int;
 
@@ -1033,6 +1033,17 @@ typedef T = int;
 ''');
   }
 
+  test_typedef_reachable_referencedInTypeAnnotation_castPattern() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  var r = (1.5, );
+  var (s as T, ) = r;
+}
+
+typedef T = int;
+''');
+  }
+
   test_typedef_reachable_referencedInTypeAnnotation_genericFunctionType() async {
     await assertNoDiagnostics(r'''
 void main() {
@@ -1049,17 +1060,6 @@ typedef T = int;
     await assertNoDiagnostics(r'''
 void main() {
   1.5 is T;
-}
-
-typedef T = int;
-''');
-  }
-
-  test_typedef_reachable_referencedInTypeAnnotation_castPattern() async {
-    await assertNoDiagnostics(r'''
-void main() {
-  var r = (1.5, );
-  var (s as T, ) = r;
 }
 
 typedef T = int;

--- a/test/rules/unreachable_from_main_test.dart
+++ b/test/rules/unreachable_from_main_test.dart
@@ -71,16 +71,20 @@ void f([Object? p = const C()]) {}
 ''');
   }
 
-  test_class_reachableViaTypedefBound() async {
-    await assertNoDiagnostics(r'''
+  test_class_referencedInObjectPattern() async {
+    await assertDiagnostics(r'''
+class C {}
+
 void main() {
   f();
 }
 
-class C {}
-
-void f<T extends C>() {}
-''');
+void f([Object? c]) {
+  if (c case C()) {}
+}
+''', [
+      lint(6, 1),
+    ]);
   }
 
   test_class_unreachable() async {
@@ -226,6 +230,20 @@ void main() {
 class C {}
 ''', [
       lint(31, 1),
+    ]);
+  }
+
+  test_class_unreachable_typedefBound() async {
+    await assertDiagnostics(r'''
+void main() {
+  f();
+}
+
+class C {}
+
+void f<T extends C>() {}
+''', [
+      lint(30, 1),
     ]);
   }
 
@@ -582,22 +600,6 @@ void f([C? c]) {
 }
 ''', [
       lint(21, 1),
-    ]);
-  }
-
-  test_constructor_unnamed_referencedInObjectPattern() async {
-    await assertDiagnostics(r'''
-class C {}
-
-void main() {
-  f();
-}
-
-void f([Object? c]) {
-  if (c case C()) {}
-}
-''', [
-      lint(6, 1),
     ]);
   }
 
@@ -1005,6 +1007,109 @@ int x = 1;
 ''', [
       lint(20, 1),
     ]);
+  }
+
+  test_typedef_reachable_eferencedInObjectPattern() async {
+    await assertNoDiagnostics(r'''
+typedef T = int;
+
+void main() {
+  f();
+}
+
+void f([Object? c]) {
+  if (c case T()) {}
+}
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_asExpression() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  1.5 as T;
+}
+
+typedef T = int;
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_genericFunctionType() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  t = () => 7;
+}
+
+T? Function()? t;
+
+typedef T = int;
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_isExpression() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  1.5 is T;
+}
+
+typedef T = int;
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_castPattern() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  var r = (1.5, );
+  var (s as T, ) = r;
+}
+
+typedef T = int;
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_parameter() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  f(() {});
+}
+
+void f([Cb? c]) {}
+
+typedef Cb = void Function();
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_recordType() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  t = (1, );
+}
+
+(T, )? t;
+
+typedef T = int;
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_topLevelVariable() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  c = () {};
+}
+
+Cb? c;
+
+typedef Cb = void Function();
+''');
+  }
+
+  test_typedef_reachable_referencedInTypeAnnotation_variableDeclaration() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  Cb c = () {};
+}
+
+typedef Cb = void Function();
+''');
   }
 
   test_typedef_unreachable() async {


### PR DESCRIPTION
# Description

A reference in a type annotation is not good enough to count as "reachable". Marking a type as reachable only because it was seen in a type annotation would be a miscategorization if the type is never instantiated or subtyped.

This was inspired by a comment @bwilkerson made in an earlier review.

CC @goderbauer This is the last change I plan for this rule 😁 