### PR TITLE
move to new "versioning" scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-1.35.0
+# 3.1.0
+
+- new lint: `no_wildcard_variable_uses`
+
+---
+
+# 1.35.0
 
 - add new lints: 
   - `implicit_reopen`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.1.0
+# 3.1.0-wip
 
 - new lint: `no_wildcard_variable_uses`
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,6 @@
 name: linter
 # This package is not intended for consumption on pub.dev. DO NOT publish.
 publish_to: none
-# TODO (pq): remove (https://github.com/dart-lang/linter/issues/4389)
-version: 1.35.0
 
 description: >-
   The implementation of the lint rules supported by the analyzer framework.


### PR DESCRIPTION
Removes the `version` from our pubspec and updates the changelog to a new scheme based on 3.1.0 (the next stable Dart version).

My thinking is we do not need to suffix this with `-dev` since we're not really using semver and don't see the value of a suffix that we'll have to remember to update.

Very open to input though.

See: #4389

/cc @bwilkerson @natebosch @devoncarew 


