### PR TITLE
Move many use_build_context_synchronously tests to reflective

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -615,12 +615,19 @@ class _AsyncStateVisitor extends SimpleAstVisitor<_AsyncState> {
     } else if (node.catchClauses.any((clause) => clause == reference)) {
       return node.body.accept(this)?.asynchronousOrNull;
     } else if (node.finallyBlock == reference) {
-      return node.body.accept(this);
+      return node.body.accept(this)?.asynchronousOrNull;
     }
 
+    var finallyAsyncState = node.finallyBlock?.accept(this);
+    if (finallyAsyncState == _AsyncState.asynchronous) {
+      return _AsyncState.asynchronous;
+    }
+    if (finallyAsyncState == _AsyncState.notMountedCheck) {
+      return _AsyncState.notMountedCheck;
+    }
     // Only statements in the `finally` section of a try-statement can
     // sufficiently guard statements following the try-statement.
-    return node.finallyBlock?.accept(this) ?? node.body.accept(this);
+    return node.body.accept(this)?.asynchronousOrNull;
   }
 
   @override

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -463,6 +463,44 @@ Future<bool> c() async => true;
     ]);
   }
 
+  test_awaitBeforeMountedCheckInTryBody_beforeReferenceToContext() async {
+    // Await, then try-statement with mounted check in the try-body, then use of
+    // BuildContext, is REPORTED.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await c();
+  try {
+    if (!context.mounted) return;
+  } on Exception {
+  }
+  Navigator.of(context);
+}
+Future<void> c() async {}
+''', [
+      lint(159, 21),
+    ]);
+  }
+
+  test_awaitBeforeMountedCheckInTryFinally_beforeReferenceToContext() async {
+    // Await, then try-statement with mounted check in the try-finally, then use
+    // of BuildContext, is OK.
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await c();
+  try {
+  } finally {
+    if (!context.mounted) return;
+  }
+  Navigator.of(context);
+}
+Future<void> c() async {}
+''');
+  }
+
   test_awaitBeforeReferenceToContext_inClosure() async {
     // Await, then use of BuildContext in a closure, is REPORTED.
     // todo (pq): what about closures?
@@ -1295,8 +1333,7 @@ Future<int> c() async => 1;
   }
 
   test_awaitInTryBody_beforeReferenceToContext() async {
-    // Await in a try-body, then use of BuildContext in try-catch clause,
-    // is REPORTED.
+    // Await in a try-body, then use of BuildContext, is REPORTED.
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 

--- a/test_data/rules/use_build_context_synchronously.dart
+++ b/test_data/rules/use_build_context_synchronously.dart
@@ -54,15 +54,7 @@ void nullableContext3() async {
   var renderObject = contextOrNull?.findRenderObject(); // OK
 }
 
-void unawaited(Future<void> future) {}
-
-class WidgetStateContext {
-  bool get mounted => false;
-}
-
 void f(BuildContext context) {}
-
-void func(Function f) {}
 
 class MyWidget extends StatefulWidget {
   @override
@@ -75,105 +67,7 @@ void directAccess(BuildContext context) async {
   var renderObject = context.findRenderObject(); // LINT
 }
 
-Future<bool> binaryExpression(BuildContext context) async {
-  bool f2(BuildContext context) => true;
-
-  f2(context);
-
-  await Future<void>.delayed(Duration());
-
-  return true || f2(context); // LINT
-}
-
-class C {
-  BuildContext context;
-  C(this.context);
-}
-
 class _MyState extends State<MyWidget> {
-  void methodUsingStateContext1() async {
-    // Uses context from State.
-    Navigator.of(context).pushNamed('routeName'); // OK
-
-    await Future<void>.delayed(Duration());
-
-    // Not ok. Used after an async gap without checking mounted.
-    Navigator.of(context).pushNamed('routeName'); // LINT
-  }
-
-  void methodUsingStateContext2() async {
-    // Uses context from State.
-    Navigator.of(context).pushNamed('routeName'); // OK
-
-    await Future<void>.delayed(Duration());
-
-    if (!mounted) return;
-
-    // OK. mounted checked first.
-    Navigator.of(context).pushNamed('routeName'); // OK
-  }
-
-  void methodUsingStateContext2a() async {
-    await Future<void>.delayed(Duration());
-    if (!mounted) print('oops');
-
-    // Need a return after the mounted check.
-    Navigator.of(context).pushNamed('routeName'); // LINT
-  }
-
-  void methodUsingStateContext2b() async {
-    await Future<void>.delayed(Duration());
-    if (!mounted) {
-      print('ok');
-      return;
-    }
-
-    // Mounted check does return.
-    Navigator.of(context).pushNamed('routeName'); //OK
-  }
-
-  void methodUsingStateContext3() async {
-    f(context);
-
-    await Future<void>.delayed(Duration());
-
-    f(context); // LINT
-  }
-
-  void methodUsingStateContext4() async {
-    void f(BuildContext context) {}
-
-    f(context);
-
-    await Future<void>.delayed(Duration());
-
-    f(context); // LINT
-  }
-
-  void methodUsingStateContext5() async {
-    C(context);
-
-    await Future<void>.delayed(Duration());
-
-    C(context); // LINT
-  }
-
-  void methodUsingStateContext6() async {
-    Future<int> f() async => Future.value(10);
-
-    print(await f());
-
-    C(context); // LINT
-  }
-
-  // Method given a build context to use.
-  void methodWithBuildContextParameter1(BuildContext context) async {
-    Navigator.of(context).pushNamed('routeName'); // OK
-
-    await Future<void>.delayed(Duration());
-    Navigator.of(context).pushNamed('routeName'); // LINT
-  }
-
   // Same as above, but using a conditional path.
   void methodWithBuildContextParameter2(BuildContext context) async {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
@@ -216,12 +110,6 @@ class _MyState extends State<MyWidget> {
     Navigator.of(context).pushNamed('routeName'); // LINT
   }
 
-  Future<void> methodWithBuildContextParameter2e(BuildContext context) async {
-    await Future<void>.delayed(Duration());
-    if (!mounted) return;
-    unawaited(methodWithBuildContextParameter2e(context)); //OK
-  }
-
   void methodWithBuildContextParameter2g(BuildContext context) async {
     await Future<void>.delayed(Duration());
     switch (1) {
@@ -230,41 +118,6 @@ class _MyState extends State<MyWidget> {
         await Navigator.of(context).pushNamed('routeName'); // OK
         break;
     }
-  }
-
-  void methodWithBuildContextParameter2i(BuildContext context) async {
-    try {
-      await Future<void>.delayed(Duration());
-    } finally {
-      if (!mounted) return;
-    }
-
-    f(context); // OK
-  }
-
-  // Mounted checks are deliberately naive.
-  void methodWithBuildContextParameter3(BuildContext context) async {
-    Navigator.of(context).pushNamed('routeName'); // OK
-
-    await Future<void>.delayed(Duration());
-
-    if (!mounted) return;
-
-    // Mounted doesn't cover provided context but that's by design.
-    Navigator.of(context).pushNamed('routeName'); // OK
-  }
-
-  void methodWithBuildContextParameter4(BuildContext context) async {
-    await Future<void>.delayed(Duration());
-    if (!context.mounted) return;
-    await Navigator.of(context).pushNamed('routeName'); // OK
-  }
-
-  void methodWithMountedFieldCheck(
-      BuildContext context, WidgetStateContext stateContext) async {
-    await Future<void>.delayed(Duration());
-    if (!stateContext.mounted) return;
-    f(context); // OK
   }
 
   @override


### PR DESCRIPTION
# Description

Many of the tests already have equivalent reflective tests, so they are just deleted.

But the try/catch tests, when improving them for reflective tests, found some bugs in `AsyncVisitor.visitTryStatement`, so the impl is changed to fix those:

* a BuildContext reference _found in a finally-block_ is not guarded by any "if not mounted then exit" in the try-body; any such check is not guaranteed to be run before the code in the finally.
* a BuildContext reference _found after a try/catch/finally_ is not guarded by any "if not mounted then exit" in the try-body; any such check is not guaranteed to be run before the code in the finally.


CC @pq @keertip 