### PR TITLE
New lint: type_test_on_generic_type_variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.1.0-wip
 
+- new lint: `type_test_on_generic_type_variable`
 - new lint: `no_wildcard_variable_uses`
 
 ---

--- a/example/all.yaml
+++ b/example/all.yaml
@@ -169,6 +169,7 @@ linter:
     - type_annotate_public_apis
     - type_init_formals
     - type_literal_in_constant_pattern
+    - type_test_on_generic_type_variable
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps

--- a/lib/src/rules.dart
+++ b/lib/src/rules.dart
@@ -181,6 +181,7 @@ import 'rules/tighten_type_of_initializing_formals.dart';
 import 'rules/type_annotate_public_apis.dart';
 import 'rules/type_init_formals.dart';
 import 'rules/type_literal_in_constant_pattern.dart';
+import 'rules/type_test_on_generic_type_variable.dart';
 import 'rules/unawaited_futures.dart';
 import 'rules/unnecessary_await_in_return.dart';
 import 'rules/unnecessary_brace_in_string_interps.dart';
@@ -412,6 +413,7 @@ void registerLintRules({bool inTestMode = false}) {
     ..register(TypeAnnotatePublicApis())
     ..register(TypeInitFormals())
     ..register(TypeLiteralInConstantPattern())
+    ..register(TypeTestOnGenericTypeVariable())
     ..register(UnawaitedFutures())
     ..register(UnnecessaryAwaitInReturn())
     ..register(UnnecessaryBraceInStringInterps())

--- a/lib/src/rules/type_test_on_generic_type_variable.dart
+++ b/lib/src/rules/type_test_on_generic_type_variable.dart
@@ -14,9 +14,12 @@ const _desc = r' ';
 const _details = r'''
 **DON'T** perform type tests on generic type variables.
 
-A type variable for a generic class or method will always be a `Type`. A type
-test with `is` or `as` does not check what the type variable is bound to, and
-does not relate to the values which have a type specified by the type variable.
+A type variable, the type parameter of a generic class or method,
+used as an expression always evalautes to a `Type` object.
+The first operand of `is` or `as` type tests is an expression,
+so a type test of a type variable is always type test on a `Type` instance.
+Such a test does not relate to the values which have a type specified by the
+type variable.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/type_test_on_generic_type_variable.dart
+++ b/lib/src/rules/type_test_on_generic_type_variable.dart
@@ -15,8 +15,8 @@ const _details = r'''
 **DON'T** perform type tests on generic type variables.
 
 A type variable for a generic class or method will always be a `Type`. A type
-test with `is` or `as` does not check any aspect of the _values_ of that type
-variable.
+test with `is` or `as` does not check what the type variable is bound to, and
+does not relate to the values which have a type specified by the type variable.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/type_test_on_generic_type_variable.dart
+++ b/lib/src/rules/type_test_on_generic_type_variable.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+import '../analyzer.dart';
+
+const _desc = r' ';
+
+const _details = r'''
+**DON'T** perform type tests on generic type variables.
+
+A type variable for a generic class or method will always be a `Type`. A type
+test with `is` or `as` does not check any aspect of the _values_ of that type
+variable.
+
+**BAD:**
+```dart
+class C<T> {
+  void m(T value) {
+    assert(T is SomeType);
+  }
+}
+```
+
+**GOOD:**
+```dart
+class C<T> {
+  void m(T value) {
+    assert(value is SomeType);
+  }
+}
+```
+
+''';
+
+class TypeTestOnGenericTypeVariable extends LintRule {
+  static const LintCode code = LintCode(
+      'type_test_on_generic_type_variable', "Type test on type variable '{0}'.",
+      correctionMessage:
+          'Avoid using `is`, or `as` with generic type variables,'
+          ' which always will be a `Type`.');
+
+  TypeTestOnGenericTypeVariable()
+      : super(
+            name: 'type_test_on_generic_type_variable',
+            description: _desc,
+            details: _details,
+            group: Group.style);
+
+  @override
+  LintCode get lintCode => code;
+
+  @override
+  void registerNodeProcessors(
+      NodeLintRegistry registry, LinterContext context) {
+    var visitor = _Visitor(this);
+    registry.addIsExpression(this, visitor);
+    registry.addAsExpression(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor {
+  final LintRule rule;
+
+  _Visitor(this.rule);
+
+  @override
+  void visitIsExpression(IsExpression node) {
+    _reportTypeVariable(node.expression, node.isOperator);
+  }
+
+  @override
+  void visitAsExpression(AsExpression node) {
+    _reportTypeVariable(node.expression, node.asOperator);
+  }
+
+  void _reportTypeVariable(Expression expression, Token typeTestToken) {
+    if (expression is! Identifier) return;
+    var element = expression.staticElement;
+    if (element is! TypeParameterElement) return;
+    rule.reportLintForToken(typeTestToken,
+        arguments: [expression.name],
+        errorCode: TypeTestOnGenericTypeVariable.code);
+  }
+}

--- a/test/rules/all.dart
+++ b/test/rules/all.dart
@@ -122,6 +122,7 @@ import 'tighten_type_of_initializing_formals_test.dart'
 import 'type_init_formals_test.dart' as type_init_formals;
 import 'type_literal_in_constant_pattern_test.dart'
     as type_literal_in_constant_pattern;
+import 'type_test_on_generic_type_variable_test.dart' as type;
 import 'unawaited_futures_test.dart' as unawaited_futures;
 import 'unnecessary_brace_in_string_interps_test.dart'
     as unnecessary_brace_in_string_interps;
@@ -244,6 +245,7 @@ void main() {
   tighten_type_of_initializing_formals.main();
   type_init_formals.main();
   type_literal_in_constant_pattern.main();
+  type.main();
   unawaited_futures.main();
   unnecessary_brace_in_string_interps.main();
   unnecessary_breaks.main();

--- a/test/rules/type_test_on_generic_type_variable_test.dart
+++ b/test/rules/type_test_on_generic_type_variable_test.dart
@@ -1,0 +1,100 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(TypeTestOnGenericTypeVariableTest);
+  });
+}
+
+@reflectiveTest
+class TypeTestOnGenericTypeVariableTest extends LintRuleTest {
+  @override
+  String get lintRule => 'type_test_on_generic_type_variable';
+
+  test_classGeneric() async {
+    await assertDiagnostics(r'''
+class C<T> {
+  void m() {
+    T is! String;
+    T is int;
+    T as num;
+  }
+}
+''', [
+      lint(32, 2),
+      lint(50, 2),
+      lint(64, 2),
+    ]);
+  }
+
+  test_memberGeneric() async {
+    await assertDiagnostics(r'''
+class C {
+  void m<T>() {
+    T is! String;
+    T is int;
+    T as num;
+  }
+}
+''', [
+      lint(32, 2),
+      lint(50, 2),
+      lint(64, 2),
+    ]);
+  }
+
+  test_topLevelGeneric() async {
+    await assertDiagnostics(r'''
+void f<T>() {
+  T is! String;
+  T is int;
+  T as num;
+}
+''', [
+      lint(18, 2),
+      lint(34, 2),
+      lint(46, 2),
+    ]);
+  }
+
+  test_classNonGeneric() async {
+    await assertNoDiagnostics(r'''
+class C {
+  Object? o;
+  void m() {
+    o is! String;
+    o is int;
+    o as num;
+  }
+}
+''');
+  }
+
+  test_memberNonGeneric() async {
+    await assertNoDiagnostics(r'''
+class C {
+  void m(Object o) {
+    o is! String;
+    o is int;
+    o as num;
+  }
+}
+''');
+  }
+
+  test_topLevelNonGeneric() async {
+    await assertNoDiagnostics(r'''
+void f(Object o) {
+  o is! String;
+  o is int;
+  o as num;
+}
+''');
+  }
+}

--- a/tool/since/sdk.yaml
+++ b/tool/since/sdk.yaml
@@ -176,6 +176,7 @@ tighten_type_of_initializing_formals: 2.12.0
 type_annotate_public_apis: 2.0.0
 type_init_formals: 2.0.0
 type_literal_in_constant_pattern: 3.0.0
+type_test_on_generic_type_variable: 3.1.0-wip
 unawaited_futures: 2.0.0
 unnecessary_await_in_return: 2.1.1
 unnecessary_brace_in_string_interps: 2.0.0


### PR DESCRIPTION
Closes #4480

A generic type variable will always be a `Type` and the check is never
useful. Some authors may expect an `is` to check what type the variable
represents. It's less likely an author would expect `as` to do something
useful, but it is also not useful.
