### PR TITLE
Expand constraint on `http`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,13 +9,13 @@ repository: https://github.com/dart-lang/linter
 documentation: https://dart-lang.github.io/linter/lints
 
 environment:
-  sdk: ^3.0.0-0
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ^5.13.0
   args: ^2.1.0
   collection: ^1.15.0
-  http: ^0.13.0
+  http: ">=0.13.0 <2.0.0"
   meta: ^1.3.0
   path: ^1.8.0
   pub_semver: ^2.0.0


### PR DESCRIPTION
The `1.0.0` release does not have any breaking changes.

Remove the pre-release suffix from the SDK constraint now that the SDK
is published.
