### PR TITLE
Allow overloading of operators in unnecessary_statements

### DIFF
--- a/lib/src/rules/unnecessary_statements.dart
+++ b/lib/src/rules/unnecessary_statements.dart
@@ -106,19 +106,20 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
           (c) => c.declaredElement!.extendedType == node.leftOperand.staticType,
         );
 
-    // if the operator in the class definition is overloaded, it has a clear effect
+    // if the operator in the class definition is overloaded, it has a possible effect
     if (clazz != null) {
       // look for the operator in the members of the class
       var op = clazz.members
           .whereType<MethodDeclaration>()
           .firstWhereOrNull((m) => m.name.lexeme == node.operator.lexeme);
       if (op != null) {
-        // Has a clear effect
+        // Has a possible effect. For simplicity sake, we don't check
+        // if the method body has side effects.
         return;
       }
     }
 
-    // if the operator is overloaded in one of the extensions, it has a clear effect
+    // if the operator is overloaded in one of the extensions, it has a possible effect
     if (extensions.isNotEmpty) {
       // look for the operator in the members of the extensions
       var op = extensions
@@ -129,7 +130,8 @@ class _ReportNoClearEffectVisitor extends UnifyingAstVisitor {
           )
           .firstOrNull;
       if (op != null) {
-        // Has a clear effect
+        // Has a possible effect. For simplicity sake, we don't check
+        // if the method body has side effects.
         return;
       }
     }

--- a/test_data/rules/unnecessary_statements.dart
+++ b/test_data/rules/unnecessary_statements.dart
@@ -80,8 +80,7 @@ asConditionAndReturnOk() {
   do {} while ("blah".isEmpty); // OK
   for (var i in []) {} // OK
   switch (~1) // OK
-      {
-  }
+  {}
 
   () => new MyClass().foo; // LINT
   myfun() => new MyClass().foo; // OK
@@ -188,4 +187,30 @@ class MyClass {
 
   MyClass();
   MyClass.named();
+}
+
+class Logger {
+  void operator <<(String message) {}
+}
+
+extension LoggerX on Logger {
+  void operator <(String message) {}
+}
+
+loggingMethod() {
+  final l = Logger();
+
+  l << "Hello world (づ｡◕‿‿◕｡)づ"; // OK
+
+  l < "How are you ?"; // OK
+}
+
+extension StringX on String {
+  void operator <<(String message) {}
+}
+
+loggingMethod2() {
+  "hello" << "world"; // OK
+
+  "Hello" + "world"; // LINT
 }


### PR DESCRIPTION
# Description

This PR disables the `unnecessary_statements` for overloaded operators, so that code like this is possible:

```dart
class Logger {
	void operator<<(String message) {/*...*/}
}

void main() {
	final l = Logger();

	l << "Hello world (づ｡◕‿‿◕｡)づ"; 
	// Unnecessary statement.
	// Try completing the statement or breaking it up. (unnecessary_statements)
}
```

Fixes #4468
