### PR TITLE
Revert "extension type support for `avoid_shadowing_type_parameters`"

### DIFF
--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -98,9 +98,6 @@ class _Visitor extends SimpleAstVisitor<void> {
         _checkForShadowing(typeParameters, parent.typeParameters, 'enum');
       } else if (parent is ExtensionDeclaration) {
         _checkForShadowing(typeParameters, parent.typeParameters, 'extension');
-      } else if (parent is ExtensionTypeDeclaration) {
-        _checkForShadowing(
-            typeParameters, parent.typeParameters, 'extension type');
       } else if (parent is MethodDeclaration) {
         _checkForShadowing(typeParameters, parent.typeParameters, 'method');
       } else if (parent is MixinDeclaration) {

--- a/test/rules/avoid_shadowing_type_parameters_test.dart
+++ b/test/rules/avoid_shadowing_type_parameters_test.dart
@@ -8,15 +8,13 @@ import '../rule_test_support.dart';
 
 main() {
   defineReflectiveSuite(() {
+    defineReflectiveTests(AvoidShadowingTypeParametersEnumTest);
     defineReflectiveTests(AvoidShadowingTypeParametersTest);
   });
 }
 
 @reflectiveTest
-class AvoidShadowingTypeParametersTest extends LintRuleTest {
-  @override
-  List<String> get experiments => ['inline-class'];
-
+class AvoidShadowingTypeParametersEnumTest extends LintRuleTest {
   @override
   String get lintRule => 'avoid_shadowing_type_parameters';
 
@@ -30,16 +28,12 @@ enum E<T> {
       lint(33, 1),
     ]);
   }
-
-  test_extensionType() async {
-    await assertDiagnostics(r'''
-extension type E<T>(int i) {
-  void m<T>() {}
 }
-''', [
-      lint(38, 1),
-    ]);
-  }
+
+@reflectiveTest
+class AvoidShadowingTypeParametersTest extends LintRuleTest {
+  @override
+  String get lintRule => 'avoid_shadowing_type_parameters';
 
   test_wrongNumberOfTypeArguments() async {
     await assertDiagnostics(r'''


### PR DESCRIPTION
This reverts commit e32b6e9817789374dc38bc2a3603c0bcf3970bee.

(Accidental un-reviewed commit to main.)

/cc @bwilkerson @srawlins 
