### PR TITLE
consider referencing a type in a type argument as 'usage'

### DIFF
--- a/lib/src/rules/unreachable_from_main.dart
+++ b/lib/src/rules/unreachable_from_main.dart
@@ -596,11 +596,16 @@ extension on Declaration {
 
 extension on AstNode {
   bool get isInExternalVariableTypeOrFunctionReturnType {
-    var ancestorTypeAnnotation = thisOrAncestorOfType<TypeAnnotation>();
-    if (ancestorTypeAnnotation == null) return false;
+    AstNode topTypeAnnotation = this;
+    var parent = this.parent;
+    while (parent is TypeAnnotation) {
+      topTypeAnnotation = parent;
+      parent = topTypeAnnotation.parent;
+    }
+    if (parent == null) return false;
     switch (parent) {
       case MethodDeclaration(:var externalKeyword, :var returnType):
-        return externalKeyword != null && returnType == ancestorTypeAnnotation;
+        return externalKeyword != null && returnType == topTypeAnnotation;
       case VariableDeclarationList(
           parent: FieldDeclaration(:var externalKeyword),
         ):

--- a/lib/src/rules/unreachable_from_main.dart
+++ b/lib/src/rules/unreachable_from_main.dart
@@ -594,7 +594,7 @@ extension on Declaration {
   }
 }
 
-extension on AstNode {
+extension on NamedType {
   bool get isInExternalVariableTypeOrFunctionReturnType {
     AstNode topTypeAnnotation = this;
     var parent = this.parent;
@@ -602,7 +602,6 @@ extension on AstNode {
       topTypeAnnotation = parent;
       parent = topTypeAnnotation.parent;
     }
-    if (parent == null) return false;
     switch (parent) {
       case MethodDeclaration(:var externalKeyword, :var returnType):
         return externalKeyword != null && returnType == topTypeAnnotation;

--- a/lib/src/rules/unreachable_from_main.dart
+++ b/lib/src/rules/unreachable_from_main.dart
@@ -271,12 +271,16 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
       return;
     }
 
+    var nodeIsInTypeArgument =
+        node.thisOrAncestorOfType<TypeArgumentList>() != null;
+
     // Any reference to a typedef is reachable, since structural typing is used
     // to match against objects.
     //
     // The return type of an external variable declaration is reachable, since
     // the external implementation can instantiate it.
     if (node.type?.alias != null ||
+        nodeIsInTypeArgument ||
         node.isInExternalVariableTypeOrFunctionReturnType) {
       _addDeclaration(element);
     }

--- a/lib/src/rules/unreachable_from_main.dart
+++ b/lib/src/rules/unreachable_from_main.dart
@@ -595,14 +595,20 @@ extension on Declaration {
 }
 
 extension on NamedType {
-  bool get isInExternalVariableTypeOrFunctionReturnType {
-    AstNode topTypeAnnotation = this;
+  TypeAnnotation get topmostTypeAnnotation {
+    TypeAnnotation topTypeAnnotation = this;
     var parent = this.parent;
     while (parent is TypeAnnotation) {
       topTypeAnnotation = parent;
       parent = topTypeAnnotation.parent;
     }
-    switch (parent) {
+    return topTypeAnnotation;
+  }
+
+  bool get isInExternalVariableTypeOrFunctionReturnType {
+    var topTypeAnnotation = topmostTypeAnnotation;
+
+    switch (topTypeAnnotation.parent) {
       case MethodDeclaration(:var externalKeyword, :var returnType):
         return externalKeyword != null && returnType == topTypeAnnotation;
       case VariableDeclarationList(

--- a/test/rules/unreachable_from_main_test.dart
+++ b/test/rules/unreachable_from_main_test.dart
@@ -281,6 +281,18 @@ class D {
 ''');
   }
 
+  test_class_reachable_referencedInTypeArgument() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  C<D>();
+}
+
+class C<T> {}
+
+class D {}
+''');
+  }
+
   test_class_reachableViaAnnotation() async {
     await assertNoDiagnostics(r'''
 void main() {

--- a/test/rules/unreachable_from_main_test.dart
+++ b/test/rules/unreachable_from_main_test.dart
@@ -253,6 +253,32 @@ class A {}
 ''');
   }
 
+  test_class_reachable_referencedDeepInTypeAnnotation_externalMethodDeclaration() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  D().f;
+}
+
+class C {}
+
+class D {
+  external C Function() f();
+}
+''');
+  }
+
+  test_class_reachable_referencedDeepInTypeArgument() async {
+    await assertNoDiagnostics(r'''
+void main() {
+  C<D Function()>();
+}
+
+class C<T> {}
+
+class D {}
+''');
+  }
+
   test_class_reachable_referencedInTypeAnnotation_externalFieldDeclaration() async {
     await assertNoDiagnostics(r'''
 void main() {
@@ -434,6 +460,22 @@ part 'part.dart';
 class A {}
 ''', [
       lint(25, 1),
+    ]);
+  }
+
+  test_class_unreachable_referencedInParameter_externalMethodDeclaration() async {
+    await assertDiagnostics(r'''
+void main() {
+  D().f;
+}
+
+class C {}
+
+class D {
+  external f(C c);
+}
+''', [
+      lint(32, 1),
     ]);
   }
 


### PR DESCRIPTION
# Description

Since classes in type arguments can affect compile-time errors, they can have "side effects" even without instantiation. I guess its a valid use of a class.

Fixes #4471
