### PR TITLE
extension type support for `avoid_shadowing_type_parameters`

### DIFF
--- a/lib/src/rules/avoid_shadowing_type_parameters.dart
+++ b/lib/src/rules/avoid_shadowing_type_parameters.dart
@@ -98,6 +98,9 @@ class _Visitor extends SimpleAstVisitor<void> {
         _checkForShadowing(typeParameters, parent.typeParameters, 'enum');
       } else if (parent is ExtensionDeclaration) {
         _checkForShadowing(typeParameters, parent.typeParameters, 'extension');
+      } else if (parent is ExtensionTypeDeclaration) {
+        _checkForShadowing(
+            typeParameters, parent.typeParameters, 'extension type');
       } else if (parent is MethodDeclaration) {
         _checkForShadowing(typeParameters, parent.typeParameters, 'method');
       } else if (parent is MixinDeclaration) {

--- a/test/rules/avoid_shadowing_type_parameters_test.dart
+++ b/test/rules/avoid_shadowing_type_parameters_test.dart
@@ -8,13 +8,15 @@ import '../rule_test_support.dart';
 
 main() {
   defineReflectiveSuite(() {
-    defineReflectiveTests(AvoidShadowingTypeParametersEnumTest);
     defineReflectiveTests(AvoidShadowingTypeParametersTest);
   });
 }
 
 @reflectiveTest
-class AvoidShadowingTypeParametersEnumTest extends LintRuleTest {
+class AvoidShadowingTypeParametersTest extends LintRuleTest {
+  @override
+  List<String> get experiments => ['inline-class'];
+
   @override
   String get lintRule => 'avoid_shadowing_type_parameters';
 
@@ -28,12 +30,16 @@ enum E<T> {
       lint(33, 1),
     ]);
   }
-}
 
-@reflectiveTest
-class AvoidShadowingTypeParametersTest extends LintRuleTest {
-  @override
-  String get lintRule => 'avoid_shadowing_type_parameters';
+  test_extensionType() async {
+    await assertDiagnostics(r'''
+extension type E<T>(int i) {
+  void m<T>() {}
+}
+''', [
+      lint(38, 1),
+    ]);
+  }
 
   test_wrongNumberOfTypeArguments() async {
     await assertDiagnostics(r'''


### PR DESCRIPTION
Fixes #4690


/cc @bwilkerson 