### PR TITLE
extension type support for `non_constant_identifier_names`

### DIFF
--- a/lib/src/rules/non_constant_identifier_names.dart
+++ b/lib/src/rules/non_constant_identifier_names.dart
@@ -56,6 +56,7 @@ class NonConstantIdentifierNames extends LintRule {
     registry.addCatchClause(this, visitor);
     registry.addConstructorDeclaration(this, visitor);
     registry.addDeclaredVariablePattern(this, visitor);
+    registry.addExtensionTypeDeclaration(this, visitor);
     registry.addForEachPartsWithDeclaration(this, visitor);
     registry.addFormalParameterList(this, visitor);
     registry.addFunctionDeclaration(this, visitor);
@@ -103,6 +104,11 @@ class _Visitor extends SimpleAstVisitor<void> {
   void visitDeclaredVariablePattern(DeclaredVariablePattern node) {
     if (node.parent.isFieldNameShortcut) return;
     checkIdentifier(node.name);
+  }
+
+  @override
+  void visitExtensionTypeDeclaration(ExtensionTypeDeclaration node) {
+    checkIdentifier(node.representation.constructorName?.name);
   }
 
   @override

--- a/test/rules/non_constant_identifier_names_test.dart
+++ b/test/rules/non_constant_identifier_names_test.dart
@@ -17,7 +17,18 @@ main() {
 @reflectiveTest
 class NonConstantIdentifierNamesPatternsTest extends LintRuleTest {
   @override
+  List<String> get experiments => ['inline-class'];
+
+  @override
   String get lintRule => 'non_constant_identifier_names';
+
+  test_extensionType_representationConstructorName() async {
+    await assertDiagnostics(r'''
+extension type e.Efg(int i) {}
+''', [
+      lint(17, 3),
+    ]);
+  }
 
   test_patternForStatement() async {
     await assertDiagnostics(r'''


### PR DESCRIPTION
Fixes #4695


/cc @bwilkerson 