### PR TITLE
Fix directives_ordering for a leading dot in path

### DIFF
--- a/lib/src/rules/directives_ordering.dart
+++ b/lib/src/rules/directives_ordering.dart
@@ -116,6 +116,9 @@ const _importKeyword = 'import';
 ///
 /// Package is everything until the first `/`.
 int compareDirectives(String a, String b) {
+  if (!a.startsWith('package:') || !b.startsWith('package:')) {
+    return a.compareTo(b);
+  }
   var indexA = a.indexOf('/');
   var indexB = b.indexOf('/');
   if (indexA == -1 || indexB == -1) return a.compareTo(b);

--- a/test/rules/directives_ordering_test.dart
+++ b/test/rules/directives_ordering_test.dart
@@ -274,4 +274,24 @@ import 'a.dart';
       lint(102, 16),
     ]);
   }
+
+  test_sortDirectiveSectionsAlphabetically_dotInRelativePath_import() async {
+    await assertDiagnostics(r'''
+import './foo1.dart';
+import '../../foo2.dart';
+import '../foo3.dart';
+import 'foo4.dart';
+// ignore_for_file: unused_import, uri_does_not_exist
+''', [lint(22, 25)]);
+  }
+
+  test_sortDirectiveSectionsAlphabetically_dotInRelativePath_import_ok() async {
+    await assertNoDiagnostics(r'''
+import '../../foo4.dart';
+import '../foo3.dart';
+import './foo2.dart';
+import 'foo1.dart';
+// ignore_for_file: unused_import, uri_does_not_exist
+''');
+  }
 }


### PR DESCRIPTION
It sorts imports as follows:

```dart
import './foo1.dart';
import '../../foo2.dart';
import '../foo3.dart';
import 'foo4.dart';
```

This change corrects it to the following:

```dart
import '../../foo1.dart';
import '../foo2.dart';
import './foo3.dart';
import 'foo4.dart';
```

Fixes #2678

See https://github.com/dart-lang/linter/issues/2678#issuecomment-1610144987 for an explanation on how this edit relates to the behavior