### PR TITLE
Add a getter to lint rules that can work with just a parsed AST.

### DIFF
--- a/lib/src/rules/avoid_return_types_on_setters.dart
+++ b/lib/src/rules/avoid_return_types_on_setters.dart
@@ -27,6 +27,8 @@ set speed(int ms);
 ''';
 
 class AvoidReturnTypesOnSetters extends LintRule {
+  bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode(
       'avoid_return_types_on_setters', 'Unnecessary return type on a setter.',
       correctionMessage: 'Try removing the return type.');

--- a/lib/src/rules/curly_braces_in_flow_control_structures.dart
+++ b/lib/src/rules/curly_braces_in_flow_control_structures.dart
@@ -51,6 +51,8 @@ if (overflowChars != other.overflowChars) {
 ''';
 
 class CurlyBracesInFlowControlStructures extends LintRule {
+  bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode(
       'curly_braces_in_flow_control_structures',
       'Statements in {0} should be enclosed in a block.',

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -33,6 +33,8 @@ typedef F = void Function();
 ''';
 
 class PreferGenericFunctionTypeAliases extends LintRule {
+   bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode('prefer_generic_function_type_aliases',
       "Use the generic function type syntax in 'typedef's.",
       correctionMessage: "Try using the generic function type syntax ('{0}').");

--- a/lib/src/rules/prefer_generic_function_type_aliases.dart
+++ b/lib/src/rules/prefer_generic_function_type_aliases.dart
@@ -33,7 +33,7 @@ typedef F = void Function();
 ''';
 
 class PreferGenericFunctionTypeAliases extends LintRule {
-   bool get canUseParsedResult => true;
+  bool get canUseParsedResult => true;
 
   static const LintCode code = LintCode('prefer_generic_function_type_aliases',
       "Use the generic function type syntax in 'typedef's.",

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -43,7 +43,6 @@ bool isJavaStyle(Comment comment) {
 }
 
 class SlashForDocComments extends LintRule {
-
   bool get canUseParsedResult => true;
 
   static const LintCode code = LintCode('slash_for_doc_comments',

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -43,6 +43,9 @@ bool isJavaStyle(Comment comment) {
 }
 
 class SlashForDocComments extends LintRule {
+
+  bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode('slash_for_doc_comments',
       "Use the end-of-line form ('///') for doc comments.",
       correctionMessage: "Try rewriting the comment to use '///'.");

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -34,6 +34,8 @@ m(){
 ''';
 
 class UnnecessaryConst extends LintRule {
+  bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode(
       'unnecessary_const', "Unnecessary 'const' keyword.",
       correctionMessage: 'Try removing the keyword.');

--- a/lib/src/rules/unnecessary_new.dart
+++ b/lib/src/rules/unnecessary_new.dart
@@ -32,6 +32,8 @@ m(){
 ''';
 
 class UnnecessaryNew extends LintRule {
+  bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode(
       'unnecessary_new', "Unnecessary 'new' keyword.",
       correctionMessage: "Try removing the 'new' keyword.");

--- a/lib/src/rules/unnecessary_string_escapes.dart
+++ b/lib/src/rules/unnecessary_string_escapes.dart
@@ -28,6 +28,8 @@ Remove unnecessary backslashes in strings.
 ''';
 
 class UnnecessaryStringEscapes extends LintRule {
+  bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode(
       'unnecessary_string_escapes', 'Unnecessary escape in string literal.',
       correctionMessage: "Remove the '\\' escape.");

--- a/lib/src/rules/use_function_type_syntax_for_parameters.dart
+++ b/lib/src/rules/use_function_type_syntax_for_parameters.dart
@@ -25,6 +25,8 @@ Iterable<T> where(bool Function(T) predicate) {}
 ''';
 
 class UseFunctionTypeSyntaxForParameters extends LintRule {
+  bool get canUseParsedResult => true;
+
   static const LintCode code = LintCode(
       'use_function_type_syntax_for_parameters',
       "Use the generic function type syntax to declare the parameter '{0}'.",


### PR DESCRIPTION
This will override a getter in the base class `LintRule` when the analyzer package is upgraded. These changes are part of the work for adding a lightweight parse only mode to dart fix.
