### PR TITLE
Finalize retirement of gh-pages branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.DS_Store
 .idea
-*.md
+/lints/*.md
 /lints/machine/.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+## Linter documentation has moved
+
+You can find up-to-date linter documentation on the Dart website
+at https://dart.dev/lints.

--- a/index.html
+++ b/index.html
@@ -14,32 +14,15 @@
   <body>
     <div class="wrapper">
       <header>
-        <h1>Linter for Dart</h1>
-        <p>Style linter for Dart</p>
-        <ul>
-          <li><a href="https://dart.dev/lints">View all <strong>Lint Rules</strong></a></li>
-          <li><a href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></li>
-        </ul>
-        <p><a class="overflow-link" href="https://dart.dev/lints">View all <strong>Lint Rules</strong></a></p>
-        <p><a class="overflow-link" href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></p>
+        <a href="https://dart.dev/lints"><h1>Linter for Dart</h1></a>
       </header>
       <section>
-        <h1>
-          <a id="linter-for-dart" class="anchor" href="#linter-for-dart" aria-hidden="true"></a>
-          Linter for Dart
-        </h1>
-
-        <h2>The content on this site has moved</h2>
+        <h2>Linter documentation has moved!</h2>
         <p>
-          To find up-to-date information about the Dart linter
-          and its various linter rules,
-          visit <a href="https://dart.dev/lints">dart.dev</a>.
+          Find up-to-date linter and lint rule documentation at
+          <a href="https://dart.dev/lints">https://dart.dev/lints</a>.
         </p>
       </section>
     </div>
-    <footer>
-      <p>Maintained by the <a href="https://dart.dev/">Dart Team</a></p>
-      <p>Visit us on <a href="https://github.com/dart-lang/linter">Github</a></p>
-    </footer>
   </body>
 </html>

--- a/lints/use_super_initializers.html
+++ b/lints/use_super_initializers.html
@@ -1,63 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-   <head>
-      <meta charset="utf-8">
-      <link rel="shortcut icon" href="../dart-192.png">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-      <meta name="mobile-web-app-capable" content="yes">
-      <meta name="apple-mobile-web-app-capable" content="yes">
-      <title>use_super_initializers</title>
-      <link rel="stylesheet" href="../styles.css">
-   </head>
-   <body>
-      <div class="wrapper">
-         <header>
-            <h1>use_super_initializers</h1>
-            <p>Group: style</p>
-            <p>Maturity: <span style="color:hotpink;font-weight:bold;" >experimental</span></p>
-            <div class="tooltip">
-               <p>Linter v1.19</p>
-               <span class="tooltip-content">Since info is static, may be stale</span>
-            </div>
-            
-            <ul>
-               <li><a href="index.html">View all <strong>Lint Rules</strong></a></li>
-               <li><a href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></li>
-            </ul>
-            <p><a class="overflow-link" href="index.html">View all <strong>Lint Rules</strong></a></p>
-            <p><a class="overflow-link" href="https://dart.dev/guides/language/analysis-options#enabling-linter-rules">Using the <strong>Linter</strong></a></p>
-         </header>
-         <section>
-
-            <p>"Forwarding constructor"s, that do nothing except forward parameters to their 
-superclass constructors should take advantage of super-initializer parameters 
-rather than repeating the names of parameters when passing them to the 
-superclass constructors.  This makes the code more concise and easier to read
-and maintain.</p>
-<p><strong>DO</strong> use super-initializer parameters where possible.</p>
-<p><strong>BAD:</strong></p>
-<pre><code class="language-dart">class A {
-  A({int? x, int? y});
-}
-class B extends A {
-  B({int? x, int? y}) : super(x: x, y: y);
-}
-</code></pre>
-<p><strong>GOOD:</strong></p>
-<pre><code class="language-dart">class A {
-  A({int? x, int? y});
-}
-class B extends A {
-  B({super.x, super.y});
-}
-</code></pre>
-
-            
-         </section>
-      </div>
-      <footer>
-         <p>Maintained by the <a href="https://dart.dev/">Dart Team</a></p>
-         <p>Visit us on <a href="https://github.com/dart-lang/linter">GitHub</a></p>
-      </footer>
-   </body>
+<head>
+  <meta charset="utf-8">
+  <link rel="shortcut icon" href="../dart-192.png">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta http-equiv="refresh" content="0; url=https://dart.dev/lints/use_super_parameters">
+  <link rel="canonical" href="https://dart.dev/lints/use_super_parameters">
+  <title>use_super_initializers</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+<div class="wrapper">
+  <header>
+    <a href="https://dart.dev/lints/use_super_parameters"><h1>use_super_initializers/use_super_parameters</h1></a>
+  </header>
+  <section>
+    <h2>Lint documentation has moved!</h2>
+    <p>
+      Find up-to-date documentation for the 
+      <code>use_super_initializers</code> linter rule 
+      (now named <code>use_super_parameters</code>) at
+      <a href="https://dart.dev/lints/use_super_parameters">https://dart.dev/lints/use_super_parameters</a>.
+    </p>
+  </section>
+</div>
+</body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,129 +1,24 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400&display=swap');
-
 body {
     background: #12202f;
-    font-family: "Roboto", sans-serif;
-    font-size: 15px;
+    font-family: ui-sans, sans-serif;
     font-weight: 300;
     padding: 50px;
-    transition: padding .5s, margin .5s;
 }
 
 .wrapper {
-    box-shadow:
-            rgba(0, 0, 0, 0.3) 0 1px 2px 4px,
-            rgba(0, 0, 0, 0.8) 0 6px 15px 0;
     margin: 0 auto;
-    transition: width .5s;
     width: 900px;
 }
 
 header {
     background: #075697;
-    color: #f6f6f6;
     padding: 15px 20px;
-    position: relative;
-}
-
-/* Limit header link to its own size. */
-header a {
-    display: block;
-    width: max-content;
-}
-
-header a.overflow-link {
-    color: white;
-    display: none;
-}
-
-header a.overflow-link:hover {
-    color: #16adca;
 }
 
 header h1 {
     color: white;
-    font-size: 26px;
     margin: 0;
     padding: 0;
-}
-
-header p {
-    color: white;
-    font-size: 14px;
-    line-height: 1.4;
-    margin: 0;
-    width: 240px;
-}
-
-header .tooltip {
-    position: relative;
-}
-
-header .tooltip .tooltip-content {
-    background-color: #222c37;
-    left: 20%;
-    opacity: 0;
-    padding: 4px;
-    position: absolute;
-    text-align: center;
-    visibility: hidden;
-    width: 140px;
-    z-index: 999;
-}
-
-header .tooltip:hover .tooltip-content {
-    opacity: .95;
-    transition: opacity .4s;
-    visibility: visible;
-}
-
-header ul {
-    height: 38px;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    position: absolute;
-    right: 20px;
-    top: 20px;
-    width: auto;
-}
-
-header ul li {
-    background: #f6f6f6;
-    border-radius: 4px;
-    box-shadow:
-            rgba(0, 0, 0, 0.1) 0 0 1px 2px,
-            rgba(0, 0, 0, 0.2) 0 2px 5px 0;
-    float: left;
-    height: 38px;
-    margin-left: 20px;
-    width: 84px;
-}
-
-header ul li:hover, header ul li:active, header ul li:focus {
-    background: #eaeaea;
-}
-
-header ul a {
-    color: #075697;
-    display: block;
-    font-size: 12px;
-    font-weight: 300;
-    height: 36px;
-    padding-top: 5px;
-    text-align: center;
-    width: 86px;
-}
-
-header ul a:hover, header ul a:active, header ul a:focus {
-    color: #4388d2;
-}
-
-header ul a strong {
-    display: block;
-    font-size: 14px;
-    font-weight: 400;
-    margin-top: -2px;
 }
 
 section {
@@ -131,151 +26,36 @@ section {
     padding: 15px 20px;
 }
 
-section strong {
-    color: #333333;
-}
-
-section h1 {
-    color: #12202f;
-    font-size: 28px;
-    margin-top: 0;
-}
-
 section h2 {
     color: #12202f;
-    font-size: 22px;
 }
 
 section a {
     color: #075697;
 }
 
-section a:visited {
-    color: #075697;
-}
-
-section a:active,section a:hover,section a:focus,footer a:active,footer a:hover,footer a:focus {
+section a:hover, section a:focus {
     color: #16adca;
 }
-
-footer {
-    color: #bbbbbb;
-    margin: 0 auto;
-    padding: 10px;
-    width: 640px;
-}
-
-footer p:nth-child(1) {
-    float: left;
-}
-
-footer p:nth-child(2) {
-    float: right;
-}
-
-footer a {
-    color: white;
-    font-weight: bold;
-}
-
-p, ul, pre {
-    margin: 0 0 20px;
-}
-
-/* Code item and block styles */
 
 section p code {
     color: #192532;
     font-weight: bold;
-}
-
-code, pre {
-    font-family: "Roboto Mono", monospace;
+    font-family: monospace;
     font-size: 14px;
-    overflow-x: auto;
-}
-
-pre {
-    background: #222c37;
-    margin: 0 -20px 20px;
-    padding: 20px;
-}
-
-pre code {
-    color: white;
-    font-size: 13px;
-    font-weight: 400;
-}
-
-small {
-    font-size: 12px;
-}
-
-strong {
-    font-weight: 700;
 }
 
 a {
     text-decoration: none;
 }
 
-/* Shield positioning */
-.style-type img {
-    padding-bottom: -3px;
-    padding-right: 10px;
-    padding-top: 2px;
-}
-
-header a.style-type {
-    display: inline;
-}
-
-/* Responsive style changes and corresponding transitions */
-
 @media screen and (max-width: 1024px) {
     body {
         margin: 0;
         padding: 0;
-        transition: padding .4s, margin .4s;
     }
 
     .wrapper {
-        box-shadow: none;
-        transition: width .4s, height .4s;
         width: 100%;
-    }
-
-    header {
-        width: auto;
-    }
-
-    footer {
-        width: auto;
-    }
-}
-
-@media screen and (max-width: 550px) {
-    header ul {
-        opacity: 0;
-        visibility: hidden;
-        transition: visibility .4s, opacity 1s linear;
-    }
-
-    header a.overflow-link {
-        display: unset;
-        transition: display ease-in-out;
-    }
-}
-
-@media screen and (max-width: 380px) {
-    footer p:nth-child(1) {
-        float: none;
-        margin: 0;
-    }
-
-    footer p:nth-child(2) {
-        float: none;
-        margin: 0;
-        transition: float .4s ease-in-out;
     }
 }


### PR DESCRIPTION
- Adds a README redirecting to dart.dev
- Adjust/simplify index page to match others
- Simplifies styles so only ones still used for fallback text remain, allowing for quicker page loading.
- Manually redirect old [`use_super_initializers` page](https://dart-lang.github.io/linter/lints/use_super_initializers) to new `use_super_parameters` page. It was renamed before being released, resulting in an isolated page that wasn't updated.

Closes https://github.com/dart-lang/linter/issues/4460