### PR TITLE
Account for missing lints in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 - new lint: `no_self_assignments`
 - new lint: `no_wildcard_variable_uses`
 
+# 3.0.0
+
+- new lint: `implicit_reopen`
+- new lint: `unnecessary_breaks`
+- new lint: `type_literal_in_constant_pattern`
+- new lint: `invalid_case_patterns`
+- new lint: `matching_super_parameters`
+- new lint: `no_literal_bool_comparisons`
+
+- removed lint: `enable_null_safety`
+- removed lint: `invariant_booleans`
+- removed lint: `prefer_bool_in_asserts`
+- removed lint: `prefer_equal_for_default_values`
+- removed lint: `super_goes_last`
+
 ---
 
 # 1.35.0

--- a/tool/machine/rules.json
+++ b/tool/machine/rules.json
@@ -1388,7 +1388,7 @@
     "sets": [],
     "fixStatus": "needsFix",
     "details": "**DO** use super parameter names that match their corresponding super\nconstructor's parameter names.\n\n**BAD:**\n\n```dart\nclass Rectangle {\n  final int width;\n  final int height;\n  \n  Rectangle(this.width, this.height);\n}\n\nclass ColoredRectangle extends Rectangle {\n  final Color color;\n  \n  ColoredRectangle(\n    this.color,\n    super.height, // Bad, actually corresponds to the `width` parameter.\n    super.width, // Bad, actually corresponds to the `height` parameter.\n  ); \n}\n```\n\n**GOOD:**\n\n```dart\nclass Rectangle {\n  final int width;\n  final int height;\n  \n  Rectangle(this.width, this.height);\n}\n\nclass ColoredRectangle extends Rectangle {\n  final Color color;\n  \n  ColoredRectangle(\n    this.color,\n    super.width,\n    super.height, \n  ); \n}\n```\n",
-    "sinceDartSdk": "3.1.0-wip"
+    "sinceDartSdk": "3.0.0"
   },
   {
     "name": "missing_whitespace_between_adjacent_strings",
@@ -1449,7 +1449,7 @@
     "sets": [],
     "fixStatus": "hasFix",
     "details": "From [Effective Dart](https://dart.dev/effective-dart/usage#dont-use-true-or-false-in-equality-operations):\n\n**DON'T** use `true` or `false` in equality operations.\n\nThis lint applies only if the expression is of a non-nullable `bool` type.\n\n**BAD:**\n```dart\nif (someBool == true) {\n}\nwhile (someBool == false) {\n}\n```\n\n**GOOD:**\n```dart\nif (someBool) {\n}\nwhile (!someBool) {\n}\n```\n",
-    "sinceDartSdk": "3.1.0-wip"
+    "sinceDartSdk": "3.0.0"
   },
   {
     "name": "no_runtimeType_toString",

--- a/tool/since/sdk.yaml
+++ b/tool/since/sdk.yaml
@@ -92,14 +92,14 @@ library_private_types_in_public_api: 2.14.0
 lines_longer_than_80_chars: 2.0.0
 list_remove_unrelated_type: 2.0.0
 literal_only_boolean_expressions: 2.0.0
-matching_super_parameters: 3.1.0-wip
+matching_super_parameters: 3.0.0
 missing_whitespace_between_adjacent_strings: 2.8.1
 no_adjacent_strings_in_list: 2.0.0
 no_default_cases: 2.9.0
 no_duplicate_case_values: 2.0.0
 no_leading_underscores_for_library_prefixes: 2.16.0
 no_leading_underscores_for_local_identifiers: 2.16.0
-no_literal_bool_comparisons: 3.1.0-wip
+no_literal_bool_comparisons: 3.0.0
 no_logic_in_create_state: 2.8.1
 no_runtimeType_toString: 2.8.1
 no_self_assignments: 3.1.0-wip


### PR DESCRIPTION
Some of this is replicated from the `1.35.0` section, but there were linter rules added after `1.35.0` but before the linter commit included in Dart 3, which were missing from the changelog completely: `matching_super_parameters` and `no_literal_bool_comparisons`.

To clearly indicate to users all of the lints that were added and removed, I added an entry for 3.0.0 including both those already included and missing previously. This has the added benefit of beginning the new style with a full major version :)