### PR TITLE
Call out move in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ The Dart linter is now developed within the [Dart SDK][] repository,
 and can be found at https://github.com/dart-lang/sdk/tree/main/pkg/linter.
 
 For now, please continue to file new linter issues on
-this repository. 
+[this repository][]. 
 To contribute changes, check out the [SDK contribution guide][].
 
 [Repository has moved]: https://github.com/dart-lang/sdk/tree/main/pkg/linter
 [Dart SDK]: https://github.com/dart-lang/sdk
+[this repository]: https://github.com/dart-lang/linter/issues
 [SDK contribution guide]: https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ The Dart linter is now developed within the [Dart SDK][] repository,
 and can be found at https://github.com/dart-lang/sdk/tree/main/pkg/linter.
 
 Please open new linter issues on the [dart-lang/sdk repo][issues].
-To contribute, check out the [SDK contributing guide][].
+To contribute, check out the [SDK contribution guide][].
 
 [Repository has moved]: https://github.com/dart-lang/sdk/tree/main/pkg/linter
 [Dart SDK]: https://github.com/dart-lang/sdk
 [issues]: https://github.com/dart-lang/sdk/issues/new/choose
-[SDK contributing guide]: https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md
+[SDK contribution guide]: https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 The Dart linter is now developed within the [Dart SDK][] repository,
 and can be found at https://github.com/dart-lang/sdk/tree/main/pkg/linter.
 
-Please open [new linter issues][] in that repository.
+Please open new linter issues on the [dart-lang/sdk repo][issues].
 To contribute, check out the [SDK contributing guide][].
 
 [Repository has moved]: https://github.com/dart-lang/sdk/tree/main/pkg/linter
 [Dart SDK]: https://github.com/dart-lang/sdk
-[new linter issues]: https://github.com/dart-lang/sdk/issues/new/choose
+[issues]: https://github.com/dart-lang/sdk/issues/new/choose
 [SDK contributing guide]: https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Linter for Dart
 
+## [Repository has moved][]
+
+The Dart linter is now developed within the [Dart SDK][] repository,
+and can be found at https://github.com/dart-lang/sdk/tree/main/pkg/linter.
+
+Please open [new linter issues][] in that repository.
+To contribute, check out the [SDK contributing guide][].
+
+[Repository has moved]: https://github.com/dart-lang/sdk/tree/main/pkg/linter
+[Dart SDK]: https://github.com/dart-lang/sdk
+[new linter issues]: https://github.com/dart-lang/sdk/issues/new/choose
+[SDK contributing guide]: https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md
+
+---
+
 The Dart Linter package defines lint rules that identify and report on "lints" found in Dart code.  Linting is performed by the Dart
 analysis server and the `dart analyze` command in the [Dart command-line tool][dart_cli].
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 The Dart linter is now developed within the [Dart SDK][] repository,
 and can be found at https://github.com/dart-lang/sdk/tree/main/pkg/linter.
 
-Please open new linter issues on the [dart-lang/sdk repo][issues].
-To contribute, check out the [SDK contribution guide][].
+For now, please continue to file new linter issues on
+this repository. 
+To contribute changes, check out the [SDK contribution guide][].
 
 [Repository has moved]: https://github.com/dart-lang/sdk/tree/main/pkg/linter
 [Dart SDK]: https://github.com/dart-lang/sdk
-[issues]: https://github.com/dart-lang/sdk/issues/new/choose
 [SDK contribution guide]: https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md
 
 ---


### PR DESCRIPTION
Contributes to https://github.com/dart-lang/linter/issues/4411
Closes https://github.com/dart-lang/linter/issues/4707 

Redirects contributions to the appropriate repository.