### PR TITLE
Remove irrelevant pubspec links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,9 +5,6 @@ publish_to: none
 description: >-
   The implementation of the lint rules supported by the analyzer framework.
   This package is not intended to be used directly.
-homepage: https://github.com/dart-lang/linter
-repository: https://github.com/dart-lang/linter
-documentation: https://dart-lang.github.io/linter/lints
 
 environment:
   sdk: ^3.0.0


### PR DESCRIPTION
Without publishing, these links aren't useful, plus removes a link to the old linter site.
