### PR TITLE
extension type support for `unnecessary_constructor_name`

### DIFF
--- a/lib/src/rules/unnecessary_constructor_name.dart
+++ b/lib/src/rules/unnecessary_constructor_name.dart
@@ -59,7 +59,7 @@ class UnnecessaryConstructorName extends LintRule {
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
-    registry.addExtensionTypeDeclaration(this, visitor);
+    registry.addRepresentationConstructorName(this, visitor);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }
@@ -81,13 +81,13 @@ class _Visitor extends SimpleAstVisitor {
   }
 
   @override
-  void visitExtensionTypeDeclaration(ExtensionTypeDeclaration node) {
-    _check(node.representation.constructorName?.name);
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    _check(node.constructorName.name?.token);
   }
 
   @override
-  void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    _check(node.constructorName.name?.token);
+  void visitRepresentationConstructorName(RepresentationConstructorName node) {
+    _check(node.name);
   }
 
   void _check(Token? name) {

--- a/lib/src/rules/unnecessary_constructor_name.dart
+++ b/lib/src/rules/unnecessary_constructor_name.dart
@@ -70,6 +70,7 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
+    if (node.parent is ExtensionTypeDeclaration) return;
     _check(node.name);
   }
 

--- a/lib/src/rules/unnecessary_constructor_name.dart
+++ b/lib/src/rules/unnecessary_constructor_name.dart
@@ -59,6 +59,7 @@ class UnnecessaryConstructorName extends LintRule {
       NodeLintRegistry registry, LinterContext context) {
     var visitor = _Visitor(this);
     registry.addConstructorDeclaration(this, visitor);
+    registry.addExtensionTypeDeclaration(this, visitor);
     registry.addInstanceCreationExpression(this, visitor);
   }
 }
@@ -77,6 +78,11 @@ class _Visitor extends SimpleAstVisitor {
     }
 
     _check(node.name);
+  }
+
+  @override
+  void visitExtensionTypeDeclaration(ExtensionTypeDeclaration node) {
+    _check(node.representation.constructorName?.name);
   }
 
   @override

--- a/lib/src/rules/unnecessary_constructor_name.dart
+++ b/lib/src/rules/unnecessary_constructor_name.dart
@@ -70,7 +70,12 @@ class _Visitor extends SimpleAstVisitor {
 
   @override
   void visitConstructorDeclaration(ConstructorDeclaration node) {
-    if (node.parent is ExtensionTypeDeclaration) return;
+    var parent = node.parent;
+    if (parent is ExtensionTypeDeclaration &&
+        parent.representation.constructorName == null) {
+      return;
+    }
+
     _check(node.name);
   }
 

--- a/test/rules/unnecessary_constructor_name_test.dart
+++ b/test/rules/unnecessary_constructor_name_test.dart
@@ -38,6 +38,22 @@ class A {
     ]);
   }
 
+  @FailingTest(
+      reason:
+          'https://github.com/dart-lang/linter/pull/4677#discussion_r1291784807')
+  test_constructorDeclaration_new_alreadyDefined() async {
+    await assertDiagnostics(r'''
+class A {
+  A();
+  A.new();
+}
+''', [
+      error(CompileTimeErrorCode.DUPLICATE_CONSTRUCTOR_DEFAULT, 19, 5),
+      // A lint should likely not get reported here since we're already
+      // producing a compilation error.
+    ]);
+  }
+
   test_constructorTearoff_new() async {
     await assertNoDiagnostics(r'''
 class A {

--- a/test/rules/unnecessary_constructor_name_test.dart
+++ b/test/rules/unnecessary_constructor_name_test.dart
@@ -67,6 +67,14 @@ extension type E.a(int i) {
     ]);
   }
 
+  test_extensionTypeDeclaration_primaryNamedNew() async {
+    await assertDiagnostics(r'''
+extension type E.new(int i) { }
+''', [
+      lint(17, 3),
+    ]);
+  }
+
   test_instanceCreation_named() async {
     await assertNoDiagnostics(r'''
 class A {

--- a/test/rules/unnecessary_constructor_name_test.dart
+++ b/test/rules/unnecessary_constructor_name_test.dart
@@ -15,6 +15,9 @@ main() {
 @reflectiveTest
 class UnnecessaryConstructorNameTest extends LintRuleTest {
   @override
+  List<String> get experiments => ['inline-class'];
+
+  @override
   String get lintRule => 'unnecessary_constructor_name';
 
   test_constructorDeclaration_named() async {
@@ -41,6 +44,17 @@ class A {
 }
 var makeA = A.new;
 ''');
+  }
+
+  test_extensionTypeDeclaration() async {
+    await assertDiagnostics(r'''
+extension type E(int i) {
+  E.new(this.i);
+}
+''', [
+      // No lint.
+      // Specify `duplicate_constructor` diagnostic once reported.
+    ]);
   }
 
   test_instanceCreation_named() async {

--- a/test/rules/unnecessary_constructor_name_test.dart
+++ b/test/rules/unnecessary_constructor_name_test.dart
@@ -57,6 +57,16 @@ extension type E(int i) {
     ]);
   }
 
+  test_extensionTypeDeclaration_primaryNamed() async {
+    await assertDiagnostics(r'''
+extension type E.a(int i) {
+  E.new(this.i);
+}
+''', [
+      lint(32, 3),
+    ]);
+  }
+
   test_instanceCreation_named() async {
     await assertNoDiagnostics(r'''
 class A {


### PR DESCRIPTION
Fixes #4676

/cc @bwilkerson 