### PR TITLE
Report unnecessary_parenthesis around Literal and PrefixedIdentifier

### DIFF
--- a/lib/src/rules/unnecessary_parenthesis.dart
+++ b/lib/src/rules/unnecessary_parenthesis.dart
@@ -219,12 +219,12 @@ class _Visitor extends SimpleAstVisitor<void> {
       // TODO an API to the AST for better usage
       // Precedence isn't sufficient (e.g. PostfixExpression requires parenthesis)
       if (expression is PropertyAccess ||
+          expression is ConstructorReference ||
+          expression is PrefixedIdentifier ||
           expression is MethodInvocation ||
-          expression is IndexExpression) {
-        rule.reportLint(node);
-      }
-
-      if (parent.precedence < expression.precedence) {
+          expression is IndexExpression ||
+          expression is Literal ||
+          parent.precedence < expression.precedence) {
         rule.reportLint(node);
       }
     } else {

--- a/test_data/rules/unnecessary_parenthesis.dart
+++ b/test_data/rules/unnecessary_parenthesis.dart
@@ -145,7 +145,24 @@ main() async {
   a2 = (1 == 1); // OK
   a2 = (1 == 1) || "".isEmpty; // OK
   var a3 = (1 + 1); // LINT
+
+  // Tests for Literal and PrefixedIdentifier
+  var a4 = (''); // LINT
+  var a5 = ((a4.isEmpty), 2); // LINT
+  var a6 = (1, (2)); // LINT
+
+  withManyArgs((''), false, 1); // LINT
+  withManyArgs('', (a4.isEmpty), 1); // LINT
+  withManyArgs('', (''.isEmpty), 1); // LINT
+  withManyArgs('', false, (1)); // LINT
+
+  var a7 = (double.infinity).toString(); // LINT
+
+  var list2 = ["a", null];
+  var a8 = (list2.first)!.length; // LINT
 }
+
+void withManyArgs(String a, bool b, int c) {}
 
 bool testTernaryAndEquality() {
   if ((1 == 1 ? true : false)) // LINT


### PR DESCRIPTION
Fixes a few false ~~positives~~ negatives that I noticed when mass-editing code and gratuitously sprinkling parentheses everywhere