### PR TITLE
stop documenting "since" linter versions

### DIFF
--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -647,10 +647,7 @@ class RuleHtmlGenerator extends RuleGenerator {
     var sdkVersion = info.sinceDartSdk != null
         ? '>= ${info.sinceDartSdk}'
         : '<strong>Unreleased</strong>';
-    var linterVersion = info.sinceLinter != null
-        ? 'v${info.sinceLinter}'
-        : '<strong>Unreleased</strong>';
-    return 'Dart SDK: $sdkVersion • <small>(Linter $linterVersion)</small>';
+    return 'Dart SDK: $sdkVersion';
   }
 
   String get stateString {
@@ -731,9 +728,7 @@ class RuleMarkdownGenerator extends RuleGenerator {
     var sdkVersion = info.sinceDartSdk != null
         ? '>= ${info.sinceDartSdk}'
         : '**Unreleased**';
-    var linterVersion =
-        info.sinceLinter != null ? 'v${info.sinceLinter}' : '**Unreleased**';
-    return 'Dart SDK: $sdkVersion • _(Linter $linterVersion)_';
+    return 'Dart SDK: $sdkVersion';
   }
 
   String get stateString => describeState(rule);

--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -45,8 +45,6 @@ String getMachineListing(Iterable<LintRule> ruleRegistry,
         'name': rule.name,
         'description': rule.description,
         'group': rule.group.name,
-        // todo(pq): here for backwards compatibility -- should be removed.
-        'maturity': rule.state.label,
         'state': rule.state.label,
         'incompatible': rule.incompatibleRules,
         'sets': [
@@ -58,8 +56,6 @@ String getMachineListing(Iterable<LintRule> ruleRegistry,
         'details': rule.details,
         if (sinceInfo != null)
           'sinceDartSdk': sinceInfo[rule.name]?.sinceDartSdk ?? 'Unreleased',
-        if (sinceInfo != null)
-          'sinceLinter': sinceInfo[rule.name]?.sinceLinter ?? 'Unreleased',
       }
   ]);
   return json;

--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -22,7 +22,6 @@ void main() async {
   var scorecard = await ScoreCard.calculate();
   var details = <Detail>[
     Detail.rule,
-    Detail.linter,
     Detail.sdk,
     Detail.fix,
     Detail.flutterUser,
@@ -103,10 +102,7 @@ StringBuffer buildFooter(ScoreCard scorecard, List<Detail> details) {
 
 class Detail {
   static const Detail rule = Detail('name', header: Header.left);
-  static const Detail linter = Detail('linter', header: Header.left);
-
   static const Detail sdk = Detail('dart sdk', header: Header.left);
-
   static const Detail fix = Detail('fix');
   static const Detail flutterUser = Detail('flutter user');
   static const Detail flutterRepo = Detail('flutter repo');
@@ -152,8 +148,6 @@ class LintScore {
         case Detail.rule:
           sb.write(
               ' [$name](https://dart-lang.github.io/linter/lints/$name.html) |');
-        case Detail.linter:
-          sb.write(' ${since!.sinceLinter} |');
         case Detail.sdk:
           sb.write(' ${since!.sinceDartSdk} |');
         case Detail.fix:

--- a/tool/since.dart
+++ b/tool/since.dart
@@ -5,77 +5,12 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:args/args.dart';
-import 'package:collection/collection.dart';
 import 'package:github/github.dart';
 import 'package:linter/src/utils.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
 import 'crawl.dart';
-
-void main(List<String> args) async {
-  var parser = ArgParser()
-    ..addOption(
-      'token',
-      abbr: 't',
-      help: 'Specifies a GitHub auth token.',
-    )
-    ..addFlag(
-      'linter',
-      abbr: 'l',
-      help: 'Prints out latest linter rule to linter release information.',
-    )
-    ..addFlag(
-      'sdk',
-      abbr: 's',
-      help: 'Prints out latest SDK release to linter release information.',
-    );
-
-  ArgResults options;
-  try {
-    options = parser.parse(args);
-  } on FormatException {
-    printToConsole(parser.usage);
-    return;
-  }
-
-  var printLinter = options['linter'] == true;
-  var printSdk = options['sdk'] == true;
-
-  if (!printLinter && !printSdk) {
-    printToConsole('Either --linter or --sdk must be specified!');
-    return;
-  }
-
-  var token = options['token'];
-  var auth = token is String ? Authentication.withToken(token) : null;
-
-  if (printLinter) {
-    var sinceInfo = await getSinceMap(auth);
-
-    for (var MapEntry(key: lintName, value: sinceInfo) in sinceInfo.entries) {
-      var sinceLinter = sinceInfo.sinceLinter;
-      if (sinceLinter != null) {
-        printToConsole('$lintName: $sinceLinter');
-      }
-    }
-
-    if (printSdk) {
-      printToConsole('\n================\n');
-    }
-  }
-
-  if (printSdk) {
-    var sinceSdk = await getDartSdkMap(auth);
-
-    for (var MapEntry(key: sdkVersion, value: linterVersion) in sinceSdk.entries
-        .sorted(
-            (a, b) => Version.parse(b.key).compareTo(Version.parse(a.key)))) {
-      printToConsole('$sdkVersion: $linterVersion');
-    }
-  }
-}
 
 final Version earliestLinterInDart2 = Version.parse('0.1.58');
 


### PR DESCRIPTION
The linter version cache is still required to lookup corresponding Dart SDKs but this at least stops putting the version in the documentation. (Removes the stale "maturity" field from `rules.json` too.)

Fixes #4432

/cc @bwilkerson @parlough 

