### PR TITLE
rule.dart: auto-gen changelog and since map entries

### DIFF
--- a/tool/changelog.dart
+++ b/tool/changelog.dart
@@ -11,7 +11,7 @@ class Changelog {
   void addEntry(RuleStateChange change, String rule) {
     var logFile = File(fileName);
     var lines = LineSplitter().convert(logFile.readAsStringSync());
-    lines.insert(2, '- ${change.descriptionPrefix} lint: $rule');
+    lines.insert(2, '- ${change.descriptionPrefix} lint: `$rule`');
 
     var output = StringBuffer();
     // ignore: prefer_foreach

--- a/tool/changelog.dart
+++ b/tool/changelog.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+class Changelog {
+  static final fileName = 'CHANGELOG.md';
+
+  void addEntry(RuleStateChange change, String rule) {
+    var logFile = File(fileName);
+    var lines = LineSplitter().convert(logFile.readAsStringSync());
+    lines.insert(2, '- ${change.descriptionPrefix} lint: $rule');
+
+    var output = StringBuffer();
+    // ignore: prefer_foreach
+    for (var line in lines) {
+      output.writeln(line);
+    }
+    logFile.writeAsStringSync(output.toString());
+  }
+
+  String readCurrentRelease() {
+    var logFile = File(fileName).readAsStringSync();
+    for (var line in LineSplitter().convert(logFile)) {
+      if (line.startsWith('#')) {
+        return line.split('#')[1].trim();
+      }
+    }
+    return 'UNKNOWN';
+  }
+}
+
+enum RuleStateChange {
+  added('new'),
+  deprecated('deprecated'),
+  removed('removed');
+
+  final String descriptionPrefix;
+  const RuleStateChange(this.descriptionPrefix);
+}

--- a/tool/rule.dart
+++ b/tool/rule.dart
@@ -13,6 +13,8 @@ import 'package:linter/src/utils.dart';
 import 'package:path/path.dart' as path;
 
 import '../test/test_constants.dart';
+import 'changelog.dart';
+import 'since.dart';
 
 /// Generates rule and rule test stub files (into `src/rules` and `test/rules`
 /// respectively), as well as the rule index (`rules.dart`).
@@ -93,6 +95,11 @@ void generateRule(String ruleName, {String? outDir}) {
   // Generate an example `all.yaml`
   generateFile(ruleName, 'example', _generateAllYaml,
       outDir: outDir, overwrite: true);
+
+  printToConsole('Updating ${SdkVersionFile.filePath}');
+  SdkVersionFile().addRule(ruleName);
+  printToConsole('Updating ${Changelog.fileName}');
+  Changelog().addEntry(RuleStateChange.added, ruleName);
 
   // Update rule registry.
   generateFile(ruleName, path.join('lib', 'src'), _generateRulesFile,

--- a/tool/since.dart
+++ b/tool/since.dart
@@ -2,10 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
 import 'dart:io';
 
 import 'package:yaml/yaml.dart';
 
+import 'changelog.dart';
 import 'crawl.dart';
 
 final Map<String, SinceInfo> sinceMap = _readSinceMap();
@@ -21,6 +23,24 @@ Map<String, SinceInfo> _readSinceMap() {
   }
 
   return sinceMap;
+}
+
+class SdkVersionFile {
+  static final filePath = 'tool/since/sdk.yaml';
+
+  void addRule(String rule) {
+    var sinceFile = File(filePath);
+    var versionMap = loadYamlNode(sinceFile.readAsStringSync()) as Map;
+    var sortedMap = SplayTreeMap()..addAll(versionMap);
+    sortedMap[rule] = Changelog().readCurrentRelease();
+
+    var output = StringBuffer();
+    for (var entry in sortedMap.entries) {
+      output.writeln('${entry.key}: ${entry.value}');
+    }
+
+    sinceFile.writeAsStringSync(output.toString());
+  }
 }
 
 class SinceInfo {


### PR DESCRIPTION
Taking automation nearly as far as we can go... This updates `rule.dart` to generate a `CHANGELOG` entry and update the since SDK version map.

Sample run:

```
☁  linter [main] ⚡  dart tool/rule.dart -n foo_bar
Writing to ./lib/src/rules/foo_bar.dart
Writing to ./test/rules/foo_bar_test.dart
Writing to ./test/rules/all.dart
Writing to ./example/all.yaml
Updating tool/since/sdk.yaml
Updating CHANGELOG.md
Writing to ./lib/src/rules.dart
A unit test has been stubbed out in:
  test/rules/foo_bar_test.dart
```


<img width="857" alt="image" src="https://github.com/dart-lang/linter/assets/67586/c23fe2c9-f72c-47a4-a8c9-068b4d34e595">

![image](https://github.com/dart-lang/linter/assets/67586/28abc540-80da-48e0-a6de-498a864fb564)


/cc @bwilkerson @srawlins 

/fyi @parlough 
