### PR TITLE
Enable more lints used in sdk analysis packages

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,7 +28,6 @@ linter:
     - collection_methods_unrelated_type
     - comment_references
     - dangling_library_doc_comments
-    - depend_on_referenced_packages
     - directives_ordering
     - discarded_futures
     - implicit_call_tearoffs

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,6 +13,7 @@ linter:
     - avoid_annotating_with_dynamic
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
+    - avoid_dynamic_calls
     - avoid_positional_boolean_parameters
     - avoid_print
     - avoid_redundant_argument_values
@@ -21,13 +22,18 @@ linter:
     - avoid_returning_this
     - avoid_setters_without_getters
     - avoid_slow_async_io
+    - avoid_unused_constructor_parameters
     - cancel_subscriptions
     - cast_nullable_to_non_nullable
+    - collection_methods_unrelated_type
     - comment_references
     - dangling_library_doc_comments
+    - depend_on_referenced_packages
     - directives_ordering
     - discarded_futures
+    - implicit_call_tearoffs
     - join_return_with_assignment
+    - library_annotations
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list
     - noop_primitive_operations
@@ -49,6 +55,7 @@ linter:
     - unnecessary_breaks
     - unnecessary_final
     - unnecessary_lambdas
+    - unnecessary_library_directive
     - unnecessary_null_checks
     - unnecessary_parenthesis
     - unnecessary_statements

--- a/lib/src/rules/avoid_web_libraries_in_flutter.dart
+++ b/lib/src/rules/avoid_web_libraries_in_flutter.dart
@@ -73,16 +73,20 @@ class AvoidWebLibrariesInFlutter extends LintRule {
       return false;
     }
 
-    // Check for Flutter.
-    if ((parsedPubspec['dependencies'] ?? const {})['flutter'] == null) {
-      return false;
+    // If it has Flutter as a dependency, continue checking.
+    if (parsedPubspec['dependencies'] case {'flutter': var _?}) {
+      if (parsedPubspec['flutter']
+          case {'plugin': {'platforms': {'web': _?}}}) {
+        // Is a Flutter web plugin, allow web libraries.
+        return false;
+      } else {
+        // Is a non-web Flutter package, don't allow web libraries.
+        return true;
+      }
     }
 
-    // Check for a web plugin context declaration.
-    return (((parsedPubspec['flutter'] ?? const {})['plugin'] ??
-                const {})['platforms'] ??
-            const {})['web'] ==
-        null;
+    // Is not a Flutter package, allow web libraries.
+    return false;
   }
 
   @override

--- a/test/verify_machine_json_test.dart
+++ b/test/verify_machine_json_test.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
-import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../tool/machine.dart';
@@ -14,8 +11,8 @@ void main() {
   group('machine output tests', () {
     setUp(setUpSharedTestEnvironment);
     test("ensure 'rules.json' is up to date", () async {
-      var rulesFilePath = path.join('tool', 'machine', 'rules.json');
-      var onDisk = File(rulesFilePath).readAsStringSync();
+      var rulesFile = machineJsonFile();
+      var onDisk = rulesFile.readAsStringSync();
       var generated = await generateRulesJson();
       expect(
         generated,

--- a/tool/labeler/issue_config.dart
+++ b/tool/labeler/issue_config.dart
@@ -5,28 +5,29 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:http/http.dart' as http;
 import 'package:linter/src/utils.dart';
 
-/// Generate issue labeler workflow config data.
-main(List<String> args) async {
-  var client = http.Client();
-  var req = await client.get(
-      Uri.parse('https://dart-lang.github.io/linter/lints/machine/rules.json'));
+import '../machine.dart';
 
-  var machine = json.decode(req.body) as Iterable;
+/// Generate issue labeler workflow config data.
+void main(List<String> args) async {
+  var rulesFile = machineJsonFile();
+  var req = rulesFile.readAsStringSync();
+
+  var machine = json.decode(req) as Iterable<Object?>;
 
   var coreLints = <String>[];
   var recommendedLints = <String>[];
   var flutterLints = <String>[];
   for (var entry in machine) {
-    var sets = entry['sets'] as List;
-    if (sets.contains('core')) {
-      coreLints.add(entry['name'] as String);
-    } else if (sets.contains('recommended')) {
-      recommendedLints.add(entry['name'] as String);
-    } else if (sets.contains('flutter')) {
-      flutterLints.add(entry['name'] as String);
+    if (entry case {'name': String name, 'sets': List<Object?> sets}) {
+      if (sets.contains('core')) {
+        coreLints.add(name);
+      } else if (sets.contains('recommended')) {
+        recommendedLints.add(name);
+      } else if (sets.contains('flutter')) {
+        flutterLints.add(name);
+      }
     }
   }
 

--- a/tool/labeler/pr_config.dart
+++ b/tool/labeler/pr_config.dart
@@ -10,7 +10,7 @@ import 'package:linter/src/utils.dart';
 import '../machine.dart';
 
 /// Generate PR labeler workflow config data.
-main(List<String> args) async {
+void main(List<String> args) async {
   var rulesFile = machineJsonFile();
   var req = rulesFile.readAsStringSync();
 

--- a/tool/labeler/pr_config.dart
+++ b/tool/labeler/pr_config.dart
@@ -5,28 +5,29 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:http/http.dart' as http;
 import 'package:linter/src/utils.dart';
+
+import '../machine.dart';
 
 /// Generate PR labeler workflow config data.
 main(List<String> args) async {
-  var client = http.Client();
-  var req = await client.get(
-      Uri.parse('https://dart-lang.github.io/linter/lints/machine/rules.json'));
+  var rulesFile = machineJsonFile();
+  var req = rulesFile.readAsStringSync();
 
-  var machine = json.decode(req.body) as Iterable;
+  var machine = json.decode(req) as Iterable<Object?>;
 
   var coreLints = <String>[];
   var recommendedLints = <String>[];
   var flutterLints = <String>[];
   for (var entry in machine) {
-    var sets = entry['sets'] as List;
-    if (sets.contains('core')) {
-      coreLints.add(entry['name'] as String);
-    } else if (sets.contains('recommended')) {
-      recommendedLints.add(entry['name'] as String);
-    } else if (sets.contains('flutter')) {
-      flutterLints.add(entry['name'] as String);
+    if (entry case {'name': String name, 'sets': List<Object?> sets}) {
+      if (sets.contains('core')) {
+        coreLints.add(name);
+      } else if (sets.contains('recommended')) {
+        recommendedLints.add(name);
+      } else if (sets.contains('flutter')) {
+        flutterLints.add(name);
+      }
     }
   }
 

--- a/tool/machine.dart
+++ b/tool/machine.dart
@@ -32,12 +32,17 @@ void main(List<String> args) async {
       includeSetInfo: options['sets'] == true);
 
   if (options['write'] == true) {
-    var outPath = path.join('tool', 'machine', 'rules.json');
-    printToConsole('Writing to $outPath');
-    File(outPath).writeAsStringSync(json);
+    var outFile = machineJsonFile();
+    printToConsole('Writing to ${outFile.path}');
+    outFile.writeAsStringSync(json);
   } else {
     printToConsole(json);
   }
+}
+
+File machineJsonFile() {
+  var outPath = path.join('tool', 'machine', 'rules.json');
+  return File(outPath);
 }
 
 Future<Map<String, String>> fetchFixStatusMap() async {


### PR DESCRIPTION
To ease transition to the SDK and for consistency, adds a few linter rules enabled on the [analyzer](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/analysis_options.yaml) and the [analysis_server](https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server/analysis_options.yaml).

The only lint that triggered is `avoid_dynamic_calls`, so this PR fixes those.