### PR TITLE
Redirect gh-pages homepage to dart.dev

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta http-equiv="refresh" content="0; url=https://dart.dev/lints">
-    <link rel="canonical" href="https://dart.dev/lints">
     <link rel="stylesheet" href="styles.css">
     <title>Linter for Dart</title>
   </head>
@@ -17,10 +15,10 @@
         <h1>Linter for Dart</h1>
         <p>Style linter for Dart</p>
         <ul>
-          <li><a href="lints/index.html">View all <strong>Lint Rules</strong></a></li>
+          <li><a href="https://dart.dev/lints">View all <strong>Lint Rules</strong></a></li>
           <li><a href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></li>
         </ul>
-        <p><a class="overflow-link" href="lints/index.html">View all <strong>Lint Rules</strong></a></p>
+        <p><a class="overflow-link" href="https://dart.dev/lints">View all <strong>Lint Rules</strong></a></p>
         <p><a class="overflow-link" href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></p>
       </header>
       <section>
@@ -29,28 +27,12 @@
           Linter for Dart
         </h1>
 
+        <h2>The content on this site has moved</h2>
         <p>
-          A Dart style linter which defines lint rules that identify and report on "lints" found within Dart code.
-          Linting is performed by the Dart analysis server and the <code>dart analyze</code> command.
+          To find up-to-date information about the Dart linter
+          and its various linter rules,
+          visit <a href="https://dart.dev/lints">dart.dev</a>.
         </p>
-
-        <h2>
-          <a id="contributing" class="anchor" href="#contributing" aria-hidden="true"></a>
-          Contributing
-        </h2>
-
-        <p>
-          Contributions welcome! Please read the
-          <a href="https://github.com/dart-lang/linter/blob/master/CONTRIBUTING.md">
-            contribution guidelines</a>.</p>
-
-        <h2>
-          <a id="features-and-bugs" class="anchor" href="#features-and-bugs" aria-hidden="true"></a>
-          Features and bugs
-        </h2>
-
-        <p>Please file feature requests and bugs on the
-          <a href="https://github.com/dart-lang/linter/issues">issue tracker</a>.</p>
       </section>
     </div>
     <footer>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta http-equiv="refresh" content="0; url=https://dart.dev/lints">
+    <link rel="canonical" href="https://dart.dev/lints">
     <link rel="stylesheet" href="styles.css">
     <title>Linter for Dart</title>
   </head>


### PR DESCRIPTION
Followup to https://github.com/dart-lang/linter/pull/4504 since the home page is not generated, and just lives in the `gh-pages` branch.

Contributes to https://github.com/dart-lang/linter/issues/4460 and https://github.com/dart-lang/site-www/issues/4499