### PR TITLE
tidy shared test setup

### DIFF
--- a/test/doc_test.dart
+++ b/test/doc_test.dart
@@ -5,9 +5,11 @@
 import 'package:test/test.dart';
 
 import '../tool/doc.dart';
+import 'util/test_utils.dart';
 
 void main() {
   group('doc generation', () {
+    setUp(setUpSharedTestEnvironment);
     test('fixStatus (sanity)', () async {
       var fixStatusMap = await fetchFixStatusMap();
       // Doc generation reads the fix status map to associate fix status

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -19,6 +19,7 @@ import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'test_constants.dart';
+import 'util/test_utils.dart';
 
 void main() {
   defineLinterEngineTests();
@@ -27,6 +28,7 @@ void main() {
 /// Linter engine tests
 void defineLinterEngineTests() {
   group('engine', () {
+    setUp(setUpSharedTestEnvironment);
     group('reporter', () {
       void doTest(
           String label, String expected, Function(PrintingReporter r) report) {

--- a/test/experiments_test.dart
+++ b/test/experiments_test.dart
@@ -10,10 +10,11 @@ import 'package:test/test.dart';
 import '../test_data/rules/experiments/experiments.dart';
 import 'rule_test.dart';
 import 'test_constants.dart';
+import 'util/test_utils.dart';
 
 void main() {
   group('experiments', () {
-    registerLintRuleExperiments();
+    setUp(setUpSharedTestEnvironment);
 
     for (var entry
         in Directory(p.join(ruleTestDataDir, 'experiments')).listSync()) {

--- a/test/experiments_test.dart
+++ b/test/experiments_test.dart
@@ -10,11 +10,10 @@ import 'package:test/test.dart';
 import '../test_data/rules/experiments/experiments.dart';
 import 'rule_test.dart';
 import 'test_constants.dart';
-import 'util/test_utils.dart';
 
 void main() {
   group('experiments', () {
-    setUp(setUpSharedTestEnvironment);
+    registerLintRuleExperiments();
 
     for (var entry
         in Directory(p.join(ruleTestDataDir, 'experiments')).listSync()) {

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -33,10 +33,13 @@ import 'util/annotation_matcher.dart';
 import 'util/test_utils.dart';
 
 void main() {
-  defineSanityTests();
-  defineRuleTests();
-  experiment_tests.main();
-  defineRuleUnitTests();
+  group('rule tests', () {
+    setUp(setUpSharedTestEnvironment);
+    defineSanityTests();
+    defineRuleTests();
+    experiment_tests.main();
+    defineRuleUnitTests();
+  });
 }
 
 /// Rule tests

--- a/test/util/test_utils.dart
+++ b/test/util/test_utils.dart
@@ -1,8 +1,17 @@
 // Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
+import 'package:analyzer/src/lint/io.dart';
+import 'package:linter/src/rules.dart';
 import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void setUpSharedTestEnvironment() {
+  // Redirect output.
+  outSink = MockIOSink();
+  registerLintRules();
+}
 
 void testEach<T>(Iterable<T> values, bool Function(T s) f, Matcher m) {
   for (var s in values) {

--- a/test/validate_rule_description_format_test.dart
+++ b/test/validate_rule_description_format_test.dart
@@ -5,6 +5,8 @@
 import 'package:analyzer/src/lint/registry.dart';
 import 'package:test/test.dart';
 
+import 'util/test_utils.dart';
+
 void main() {
   const keywords = [
     'GOOD',
@@ -16,6 +18,8 @@ void main() {
   ];
 
   group('rule doc format', () {
+    setUp(setUpSharedTestEnvironment);
+
     var rules = Registry.ruleRegistry.rules;
     test('(setup)', () {
       expect(rules, isNotEmpty,


### PR DESCRIPTION
Changes required to make tests "hermetic" and runnable via `dart test` and from within the idea using the "run all tests" action.

```
☁  linter [main] ⚡  dart test test
01:23 +1554: test/doc_test.dart: doc generation fixStatus (sanity)                                              
loading https://raw.githubusercontent.com/dart-lang/sdk/main/pkg/analysis_server/lib/src/services/correction/error_fix_status.yaml...
01:27 +1594: All tests passed!  
```

![image](https://github.com/dart-lang/linter/assets/67586/55796f49-6b47-4c29-8c9e-c2893b91bcf1)


See: #4404 

/cc @bwilkerson @srawlins 

