### PR TITLE
use_build_context_synchronously: Fix not-mounted-or case

### DIFF
--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -269,8 +269,7 @@ class AsyncStateVisitor extends SimpleAstVisitor<AsyncState> {
         // A mounted guard only applies if both sides are guarded.
         (AsyncState.mountedCheck, AsyncState.mountedCheck) =>
           AsyncState.mountedCheck,
-        (AsyncState.notMountedCheck, AsyncState.notMountedCheck) =>
-          AsyncState.notMountedCheck,
+        (AsyncState.notMountedCheck, _) => AsyncState.notMountedCheck,
         // Otherwise it's just uninteresting.
         (_, _) => null,
       };

--- a/test/rules/use_build_context_synchronously_test.dart
+++ b/test/rules/use_build_context_synchronously_test.dart
@@ -726,6 +726,66 @@ void foo(BuildContext context) async {
     expect(ifStatement.asyncStateFor(reference), isNull);
   }
 
+  test_ifStatement_referenceInElse_notMounted() async {
+    await resolveCode(r'''
+import 'package:flutter/widgets.dart';
+void foo(BuildContext context) async {
+  if (!context.mounted) {
+  } else {
+    context /* ref */;
+  }
+}
+''');
+    var ifStatement = findNode.ifStatement('if ');
+    var reference = findNode.block('context /* ref */');
+    expect(ifStatement.asyncStateFor(reference), AsyncState.mountedCheck);
+  }
+
+  test_ifStatement_referenceInElse_notMountedOrUninterestingInCondition() async {
+    await resolveCode(r'''
+import 'package:flutter/widgets.dart';
+void foo(BuildContext context) async {
+  if (!context.mounted || 1 == 2) {
+  } else {
+    context /* ref */;
+  }
+}
+''');
+    var ifStatement = findNode.ifStatement('if ');
+    var reference = findNode.block('context /* ref */');
+    expect(ifStatement.asyncStateFor(reference), AsyncState.mountedCheck);
+  }
+
+  test_ifStatement_referenceInElse_uninterestingAndNotMountedInCondition() async {
+    await resolveCode(r'''
+import 'package:flutter/widgets.dart';
+void foo(BuildContext context) async {
+  if (1 == 2 && !context.mounted) {
+  } else {
+    context /* ref */;
+  }
+}
+''');
+    var ifStatement = findNode.ifStatement('if ');
+    var reference = findNode.block('context /* ref */');
+    expect(ifStatement.asyncStateFor(reference), AsyncState.mountedCheck);
+  }
+
+  test_ifStatement_referenceInElse_uninterestingOrNotMountedInCondition() async {
+    await resolveCode(r'''
+import 'package:flutter/widgets.dart';
+void foo(BuildContext context) async {
+  if (1 == 2 || !context.mounted) {
+  } else {
+    context /* ref */;
+  }
+}
+''');
+    var ifStatement = findNode.ifStatement('if ');
+    var reference = findNode.block('context /* ref */');
+    expect(ifStatement.asyncStateFor(reference), isNull);
+  }
+
   test_ifStatement_referenceInThen_asyncInAssignmentInCondition() async {
     await resolveCode(r'''
 import 'package:flutter/widgets.dart';
@@ -796,20 +856,6 @@ void foo(BuildContext context) async {
     expect(ifStatement.asyncStateFor(reference), AsyncState.mountedCheck);
   }
 
-  test_ifStatement_referenceInThen_conditionOrMountedInCondition() async {
-    await resolveCode(r'''
-import 'package:flutter/widgets.dart';
-void foo(BuildContext context) async {
-  if (1 == 2 || context.mounted) {
-    context /* ref */;
-  }
-}
-''');
-    var ifStatement = findNode.ifStatement('if ');
-    var reference = findNode.block('context /* ref */');
-    expect(ifStatement.asyncStateFor(reference), isNull);
-  }
-
   test_ifStatement_referenceInThen_mountedAndAwaitInCondition() async {
     await resolveCode(r'''
 import 'package:flutter/widgets.dart';
@@ -850,6 +896,20 @@ void foo(BuildContext context) async {
     var ifStatement = findNode.ifStatement('if ');
     var reference = findNode.block('context /* ref */');
     expect(ifStatement.asyncStateFor(reference), AsyncState.asynchronous);
+  }
+
+  test_ifStatement_referenceInThen_uninterestingOrMountedInCondition() async {
+    await resolveCode(r'''
+import 'package:flutter/widgets.dart';
+void foo(BuildContext context) async {
+  if (1 == 2 || context.mounted) {
+    context /* ref */;
+  }
+}
+''');
+    var ifStatement = findNode.ifStatement('if ');
+    var reference = findNode.block('context /* ref */');
+    expect(ifStatement.asyncStateFor(reference), isNull);
   }
 
   test_indexExpression_referenceInRhs_asyncInIndex() async {


### PR DESCRIPTION
This issue was reported internally. The motivating test case was:

```dart
  if (!context.mounted || 1 == 2) {
  } else {
    context /* ref */;
  }
```

The only way to get into the else branch is if `context.mounted` is true.