### PR TITLE
extension type support for `sort_constructors_first`

### DIFF
--- a/lib/src/rules/sort_constructors_first.dart
+++ b/lib/src/rules/sort_constructors_first.dart
@@ -54,6 +54,7 @@ class SortConstructorsFirst extends LintRule {
     var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addEnumDeclaration(this, visitor);
+    registry.addExtensionTypeDeclaration(this, visitor);
   }
 }
 
@@ -83,6 +84,11 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitEnumDeclaration(EnumDeclaration node) {
+    check(node.members);
+  }
+
+  @override
+  void visitExtensionTypeDeclaration(ExtensionTypeDeclaration node) {
     check(node.members);
   }
 }

--- a/test/rules/sort_constructors_first_test.dart
+++ b/test/rules/sort_constructors_first_test.dart
@@ -15,6 +15,9 @@ main() {
 @reflectiveTest
 class SortConstructorsFirstTest extends LintRuleTest {
   @override
+  List<String> get experiments => ['inline-class'];
+
+  @override
   String get lintRule => 'sort_constructors_first';
 
   test_constructorBeforeMethod() async {
@@ -45,6 +48,19 @@ abstract class A {
 }
 ''', [
       lint(39, 1),
+    ]);
+  }
+
+  test_methodBeforeConstructor_extensionType() async {
+    // Since the check logic is shared w/ classes and enums, one test should
+    // provide sufficient coverage for extension types.
+    await assertDiagnostics(r'''
+extension type E(Object o) {
+  void f() {}
+  E.e(this.o);
+}
+''', [
+      lint(45, 1),
     ]);
   }
 


### PR DESCRIPTION
Fixes #4668

/cc @bwilkerson 