### PR TITLE
Block github package 9.15.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,9 @@ dependencies:
 dev_dependencies:
   benchmark_harness: ^2.0.0
   cli_util: ^0.4.0
-  github: ^9.0.0
+  # 9.15.0 makes a parameter in GitHub constructor non-nullable.
+  # TODO(https://github.com/dart-lang/linter/issues/4475): Support this version.
+  github: ">=9.0.0 <9.15.0"
   lints: ^2.0.0
   markdown: ^7.0.0
   matcher: ^0.12.10


### PR DESCRIPTION
# Description

Blocks github package version 9.15.0, which includes a breaking change. See https://github.com/dart-lang/linter/issues/4475
