### PR TITLE
Mark types of external declarations as "reachable"

### DIFF
--- a/test/rules/unreachable_from_main_test.dart
+++ b/test/rules/unreachable_from_main_test.dart
@@ -253,6 +253,34 @@ class A {}
 ''');
   }
 
+  test_class_reachable_referencedInTypeAnnotation_externalFieldDeclaration() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  D().c;
+}
+
+class C {}
+
+class D {
+  external C? c;
+}
+''');
+  }
+
+  test_class_reachable_referencedInTypeAnnotation_externalMethodDeclaration() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  D().f;
+}
+
+class C {}
+
+class D {
+  external C f();
+}
+''');
+  }
+
   test_class_reachableViaAnnotation() async {
     await assertNoDiagnostics(r'''
 void main() {
@@ -411,20 +439,6 @@ class D {
 ''', [
       lint(32, 1),
     ]);
-  }
-
-  test_class_reachable_referencedInTypeAnnotation_externalFieldDeclaration() async {
-    await assertNoDiagnostics(r'''
-void main() {
-  D().c;
-}
-
-class C {}
-
-class D {
-  external C? c;
-}
-''');
   }
 
   test_class_unreachable_referencedInTypeAnnotation_parameter() async {

--- a/test/rules/unreachable_from_main_test.dart
+++ b/test/rules/unreachable_from_main_test.dart
@@ -413,6 +413,20 @@ class D {
     ]);
   }
 
+  test_class_reachable_referencedInTypeAnnotation_externalFieldDeclaration() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  D().c;
+}
+
+class C {}
+
+class D {
+  external C? c;
+}
+''');
+  }
+
   test_class_unreachable_referencedInTypeAnnotation_parameter() async {
     await assertDiagnostics(r'''
 void main() {


### PR DESCRIPTION
# Description

When looking at a NamedType, if it is found in the return type of an external member, call it reachable.

Fixes #4474 