### PR TITLE
remove fix entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # 3.1.0-wip
 
 - new lint: `no_wildcard_variable_uses`
-- fix `prefer_interpolation_to_compose_strings` for false-positive when
-  `toString()` is invoked with arguments.
 
 ---
 


### PR DESCRIPTION
As per new CHANGELOG policy, keep it lean (only lint adds, removes, and deprecations).

See: #4389

/cc @scheglov 
