### PR TITLE
+ changelog process notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,14 @@ To send us a pull request:
 
 Please make sure all your checkins have detailed commit messages explaining the patch and if a PR is *not* ready to land, consider making it clear in the description and/or prefixing the title with "WIP".
 
+Please note that a few kinds of changes require a `CHANGELOG` entry. Notably, any change that:
+
+1. adds a new lint
+2. removes or deprecates a lint or
+3. fundamentally changes the semantics of an existing lint
+
+should have a short entry in the `CHANGELOG`. Feel free to bring up any questions in your PR.
+
 Once you've gotten an LGTM from a project maintainer, submit your changes to the
 `main` branch using one of the following methods:
 

--- a/doc/lint-lifecycle.md
+++ b/doc/lint-lifecycle.md
@@ -74,6 +74,6 @@ Experimental lints should aspire to be stable. An experimental lint is a candida
 
 ### Removal
 
-Implemented lints can be removed.
+Deprecated or experimental lints can be removed. A stable lint should be deprecated before removal.
 
 (**NOTE**: A change that removes an existing lint should have a corresponding `CHANGELOG` entry.)

--- a/doc/lint-lifecycle.md
+++ b/doc/lint-lifecycle.md
@@ -50,12 +50,19 @@ In general removal is preceded by a period of deprecation.
 
 ## State Transitions
 
+### Implementation
+
+Once a lint proposal is accepted, it is safe to implement. A change that lands a new lint should
+have a corresponding `CHANGELOG` entry.
+
 ### Deprecation
 
 Implemented lints can be deprecated.
 
 Deprecating lints that are in common lint sets (e.g., in [package:lints](https://github.com/dart-lang/lints)
 can be impactful so should be done with care.
+
+(**NOTE**: A change that deprecates an existing lint should have a corresponding `CHANGELOG` entry.)
 
 ### Marking Stable
 
@@ -64,3 +71,9 @@ Experimental lints should aspire to be stable. An experimental lint is a candida
 * complete semantics
 * complete implementation (with no false-positives)
 * established long-term value (e.g., inclusion in a recommended lint set)
+
+### Removal
+
+Implemented lints can be removed.
+
+(**NOTE**: A change that removes an existing lint should have a corresponding `CHANGELOG` entry.)


### PR DESCRIPTION
Some notes on `CHANGELOG` updates.

In support of https://github.com/dart-lang/linter/issues/4389.

