### PR TITLE
test hidden issue templates

### DIFF
--- a/.github/hidden_issue_template.md
+++ b/.github/hidden_issue_template.md
@@ -1,0 +1,22 @@
+---
+name: Lint bug report (TEST HIDDEN TEMPLATE)
+about: Report a bug with, or propose a modification to, an existing lint.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+If you're seeing unexpected behavior in a lint rule, please include the name of the rule in the issue description.
+
+**To Reproduce**
+Ideally, please include an example.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This is a test and will be deleted.

I'm trying to suss out how we might support some issue templates that do not show up in an issue template chooser.

/fyi @devoncarew 