### PR TITLE
fix `library_private_types_in_public_api` overreporting on enum constructor params

### DIFF
--- a/lib/src/rules/library_private_types_in_public_api.dart
+++ b/lib/src/rules/library_private_types_in_public_api.dart
@@ -94,6 +94,9 @@ class Validator extends SimpleAstVisitor<void> {
     if (name != null && Identifier.isPrivateName(name.lexeme)) {
       return;
     }
+    // Enum constructors are effectively private so don't visit their params.
+    if (node.parent is EnumDeclaration) return;
+
     node.parameters.accept(this);
   }
 

--- a/test/rules/library_private_types_in_public_api_test.dart
+++ b/test/rules/library_private_types_in_public_api_test.dart
@@ -33,6 +33,19 @@ enum E {
       lint(75, 2),
     ]);
   }
+
+  /// https://github.com/dart-lang/linter/issues/4470
+  test_enum_constructorParams() async {
+    await assertNoDiagnostics(r'''
+class _O {    
+  const _O();
+}
+enum E {
+  a(_O());
+  const E(_O o);
+}
+''');
+  }
 }
 
 @reflectiveTest


### PR DESCRIPTION
Fixes #4470

/cc @bwilkerson 