### PR TITLE
extension type support for `use_late_for_private_fields_and_variables`

### DIFF
--- a/lib/src/rules/use_late_for_private_fields_and_variables.dart
+++ b/lib/src/rules/use_late_for_private_fields_and_variables.dart
@@ -162,6 +162,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   @override
   void visitFieldDeclaration(FieldDeclaration node) {
     var parent = node.parent;
+    if (parent is ExtensionTypeDeclaration && !node.isStatic) return;
     if (parent != null) {
       var parentIsPrivateExtension = _isPrivateExtension(parent);
       for (var variable in node.fields.variables) {

--- a/test/rules/use_late_for_private_fields_and_variables_test.dart
+++ b/test/rules/use_late_for_private_fields_and_variables_test.dart
@@ -15,7 +15,34 @@ main() {
 @reflectiveTest
 class UseLateForPrivateFieldsAndVariablesTest extends LintRuleTest {
   @override
+  List<String> get experiments => ['inline-class'];
+
+  @override
   String get lintRule => 'use_late_for_private_fields_and_variables';
+
+  test_extensionType_instanceField() async {
+    await assertDiagnostics('''
+extension type E(int i) {
+  int? _i;
+}
+''', [
+      error(WarningCode.UNUSED_FIELD, 33, 2),
+      // No lint.
+      // todo(pq): report invalid field diagnostic when it's reported.
+    ]);
+  }
+
+  @soloTest
+  test_extensionType_staticField() async {
+    await assertDiagnostics('''
+extension type E(int i) {
+  static int? _i;
+}
+''', [
+      error(WarningCode.UNUSED_FIELD, 40, 2),
+      lint(40, 2),
+    ]);
+  }
 
   test_instanceField_private() async {
     await assertDiagnostics('''

--- a/test/rules/use_late_for_private_fields_and_variables_test.dart
+++ b/test/rules/use_late_for_private_fields_and_variables_test.dart
@@ -32,7 +32,6 @@ extension type E(int i) {
     ]);
   }
 
-  @soloTest
   test_extensionType_staticField() async {
     await assertDiagnostics('''
 extension type E(int i) {


### PR DESCRIPTION
Fixes #4681

/cc @bwilkerson 