### PR TITLE
migrate test stub generation to unit test style

### DIFF
--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -110,7 +110,7 @@ void defineLinterEngineTests() {
       });
       test('smoke', () async {
         var firstRuleTest =
-            Directory(ruleTestDir).listSync().firstWhere(isDartFile);
+            Directory(ruleTestDataDir).listSync().firstWhere(isDartFile);
         await cli.run([firstRuleTest.path]);
         expect(cli.isLinterErrorCode(exitCode), isFalse);
       });
@@ -130,7 +130,7 @@ void defineLinterEngineTests() {
       test('custom sdk path', () async {
         // Smoke test to ensure a custom sdk path doesn't sink the ship
         var firstRuleTest =
-            Directory(ruleTestDir).listSync().firstWhere(isDartFile);
+            Directory(ruleTestDataDir).listSync().firstWhere(isDartFile);
         var sdk = getSdkPath();
         await cli.run(['--dart-sdk', sdk, firstRuleTest.path]);
         expect(cli.isLinterErrorCode(exitCode), isFalse);

--- a/test/experiments_test.dart
+++ b/test/experiments_test.dart
@@ -16,7 +16,7 @@ void main() {
     registerLintRuleExperiments();
 
     for (var entry
-        in Directory(p.join(ruleTestDir, 'experiments')).listSync()) {
+        in Directory(p.join(ruleTestDataDir, 'experiments')).listSync()) {
       if (entry is! Directory) continue;
 
       group(p.basename(entry.path), () {

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -44,7 +44,7 @@ void defineRuleTests() {
   group('rule', () {
     group('dart', () {
       // Rule tests run with default analysis options.
-      testRules(ruleTestDir);
+      testRules(ruleTestDataDir);
 
       // Rule tests run against specific configurations.
       for (var entry in Directory(testConfigDir).listSync()) {
@@ -53,12 +53,12 @@ void defineRuleTests() {
           var analysisOptionsFile =
               File(p.join(entry.path, 'analysis_options.yaml'));
           var analysisOptions = analysisOptionsFile.readAsStringSync();
-          testRules(ruleTestDir, analysisOptions: analysisOptions);
+          testRules(ruleTestDataDir, analysisOptions: analysisOptions);
         });
       }
     });
     group('pub', () {
-      for (var entry in Directory(p.join(ruleTestDir, 'pub')).listSync()) {
+      for (var entry in Directory(p.join(ruleTestDataDir, 'pub')).listSync()) {
         if (entry is Directory) {
           for (var child in entry.listSync()) {
             if (child is File && isPubspecFile(child)) {
@@ -187,7 +187,7 @@ void defineSanityTests() {
 
 /// Handy for debugging.
 void defineSoloRuleTest(String ruleToTest) {
-  for (var entry in Directory(ruleTestDir).listSync()) {
+  for (var entry in Directory(ruleTestDataDir).listSync()) {
     if (entry is! File || !isDartFile(entry)) continue;
     var ruleName = p.basenameWithoutExtension(entry.path);
     if (ruleName == ruleToTest) {

--- a/test/test_constants.dart
+++ b/test/test_constants.dart
@@ -5,5 +5,6 @@
 import 'package:path/path.dart' as path;
 
 final String integrationTestDir = path.join('test_data', 'integration');
-final String ruleTestDir = path.join('test_data', 'rules');
+final String ruleTestDataDir = path.join('test_data', 'rules');
+final String ruleTestDir = path.join('test', 'rules');
 final String testConfigDir = path.join('test', 'configs');

--- a/test/unmocked_sdk_rule_test.dart
+++ b/test/unmocked_sdk_rule_test.dart
@@ -14,7 +14,8 @@ void main() {
   group('un-mocked', () {
     // Validate that rule tests produce the expected results when run against
     // an un-mocked SDK.
-    for (var entry in Directory(p.join(ruleTestDataDir, 'unmocked')).listSync()) {
+    for (var entry
+        in Directory(p.join(ruleTestDataDir, 'unmocked')).listSync()) {
       if (entry is! File) continue;
 
       var ruleName = p.basenameWithoutExtension(entry.path);

--- a/test/unmocked_sdk_rule_test.dart
+++ b/test/unmocked_sdk_rule_test.dart
@@ -14,7 +14,7 @@ void main() {
   group('un-mocked', () {
     // Validate that rule tests produce the expected results when run against
     // an un-mocked SDK.
-    for (var entry in Directory(p.join(ruleTestDir, 'unmocked')).listSync()) {
+    for (var entry in Directory(p.join(ruleTestDataDir, 'unmocked')).listSync()) {
       if (entry is! File) continue;
 
       var ruleName = p.basenameWithoutExtension(entry.path);

--- a/test/util/rule_debug.dart
+++ b/test/util/rule_debug.dart
@@ -20,6 +20,6 @@ import '../test_constants.dart';
 ///
 void main(List<String> args) {
   var ruleName = args.first;
-  var dir = Directory(ruleTestDir).absolute;
+  var dir = Directory(ruleTestDataDir).absolute;
   testRule(ruleName, File(p.join(dir.path, '$ruleName.dart')));
 }

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -61,22 +61,25 @@ void generateRule(String ruleName, {String? outDir}) {
 
   // Update rule registry.
   updateRuleRegistry(ruleName);
+
+  print('A unit test has been stubbed out in:');
+  print('  $ruleTestDir/${ruleName}_test.dart');
 }
 
 void generateStub(String ruleName, String stubPath, Generator generator,
     {String? outDir}) {
-  var generated = generator(ruleName, toClassName(ruleName));
+  var (:file, :contents) = generator(ruleName, toClassName(ruleName));
   if (outDir != null) {
-    var outPath = path.join(outDir, stubPath, '$ruleName.dart');
+    var outPath = path.join(outDir, stubPath, file);
     var outFile = File(outPath);
     if (outFile.existsSync()) {
       print('Warning: stub already exists at $outPath; skipping');
       return;
     }
     print('Writing to $outPath');
-    outFile.writeAsStringSync(generated);
+    outFile.writeAsStringSync(contents);
   } else {
-    print(generated);
+    print(contents);
   }
 }
 
@@ -96,11 +99,11 @@ void updateRuleRegistry(String ruleName) {
   print("Don't forget to update lib/src/rules.dart with a line like:");
   print('  ..register(${toClassName(ruleName)}())');
   print('and add your rule to `example/all.yaml`.');
-  print('Then run your test like so:');
-  print('  dart test -N $ruleName');
 }
 
-String _generateClass(String ruleName, String className) => """
+GeneratedFile _generateClass(String ruleName, String className) => (
+      file: '$ruleName.dart',
+      contents: """
 // Copyright (c) $_thisYear, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
@@ -159,16 +162,44 @@ class _Visitor extends SimpleAstVisitor {
     // TODO: implement
   }
 }
-""";
+"""
+    );
 
-// todo(pq): update to generate a unit test instead.
-String _generateTest(String libName, String className) => '''
+GeneratedFile _generateTest(String libName, String className) => (
+      file: '${libName}_test.dart',
+      contents: '''
 // Copyright (c) $_thisYear, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// test w/ `dart test -N $libName`
+import 'package:test_reflective_loader/test_reflective_loader.dart';
 
-''';
+import '../rule_test_support.dart';
 
-typedef Generator = String Function(String libName, String className);
+//todo: add to all.dart
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(${className}Test);
+  });
+}
+
+@reflectiveTest
+class ${className}Test extends LintRuleTest {
+  @override
+  String get lintRule => '$libName';
+  
+  test_firstTest() async {
+    await assertDiagnostics(r\'\'\'
+  
+\'\'\', [
+   lint(0, 0),
+    ]);
+  }
+}
+'''
+    );
+
+typedef GeneratedFile = ({String file, String contents});
+
+typedef Generator = GeneratedFile Function(String libName, String className);

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -176,7 +176,7 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import '../rule_test_support.dart';
 
-//todo: add to all.dart
+// TODO: add to all.dart
 
 main() {
   defineReflectiveSuite(() {


### PR DESCRIPTION
Sample output:


```
☁  linter [generate_unit_test_stub] ⚡  dart tool/rule.dart -n no_wildcard_variable_uses
Writing to ./lib/src/rules/no_wildcard_variable_uses.dart
Writing to ./test/rules/no_wildcard_variable_uses_test.dart
Don't forget to update lib/src/rules.dart with a line like:
  ..register(NoWildcardVariableUses())
and add your rule to `example/all.yaml`.
A unit test has been stubbed out in:
  test/rules/no_wildcard_variable_uses_test.dart
```


```dart
// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
// for details. All rights reserved. Use of this source code is governed by a
// BSD-style license that can be found in the LICENSE file.

import 'package:analyzer/dart/ast/ast.dart';
import 'package:analyzer/dart/ast/visitor.dart';

import '../analyzer.dart';

const _desc = r' ';

const _details = r'''
**DO** ...

**BAD:**
\`\`\`dart

\`\`\`

**GOOD:**
\`\`\`dart

\`\`\`

''';

class NoWildcardVariableUses extends LintRule {
  static const LintCode code = LintCode(
      'no_wildcard_variable_uses', '<add problem message here>',
      correctionMessage: '<add correction message here>');

  NoWildcardVariableUses()
      : super(
            name: 'no_wildcard_variable_uses',
            description: _desc,
            details: _details,
            group: Group.style);

  @override
  LintCode get lintCode => code;

  @override
  void registerNodeProcessors(NodeLintRegistry registry, LinterContext context) {
    var visitor = _Visitor(this);
    registry.addSimpleIdentifier(this, visitor);
  }
}

class _Visitor extends SimpleAstVisitor {
  final LintRule rule;

  _Visitor(this.rule);

  @override
  void visitSimpleIdentifier(SimpleIdentifier node) {
    // TODO: implement
  }
}
```

(Ignore the code block escapes.)


```dart
// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
// for details. All rights reserved. Use of this source code is governed by a
// BSD-style license that can be found in the LICENSE file.

import 'package:test_reflective_loader/test_reflective_loader.dart';

import '../rule_test_support.dart';

//todo: add to all.dart

main() {
  defineReflectiveSuite(() {
    defineReflectiveTests(NoWildcardVariableUsesTest);
  });
}

@reflectiveTest
class NoWildcardVariableUsesTest extends LintRuleTest {
  @override
  String get lintRule => 'no_wildcard_variable_uses';
  
  test_firstTest() async {
    await assertDiagnostics(r'''
  
''', [
   lint(0, 0),
    ]);
  }
}
```


/cc @bwilkerson @srawlins @parlough 