### PR TITLE
Enable `unreachable_from_main` linter rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -79,10 +79,10 @@ linter:
     - unnecessary_null_checks
     - unnecessary_parenthesis
     - unnecessary_statements
+    - unreachable_from_main
     - use_if_null_to_convert_nulls_to_bools
     - use_late_for_private_fields_and_variables
     - use_setters_to_change_properties
     - use_string_buffers
     - use_super_parameters
     - use_to_and_as_if_applicable
-    - unreachable_from_main

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -85,3 +85,4 @@ linter:
     - use_string_buffers
     - use_super_parameters
     - use_to_and_as_if_applicable
+    - unreachable_from_main

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -179,17 +179,6 @@ void defineRuleUnitTests() {
   });
 }
 
-/// Handy for debugging.
-// void defineSoloRuleTest(String ruleToTest) {
-//   for (var entry in Directory(ruleTestDataDir).listSync()) {
-//     if (entry is! File || !isDartFile(entry)) continue;
-//     var ruleName = p.basenameWithoutExtension(entry.path);
-//     if (ruleName == ruleToTest) {
-//       testRule(ruleName, entry);
-//     }
-//   }
-// }
-
 void testRule(String ruleName, File file,
     {bool debug = true,
     bool failOnErrors = true,

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -180,15 +180,15 @@ void defineRuleUnitTests() {
 }
 
 /// Handy for debugging.
-void defineSoloRuleTest(String ruleToTest) {
-  for (var entry in Directory(ruleTestDataDir).listSync()) {
-    if (entry is! File || !isDartFile(entry)) continue;
-    var ruleName = p.basenameWithoutExtension(entry.path);
-    if (ruleName == ruleToTest) {
-      testRule(ruleName, entry);
-    }
-  }
-}
+// void defineSoloRuleTest(String ruleToTest) {
+//   for (var entry in Directory(ruleTestDataDir).listSync()) {
+//     if (entry is! File || !isDartFile(entry)) continue;
+//     var ruleName = p.basenameWithoutExtension(entry.path);
+//     if (ruleName == ruleToTest) {
+//       testRule(ruleName, entry);
+//     }
+//   }
+// }
 
 void testRule(String ruleName, File file,
     {bool debug = true,

--- a/tool/scorecard.dart
+++ b/tool/scorecard.dart
@@ -193,10 +193,6 @@ class ScoreCard {
     scores.forEach(f);
   }
 
-  void removeWhere(bool Function(LintScore element) test) {
-    scores.removeWhere(test);
-  }
-
   static Future<ScoreCard> calculate() async {
     var lintsWithFixes = await _getLintsWithFixes();
     var lintsWithAssists = await _getLintsWithAssists();


### PR DESCRIPTION
It has been quite useful when removing old/stale functionality, especially in `/tool`.