### PR TITLE
extension type support for `sort_unnamed_constructors_first`

### DIFF
--- a/lib/src/rules/sort_unnamed_constructors_first.dart
+++ b/lib/src/rules/sort_unnamed_constructors_first.dart
@@ -54,6 +54,7 @@ class SortUnnamedConstructorsFirst extends LintRule {
     var visitor = _Visitor(this);
     registry.addClassDeclaration(this, visitor);
     registry.addEnumDeclaration(this, visitor);
+    registry.addExtensionTypeDeclaration(this, visitor);
   }
 }
 
@@ -85,6 +86,12 @@ class _Visitor extends SimpleAstVisitor<void> {
 
   @override
   void visitEnumDeclaration(EnumDeclaration node) {
+    check(node.members);
+  }
+
+  @override
+  void visitExtensionTypeDeclaration(ExtensionTypeDeclaration node) {
+    if (node.representation.constructorName == null) return;
     check(node.members);
   }
 }

--- a/test/rules/sort_unnamed_constructors_first_test.dart
+++ b/test/rules/sort_unnamed_constructors_first_test.dart
@@ -15,6 +15,9 @@ main() {
 @reflectiveTest
 class SortUnnamedConstructorsFirstTest extends LintRuleTest {
   @override
+  List<String> get experiments => ['inline-class'];
+
+  @override
   String get lintRule => 'sort_unnamed_constructors_first';
 
   test_class_sorted() async {
@@ -60,6 +63,18 @@ enum A {
 }
 ''', [
       lint(47, 1),
+    ]);
+  }
+
+  test_extensionType() async {
+    await assertDiagnostics(r'''
+extension type E(Object o) {
+  void m() { }
+  E(this.o);
+}
+''', [
+      // No lint.
+      // todo(pq): Add `duplicate_constructor` diagnostic when it is reported.
     ]);
   }
 }

--- a/test/rules/sort_unnamed_constructors_first_test.dart
+++ b/test/rules/sort_unnamed_constructors_first_test.dart
@@ -68,6 +68,18 @@ enum A {
 
   test_extensionType() async {
     await assertDiagnostics(r'''
+extension type E.a(Object o) {
+  void m() { }
+  E.b(this.o);
+  E(this.o);
+}
+''', [
+      lint(63, 1),
+    ]);
+  }
+
+  test_extensionType_invalidConstructor() async {
+    await assertDiagnostics(r'''
 extension type E(Object o) {
   void m() { }
   E(this.o);


### PR DESCRIPTION
Fixes #4670

/cc @bwilkerson 