### PR TITLE
Improve sort_pub_dependencies.dart messages

### DIFF
--- a/lib/src/rules/pub/sort_pub_dependencies.dart
+++ b/lib/src/rules/pub/sort_pub_dependencies.dart
@@ -17,8 +17,8 @@ Sorting list of pub dependencies makes maintenance easier.
 
 class SortPubDependencies extends LintRule {
   static const LintCode code = LintCode(
-      'sort_pub_dependencies', 'Unsorted dependencies.',
-      correctionMessage: 'Try sorting the dependencies.');
+      'sort_pub_dependencies', 'Dependencies not sorted alphabetically.',
+      correctionMessage: 'Try sorting the dependencies alphabetically (A to Z).');
 
   SortPubDependencies()
       : super(


### PR DESCRIPTION
# Description

This is a minor improvement for both messages that user sees when `sort_pub_dependencies` rule is enabled. For developers not familiar with this rule the analyzer report with current message isn't really clear from my point of view. 
Thus, to save time of people who are haven't seen this rule before I decided to improve the text, so the person wouldn't have to search this rule.

<img width="619" alt="Screenshot 2024-02-01 at 16 18 09" src="https://github.com/dart-lang/linter/assets/13467769/e0742d34-9433-4aa3-b74c-97cbccc20ced">
