### PR TITLE
use_build_context: Fix a failing test regarding the looping of while loops

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:collection/collection.dart';
 
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
@@ -243,17 +244,27 @@ class _AsyncStateVisitor extends SimpleAstVisitor<_AsyncState> {
 
   @override
   _AsyncState? visitBlock(Block node) {
-    for (var i = node.statements.length - 1; i >= 0; i--) {
-      var statement = node.statements[i];
-      var asyncState = statement.accept(this);
-      if (asyncState != null) {
-        // Walking from the last statement to the first, as soon as we encounter
-        // asynchronous code or a mounted check (positive or negative), that's
-        // the state of the block.
-        return asyncState;
+    if (reference is Statement) {
+      var index = node.statements.indexOf(reference as Statement);
+      if (index >= 0) {
+        var precedingAsyncState = _inOrderAsyncStateGuardable(node.statements);
+        if (precedingAsyncState != null) return precedingAsyncState;
+        if (node.parent is WhileStatement) {
+          // Check for asynchrony in the statements that _follow_ [reference],
+          // as they may lead to an async gap before we loop back to
+          // [reference].
+          return _inOrderAsyncStateGuardable(node.statements.skip(index + 1))
+              ?.asynchronousOrNull;
+        }
+        return null;
       }
     }
-    return null;
+
+    // When [reference] is not one of [node.statements], walk through all of
+    // them.
+    return node.statements.reversed
+        .map((s) => s.accept(this))
+        .firstWhereOrNull((state) => state != null);
   }
 
   @override
@@ -568,11 +579,11 @@ class _AsyncStateVisitor extends SimpleAstVisitor<_AsyncState> {
 
   @override
   _AsyncState? visitSwitchCase(SwitchCase node) =>
-      _asynchronousIfAnyIsAsync([node.expression, ...node.statements]);
+      _inOrderAsyncStateGuardable([node.expression, ...node.statements]);
 
   @override
   _AsyncState? visitSwitchPatternCase(SwitchPatternCase node) =>
-      _asynchronousIfAnyIsAsync(
+      _inOrderAsyncStateGuardable(
           [node.guardedPattern.whenClause, ...node.statements]);
 
   @override
@@ -683,7 +694,7 @@ class _AsyncStateVisitor extends SimpleAstVisitor<_AsyncState> {
       var (:node, :mountedCanGuard) = nodes[i];
       if (node == null) continue;
       var asyncState = node.accept(this);
-      if (!mountedCanGuard && asyncState == _AsyncState.asynchronous) {
+      if (asyncState == _AsyncState.asynchronous) {
         return _AsyncState.asynchronous;
       }
       if (mountedCanGuard && asyncState != null) {
@@ -695,6 +706,13 @@ class _AsyncStateVisitor extends SimpleAstVisitor<_AsyncState> {
     }
     return null;
   }
+
+  /// A simple wrapper for [_inOrderAsyncState] for [nodes] which can all guard
+  /// [reference] with a mounted check.
+  _AsyncState? _inOrderAsyncStateGuardable(Iterable<AstNode?> nodes) =>
+      _inOrderAsyncState([
+        for (var node in nodes) (node: node, mountedCanGuard: true),
+      ]);
 }
 
 class _Visitor extends SimpleAstVisitor {
@@ -711,71 +729,34 @@ class _Visitor extends SimpleAstVisitor {
     /// Checks each of the [statements] before [child] for a `mounted` check,
     /// and returns whether it did not find one (and the caller should keep
     /// looking).
-    bool checkStatements(AstNode child, NodeList<Statement> statements) {
-      if (child is! Statement) {
-        assert(false, 'child must be a Statement, but is ${child.runtimeType}');
-        return true;
-      }
-      var index = statements.indexOf(child);
-      for (var i = index - 1; i >= 0; i--) {
-        var s = statements[i];
-        var asyncState = s.asyncStateFor(child);
-        if (asyncState == _AsyncState.asynchronous) {
-          rule.reportLint(node);
-          return true;
-        } else if (asyncState.isGuarded) {
-          return false;
-        }
-      }
-      return true;
-    }
 
     // Walk back and look for an async gap that is not guarded by a mounted
     // property check.
     AstNode? child = node;
     while (child != null && child is! FunctionBody) {
       var parent = child.parent;
-      if (parent is Block) {
-        var keepChecking = checkStatements(child, parent.statements);
-        if (!keepChecking) {
-          return;
-        }
-      } else if (parent is SwitchCase) {
-        // Necessary for Dart 2.19 code.
-        var keepChecking = checkStatements(child, parent.statements);
-        if (!keepChecking) {
-          return;
-        }
-      } else if (parent is SwitchPatternCase) {
-        // Necessary for Dart 3.0 code.
-        var keepChecking = checkStatements(child, parent.statements);
-        if (!keepChecking) {
-          return;
-        }
-      } else if (parent is CollectionElement) {
-        // mounted ? ... : ...
-        var asyncState = parent.asyncStateFor(child);
-        if (asyncState == _AsyncState.asynchronous) {
-          rule.reportLint(node);
-          return;
-        } else if (asyncState.isGuarded) {
-          return;
-        }
-      } else if (parent is TryStatement) {
-        var asyncState = parent.asyncStateFor(child);
-        if (asyncState == _AsyncState.asynchronous) {
-          rule.reportLint(node);
-          return;
-        }
-      } else if (parent is IfStatement) {
-        // if (mounted) { ... }
-        var asyncState = parent.asyncStateFor(child);
-        if (asyncState == _AsyncState.asynchronous) {
-          rule.reportLint(node);
-          return;
-        } else if (asyncState.isGuarded) {
-          return;
-        }
+      switch (parent) {
+        case Block():
+        case CollectionElement():
+        case IfStatement():
+        // Dart 2.19 code.
+        case SwitchCase():
+        // Dart 3.0 code.
+        case SwitchPatternCase():
+          var asyncState = parent!.asyncStateFor(child);
+          if (asyncState == _AsyncState.asynchronous) {
+            rule.reportLint(node);
+            return;
+          } else if (asyncState.isGuarded) {
+            return;
+          }
+
+        case TryStatement():
+          var asyncState = parent.asyncStateFor(child);
+          if (asyncState == _AsyncState.asynchronous) {
+            rule.reportLint(node);
+            return;
+          }
       }
 
       child = parent;

--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -249,6 +249,7 @@ class _AsyncStateVisitor extends SimpleAstVisitor<_AsyncState> {
       if (index >= 0) {
         var precedingAsyncState = _inOrderAsyncStateGuardable(node.statements);
         if (precedingAsyncState != null) return precedingAsyncState;
+        // TODO(srawlins): Also DoStatement and ForStatement.
         if (node.parent is WhileStatement) {
           // Check for asynchrony in the statements that _follow_ [reference],
           // as they may lead to an async gap before we loop back to

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -544,6 +544,27 @@ Future<void> f() async {}
 ''');
   }
 
+  test_awaitBeforeWhileBody_referenceToContext_thenMountedGuard() async {
+    // Await, then While-true statement, and inside the while-body: use of
+    // BuildContext, then mounted guard, is REPORTED.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  await f();
+  while (true) {
+    Navigator.of(context);
+    if (context.mounted) return;
+  }
+}
+
+bool mounted = false;
+Future<void> f() async {}
+''', [
+      lint(113, 21),
+    ]);
+  }
+
   test_awaitInAdjacentStrings_beforeReferenceToContext() async {
     // Await in an adjacent strings, then use of BuildContext, is REPORTED.
     await assertDiagnostics(r'''
@@ -1313,6 +1334,24 @@ Future<bool> c() async => true;
     ]);
   }
 
+  test_awaitInSwitchStatementCaseGuard_beforeReferenceToContext2() async {
+    // Await in a switch statement case guard, then use of BuildContext in the
+    // case statements, is REPORTED.
+    await assertDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  switch (1) {
+    case 1 when await c():
+      Navigator.of(context);
+  }
+}
+Future<bool> c() async => true;
+''', [
+      lint(127, 21),
+    ]);
+  }
+
   test_awaitInSwitchStatementDefault_beforeReferenceToContext() async {
     // Await in a switch statement default case, then use of BuildContext, is
     // REPORTED.
@@ -1390,10 +1429,9 @@ Future<void> c() async {}
     ]);
   }
 
-  @FailingTest(reason: 'Logic not implemented yet.')
   test_awaitInWhileBody_afterReferenceToContext() async {
-    // While-true statement, and inside the while-body: use of
-    // BuildContext, then await, is OK.
+    // While-true statement, and inside the while-body: use of BuildContext,
+    // then await, is REPORTED.
     await assertDiagnostics(r'''
 import 'package:flutter/widgets.dart';
 
@@ -1405,11 +1443,28 @@ void foo(BuildContext context) async {
   }
 }
 
-bool mounted = false;
 Future<void> f() async {}
 ''', [
-      lint(149, 21),
+      lint(131, 21),
     ]);
+  }
+
+  test_awaitInWhileBody_afterReferenceToContext2() async {
+    // While-true statement, and inside the while-body: use of BuildContext,
+    // then await, then mounted guard, is OK.
+    await assertNoDiagnostics(r'''
+import 'package:flutter/widgets.dart';
+
+void foo(BuildContext context) async {
+  while (true) {
+    Navigator.of(context);
+    await f();
+    if (!context.mounted) return;
+  }
+}
+
+Future<void> f() async {}
+''');
   }
 
   test_awaitInWhileBody_afterReferenceToContextOutsideWait() async {


### PR DESCRIPTION
# Description

In a while loop, an async gap that comes _after_ a BuildContext reference should be reported!

Statements that precede a BuildContext reference can guard it with a mounted check, but not statements that follow the BuildContextReference.

In order to accomplish this, note that a _lot_ of the complexity in `check()` is moved to the `_AsyncStateVisitor`, mostly in `visitBlock`. I think it is a big benefit to make `check()` simpler, when it comes to special treatment of parent node types.

CC @keertip 