### PR TITLE
Add redirects and specify canonical URLs pointing to dart.dev

### DIFF
--- a/tool/doc.dart
+++ b/tool/doc.dart
@@ -311,6 +311,8 @@ class HtmlIndexer {
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
       <meta name="mobile-web-app-capable" content="yes">
       <meta name="apple-mobile-web-app-capable" content="yes">
+      <meta http-equiv="refresh" content="0; url=https://dart.dev/lints">
+      <link rel="canonical" href="https://dart.dev/lints">
       <link rel="stylesheet" href="../styles.css">
       <title>Linter for Dart</title>
    </head>
@@ -509,6 +511,8 @@ linter:
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
       <meta name="mobile-web-app-capable" content="yes">
       <meta name="apple-mobile-web-app-capable" content="yes">
+      <meta http-equiv="refresh" content="0; url=https://dart.dev/lints/all">
+      <link rel="canonical" href="https://dart.dev/lints/all">
       <link rel="stylesheet" href="../../styles.css">
       <title>Analysis Options</title>
    </head>
@@ -656,6 +660,8 @@ class RuleHtmlGenerator extends RuleGenerator {
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
       <meta name="mobile-web-app-capable" content="yes">
       <meta name="apple-mobile-web-app-capable" content="yes">
+      <meta http-equiv="refresh" content="0; url=https://dart.dev/lints/$name">
+      <link rel="canonical" href="https://dart.dev/lints/$name">
       <title>$name</title>
       <link rel="stylesheet" href="../styles.css">
    </head>


### PR DESCRIPTION
This is step #1 in retiring the old linter site. Using [`http-equiv`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv) it redirects from the generated pages to their dart.dev equivalents. It also specifies a [canonical URL](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method) to clearly signal to search engines that the content has moved.

Eventually we'll be able to cleanup and eventually disable the automatic generation, but this gets the redirects functional immediately. 

I've staged a version of the site generated with these changes. Visit the below links to see the redirects functional:

**Staged rule index page:** https://parlough-linter.web.app/lints/index.html
**Staged rule page:** https://parlough-linter.web.app/lints/prefer_final_fields.html
**Staged all rule list:** https://parlough-linter.web.app/lints/options/options.html

Contributes to https://github.com/dart-lang/linter/issues/4460 and https://github.com/dart-lang/site-www/issues/4499