### PR TITLE
use_build_context_synchronously: handle asynchrony in for- and do-statements better

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -722,13 +722,15 @@ class AsyncStateVisitor extends SimpleAstVisitor<AsyncState> {
   /// Compute the [AsyncState] of a "block-like" node which has [statements].
   AsyncState? _visitBlockLike(List<Statement> statements,
       {required AstNode? parent}) {
+    var reference = this.reference;
     if (reference is Statement) {
-      var index = statements.indexOf(reference as Statement);
+      var index = statements.indexOf(reference);
       if (index >= 0) {
         var precedingAsyncState = _inOrderAsyncStateGuardable(statements);
         if (precedingAsyncState != null) return precedingAsyncState;
-        // TODO(srawlins): Also DoStatement and ForStatement.
-        if (parent is WhileStatement) {
+        if (parent is DoStatement ||
+            parent is ForStatement ||
+            parent is WhileStatement) {
           // Check for asynchrony in the statements that _follow_ [reference],
           // as they may lead to an async gap before we loop back to
           // [reference].

--- a/test_data/rules/use_build_context_synchronously.dart
+++ b/test_data/rules/use_build_context_synchronously.dart
@@ -76,24 +76,6 @@ class _MyState extends State<MyWidget> {
     Navigator.of(context).pushNamed('routeName'); // LINT
   }
 
-  // Another conditional path.
-  void methodWithBuildContextParameter2a(BuildContext context) async {
-    bool f() => true;
-    while (f()) {
-      await Future<void>.delayed(Duration());
-    }
-    Navigator.of(context).pushNamed('routeName'); // LINT
-  }
-
-  // And another.
-  void methodWithBuildContextParameter2d(BuildContext context) async {
-    bool f() => true;
-    do {
-      await Future<void>.delayed(Duration());
-    } while (f());
-    Navigator.of(context).pushNamed('routeName'); // LINT
-  }
-
   void methodWithBuildContextParameter2g(BuildContext context) async {
     await Future<void>.delayed(Duration());
     switch (1) {


### PR DESCRIPTION
If an `await` is found in a for-statement or a do-statement (or a while-statement, already implemented), even if it is _after_ a reference to a BuildContext, the reference is not safe. This implements that behavior.

There are new unit tests, and some legacy tests are moved.