### PR TITLE
Leave backup text crumbs pointing to new docs

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -85,4 +85,3 @@ linter:
     - use_string_buffers
     - use_super_parameters
     - use_to_and_as_if_applicable
-    - unreachable_from_main

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -85,3 +85,4 @@ linter:
     - use_string_buffers
     - use_super_parameters
     - use_to_and_as_if_applicable
+    - unreachable_from_main


### PR DESCRIPTION
This PR will regenerate each page with textual directions pointing and linking to the new documentation. It should likely never be seen due to the redirects created in https://github.com/dart-lang/linter/pull/4504, however it acts as a backup in case a client doesn't support those for some reason. It also removes unnecessary doc generation code that is no longer used after these changes.

After this lands and the pages on `gh-pages` are updated, this generation logic can be _(mostly)_ removed.

Contributes to https://github.com/dart-lang/linter/issues/4460#issuecomment-1595810116
