### PR TITLE
Prepare for the breaking change to NamedType.

### DIFF
--- a/lib/src/rules/deprecated_member_use_from_same_package.dart
+++ b/lib/src/rules/deprecated_member_use_from_same_package.dart
@@ -383,6 +383,12 @@ class _RecursiveVisitor extends RecursiveAstVisitor<void> {
   }
 
   @override
+  void visitNamedType(NamedType node) {
+    _deprecatedVerifier.namedType(node);
+    super.visitNamedType(node);
+  }
+
+  @override
   void visitPostfixExpression(PostfixExpression node) {
     _deprecatedVerifier.postfixExpression(node);
     super.visitPostfixExpression(node);


### PR DESCRIPTION
We will stop visiting `NamedType.name` node (and remove it). So, `NamedType.element` should be used explicitly.