### PR TITLE
Make descriptions more consistent in using code-quotes.

### DIFF
--- a/lib/src/rules/avoid_annotating_with_dynamic.dart
+++ b/lib/src/rules/avoid_annotating_with_dynamic.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid annotating with dynamic when not required.';
+const _desc = r'Avoid annotating with `dynamic` when not required.';
 
 const _details = r'''
-**AVOID** annotating with dynamic when not required.
+**AVOID** annotating with `dynamic` when not required.
 
 As `dynamic` is the assumed return value of a function or method, it is usually
 not necessary to annotate it.

--- a/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
+++ b/lib/src/rules/avoid_bool_literals_in_conditional_expressions.dart
@@ -7,10 +7,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid bool literals in conditional expressions.';
+const _desc = r'Avoid `bool` literals in conditional expressions.';
 
 const _details = r'''
-**AVOID** bool literals in conditional expressions.
+**AVOID** `bool` literals in conditional expressions.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/avoid_catching_errors.dart
+++ b/lib/src/rules/avoid_catching_errors.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r"Don't explicitly catch Error or types that implement it.";
+const _desc = r"Don't explicitly catch `Error` or types that implement it.";
 
 const _details = r'''
-**DON'T** explicitly catch Error or types that implement it.
+**DON'T** explicitly catch `Error` or types that implement it.
 
 Errors differ from Exceptions in that Errors can be analyzed and prevented prior
 to runtime.  It should almost never be necessary to catch an error at runtime.

--- a/lib/src/rules/avoid_double_and_int_checks.dart
+++ b/lib/src/rules/avoid_double_and_int_checks.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid double and int checks.';
+const _desc = r'Avoid `double` and `int` checks.';
 
 const _details = r'''
-**AVOID** to check if type is double or int.
+**AVOID** to check if type is `double` or `int`.
 
 When compiled to JS, integer values are represented as floats. That can lead to
 some unexpected behavior when using either `is` or `is!` where the type is

--- a/lib/src/rules/avoid_dynamic_calls.dart
+++ b/lib/src/rules/avoid_dynamic_calls.dart
@@ -9,31 +9,31 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid method calls or property accesses on a "dynamic" target.';
+const _desc = r'Avoid method calls or property accesses on a `dynamic` target.';
 
 const _details = r'''
 **DO** avoid method calls or accessing properties on an object that is either
-explicitly or implicitly statically typed "dynamic". Dynamic calls are treated
+explicitly or implicitly statically typed `dynamic`. Dynamic calls are treated
 slightly different in every runtime environment and compiler, but most
 production modes (and even some development modes) have both compile size and
 runtime performance penalties associated with dynamic calls.
 
-Additionally, targets typed "dynamic" disables most static analysis, meaning it
-is easier to lead to a runtime "NoSuchMethodError" or "NullError" than properly
+Additionally, targets typed `dynamic` disables most static analysis, meaning it
+is easier to lead to a runtime `NoSuchMethodError` or `TypeError` than properly
 statically typed Dart code.
 
-There is an exception to methods and properties that exist on "Object?":
-- a.hashCode
-- a.runtimeType
-- a.noSuchMethod(someInvocation)
-- a.toString()
+There is an exception to methods and properties that exist on `Object?`:
+- `a.hashCode`
+- `a.runtimeType`
+- `a.noSuchMethod(someInvocation)`
+- `a.toString()`
 
 ... these members are dynamically dispatched in the web-based runtimes, but not
 in the VM-based ones. Additionally, they are so common that it would be very
 punishing to disallow `any.toString()` or `any == true`, for example.
 
-Note that despite "Function" being a type, the semantics are close to identical
-to "dynamic", and calls to an object that is typed "Function" will also trigger
+Note that despite `Function` being a type, the semantics are close to identical
+to `dynamic`, and calls to an object that is typed `Function` will also trigger
 this lint.
 
 **BAD:**

--- a/lib/src/rules/avoid_final_parameters.dart
+++ b/lib/src/rules/avoid_final_parameters.dart
@@ -7,13 +7,13 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid final for parameter declarations.';
+const _desc = r'Avoid `final` for parameter declarations.';
 
 const _details = r'''
-**AVOID** declaring parameters as final.
+**AVOID** declaring parameters as `final`.
 
-Declaring parameters as final can lead to unnecessarily verbose code, especially
-when using the "parameter_assignments" rule.
+Declaring parameters as `final` can lead to unnecessarily verbose code,
+especially when using the "parameter_assignments" rule.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/avoid_init_to_null.dart
+++ b/lib/src/rules/avoid_init_to_null.dart
@@ -11,19 +11,19 @@ import 'package:analyzer/dart/element/type.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r"Don't explicitly initialize variables to null.";
+const _desc = r"Don't explicitly initialize variables to `null`.";
 
 const _details = r'''
 From [Effective Dart](https://dart.dev/effective-dart/usage#dont-explicitly-initialize-variables-to-null):
 
 **DON'T** explicitly initialize variables to `null`.
 
-If a variable has a non-nullable type or is `final`, 
+If a variable has a non-nullable type or is `final`,
 Dart reports a compile error if you try to use it
-before it has been definitely initialized. 
-If the variable is nullable and not `const` or `final`, 
-then it is implicitly initialized to `null` for you. 
-There's no concept of "uninitialized memory" in Dart 
+before it has been definitely initialized.
+If the variable is nullable and not `const` or `final`,
+then it is implicitly initialized to `null` for you.
+There's no concept of "uninitialized memory" in Dart
 and no need to explicitly initialize a variable to `null` to be "safe".
 Adding `= null` is redundant and unneeded.
 

--- a/lib/src/rules/avoid_null_checks_in_equality_operators.dart
+++ b/lib/src/rules/avoid_null_checks_in_equality_operators.dart
@@ -12,14 +12,14 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r"Don't check for null in custom == operators.";
+const _desc = r"Don't check for `null` in custom `==` operators.";
 
 const _details = r'''
-**DON'T** check for null in custom == operators.
+**DON'T** check for `null` in custom `==` operators.
 
-As null is a special value, no instance of any class (other than `Null`) can be
-equivalent to it.  Thus, it is redundant to check whether the other instance is
-null.
+As `null` is a special value, no instance of any class (other than `Null`) can
+be equivalent to it.  Thus, it is redundant to check whether the other instance
+is `null`.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/avoid_returning_null_for_future.dart
+++ b/lib/src/rules/avoid_returning_null_for_future.dart
@@ -9,10 +9,10 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid returning null for Future.';
+const _desc = r'Avoid returning `null` for `Future`.';
 
 const _details = r'''
-**AVOID** returning null for Future.
+**AVOID** returning `null` for `Future`.
 
 It is almost always wrong to return `null` for a `Future`.  Most of the time the
 developer simply forgot to put an `async` keyword on the function.

--- a/lib/src/rules/avoid_returning_null_for_void.dart
+++ b/lib/src/rules/avoid_returning_null_for_void.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid returning null for void.';
+const _desc = r'Avoid returning `null` for `void`.';
 
 const _details = r'''
-**AVOID** returning null for void.
+**AVOID** returning `null` for `void`.
 
 In a large variety of languages `void` as return type is used to indicate that
 a function doesn't return anything. Dart allows returning `null` in functions

--- a/lib/src/rules/avoid_slow_async_io.dart
+++ b/lib/src/rules/avoid_slow_async_io.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/dart/element/type.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r'Avoid slow async `dart:io` methods.';
+const _desc = r'Avoid slow asynchronous `dart:io` methods.';
 
 const _details = r'''
 **AVOID** using the following asynchronous file I/O methods because they are

--- a/lib/src/rules/avoid_void_async.dart
+++ b/lib/src/rules/avoid_void_async.dart
@@ -9,10 +9,10 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid async functions that return void.';
+const _desc = r'Avoid `async` functions that return `void`.';
 
 const _details = r'''
-**DO** mark async functions as returning Future<void>.
+**DO** mark `async` functions as returning `Future<void>`.
 
 When declaring an async method or function which does not return a value,
 declare that it returns `Future<void>` and not just `void`.

--- a/lib/src/rules/cancel_subscriptions.dart
+++ b/lib/src/rules/cancel_subscriptions.dart
@@ -8,10 +8,10 @@ import '../analyzer.dart';
 import '../extensions.dart';
 import '../util/leak_detector_visitor.dart';
 
-const _desc = r'Cancel instances of dart.async.StreamSubscription.';
+const _desc = r'Cancel instances of `dart:async` `StreamSubscription`.';
 
 const _details = r'''
-**DO** invoke `cancel` on instances of `dart.async.StreamSubscription`.
+**DO** invoke `cancel` on instances of `dart:async` `StreamSubscription`.
 
 Cancelling instances of StreamSubscription prevents memory leaks and unexpected
 behavior.

--- a/lib/src/rules/close_sinks.dart
+++ b/lib/src/rules/close_sinks.dart
@@ -8,10 +8,10 @@ import '../analyzer.dart';
 import '../extensions.dart';
 import '../util/leak_detector_visitor.dart';
 
-const _desc = r'Close instances of `dart.core.Sink`.';
+const _desc = r'Close instances of `dart:core` `Sink`.';
 
 const _details = r'''
-**DO** invoke `close` on instances of `dart.core.Sink`.
+**DO** invoke `close` on instances of `dart:core` `Sink`.
 
 Closing instances of Sink prevents memory leaks and unexpected behavior.
 

--- a/lib/src/rules/control_flow_in_finally.dart
+++ b/lib/src/rules/control_flow_in_finally.dart
@@ -7,12 +7,12 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid control flow in finally blocks.';
+const _desc = r'Avoid control flow in `finally` blocks.';
 
 const _details = r'''
-**AVOID** control flow leaving finally blocks.
+**AVOID** control flow leaving `finally` blocks.
 
-Using control flow in finally blocks will inevitably cause unexpected behavior
+Using control flow in `finally` blocks will inevitably cause unexpected behavior
 that is hard to debug.
 
 **BAD:**

--- a/lib/src/rules/discarded_futures.dart
+++ b/lib/src/rules/discarded_futures.dart
@@ -9,7 +9,7 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r"Don't invoke asynchronous functions in non-async blocks.";
+const _desc = r"Don't invoke asynchronous functions in non-`async` blocks.";
 
 const _details = r'''
 Making asynchronous calls in non-`async` functions is usually the sign of a

--- a/lib/src/rules/iterable_contains_unrelated_type.dart
+++ b/lib/src/rules/iterable_contains_unrelated_type.dart
@@ -5,8 +5,8 @@
 import '../analyzer.dart';
 import '../util/unrelated_types_visitor.dart';
 
-const _desc = r'Invocation of Iterable<E>.contains with references of unrelated'
-    r' types.';
+const _desc = r'Invocation of `Iterable<E>.contains` with references of'
+    r' unrelated types.';
 
 const _details = r'''
 **DON'T** invoke `contains` on `Iterable` with an instance of different type

--- a/lib/src/rules/no_runtimeType_toString.dart
+++ b/lib/src/rules/no_runtimeType_toString.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid calling toString() on runtimeType.';
+const _desc = r'Avoid calling `toString()` on `runtimeType`.';
 
 const _details = r'''
 Calling `toString` on a runtime type is a non-trivial operation that can

--- a/lib/src/rules/null_check_on_nullable_type_parameter.dart
+++ b/lib/src/rules/null_check_on_nullable_type_parameter.dart
@@ -11,13 +11,14 @@ import 'package:analyzer/dart/element/type.dart';
 import '../analyzer.dart';
 import 'unnecessary_null_checks.dart';
 
-const _desc = r"Don't use null check on a potentially nullable type parameter.";
+const _desc =
+    r"Don't use `null` check on a potentially nullable type parameter.";
 
 const _details = r'''
-**DON'T** use null check on a potentially nullable type parameter.
+**DON'T** use `null` check on a potentially nullable type parameter.
 
-Given a generic type parameter `T` which has a nullable bound (e.g. the default
-bound of `Object?`), it is very easy to introduce erroneous null checks when
+Given a generic type parameter `T` which has a nullable bound (e.g., the default
+bound of `Object?`), it is very easy to introduce erroneous `null` checks when
 working with a variable of type `T?`. Specifically, it is not uncommon to have
 `T? x;` and want to assert that `x` has been set to a valid value of type `T`.
 A common mistake is to do so using `x!`. This is almost always incorrect, since
@@ -27,7 +28,7 @@ if `T` is a nullable type, `x` may validly hold `null` as a value of type `T`.
 ```dart
 T run<T>(T callback()) {
   T? result;
-   (() { result = callback(); })();
+  (() { result = callback(); })();
   return result!;
 }
 ```
@@ -36,7 +37,7 @@ T run<T>(T callback()) {
 ```dart
 T run<T>(T callback()) {
   T? result;
-   (() { result = callback(); })();
+  (() { result = callback(); })();
   return result as T;
 }
 ```

--- a/lib/src/rules/prefer_conditional_assignment.dart
+++ b/lib/src/rules/prefer_conditional_assignment.dart
@@ -10,10 +10,10 @@ import '../analyzer.dart';
 import '../extensions.dart';
 import '../util/dart_type_utilities.dart' as type_utils;
 
-const _desc = r'Prefer using `??=` over testing for null.';
+const _desc = r'Prefer using `??=` over testing for `null`.';
 
 const _details = r'''
-**PREFER** using `??=` over testing for null.
+**PREFER** using `??=` over testing for `null`.
 
 As Dart has the `??=` operator, it is advisable to use it where applicable to
 improve the brevity of your code.

--- a/lib/src/rules/prefer_const_constructors.dart
+++ b/lib/src/rules/prefer_const_constructors.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/element.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer const with constant constructors.';
+const _desc = r'Prefer `const` with constant constructors.';
 
 const _details = r'''
 **PREFER** using `const` for instantiating constant constructors.

--- a/lib/src/rules/prefer_const_constructors_in_immutables.dart
+++ b/lib/src/rules/prefer_const_constructors_in_immutables.dart
@@ -9,13 +9,13 @@ import 'package:collection/collection.dart' show IterableExtension;
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer declaring const constructors on `@immutable` classes.';
+const _desc = r'Prefer declaring `const` constructors on `@immutable` classes.';
 
 const _details = r'''
-**PREFER** declaring const constructors on `@immutable` classes.
+**PREFER** declaring `const` constructors on `@immutable` classes.
 
 If a class is immutable, it is usually a good idea to make its constructor a
-const constructor.
+`const` constructor.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/prefer_const_declarations.dart
+++ b/lib/src/rules/prefer_const_declarations.dart
@@ -9,13 +9,13 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../ast.dart';
 
-const _desc = r'Prefer const over final for declarations.';
+const _desc = r'Prefer `const` over `final` for declarations.';
 
 const _details = r'''
-**PREFER** using `const` for const declarations.
+**PREFER** using `const` for constant-valued declarations.
 
-Const declarations are more hot-reload friendly and allow to use const
-constructors if an instantiation references this declaration.
+Constant declarations are more hot-reload friendly and allows
+the value to be used in other constant expressions.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/prefer_final_fields.dart
+++ b/lib/src/rules/prefer_final_fields.dart
@@ -10,13 +10,13 @@ import 'package:analyzer/dart/element/element.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r'Private field could be final.';
+const _desc = r'Private field could be `final`.';
 
 const _details = r'''
-**DO** prefer declaring private fields as final if they are not reassigned later
-in the library.
+**DO** prefer declaring private fields as `final` if they are not reassigned
+later in the library.
 
-Declaring fields as final when possible is a good practice because it helps
+Declaring fields as `final` when possible is a good practice because it helps
 avoid accidental reassignments and allows the compiler to do optimizations.
 
 **BAD:**

--- a/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
+++ b/lib/src/rules/prefer_for_elements_to_map_fromIterable.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r"Prefer 'for' elements when building maps from iterables.";
+const _desc = r'Prefer `for` elements when building maps from iterables.';
 
 const _details = r'''
-When building maps from iterables, it is preferable to use 'for' elements.
+When building maps from iterables, it is preferable to use `for` elements.
 
 Using 'for' elements brings several benefits including:
 

--- a/lib/src/rules/prefer_if_null_operators.dart
+++ b/lib/src/rules/prefer_if_null_operators.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer using if null operators.';
+const _desc = r'Prefer using `??` operators.';
 
 const _details = r'''
-**PREFER** using if null operators instead of null checks in conditional
+**PREFER** using `??` operators instead of `null` checks and conditional
 expressions.
 
 **BAD:**

--- a/lib/src/rules/prefer_is_empty.dart
+++ b/lib/src/rules/prefer_is_empty.dart
@@ -11,7 +11,7 @@ import '../analyzer.dart';
 import '../ast.dart';
 import '../extensions.dart';
 
-const _desc = r'Use `isEmpty` for Iterables and Maps.';
+const _desc = r'Use `isEmpty` for `Iterable`s and `Map`s.';
 const _details = r'''
 **DON'T** use `length` to see if a collection is empty.
 

--- a/lib/src/rules/prefer_is_not_empty.dart
+++ b/lib/src/rules/prefer_is_not_empty.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../ast.dart';
 
-const _desc = r'Use `isNotEmpty` for Iterables and Maps.';
+const _desc = r'Use `isNotEmpty` for `Iterable`s and `Map`s.';
 
 const _details = r'''
 **PREFER** `x.isNotEmpty` to `!x.isEmpty` for `Iterable` and `Map` instances.

--- a/lib/src/rules/prefer_iterable_whereType.dart
+++ b/lib/src/rules/prefer_iterable_whereType.dart
@@ -9,7 +9,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r'Prefer to use whereType on iterable.';
+const _desc = r'Prefer to use `whereType` on iterable.';
 
 const _details = r'''
 **PREFER** `iterable.whereType<T>()` over `iterable.where((e) => e is T)`.

--- a/lib/src/rules/prefer_null_aware_method_calls.dart
+++ b/lib/src/rules/prefer_null_aware_method_calls.dart
@@ -8,11 +8,11 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer null aware method calls.';
+const _desc = r'Prefer `null`-aware method calls.';
 
 const _details = r'''
-Instead of checking nullability of a function/method `f` before calling it you
-can use `f?.call()`.
+Instead of checking nullability of a function/method `f` before calling it,
+you can use `f?.call()`.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/prefer_null_aware_operators.dart
+++ b/lib/src/rules/prefer_null_aware_operators.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer using null aware operators.';
+const _desc = r'Prefer using `null`-aware operators.';
 
 const _details = r'''
-**PREFER** using null aware operators instead of null checks in conditional
+**PREFER** using `null`-aware operators instead of `null` checks in conditional
 expressions.
 
 **BAD:**

--- a/lib/src/rules/provide_deprecation_message.dart
+++ b/lib/src/rules/provide_deprecation_message.dart
@@ -7,11 +7,11 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Provide a deprecation message, via @Deprecated("message").';
+const _desc = r'Provide a deprecation message, via `@Deprecated("message")`.';
 
 const _details = r'''
 **DO** specify a deprecation message (with migration instructions and/or a
-removal schedule) in the Deprecation constructor.
+removal schedule) in the `Deprecated` constructor.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/pub/package_names.dart
+++ b/lib/src/rules/pub/package_names.dart
@@ -13,7 +13,7 @@ From the [Pubspec format description](https://dart.dev/tools/pub/pubspec):
 **DO** use `lowercase_with_underscores` for package names.
 
 Package names should be all lowercase, with underscores to separate words,
-`just_like_this`.  Use only basic Latin letters and Arabic digits: [a-z0-9_].
+`just_like_this`.  Use only basic Latin letters and Arabic digits: \[a-z0-9\_\].
 Also, make sure the name is a valid Dart identifier -- that it doesn't start
 with digits and isn't a reserved word.
 

--- a/lib/src/rules/sized_box_for_whitespace.dart
+++ b/lib/src/rules/sized_box_for_whitespace.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
 
-const _desc = r'SizedBox for whitespace.';
+const _desc = r'`SizedBox` for whitespace.';
 
 const _details = r'''
-Use SizedBox to add whitespace to a layout.
+Use `SizedBox` to add whitespace to a layout.
 
 A `Container` is a heavier Widget than a `SizedBox`, and as bonus, `SizedBox`
 has a `const` constructor.

--- a/lib/src/rules/slash_for_doc_comments.dart
+++ b/lib/src/rules/slash_for_doc_comments.dart
@@ -7,7 +7,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Prefer using /// for doc comments.';
+const _desc = r'Prefer using `///` for doc comments.';
 
 const _details = r'''
 From [Effective Dart](https://dart.dev/effective-dart/documentation#do-use--doc-comments-to-document-members-and-types):

--- a/lib/src/rules/test_types_in_equals.dart
+++ b/lib/src/rules/test_types_in_equals.dart
@@ -7,12 +7,12 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Test type arguments in operator ==(Object other).';
+const _desc = r'Test type of argument in `operator ==(Object other)`.';
 
 const _details = r'''
-**DO** test type arguments in operator ==(Object other).
+**DO** test type of argument in `operator ==(Object other)`.
 
-Not testing types might result in null pointer exceptions which will be
+Not testing the type might result in runtime type errors which will be
 unexpected for consumers of your class.
 
 **BAD:**
@@ -119,8 +119,6 @@ class _Visitor extends SimpleAstVisitor<void> {
       return parent.name.lexeme;
     } else if (parent is MixinDeclaration) {
       return parent.name.lexeme;
-    } else if (parent is ExtensionDeclaration) {
-      return parent.extendedType.toSource();
     }
     return 'unknown';
   }

--- a/lib/src/rules/throw_in_finally.dart
+++ b/lib/src/rules/throw_in_finally.dart
@@ -8,13 +8,13 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../rules/control_flow_in_finally.dart';
 
-const _desc = r'Avoid `throw` in finally block.';
+const _desc = r'Avoid `throw` in `finally` block.';
 
 const _details = r'''
-**AVOID** throwing exceptions in finally blocks.
+**AVOID** throwing exceptions in `finally` blocks.
 
-Throwing exceptions in finally blocks will inevitably cause unexpected behavior
-that is hard to debug.
+Throwing exceptions in `finally` blocks will inevitably cause unexpected
+behavior that is hard to debug.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/unnecessary_await_in_return.dart
+++ b/lib/src/rules/unnecessary_await_in_return.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Unnecessary await keyword in return.';
+const _desc = r'Unnecessary `await` keyword in return.';
 
 const _details = r'''
 Avoid returning an awaited expression when the expression type is assignable to

--- a/lib/src/rules/unnecessary_const.dart
+++ b/lib/src/rules/unnecessary_const.dart
@@ -8,10 +8,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Avoid const keyword.';
+const _desc = r'Avoid `const` keyword.';
 
 const _details = r'''
-**AVOID** repeating const keyword in a const context.
+**AVOID** repeating `const` keyword in a `const` context.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/unnecessary_null_aware_assignments.dart
+++ b/lib/src/rules/unnecessary_null_aware_assignments.dart
@@ -10,13 +10,13 @@ import 'package:analyzer/dart/element/element.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r'Avoid null in null-aware assignment.';
+const _desc = r'Avoid `null` in `null`-aware assignment.';
 
 const _details = r'''
-**AVOID** `null` in null-aware assignment.
+**AVOID** `null` in `null`-aware assignment.
 
-Using `null` on the right-hand side of a null-aware assignment effectively makes
-the assignment redundant.
+Using `null` on the right-hand side of a `null`-aware assignment effectively
+makes the assignment redundant.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/unnecessary_null_checks.dart
+++ b/lib/src/rules/unnecessary_null_checks.dart
@@ -9,10 +9,10 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Unnecessary null checks.';
+const _desc = r'Unnecessary `null` checks.';
 
 const _details = r'''
-**DON'T** apply a null check when a nullable value is accepted.
+**DON'T** apply a `null` check where a nullable value is accepted.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/unnecessary_null_in_if_null_operators.dart
+++ b/lib/src/rules/unnecessary_null_in_if_null_operators.dart
@@ -9,10 +9,10 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r'Avoid using `null` in `if null` operators.';
+const _desc = r'Avoid using `null` in `??` operators.';
 
 const _details = r'''
-**AVOID** using `null` as an operand in `if null` operators.
+**AVOID** using `null` as an operand in `??` operators.
 
 Using `null` in an `if null` operator is redundant, regardless of which side
 `null` is used on.

--- a/lib/src/rules/unnecessary_to_list_in_spreads.dart
+++ b/lib/src/rules/unnecessary_to_list_in_spreads.dart
@@ -8,7 +8,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import '../analyzer.dart';
 import '../extensions.dart';
 
-const _desc = r'Unnecessary toList() in spreads.';
+const _desc = r'Unnecessary `toList()` in spreads.';
 
 const _details = r'''
 Unnecessary `toList()` in spreads.

--- a/lib/src/rules/use_build_context_synchronously.dart
+++ b/lib/src/rules/use_build_context_synchronously.dart
@@ -12,10 +12,10 @@ import 'package:collection/collection.dart';
 import '../analyzer.dart';
 import '../util/flutter_utils.dart';
 
-const _desc = r'Do not use BuildContexts across async gaps.';
+const _desc = r'Do not use `BuildContext` across asynchronous gaps.';
 
 const _details = r'''
-**DON'T** use BuildContext across asynchronous gaps.
+**DON'T** use `BuildContext` across asynchronous gaps.
 
 Storing `BuildContext` for later usage can easily lead to difficult to diagnose
 crashes. Asynchronous gaps are implicitly storing `BuildContext` and are some of

--- a/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
+++ b/lib/src/rules/use_if_null_to_convert_nulls_to_bools.dart
@@ -10,12 +10,12 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r'Use if-null operators to convert nulls to bools.';
+const _desc = r'Use `??` operators to convert `null`s to `bool`s.';
 
 const _details = r'''
 From [Effective Dart](https://dart.dev/effective-dart/usage#prefer-using--to-convert-null-to-a-boolean-value):
 
-Use if-null operators to convert nulls to bools.
+Use `??` operators to convert `null`s to `bool`s.
 
 **BAD:**
 ```dart

--- a/lib/src/rules/void_checks.dart
+++ b/lib/src/rules/void_checks.dart
@@ -9,10 +9,10 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../analyzer.dart';
 
-const _desc = r"Don't assign to void.";
+const _desc = r"Don't assign to `void`.";
 
 const _details = r'''
-**DON'T** assign to void.
+**DON'T** assign to `void`.
 
 **BAD:**
 ```dart


### PR DESCRIPTION
Use markdown code quotes for keywords and types more consistently.
Rephrase some descriptions as drive-by-fixups.

Removed (deprecated-member-using) case for `==` in extensions, since extensions cannot declare `==` operators.
