### PR TITLE
extension type support for `public_member_api_docs`

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -108,6 +108,9 @@ SyntacticEntity getNodeToAnnotate(Declaration node) {
   if (node is VariableDeclaration) {
     return node.name;
   }
+  if (node is ExtensionTypeDeclaration) {
+    return node.name;
+  }
   assert(false, "Unaccounted for Declaration subtype: '${node.runtimeType}'");
   return node;
 }

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -309,6 +309,11 @@ extension ExpressionExtension on Expression? {
   bool get isNullLiteral => this?.unParenthesized is NullLiteral;
 }
 
+extension FieldDeclarationExtension on FieldDeclaration {
+  bool get isInvalidExtensionTypeField =>
+      !isStatic && parent is ExtensionTypeDeclaration;
+}
+
 extension InhertanceManager3Extension on InheritanceManager3 {
   /// Returns the class member that is overridden by [member], if there is one,
   /// as defined by [getInherited].

--- a/lib/src/rules/public_member_api_docs.dart
+++ b/lib/src/rules/public_member_api_docs.dart
@@ -95,6 +95,7 @@ class PublicMemberApiDocs extends LintRule {
     registry.addEnumConstantDeclaration(this, visitor);
     registry.addEnumDeclaration(this, visitor);
     registry.addExtensionDeclaration(this, visitor);
+    registry.addExtensionTypeDeclaration(this, visitor);
     registry.addFieldDeclaration(this, visitor);
     registry.addFunctionTypeAlias(this, visitor);
     registry.addGenericTypeAlias(this, visitor);
@@ -166,6 +167,13 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitClassDeclaration(ClassDeclaration node) {
+    var element = node.declaredElement;
+    if (element == null || element.hasInternal) return;
+    _visitMembers(node, node.name, node.members);
+  }
+
+  @override
+  void visitExtensionTypeDeclaration(ExtensionTypeDeclaration node) {
     var element = node.declaredElement;
     if (element == null || element.hasInternal) return;
     _visitMembers(node, node.name, node.members);
@@ -269,6 +277,7 @@ class _Visitor extends SimpleAstVisitor {
     // todo(pq): update this to be called from the parent (like with visitMembers)
     if (node.isInternal) return;
     if (inPrivateMember(node)) return;
+    if (node.isInvalidExtensionTypeField) return;
 
     for (var field in node.fields.variables) {
       if (!isPrivate(field.name)) {

--- a/test/rules/public_member_api_docs_test.dart
+++ b/test/rules/public_member_api_docs_test.dart
@@ -10,7 +10,74 @@ main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(PublicMemberApiDocsTest);
     defineReflectiveTests(PublicMemberApiDocsTestDirTest);
+    defineReflectiveTests(PublicMemberApiDocsExtensionTypesTest);
   });
+}
+
+@reflectiveTest
+class PublicMemberApiDocsExtensionTypesTest extends LintRuleTest {
+  @override
+  bool get addMetaPackageDep => true;
+
+  @override
+  List<String> get experiments => ['inline-class'];
+
+  @override
+  String get lintRule => 'public_member_api_docs';
+
+  test_extensionTypeDeclaration() async {
+    await assertDiagnostics(r'''
+extension type E(int i) { }
+''', [
+      lint(15, 1),
+    ]);
+  }
+
+  test_field_instance() async {
+    await assertDiagnostics(r'''
+/// Doc.    
+extension type E(int i) {
+  int? f;
+}
+''', [
+      // No lint.
+      // todo(pq): add compilation error once reported
+    ]);
+  }
+
+  test_field_static() async {
+    await assertDiagnostics(r'''
+/// Doc.    
+extension type E(int i) {
+  static int? f;
+}
+''', [
+      lint(53, 1),
+    ]);
+  }
+
+  test_method() async {
+    await assertDiagnostics(r'''
+/// Doc.    
+extension type E(int i) {
+  void m() { }
+}
+''', [
+      lint(46, 1),
+    ]);
+  }
+
+  test_method_private() async {
+    await assertDiagnostics(r'''
+/// Doc.    
+extension type E(int i) {
+  void _m() { }
+}
+''', [
+      // No lint
+      error(WarningCode.UNUSED_ELEMENT, 46, 2),
+    ]);
+  }
 }
 
 @reflectiveTest


### PR DESCRIPTION
Fixes #https://github.com/dart-lang/linter/issues/4650


/cc @bwilkerson 