### PR TITLE
New tool for moving legacy tests quickly

### DIFF
--- a/tool/move_legacy_test.dart
+++ b/tool/move_legacy_test.dart
@@ -1,0 +1,243 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+// ignore_for_file: avoid_print
+
+void main(List<String> args) {
+  var ruleName = args.first;
+  LegacyTestMover(ruleName).move();
+}
+
+class LegacyTestMover {
+  final String ruleName;
+
+  LegacyTestMover(this.ruleName);
+
+  void move() {
+    var legacyTest = File('test_data/rules/$ruleName.dart');
+    if (!legacyTest.existsSync()) {
+      print('Did not find ${legacyTest.path}!!');
+      return;
+    }
+
+    var newTest = File('test/rules/${ruleName}_test.dart');
+    if (newTest.existsSync()) {
+      print('TODO: Support appending to existing reflective test.');
+      return;
+    }
+
+    var legacyLines = legacyTest.readAsLinesSync();
+
+    var snippets = gatherSnippets(legacyLines);
+
+    // [snippets] is now our complete list of snippets.
+
+    var buffer = StringBuffer(newTestFileHeader);
+    for (var testIndex = 0; testIndex < snippets.length; testIndex++) {
+      var snippet = snippets[testIndex];
+      buffer.writeln(testBody(testIndex.toString(), snippet));
+      buffer.writeln();
+    }
+    buffer.writeln('}');
+    print(buffer);
+    newTest.writeAsStringSync(buffer.toString());
+
+    updateAllTestFile();
+
+    print('To remove legacy test: git rm ${legacyTest.path}');
+    print('To add new test: git add test');
+    print('To run new test: dart run test ${newTest.path}');
+  }
+
+  List<String> gatherSnippets(List<String> legacyLines) {
+    var snippets = <String>[];
+    var startIndex = 0;
+    while (startIndex < legacyLines.length) {
+      var endIndex = math.min(legacyLines.length, 40);
+      for (var index = startIndex; index < endIndex; index++) {
+        print('${index.toString().padLeft(3)}  ${legacyLines[index]}');
+      }
+      var ranges = getRanges();
+      if (ranges.isEmpty) {
+        // Blank input.
+        break;
+      }
+      var snippet = <String>[];
+      for (var range in ranges) {
+        snippet.addAll(legacyLines.getRange(range.start, range.end + 1));
+      }
+      snippets.add(snippet.join('\n'));
+      startIndex = math.max(0, ranges.first.start - 3);
+    }
+    return snippets;
+  }
+
+  List<Range> getRanges() {
+    List<String> lineRanges;
+    while (true) {
+      var input = stdin.readLineSync();
+      if (input == null) {
+        print('Received empty and EOF?');
+        // Blank line and EOF?
+        exit(1);
+      }
+      if (input.isEmpty) {
+        // Blank input.
+        return [];
+      }
+      if (RegExp(r'[^0-9\-,]').firstMatch(input) != null) {
+        print('Bad characters in: $input');
+        continue;
+      }
+      lineRanges = input.split(',');
+      break;
+    }
+
+    var ranges = <Range>[];
+    for (var rangeText in lineRanges) {
+      var singleNumber = RegExp(r'^([0-9]+)$').firstMatch(rangeText);
+      if (singleNumber != null) {
+        var index = int.tryParse(singleNumber[1]!);
+        if (index != null) {
+          ranges.add(Range(index, index));
+        }
+      }
+      var range = RegExp(r'^([0-9]+)-([0-9]+)$').firstMatch(rangeText);
+      if (range != null) {
+        var start = int.tryParse(range[1]!);
+        var end = int.tryParse(range[2]!);
+        if (start != null && end != null) {
+          ranges.add(Range(start, end));
+        }
+      }
+      // TODO(srawlins): report error.
+    }
+    return ranges;
+  }
+
+  String get newTestFileHeader {
+    var ruleNameCamelCase = ruleName.splitMapJoin(RegExp('(?:^|_)([a-z])'),
+        onMatch: (m) => m[1]!.toUpperCase());
+    return '''
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../rule_test_support.dart';
+
+main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(${ruleNameCamelCase}Test);
+  });
+}
+
+@reflectiveTest
+class ${ruleNameCamelCase}Test extends LintRuleTest {
+  @override
+  String get lintRule => '$ruleName';
+
+''';
+  }
+
+  String testBody(String name, String code) => code.contains('LINT')
+      ? """
+  test_$name() async {
+    await assertDiagnostics(r'''
+$code
+''', [
+  // TODO
+]);
+  }
+"""
+      : """
+  test_$name() async {
+    await assertNoDiagnostics(r'''
+$code
+''');
+  }
+""";
+
+  void updateAllTestFile() {
+    var allTest = File('test/rules/all.dart');
+    var allTestLines = allTest.readAsLinesSync();
+    var allTestBuffer = StringBuffer();
+    var allTestIndex = 0;
+
+    // Insert the import, alphabetically.
+    while (true) {
+      if (allTestIndex >= allTestLines.length) {
+        print('bad allTestIndex: $allTestIndex');
+        return;
+      }
+      var line = allTestLines[allTestIndex];
+      allTestIndex++;
+      var importMatch = RegExp(r"^import '(.*)_test.dart'").firstMatch(line);
+      if (importMatch == null) {
+        allTestBuffer.writeln(line);
+        continue;
+      }
+      var importPrefix = importMatch[1]!;
+      var comparison = importPrefix.compareTo(ruleName);
+      if (comparison == 0) {
+        print('Got same name?!');
+        allTestBuffer.writeln(line);
+        break;
+      } else if (comparison < 0) {
+        // Before; keep going.
+        allTestBuffer.writeln(line);
+      } else {
+        // After; the new import comes just before this one.
+        allTestBuffer.writeln("import '${ruleName}_test.dart' as $ruleName;");
+        allTestBuffer.writeln(line);
+        break;
+      }
+    }
+
+    // Insert the main call, alphabetically.
+    while (true) {
+      if (allTestIndex >= allTestLines.length) {
+        print('bad allTestIndex: $allTestIndex.');
+        return;
+      }
+      var line = allTestLines[allTestIndex];
+      allTestIndex++;
+      var runMatch = RegExp(r'^  (.*)\.main\(\);').firstMatch(line);
+      if (runMatch == null) {
+        allTestBuffer.writeln(line);
+        continue;
+      }
+      var testPrefix = runMatch[1]!;
+      var comparison = testPrefix.compareTo(ruleName);
+      if (comparison == 0) {
+        print('Got same name?!');
+        allTestBuffer.writeln(line);
+        break;
+      } else if (comparison < 0) {
+        // Before; keep going.
+        allTestBuffer.writeln(line);
+      } else {
+        // After; the new import comes just before this one.
+        allTestBuffer.writeln('  $ruleName.main();');
+        allTestBuffer.writeln(line);
+        break;
+      }
+    }
+
+    // Insert the rest of the file.
+    while (allTestIndex < allTestLines.length) {
+      var line = allTestLines[allTestIndex];
+      allTestIndex++;
+      allTestBuffer.writeln(line);
+    }
+
+    allTest.writeAsStringSync(allTestBuffer.toString());
+  }
+}
+
+class Range {
+  final int start;
+  final int end;
+  Range(this.start, this.end);
+}

--- a/tool/move_legacy_test.dart
+++ b/tool/move_legacy_test.dart
@@ -1,9 +1,19 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'dart:math' as math;
 
 // ignore_for_file: avoid_print
 
+/// This is an interactive script that automates parts of the process to move
+/// a legacy test to a reflective test.
 void main(List<String> args) {
+  if (args.isEmpty) {
+    print('Usage: move_legacy_test.dart <rule_name>');
+    exit(1);
+  }
   var ruleName = args.first;
   LegacyTestMover(ruleName).move();
 }
@@ -75,6 +85,7 @@ class LegacyTestMover {
   List<Range> getRanges() {
     List<String> lineRanges;
     while (true) {
+      stdout.write('Comma-separated lines and ranges (e.g. 1,3,5-7,9-11): ');
       var input = stdin.readLineSync();
       if (input == null) {
         print('Received empty and EOF?');


### PR DESCRIPTION
# Description

This introduces a command line tool which hastens the process of converting a legacy test data file into a reflective test.

It is interactive, presenting the legacy file, and asking for what snippets should be called out as individual test cases. Here is a sample run:

```none
$ dart tool/move_legacy_test.dart avoid_single_cascade_in_expression_statements
  0  // Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
  1  // for details. All rights reserved. Use of this source code is governed by a
  2  // BSD-style license that can be found in the LICENSE file.
  3
  4  // test w/ `dart test -N avoid_single_cascade_in_expression_statements`
  5
  6  main(){
  7    var o;
  8    o..toString(); // LINT
  9    o..toString()..toString(); // OK
 10    f(o..toString()); // OK
 11    if(o..hashCode){} // OK
 12    throw o..toString(); // OK
 13  }
 14
 15  f(o) => null;
6,7,8,13<RETURN>
  3
  4  // test w/ `dart test -N avoid_single_cascade_in_expression_statements`
  5
  6  main(){
  7    var o;
  8    o..toString(); // LINT
  9    o..toString()..toString(); // OK
 10    f(o..toString()); // OK
 11    if(o..hashCode){} // OK
 12    throw o..toString(); // OK
 13  }
 14
 15  f(o) => null;
6,7,9,13<RETURN>
  3
  4  // test w/ `dart test -N avoid_single_cascade_in_expression_statements`
  5
  6  main(){
  7    var o;
  8    o..toString(); // LINT
  9    o..toString()..toString(); // OK
 10    f(o..toString()); // OK
 11    if(o..hashCode){} // OK
 12    throw o..toString(); // OK
 13  }
 14
 15  f(o) => null;
6,7,10,13-15<RETURN>
  3
  4  // test w/ `dart test -N avoid_single_cascade_in_expression_statements`
  5
  6  main(){
  7    var o;
  8    o..toString(); // LINT
  9    o..toString()..toString(); // OK
 10    f(o..toString()); // OK
 11    if(o..hashCode){} // OK
 12    throw o..toString(); // OK
 13  }
 14
 15  f(o) => null;
6,7,11,13<RETURN>
  3
  4  // test w/ `dart test -N avoid_single_cascade_in_expression_statements`
  5
  6  main(){
  7    var o;
  8    o..toString(); // LINT
  9    o..toString()..toString(); // OK
 10    f(o..toString()); // OK
 11    if(o..hashCode){} // OK
 12    throw o..toString(); // OK
 13  }
 14
 15  f(o) => null;
6,7,12,13<RETURN>
  3
  4  // test w/ `dart test -N avoid_single_cascade_in_expression_statements`
  5
  6  main(){
  7    var o;
  8    o..toString(); // LINT
  9    o..toString()..toString(); // OK
 10    f(o..toString()); // OK
 11    if(o..hashCode){} // OK
 12    throw o..toString(); // OK
 13  }
 14
 15  f(o) => null;
<RETURN>
To remove legacy test: git rm test_data/rules/avoid_single_cascade_in_expression_statements.dart
To add new test: git add test
To run new test: dart run test test/rules/avoid_single_cascade_in_expression_statements_test.dart
```

Each time the tool presents to me the text in the legacy file, I write line numbers like `6,7,10,13-15`. This indicates that lines 6, 7, 10, and 13-15 should be used as an individual test case.

The script then writes out all of the new test cases into a new file, naming the test class correctly, and using the presence of "LINT" to decide whether to `assertDiagnostics` or `assertNoDiagnostics`.

There are some TODOs, and the script is not super user-friendly yet, but as we have > 150 test files to convert, I think it will be useful to get us started.